### PR TITLE
chore: align v1.2 env tables

### DIFF
--- a/backend/auth/serverless.yml
+++ b/backend/auth/serverless.yml
@@ -1,11 +1,33 @@
 service: auth
 frameworkVersion: '3'
 
+custom:
+  app: mylg
+  ver: v12
+  stage: ${opt:stage, 'dev'}
+
+  tables:
+    USERS_PROFILES:           ${self:custom.app}-${self:custom.ver}-users-profiles-${self:custom.stage}
+    USERS_INVITES:            ${self:custom.app}-${self:custom.ver}-users-invites-${self:custom.stage}
+
+    MSG_THREADS:              ${self:custom.app}-${self:custom.ver}-messages-threads-${self:custom.stage}
+    MSG_ITEMS:                ${self:custom.app}-${self:custom.ver}-messages-items-${self:custom.stage}
+    MSG_PROJECT:              ${self:custom.app}-${self:custom.ver}-projects-messages-${self:custom.stage}
+    NOTIFICATIONS:            ${self:custom.app}-${self:custom.ver}-notifications-${self:custom.stage}
+
+    PROJ_CORE:                ${self:custom.app}-${self:custom.ver}-projects-core-${self:custom.stage}
+    PROJ_TASKS:               ${self:custom.app}-${self:custom.ver}-projects-tasks-${self:custom.stage}
+    PROJ_EVENTS:              ${self:custom.app}-${self:custom.ver}-projects-events-${self:custom.stage}
+    PROJ_BUDGETS:             ${self:custom.app}-${self:custom.ver}-projects-budgets-${self:custom.stage}
+    GALLERIES:                ${self:custom.app}-${self:custom.ver}-galleries-${self:custom.stage}
+
+    WS_CONNECTIONS:           Connections
+
 provider:
   name: aws
   runtime: nodejs18.x
   region: us-west-2
-  stage: ${opt:stage, 'dev'}
+  stage: ${self:custom.stage}
   memorySize: 256
   timeout: 15
   httpApi:
@@ -17,7 +39,7 @@ provider:
     COGNITO_USER_CLIENT_ID: ${env:COGNITO_USER_CLIENT_ID}
 
     # Used by preTokenGeneration to look up role/profile
-    USER_PROFILES_TABLE: ${env:USER_PROFILES_TABLE, 'UserProfiles'}
+    USER_PROFILES_TABLE: ${self:custom.tables.USERS_PROFILES}
 
   iam:
     role:

--- a/backend/auth/serverless.yml
+++ b/backend/auth/serverless.yml
@@ -1,27 +1,7 @@
 service: auth
 frameworkVersion: '3'
 
-custom:
-  app: mylg
-  ver: v12
-  stage: ${opt:stage, 'dev'}
-
-  tables:
-    USERS_PROFILES:           ${self:custom.app}-${self:custom.ver}-users-profiles-${self:custom.stage}
-    USERS_INVITES:            ${self:custom.app}-${self:custom.ver}-users-invites-${self:custom.stage}
-
-    MSG_THREADS:              ${self:custom.app}-${self:custom.ver}-messages-threads-${self:custom.stage}
-    MSG_ITEMS:                ${self:custom.app}-${self:custom.ver}-messages-items-${self:custom.stage}
-    MSG_PROJECT:              ${self:custom.app}-${self:custom.ver}-projects-messages-${self:custom.stage}
-    NOTIFICATIONS:            ${self:custom.app}-${self:custom.ver}-notifications-${self:custom.stage}
-
-    PROJ_CORE:                ${self:custom.app}-${self:custom.ver}-projects-core-${self:custom.stage}
-    PROJ_TASKS:               ${self:custom.app}-${self:custom.ver}-projects-tasks-${self:custom.stage}
-    PROJ_EVENTS:              ${self:custom.app}-${self:custom.ver}-projects-events-${self:custom.stage}
-    PROJ_BUDGETS:             ${self:custom.app}-${self:custom.ver}-projects-budgets-${self:custom.stage}
-    GALLERIES:                ${self:custom.app}-${self:custom.ver}-galleries-${self:custom.stage}
-
-    WS_CONNECTIONS:           Connections
+custom: ${file(../serverless.common.yml):custom}
 
 provider:
   name: aws

