### PR TITLE
feat: add newsletter sns integration

### DIFF
--- a/backend/newsletter/router.mjs
+++ b/backend/newsletter/router.mjs
@@ -1,0 +1,64 @@
+// backend/newsletter/router.mjs
+import { corsHeadersFromEvent, preflightFromEvent, json } from "/opt/nodejs/utils/cors.mjs";
+import { SNSClient, SubscribeCommand, PublishCommand } from "@aws-sdk/client-sns";
+
+/* ---------- ENV ---------- */
+const REGION = process.env.AWS_REGION || "us-west-2";
+const NEWSLETTER_TOPIC_ARN = process.env.NEWSLETTER_TOPIC_ARN || "";
+
+/* ---------- SNS ---------- */
+const sns = new SNSClient({ region: REGION });
+
+/* ---------- utils ---------- */
+const M = (e) => e?.requestContext?.http?.method?.toUpperCase?.() || e?.httpMethod?.toUpperCase?.() || "GET";
+const P = (e) => (e?.rawPath || e?.path || "/");
+const B = (e) => { try { return JSON.parse(e?.body || "{}"); } catch { return {}; } };
+
+/* ---------- handlers ---------- */
+async function subscribe(event, C) {
+  const { email } = B(event);
+  if (!email) return json(400, C, { error: "email required" });
+  await sns.send(new SubscribeCommand({
+    TopicArn: NEWSLETTER_TOPIC_ARN,
+    Protocol: "email",
+    Endpoint: email,
+  }));
+  return json(200, C, { ok: true, email });
+}
+
+async function notify(event, C) {
+  const { subject, message } = B(event);
+  if (!subject || !message) return json(400, C, { error: "subject and message required" });
+  await sns.send(new PublishCommand({
+    TopicArn: NEWSLETTER_TOPIC_ARN,
+    Subject: subject,
+    Message: message,
+  }));
+  return json(200, C, { ok: true });
+}
+
+/* ---------- routes ---------- */
+const routes = [
+  { M: "POST", R: /^\/newsletter\/subscribe$/i, H: subscribe },
+  { M: "POST", R: /^\/newsletter\/notify$/i, H: notify },
+];
+
+/* ---------- entry ---------- */
+export async function handler(event) {
+  if (M(event) === "OPTIONS") return preflightFromEvent(event);
+  const CORS = corsHeadersFromEvent(event);
+  const method = M(event);
+  const path = P(event);
+  try {
+    for (const { M: mth, R, H } of routes) {
+      if (mth !== method) continue;
+      const match = R.exec(path);
+      if (match) return await H(event, CORS, match.groups || {});
+    }
+    return json(404, CORS, { error: "Not found", method, path });
+  } catch (err) {
+    console.error("newsletter_router_error", { method, path, err });
+    const msg = err?.message || "Server error";
+    return json(500, CORS, { error: msg });
+  }
+}

--- a/backend/newsletter/serverless.yml
+++ b/backend/newsletter/serverless.yml
@@ -1,0 +1,46 @@
+service: newsletter
+frameworkVersion: '3'
+
+provider:
+  name: aws
+  runtime: nodejs18.x
+  region: us-west-2
+  stage: ${opt:stage, 'dev'}
+  memorySize: 256
+  timeout: 15
+  httpApi:
+    cors: false   # dynamic CORS handled in /opt/nodejs/utils/cors.mjs
+  environment:
+    ALLOWED_ORIGINS: https://beta.mylg.studio,https://mylg.studio,http://localhost:3000
+    CORS_WILDCARD_HOSTS: mylg.studio
+    CORS_ALLOW_CREDENTIALS: "false"
+    NEWSLETTER_TOPIC_ARN: ${env:NEWSLETTER_TOPIC_ARN, ''}
+
+  iam:
+    role:
+      statements:
+        - Effect: Allow
+          Action:
+            - sns:Subscribe
+            - sns:Publish
+          Resource:
+            - ${self:provider.environment.NEWSLETTER_TOPIC_ARN}
+
+functions:
+  newsletterRouter:
+    handler: newsletter/router.handler
+    layers:
+      - ${cf:shared-layer-${sls:stage}.SharedUtilsLayerArn}
+    events:
+      - httpApi:
+          path: /newsletter/subscribe
+          method: ANY
+      - httpApi:
+          path: /newsletter/notify
+          method: ANY
+
+package:
+  patterns:
+    - newsletter/**
+    - '!**/*.map'
+    - '!node_modules/.bin/**'

--- a/backend/package.json
+++ b/backend/package.json
@@ -15,13 +15,20 @@
   "dependencies": {
     "@aws-sdk/client-apigatewaymanagementapi": "^3.0.0",
     "@aws-sdk/client-dynamodb": "^3.0.0",
-    "@aws-sdk/lib-dynamodb": "^3.0.0"
+    "@aws-sdk/lib-dynamodb": "^3.0.0",
+    "@aws-sdk/client-sns": "^3.0.0"
   },
   "devDependencies": {
     "serverless": "^3.0.0",
     "serverless-offline": "^13.0.0"
   },
-  "keywords": ["serverless", "aws", "lambda", "api", "websocket"],
+  "keywords": [
+    "serverless",
+    "aws",
+    "lambda",
+    "api",
+    "websocket"
+  ],
   "author": "MYLG Team",
   "license": "MIT"
 }


### PR DESCRIPTION
## Summary
- add newsletter router with subscribe and notify endpoints
- wire up SNS topic for newsletters with serverless config and IAM
- include SNS client dependency

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c0b80a78cc83248448f50865c96d11