### PR TITLE
feat(auth): add refresh token and role sync endpoints

### DIFF
--- a/backend/auth/routes/refreshToken.mjs
+++ b/backend/auth/routes/refreshToken.mjs
@@ -1,0 +1,25 @@
+import { InitiateAuthCommand, CognitoIdentityProviderClient } from "@aws-sdk/client-cognito-identity-provider";
+import { corsHeadersFromEvent, preflightFromEvent, json } from "/opt/nodejs/utils/cors.mjs";
+
+const cognito = new CognitoIdentityProviderClient({});
+const M = (e) => e?.requestContext?.http?.method?.toUpperCase?.() || e?.httpMethod?.toUpperCase?.() || "GET";
+
+export async function handler(event) {
+  if (M(event) === "OPTIONS") return preflightFromEvent(event);
+  const CORS = corsHeadersFromEvent(event);
+  try {
+    const body = JSON.parse(event.body || "{}");
+    const refreshToken = body.refreshToken || body.refresh_token;
+    if (!refreshToken) return json(400, CORS, { error: "refreshToken required" });
+    const cmd = new InitiateAuthCommand({
+      ClientId: process.env.COGNITO_USER_CLIENT_ID,
+      AuthFlow: "REFRESH_TOKEN_AUTH",
+      AuthParameters: { REFRESH_TOKEN: refreshToken },
+    });
+    const r = await cognito.send(cmd);
+    return json(200, CORS, r.AuthenticationResult || {});
+  } catch (err) {
+    console.error("refresh_token_error", err);
+    return json(500, CORS, { error: err?.message || "Failed to refresh token" });
+  }
+}

--- a/backend/auth/routes/updateRoles.mjs
+++ b/backend/auth/routes/updateRoles.mjs
@@ -1,0 +1,47 @@
+import {
+  CognitoIdentityProviderClient,
+  AdminListGroupsForUserCommand,
+  AdminAddUserToGroupCommand,
+  AdminRemoveUserFromGroupCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import { corsHeadersFromEvent, preflightFromEvent, json } from "/opt/nodejs/utils/cors.mjs";
+
+const cognito = new CognitoIdentityProviderClient({});
+const M = (e) => e?.requestContext?.http?.method?.toUpperCase?.() || e?.httpMethod?.toUpperCase?.() || "GET";
+
+export async function handler(event) {
+  if (M(event) === "OPTIONS") return preflightFromEvent(event);
+  const CORS = corsHeadersFromEvent(event);
+  try {
+    const body = JSON.parse(event.body || "{}");
+    const userId = body.userId || body.username || body.sub;
+    const roles = Array.isArray(body.roles) ? body.roles : [];
+    if (!userId || !roles.length) return json(400, CORS, { error: "userId and roles required" });
+
+    const poolId = process.env.COGNITO_USER_POOL_ID;
+    const listResp = await cognito.send(new AdminListGroupsForUserCommand({
+      UserPoolId: poolId,
+      Username: userId,
+    }));
+    const current = (listResp.Groups || []).map((g) => g.GroupName);
+
+    const toAdd = roles.filter((r) => !current.includes(r));
+    const toRemove = current.filter((g) => !roles.includes(g));
+
+    for (const group of toAdd) {
+      await cognito.send(
+        new AdminAddUserToGroupCommand({ UserPoolId: poolId, Username: userId, GroupName: group })
+      );
+    }
+    for (const group of toRemove) {
+      await cognito.send(
+        new AdminRemoveUserFromGroupCommand({ UserPoolId: poolId, Username: userId, GroupName: group })
+      );
+    }
+
+    return json(200, CORS, { userId, added: toAdd, removed: toRemove, roles });
+  } catch (err) {
+    console.error("update_roles_error", err);
+    return json(500, CORS, { error: err?.message || "Failed to update roles" });
+  }
+}

--- a/backend/auth/serverless.yml
+++ b/backend/auth/serverless.yml
@@ -8,6 +8,8 @@ provider:
   stage: ${opt:stage, 'dev'}
   memorySize: 256
   timeout: 15
+  httpApi:
+    cors: false  # dynamic CORS handled in Lambda
   environment:
     # Wire to your existing pool/client (set via shell/CI or .env)
     COGNITO_USER_POOL_ID: ${env:COGNITO_USER_POOL_ID}
@@ -29,6 +31,14 @@ provider:
             - dynamodb:DescribeTable
           Resource:
             - arn:aws:dynamodb:${self:provider.region}:${aws:accountId}:table/${self:provider.environment.USER_PROFILES_TABLE}
+        - Effect: Allow
+          Action:
+            - cognito-idp:InitiateAuth
+            - cognito-idp:AdminListGroupsForUser
+            - cognito-idp:AdminAddUserToGroup
+            - cognito-idp:AdminRemoveUserFromGroup
+          Resource:
+            - arn:aws:cognito-idp:${self:provider.region}:${aws:accountId}:userpool/${self:provider.environment.COGNITO_USER_POOL_ID}
 
 functions:
   # 1) Cognito Pre-Token Generation (adds role/claims)
@@ -48,9 +58,28 @@ functions:
       COGNITO_POOL_ID: ${self:provider.environment.COGNITO_USER_POOL_ID}
       COGNITO_CLIENT_ID: ${self:provider.environment.COGNITO_USER_CLIENT_ID}
 
+  refreshToken:
+    handler: routes/refreshToken.handler
+    layers:
+      - ${cf:shared-layer-${sls:stage}.SharedUtilsLayerArn}
+    events:
+      - httpApi:
+          path: /auth/refresh-token
+          method: POST
+
+  updateRoles:
+    handler: routes/updateRoles.handler
+    layers:
+      - ${cf:shared-layer-${sls:stage}.SharedUtilsLayerArn}
+    events:
+      - httpApi:
+          path: /auth/update-roles
+          method: POST
+
 package:
   patterns:
     - triggers/**
+    - routes/**
     - '!**/*.map'
     - '!node_modules/.bin/**'
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -15,7 +15,8 @@
   "dependencies": {
     "@aws-sdk/client-apigatewaymanagementapi": "^3.0.0",
     "@aws-sdk/client-dynamodb": "^3.0.0",
-    "@aws-sdk/lib-dynamodb": "^3.0.0"
+    "@aws-sdk/lib-dynamodb": "^3.0.0",
+    "@aws-sdk/client-cognito-identity-provider": "^3.0.0"
   },
   "devDependencies": {
     "serverless": "^3.0.0",


### PR DESCRIPTION
## Summary
- add `POST /auth/refresh-token` lambda to exchange Cognito refresh tokens
- add `POST /auth/update-roles` lambda to sync Cognito user groups
- wire auth service for new routes, IAM permissions, and shared utils

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c0b80d840483248cc3e090d0e7bf0d