--- a/backend/messages/serverless.yml
+++ b/backend/messages/serverless.yml
@@ -1,27 +1,7 @@
 service: messages
 frameworkVersion: '3'
 
-custom:
-  app: mylg
-  ver: v12
-  stage: ${opt:stage, 'dev'}
-
-  tables:
-    USERS_PROFILES:           ${self:custom.app}-${self:custom.ver}-users-profiles-${self:custom.stage}
-    USERS_INVITES:            ${self:custom.app}-${self:custom.ver}-users-invites-${self:custom.stage}
-
-    MSG_THREADS:              ${self:custom.app}-${self:custom.ver}-messages-threads-${self:custom.stage}
-    MSG_ITEMS:                ${self:custom.app}-${self:custom.ver}-messages-items-${self:custom.stage}
-    MSG_PROJECT:              ${self:custom.app}-${self:custom.ver}-projects-messages-${self:custom.stage}
-    NOTIFICATIONS:            ${self:custom.app}-${self:custom.ver}-notifications-${self:custom.stage}
-
-    PROJ_CORE:                ${self:custom.app}-${self:custom.ver}-projects-core-${self:custom.stage}
-    PROJ_TASKS:               ${self:custom.app}-${self:custom.ver}-projects-tasks-${self:custom.stage}
-    PROJ_EVENTS:              ${self:custom.app}-${self:custom.ver}-projects-events-${self:custom.stage}
-    PROJ_BUDGETS:             ${self:custom.app}-${self:custom.ver}-projects-budgets-${self:custom.stage}
-    GALLERIES:                ${self:custom.app}-${self:custom.ver}-galleries-${self:custom.stage}
-
-    WS_CONNECTIONS:           Connections
+custom: ${file(../serverless.common.yml):custom}
 
 provider:
   name: aws

--- a/backend/messages/serverless.yml
+++ b/backend/messages/serverless.yml
@@ -1,11 +1,33 @@
 service: messages
 frameworkVersion: '3'
 
+custom:
+  app: mylg
+  ver: v12
+  stage: ${opt:stage, 'dev'}
+
+  tables:
+    USERS_PROFILES:           ${self:custom.app}-${self:custom.ver}-users-profiles-${self:custom.stage}
+    USERS_INVITES:            ${self:custom.app}-${self:custom.ver}-users-invites-${self:custom.stage}
+
+    MSG_THREADS:              ${self:custom.app}-${self:custom.ver}-messages-threads-${self:custom.stage}
+    MSG_ITEMS:                ${self:custom.app}-${self:custom.ver}-messages-items-${self:custom.stage}
+    MSG_PROJECT:              ${self:custom.app}-${self:custom.ver}-projects-messages-${self:custom.stage}
+    NOTIFICATIONS:            ${self:custom.app}-${self:custom.ver}-notifications-${self:custom.stage}
+
+    PROJ_CORE:                ${self:custom.app}-${self:custom.ver}-projects-core-${self:custom.stage}
+    PROJ_TASKS:               ${self:custom.app}-${self:custom.ver}-projects-tasks-${self:custom.stage}
+    PROJ_EVENTS:              ${self:custom.app}-${self:custom.ver}-projects-events-${self:custom.stage}
+    PROJ_BUDGETS:             ${self:custom.app}-${self:custom.ver}-projects-budgets-${self:custom.stage}
+    GALLERIES:                ${self:custom.app}-${self:custom.ver}-galleries-${self:custom.stage}
+
+    WS_CONNECTIONS:           Connections
+
 provider:
   name: aws
   runtime: nodejs18.x
   region: us-west-2
-  stage: ${opt:stage, 'dev'}
+  stage: ${self:custom.stage}
   memorySize: 256
   timeout: 15
   httpApi:
@@ -17,13 +39,12 @@ provider:
     CORS_ALLOW_CREDENTIALS: "false"
 
     # Tables / indexes used by the router (MUST be inside environment)
-    THREADS_TABLE: MessagesThreads
-    THREAD_MEMBERS_TABLE: MessagesThreadMembers
-    MESSAGES_TABLE: Messages
-    MESSAGES_BY_ID_INDEX: messageId-index
-    PROJECT_MESSAGES_TABLE: ProjectMessages
-    NOTIFICATIONS_TABLE: Notifications
-    NOTIFICATIONS_BY_USER_INDEX: userId-index
+    THREADS_TABLE:           ${self:custom.tables.MSG_THREADS}
+    MESSAGES_TABLE:          ${self:custom.tables.MSG_ITEMS}
+    MESSAGES_BY_ID_INDEX:    messageId-index
+    PROJECT_MESSAGES_TABLE:  ${self:custom.tables.MSG_PROJECT}
+    NOTIFICATIONS_TABLE:     ${self:custom.tables.NOTIFICATIONS}
+    NOTIFICATIONS_BY_USER_INDEX:  userId-index
 
     # dev safety toggle (router expects a string)
     SCANS_ALLOWED: "false"
@@ -42,9 +63,8 @@ provider:
             - dynamodb:Query
             - dynamodb:Scan
           Resource:
-            # Threads + membership
+            # Threads
             - arn:aws:dynamodb:${self:provider.region}:${aws:accountId}:table/${env:THREADS_TABLE}
-            - arn:aws:dynamodb:${self:provider.region}:${aws:accountId}:table/${env:THREAD_MEMBERS_TABLE}
 
             # Messages + GSIs (messageId-index)
             - arn:aws:dynamodb:${self:provider.region}:${aws:accountId}:table/${env:MESSAGES_TABLE}

--- a/backend/projects/serverless.yml
+++ b/backend/projects/serverless.yml
@@ -1,27 +1,7 @@
 service: projects
 frameworkVersion: '3'
 
-custom:
-  app: mylg
-  ver: v12
-  stage: ${opt:stage, 'dev'}
-
-  tables:
-    USERS_PROFILES:           ${self:custom.app}-${self:custom.ver}-users-profiles-${self:custom.stage}
-    USERS_INVITES:            ${self:custom.app}-${self:custom.ver}-users-invites-${self:custom.stage}
-
-    MSG_THREADS:              ${self:custom.app}-${self:custom.ver}-messages-threads-${self:custom.stage}
-    MSG_ITEMS:                ${self:custom.app}-${self:custom.ver}-messages-items-${self:custom.stage}
-    MSG_PROJECT:              ${self:custom.app}-${self:custom.ver}-projects-messages-${self:custom.stage}
-    NOTIFICATIONS:            ${self:custom.app}-${self:custom.ver}-notifications-${self:custom.stage}
-
-    PROJ_CORE:                ${self:custom.app}-${self:custom.ver}-projects-core-${self:custom.stage}
-    PROJ_TASKS:               ${self:custom.app}-${self:custom.ver}-projects-tasks-${self:custom.stage}
-    PROJ_EVENTS:              ${self:custom.app}-${self:custom.ver}-projects-events-${self:custom.stage}
-    PROJ_BUDGETS:             ${self:custom.app}-${self:custom.ver}-projects-budgets-${self:custom.stage}
-    GALLERIES:                ${self:custom.app}-${self:custom.ver}-galleries-${self:custom.stage}
-
-    WS_CONNECTIONS:           Connections
+custom: ${file(../serverless.common.yml):custom}
 
 provider:
   name: aws

--- a/backend/projects/serverless.yml
+++ b/backend/projects/serverless.yml
@@ -2,26 +2,38 @@ service: projects
 frameworkVersion: '3'
 
 custom:
-  prefix: mylg-v12
+  app: mylg
+  ver: v12
   stage: ${opt:stage, 'dev'}
-  region: ${opt:region, 'us-west-2'}
+
   tables:
-    PROJECTS_TABLE: ${self:custom.prefix}-projects-core-${self:custom.stage}
-    TASKS_TABLE:    ${self:custom.prefix}-projects-tasks-${self:custom.stage}
-    EVENTS_TABLE:   ${self:custom.prefix}-projects-events-${self:custom.stage}
-    BUDGETS_TABLE:  ${self:custom.prefix}-projects-budgets-${self:custom.stage}
+    USERS_PROFILES:           ${self:custom.app}-${self:custom.ver}-users-profiles-${self:custom.stage}
+    USERS_INVITES:            ${self:custom.app}-${self:custom.ver}-users-invites-${self:custom.stage}
+
+    MSG_THREADS:              ${self:custom.app}-${self:custom.ver}-messages-threads-${self:custom.stage}
+    MSG_ITEMS:                ${self:custom.app}-${self:custom.ver}-messages-items-${self:custom.stage}
+    MSG_PROJECT:              ${self:custom.app}-${self:custom.ver}-projects-messages-${self:custom.stage}
+    NOTIFICATIONS:            ${self:custom.app}-${self:custom.ver}-notifications-${self:custom.stage}
+
+    PROJ_CORE:                ${self:custom.app}-${self:custom.ver}-projects-core-${self:custom.stage}
+    PROJ_TASKS:               ${self:custom.app}-${self:custom.ver}-projects-tasks-${self:custom.stage}
+    PROJ_EVENTS:              ${self:custom.app}-${self:custom.ver}-projects-events-${self:custom.stage}
+    PROJ_BUDGETS:             ${self:custom.app}-${self:custom.ver}-projects-budgets-${self:custom.stage}
+    GALLERIES:                ${self:custom.app}-${self:custom.ver}-galleries-${self:custom.stage}
+
+    WS_CONNECTIONS:           Connections
 
 provider:
   name: aws
   runtime: nodejs18.x
-  region: ${self:custom.region}
+  region: us-west-2
   stage: ${self:custom.stage}
   memorySize: 256
   timeout: 15
-  stackName: ${self:custom.prefix}-${self:service}-${self:custom.stage}
+  stackName: ${self:custom.app}-${self:custom.ver}-${self:service}-${self:custom.stage}
   httpApi:
     cors: false  # dynamic CORS handled in Lambda
-    name: ${self:custom.prefix}-${self:service}-api-${self:custom.stage}
+    name: ${self:custom.app}-${self:custom.ver}-${self:service}-api-${self:custom.stage}
   tags:
     App: MYLG
     Version: v1.2
@@ -34,19 +46,19 @@ provider:
     CORS_ALLOW_CREDENTIALS: "false"
 
     # Projects domain tables
-    PROJECTS_TABLE: ${self:custom.tables.PROJECTS_TABLE}
-    TASKS_TABLE:    ${self:custom.tables.TASKS_TABLE}
-    EVENTS_TABLE:   ${self:custom.tables.EVENTS_TABLE}
-    EVENTS_STARTAT_INDEX: projectId-startAt-index
+    PROJECTS_TABLE:           ${self:custom.tables.PROJ_CORE}
+    TASKS_TABLE:              ${self:custom.tables.PROJ_TASKS}
+    EVENTS_TABLE:             ${self:custom.tables.PROJ_EVENTS}
+    EVENTS_STARTAT_INDEX:     projectId-startAt-index
 
     # Budgets (v1.1 semantics under /projects/{id}/budget*)
-    BUDGETS_TABLE:           ${self:custom.tables.BUDGETS_TABLE}
-    BUDGET_ID_INDEX:         budgetId-index
-    BUDGET_ITEM_ID_INDEX:    budgetItemId-index
+    BUDGETS_TABLE:            ${self:custom.tables.PROJ_BUDGETS}
+    BUDGET_ID_INDEX:          budgetId-index
+    BUDGET_ITEM_ID_INDEX:     budgetItemId-index
 
     # Galleries (v1.1 table: PK=galleryId, GSI on projectId)
-    GALLERIES_TABLE: ${env:GALLERIES_TABLE, 'Galleries'}
-    GALLERIES_PROJECT_INDEX: ${env:GALLERIES_PROJECT_INDEX, 'projectId-index'}
+    GALLERIES_TABLE:          ${self:custom.tables.GALLERIES}
+    GALLERIES_BY_PROJECT_INDEX: projectId-index
 
     # safer default; flip to "true" if you want dev scans
     SCANS_ALLOWED: "false"
@@ -66,26 +78,26 @@ provider:
             - dynamodb:Scan
           Resource:
             # Projects core
-            - arn:aws:dynamodb:${self:provider.region}:${aws:accountId}:table/${self:custom.tables.PROJECTS_TABLE}
+            - arn:aws:dynamodb:${self:provider.region}:${aws:accountId}:table/${self:custom.tables.PROJ_CORE}
 
             # Tasks
-            - arn:aws:dynamodb:${self:provider.region}:${aws:accountId}:table/${self:custom.tables.TASKS_TABLE}
+            - arn:aws:dynamodb:${self:provider.region}:${aws:accountId}:table/${self:custom.tables.PROJ_TASKS}
 
             # Events (+ optional startAt GSI)
-            - arn:aws:dynamodb:${self:provider.region}:${aws:accountId}:table/${self:custom.tables.EVENTS_TABLE}
-            - arn:aws:dynamodb:${self:provider.region}:${aws:accountId}:table/${self:custom.tables.EVENTS_TABLE}/index/*
+            - arn:aws:dynamodb:${self:provider.region}:${aws:accountId}:table/${self:custom.tables.PROJ_EVENTS}
+            - arn:aws:dynamodb:${self:provider.region}:${aws:accountId}:table/${self:custom.tables.PROJ_EVENTS}/index/*
 
             # Budgets (+ GSIs for budgetId and budgetItemId)
-            - arn:aws:dynamodb:${self:provider.region}:${aws:accountId}:table/${self:custom.tables.BUDGETS_TABLE}
-            - arn:aws:dynamodb:${self:provider.region}:${aws:accountId}:table/${self:custom.tables.BUDGETS_TABLE}/index/*
+            - arn:aws:dynamodb:${self:provider.region}:${aws:accountId}:table/${self:custom.tables.PROJ_BUDGETS}
+            - arn:aws:dynamodb:${self:provider.region}:${aws:accountId}:table/${self:custom.tables.PROJ_BUDGETS}/index/*
 
             # Galleries (+ projectId GSI)
-            - arn:aws:dynamodb:${self:provider.region}:${aws:accountId}:table/${env:GALLERIES_TABLE, 'Galleries'}
-            - arn:aws:dynamodb:${self:provider.region}:${aws:accountId}:table/${env:GALLERIES_TABLE, 'Galleries'}/index/*
+            - arn:aws:dynamodb:${self:provider.region}:${aws:accountId}:table/${self:provider.environment.GALLERIES_TABLE}
+            - arn:aws:dynamodb:${self:provider.region}:${aws:accountId}:table/${self:provider.environment.GALLERIES_TABLE}/index/*
 
 functions:
   projectsRouter:
-    name: ${self:custom.prefix}-projects-router-${self:custom.stage}
+    name: ${self:custom.app}-${self:custom.ver}-projects-router-${self:custom.stage}
     # NOTE: point this to where your file actually lives.
     # If the file is backend/projects/router.mjs at the service root, use "router.handler".
     # If it's in src/router.mjs, keep "src/router.handler".

--- a/backend/serverless.common.yml
+++ b/backend/serverless.common.yml
@@ -1,0 +1,21 @@
+custom:
+  app: mylg
+  ver: v12
+  stage: ${opt:stage, 'dev'}
+
+  tables:
+    USERS_PROFILES:           ${self:custom.app}-${self:custom.ver}-users-profiles-${self:custom.stage}
+    USERS_INVITES:            ${self:custom.app}-${self:custom.ver}-users-invites-${self:custom.stage}
+
+    MSG_THREADS:              ${self:custom.app}-${self:custom.ver}-messages-threads-${self:custom.stage}
+    MSG_ITEMS:                ${self:custom.app}-${self:custom.ver}-messages-items-${self:custom.stage}
+    MSG_PROJECT:              ${self:custom.app}-${self:custom.ver}-projects-messages-${self:custom.stage}
+    NOTIFICATIONS:            ${self:custom.app}-${self:custom.ver}-notifications-${self:custom.stage}
+
+    PROJ_CORE:                ${self:custom.app}-${self:custom.ver}-projects-core-${self:custom.stage}
+    PROJ_TASKS:               ${self:custom.app}-${self:custom.ver}-projects-tasks-${self:custom.stage}
+    PROJ_EVENTS:              ${self:custom.app}-${self:custom.ver}-projects-events-${self:custom.stage}
+    PROJ_BUDGETS:             ${self:custom.app}-${self:custom.ver}-projects-budgets-${self:custom.stage}
+    GALLERIES:                ${self:custom.app}-${self:custom.ver}-galleries-${self:custom.stage}
+
+    WS_CONNECTIONS:           Connections

--- a/backend/user/serverless.yml
+++ b/backend/user/serverless.yml
@@ -1,11 +1,33 @@
 service: users
 frameworkVersion: '3'
 
+custom:
+  app: mylg
+  ver: v12
+  stage: ${opt:stage, 'dev'}
+
+  tables:
+    USERS_PROFILES:           ${self:custom.app}-${self:custom.ver}-users-profiles-${self:custom.stage}
+    USERS_INVITES:            ${self:custom.app}-${self:custom.ver}-users-invites-${self:custom.stage}
+
+    MSG_THREADS:              ${self:custom.app}-${self:custom.ver}-messages-threads-${self:custom.stage}
+    MSG_ITEMS:                ${self:custom.app}-${self:custom.ver}-messages-items-${self:custom.stage}
+    MSG_PROJECT:              ${self:custom.app}-${self:custom.ver}-projects-messages-${self:custom.stage}
+    NOTIFICATIONS:            ${self:custom.app}-${self:custom.ver}-notifications-${self:custom.stage}
+
+    PROJ_CORE:                ${self:custom.app}-${self:custom.ver}-projects-core-${self:custom.stage}
+    PROJ_TASKS:               ${self:custom.app}-${self:custom.ver}-projects-tasks-${self:custom.stage}
+    PROJ_EVENTS:              ${self:custom.app}-${self:custom.ver}-projects-events-${self:custom.stage}
+    PROJ_BUDGETS:             ${self:custom.app}-${self:custom.ver}-projects-budgets-${self:custom.stage}
+    GALLERIES:                ${self:custom.app}-${self:custom.ver}-galleries-${self:custom.stage}
+
+    WS_CONNECTIONS:           Connections
+
 provider:
   name: aws
   runtime: nodejs18.x
   region: us-west-2
-  stage: ${opt:stage, 'dev'}
+  stage: ${self:custom.stage}
   memorySize: 256
   timeout: 15
   httpApi:
@@ -17,10 +39,10 @@ provider:
     CORS_ALLOW_CREDENTIALS: "false"
 
     # Users domain tables / indexes
-    USER_PROFILES_TABLE: ${env:USER_PROFILES_TABLE, 'UserProfiles'}
-    INVITES_TABLE:       ${env:INVITES_TABLE, 'UserInvites'}
-    INVITES_BY_SENDER_INDEX:    ${env:INVITES_BY_SENDER_INDEX, 'senderId-index'}
-    INVITES_BY_RECIPIENT_INDEX: ${env:INVITES_BY_RECIPIENT_INDEX, 'recipientId-index'}
+    USER_PROFILES_TABLE:        ${self:custom.tables.USERS_PROFILES}
+    INVITES_TABLE:              ${self:custom.tables.USERS_INVITES}
+    INVITES_BY_SENDER_INDEX:    senderId-index
+    INVITES_BY_RECIPIENT_INDEX: recipientId-index
 
     # Dev toggle the router reads as a string
     SCANS_ALLOWED: ${env:SCANS_ALLOWED, 'false'}

--- a/backend/user/serverless.yml
+++ b/backend/user/serverless.yml
@@ -1,27 +1,7 @@
 service: users
 frameworkVersion: '3'
 
-custom:
-  app: mylg
-  ver: v12
-  stage: ${opt:stage, 'dev'}
-
-  tables:
-    USERS_PROFILES:           ${self:custom.app}-${self:custom.ver}-users-profiles-${self:custom.stage}
-    USERS_INVITES:            ${self:custom.app}-${self:custom.ver}-users-invites-${self:custom.stage}
-
-    MSG_THREADS:              ${self:custom.app}-${self:custom.ver}-messages-threads-${self:custom.stage}
-    MSG_ITEMS:                ${self:custom.app}-${self:custom.ver}-messages-items-${self:custom.stage}
-    MSG_PROJECT:              ${self:custom.app}-${self:custom.ver}-projects-messages-${self:custom.stage}
-    NOTIFICATIONS:            ${self:custom.app}-${self:custom.ver}-notifications-${self:custom.stage}
-
-    PROJ_CORE:                ${self:custom.app}-${self:custom.ver}-projects-core-${self:custom.stage}
-    PROJ_TASKS:               ${self:custom.app}-${self:custom.ver}-projects-tasks-${self:custom.stage}
-    PROJ_EVENTS:              ${self:custom.app}-${self:custom.ver}-projects-events-${self:custom.stage}
-    PROJ_BUDGETS:             ${self:custom.app}-${self:custom.ver}-projects-budgets-${self:custom.stage}
-    GALLERIES:                ${self:custom.app}-${self:custom.ver}-galleries-${self:custom.stage}
-
-    WS_CONNECTIONS:           Connections
+custom: ${file(../serverless.common.yml):custom}
 
 provider:
   name: aws

--- a/backend/ws/serverless.yml
+++ b/backend/ws/serverless.yml
@@ -1,16 +1,38 @@
 service: mylg-v2-websocket
 frameworkVersion: '3'
 
+custom:
+  app: mylg
+  ver: v12
+  stage: ${opt:stage, 'dev'}
+
+  tables:
+    USERS_PROFILES:           ${self:custom.app}-${self:custom.ver}-users-profiles-${self:custom.stage}
+    USERS_INVITES:            ${self:custom.app}-${self:custom.ver}-users-invites-${self:custom.stage}
+
+    MSG_THREADS:              ${self:custom.app}-${self:custom.ver}-messages-threads-${self:custom.stage}
+    MSG_ITEMS:                ${self:custom.app}-${self:custom.ver}-messages-items-${self:custom.stage}
+    MSG_PROJECT:              ${self:custom.app}-${self:custom.ver}-projects-messages-${self:custom.stage}
+    NOTIFICATIONS:            ${self:custom.app}-${self:custom.ver}-notifications-${self:custom.stage}
+
+    PROJ_CORE:                ${self:custom.app}-${self:custom.ver}-projects-core-${self:custom.stage}
+    PROJ_TASKS:               ${self:custom.app}-${self:custom.ver}-projects-tasks-${self:custom.stage}
+    PROJ_EVENTS:              ${self:custom.app}-${self:custom.ver}-projects-events-${self:custom.stage}
+    PROJ_BUDGETS:             ${self:custom.app}-${self:custom.ver}-projects-budgets-${self:custom.stage}
+    GALLERIES:                ${self:custom.app}-${self:custom.ver}-galleries-${self:custom.stage}
+
+    WS_CONNECTIONS:           Connections
+
 provider:
   name: aws
   runtime: nodejs18.x
   region: us-west-2
-  stage: ${opt:stage, 'dev'}
+  stage: ${self:custom.stage}
   memorySize: 256
   timeout: 15
   environment:
     # DynamoDB
-    CONNECTIONS_TABLE: Connections                   # ← your table name
+    CONNECTIONS_TABLE: ${self:custom.tables.WS_CONNECTIONS}  # ← your table name
     CONNECTIONS_USER_GSI: userId-sessionId-index     # ← GSI used in code
     # WebSocket Management API endpoint (HTTPS domain + stage)
     # Example: https://abc123.execute-api.us-west-2.amazonaws.com/dev
@@ -29,8 +51,8 @@ provider:
             - dynamodb:Scan
             - dynamodb:BatchWriteItem
           Resource:
-            - arn:aws:dynamodb:${aws:region}:${aws:accountId}:table/Connections
-            - arn:aws:dynamodb:${aws:region}:${aws:accountId}:table/Connections/index/*
+            - arn:aws:dynamodb:${aws:region}:${aws:accountId}:table/${self:provider.environment.CONNECTIONS_TABLE}
+            - arn:aws:dynamodb:${aws:region}:${aws:accountId}:table/${self:provider.environment.CONNECTIONS_TABLE}/index/*
         - Effect: Allow
           Action:
             - execute-api:ManageConnections

--- a/backend/ws/serverless.yml
+++ b/backend/ws/serverless.yml
@@ -1,27 +1,7 @@
 service: mylg-v2-websocket
 frameworkVersion: '3'
 
-custom:
-  app: mylg
-  ver: v12
-  stage: ${opt:stage, 'dev'}
-
-  tables:
-    USERS_PROFILES:           ${self:custom.app}-${self:custom.ver}-users-profiles-${self:custom.stage}
-    USERS_INVITES:            ${self:custom.app}-${self:custom.ver}-users-invites-${self:custom.stage}
-
-    MSG_THREADS:              ${self:custom.app}-${self:custom.ver}-messages-threads-${self:custom.stage}
-    MSG_ITEMS:                ${self:custom.app}-${self:custom.ver}-messages-items-${self:custom.stage}
-    MSG_PROJECT:              ${self:custom.app}-${self:custom.ver}-projects-messages-${self:custom.stage}
-    NOTIFICATIONS:            ${self:custom.app}-${self:custom.ver}-notifications-${self:custom.stage}
-
-    PROJ_CORE:                ${self:custom.app}-${self:custom.ver}-projects-core-${self:custom.stage}
-    PROJ_TASKS:               ${self:custom.app}-${self:custom.ver}-projects-tasks-${self:custom.stage}
-    PROJ_EVENTS:              ${self:custom.app}-${self:custom.ver}-projects-events-${self:custom.stage}
-    PROJ_BUDGETS:             ${self:custom.app}-${self:custom.ver}-projects-budgets-${self:custom.stage}
-    GALLERIES:                ${self:custom.app}-${self:custom.ver}-galleries-${self:custom.stage}
-
-    WS_CONNECTIONS:           Connections
+custom: ${file(../serverless.common.yml):custom}
 
 provider:
   name: aws


### PR DESCRIPTION
## Summary
- standardize serverless env vars on v1.2 DynamoDB table names and indexes
- remove MessagesThreadMembers table

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c0becc702c8324bc25a9af3c2a679c