### PR TITLE
chore: centralize table env config

### DIFF
--- a/backend/auth/serverless.yml
+++ b/backend/auth/serverless.yml
@@ -1,25 +1,30 @@
 service: auth
 frameworkVersion: '3'
 
-custom: ${file(../serverless.common.yml):custom}
+custom:
+  env: ${file(../serverless.common.yml):env}
 
 provider:
   name: aws
   runtime: nodejs18.x
   region: us-west-2
-  stage: ${self:custom.stage}
+  stage: ${opt:stage, 'dev'}
   memorySize: 256
   timeout: 15
   httpApi:
     cors: false  # dynamic CORS handled in Lambda
   environment:
-    # Wire to your existing pool/client (set via shell/CI or .env)
+    # CORS (unchanged)
+    ALLOWED_ORIGINS: https://beta.mylg.studio,https://mylg.studio,http://localhost:3000
+    CORS_WILDCARD_HOSTS: mylg.studio
+    CORS_ALLOW_CREDENTIALS: "false"
+
     COGNITO_USER_POOL_ID: ${env:COGNITO_USER_POOL_ID}
     COGNITO_USER_POOL_NAME: ${env:COGNITO_USER_POOL_NAME}
     COGNITO_USER_CLIENT_ID: ${env:COGNITO_USER_CLIENT_ID}
 
-    # Used by preTokenGeneration to look up role/profile
-    USER_PROFILES_TABLE: ${self:custom.tables.USERS_PROFILES}
+    # Tables: pull from the shared file
+    ${self:custom.env}
 
   iam:
     role:
@@ -32,7 +37,7 @@ provider:
             - dynamodb:Query
             - dynamodb:DescribeTable
           Resource:
-            - arn:aws:dynamodb:${self:provider.region}:${aws:accountId}:table/${self:provider.environment.USER_PROFILES_TABLE}
+            - arn:aws:dynamodb:${aws:region}:${aws:accountId}:table/${env:USER_PROFILES_TABLE}
         - Effect: Allow
           Action:
             - cognito-idp:InitiateAuth
@@ -40,7 +45,7 @@ provider:
             - cognito-idp:AdminAddUserToGroup
             - cognito-idp:AdminRemoveUserFromGroup
           Resource:
-            - arn:aws:cognito-idp:${self:provider.region}:${aws:accountId}:userpool/${self:provider.environment.COGNITO_USER_POOL_ID}
+            - arn:aws:cognito-idp:${aws:region}:${aws:accountId}:userpool/${self:provider.environment.COGNITO_USER_POOL_ID}
 
 functions:
   # 1) Cognito Pre-Token Generation (adds role/claims)

--- a/backend/messages/serverless.yml
+++ b/backend/messages/serverless.yml
@@ -1,13 +1,14 @@
 service: messages
 frameworkVersion: '3'
 
-custom: ${file(../serverless.common.yml):custom}
+custom:
+  env: ${file(../serverless.common.yml):env}
 
 provider:
   name: aws
   runtime: nodejs18.x
   region: us-west-2
-  stage: ${self:custom.stage}
+  stage: ${opt:stage, 'dev'}
   memorySize: 256
   timeout: 15
   httpApi:
@@ -18,16 +19,8 @@ provider:
     CORS_WILDCARD_HOSTS: mylg.studio
     CORS_ALLOW_CREDENTIALS: "false"
 
-    # Tables / indexes used by the router (MUST be inside environment)
-    THREADS_TABLE:           ${self:custom.tables.MSG_THREADS}
-    MESSAGES_TABLE:          ${self:custom.tables.MSG_ITEMS}
-    MESSAGES_BY_ID_INDEX:    messageId-index
-    PROJECT_MESSAGES_TABLE:  ${self:custom.tables.MSG_PROJECT}
-    NOTIFICATIONS_TABLE:     ${self:custom.tables.NOTIFICATIONS}
-    NOTIFICATIONS_BY_USER_INDEX:  userId-index
-
-    # dev safety toggle (router expects a string)
-    SCANS_ALLOWED: "false"
+    # Tables: pull from the shared file
+    ${self:custom.env}
 
   iam:
     role:
@@ -44,18 +37,18 @@ provider:
             - dynamodb:Scan
           Resource:
             # Threads
-            - arn:aws:dynamodb:${self:provider.region}:${aws:accountId}:table/${env:THREADS_TABLE}
+            - arn:aws:dynamodb:${aws:region}:${aws:accountId}:table/${env:THREADS_TABLE}
 
             # Messages + GSIs (messageId-index)
-            - arn:aws:dynamodb:${self:provider.region}:${aws:accountId}:table/${env:MESSAGES_TABLE}
-            - arn:aws:dynamodb:${self:provider.region}:${aws:accountId}:table/${env:MESSAGES_TABLE}/index/*
+            - arn:aws:dynamodb:${aws:region}:${aws:accountId}:table/${env:MESSAGES_TABLE}
+            - arn:aws:dynamodb:${aws:region}:${aws:accountId}:table/${env:MESSAGES_TABLE}/index/*
 
             # Project-scoped messages
-            - arn:aws:dynamodb:${self:provider.region}:${aws:accountId}:table/${env:PROJECT_MESSAGES_TABLE}
+            - arn:aws:dynamodb:${aws:region}:${aws:accountId}:table/${env:PROJECT_MESSAGES_TABLE}
 
             # Notifications (+ optional index)
-            - arn:aws:dynamodb:${self:provider.region}:${aws:accountId}:table/${env:NOTIFICATIONS_TABLE}
-            - arn:aws:dynamodb:${self:provider.region}:${aws:accountId}:table/${env:NOTIFICATIONS_TABLE}/index/*
+            - arn:aws:dynamodb:${aws:region}:${aws:accountId}:table/${env:NOTIFICATIONS_TABLE}
+            - arn:aws:dynamodb:${aws:region}:${aws:accountId}:table/${env:NOTIFICATIONS_TABLE}/index/*
 
 functions:
   messagesRouter:

--- a/backend/projects/serverless.yml
+++ b/backend/projects/serverless.yml
@@ -1,47 +1,35 @@
 service: projects
 frameworkVersion: '3'
 
-custom: ${file(../serverless.common.yml):custom}
+custom:
+  app: mylg
+  ver: v12
+  env: ${file(../serverless.common.yml):env}
 
 provider:
   name: aws
   runtime: nodejs18.x
   region: us-west-2
-  stage: ${self:custom.stage}
+  stage: ${opt:stage, 'dev'}
   memorySize: 256
   timeout: 15
-  stackName: ${self:custom.app}-${self:custom.ver}-${self:service}-${self:custom.stage}
+  stackName: ${self:custom.app}-${self:custom.ver}-${self:service}-${sls:stage}
   httpApi:
     cors: false  # dynamic CORS handled in Lambda
-    name: ${self:custom.app}-${self:custom.ver}-${self:service}-api-${self:custom.stage}
+    name: ${self:custom.app}-${self:custom.ver}-${self:service}-api-${sls:stage}
   tags:
     App: MYLG
     Version: v1.2
     Domain: projects
-    Stage: ${self:custom.stage}
+    Stage: ${sls:stage}
   environment:
     # CORS (layer reads these)
     ALLOWED_ORIGINS: https://beta.mylg.studio,https://mylg.studio,http://localhost:3000
     CORS_WILDCARD_HOSTS: mylg.studio
     CORS_ALLOW_CREDENTIALS: "false"
 
-    # Projects domain tables
-    PROJECTS_TABLE:           ${self:custom.tables.PROJ_CORE}
-    TASKS_TABLE:              ${self:custom.tables.PROJ_TASKS}
-    EVENTS_TABLE:             ${self:custom.tables.PROJ_EVENTS}
-    EVENTS_STARTAT_INDEX:     projectId-startAt-index
-
-    # Budgets (v1.1 semantics under /projects/{id}/budget*)
-    BUDGETS_TABLE:            ${self:custom.tables.PROJ_BUDGETS}
-    BUDGET_ID_INDEX:          budgetId-index
-    BUDGET_ITEM_ID_INDEX:     budgetItemId-index
-
-    # Galleries (v1.1 table: PK=galleryId, GSI on projectId)
-    GALLERIES_TABLE:          ${self:custom.tables.GALLERIES}
-    GALLERIES_BY_PROJECT_INDEX: projectId-index
-
-    # safer default; flip to "true" if you want dev scans
-    SCANS_ALLOWED: "false"
+    # Tables: pull from the shared file
+    ${self:custom.env}
 
   iam:
     role:
@@ -58,26 +46,26 @@ provider:
             - dynamodb:Scan
           Resource:
             # Projects core
-            - arn:aws:dynamodb:${self:provider.region}:${aws:accountId}:table/${self:custom.tables.PROJ_CORE}
+            - arn:aws:dynamodb:${aws:region}:${aws:accountId}:table/${env:PROJECTS_TABLE}
 
             # Tasks
-            - arn:aws:dynamodb:${self:provider.region}:${aws:accountId}:table/${self:custom.tables.PROJ_TASKS}
+            - arn:aws:dynamodb:${aws:region}:${aws:accountId}:table/${env:TASKS_TABLE}
 
             # Events (+ optional startAt GSI)
-            - arn:aws:dynamodb:${self:provider.region}:${aws:accountId}:table/${self:custom.tables.PROJ_EVENTS}
-            - arn:aws:dynamodb:${self:provider.region}:${aws:accountId}:table/${self:custom.tables.PROJ_EVENTS}/index/*
+            - arn:aws:dynamodb:${aws:region}:${aws:accountId}:table/${env:EVENTS_TABLE}
+            - arn:aws:dynamodb:${aws:region}:${aws:accountId}:table/${env:EVENTS_TABLE}/index/*
 
             # Budgets (+ GSIs for budgetId and budgetItemId)
-            - arn:aws:dynamodb:${self:provider.region}:${aws:accountId}:table/${self:custom.tables.PROJ_BUDGETS}
-            - arn:aws:dynamodb:${self:provider.region}:${aws:accountId}:table/${self:custom.tables.PROJ_BUDGETS}/index/*
+            - arn:aws:dynamodb:${aws:region}:${aws:accountId}:table/${env:BUDGETS_TABLE}
+            - arn:aws:dynamodb:${aws:region}:${aws:accountId}:table/${env:BUDGETS_TABLE}/index/*
 
             # Galleries (+ projectId GSI)
-            - arn:aws:dynamodb:${self:provider.region}:${aws:accountId}:table/${self:provider.environment.GALLERIES_TABLE}
-            - arn:aws:dynamodb:${self:provider.region}:${aws:accountId}:table/${self:provider.environment.GALLERIES_TABLE}/index/*
+            - arn:aws:dynamodb:${aws:region}:${aws:accountId}:table/${env:GALLERIES_TABLE}
+            - arn:aws:dynamodb:${aws:region}:${aws:accountId}:table/${env:GALLERIES_TABLE}/index/*
 
 functions:
   projectsRouter:
-    name: ${self:custom.app}-${self:custom.ver}-projects-router-${self:custom.stage}
+    name: ${self:custom.app}-${self:custom.ver}-projects-router-${sls:stage}
     # NOTE: point this to where your file actually lives.
     # If the file is backend/projects/router.mjs at the service root, use "router.handler".
     # If it's in src/router.mjs, keep "src/router.handler".

--- a/backend/serverless.common.yml
+++ b/backend/serverless.common.yml
@@ -1,21 +1,38 @@
-custom:
-  app: mylg
-  ver: v12
-  stage: ${opt:stage, 'dev'}
+env:
+  # ---- Users & invites
+  USER_PROFILES_TABLE: UserProfiles
+  INVITES_TABLE: ProjectInvitations          # or CollabInvites if that’s the one live
+  INVITES_BY_SENDER_INDEX: senderId-index
+  INVITES_BY_RECIPIENT_INDEX: recipientId-index
 
-  tables:
-    USERS_PROFILES:           ${self:custom.app}-${self:custom.ver}-users-profiles-${self:custom.stage}
-    USERS_INVITES:            ${self:custom.app}-${self:custom.ver}-users-invites-${self:custom.stage}
+  # ---- Messaging & notifications (v1.1 compat)
+  THREADS_TABLE: DM_THREADS                  # used only if we ever read per-thread info
+  THREAD_MEMBERS_TABLE: DM_THREADS           # membership lives here (PK userId, SK conversationId)
+  MESSAGES_TABLE: DMs
+  MESSAGES_BY_ID_INDEX: messageId-index
+  PROJECT_MESSAGES_TABLE: ProjectMessages
 
-    MSG_THREADS:              ${self:custom.app}-${self:custom.ver}-messages-threads-${self:custom.stage}
-    MSG_ITEMS:                ${self:custom.app}-${self:custom.ver}-messages-items-${self:custom.stage}
-    MSG_PROJECT:              ${self:custom.app}-${self:custom.ver}-projects-messages-${self:custom.stage}
-    NOTIFICATIONS:            ${self:custom.app}-${self:custom.ver}-notifications-${self:custom.stage}
+  NOTIFICATIONS_TABLE: Notifications
+  NOTIFICATIONS_BY_USER_INDEX: userId-index
 
-    PROJ_CORE:                ${self:custom.app}-${self:custom.ver}-projects-core-${self:custom.stage}
-    PROJ_TASKS:               ${self:custom.app}-${self:custom.ver}-projects-tasks-${self:custom.stage}
-    PROJ_EVENTS:              ${self:custom.app}-${self:custom.ver}-projects-events-${self:custom.stage}
-    PROJ_BUDGETS:             ${self:custom.app}-${self:custom.ver}-projects-budgets-${self:custom.stage}
-    GALLERIES:                ${self:custom.app}-${self:custom.ver}-galleries-${self:custom.stage}
+  # ---- Projects / workflow
+  PROJECTS_TABLE: Projects
+  TASKS_TABLE: Tasks
+  EVENTS_TABLE: Events
+  EVENTS_STARTAT_INDEX: ""                   # leave blank if you don’t have projectId-startAt-index
 
-    WS_CONNECTIONS:           Connections
+  # ---- Budgets
+  BUDGETS_TABLE: Budgets
+  BUDGET_ID_INDEX: budgetId-index
+  BUDGET_ITEM_ID_INDEX: budgetItemId-index
+
+  # ---- Galleries / uploads
+  GALLERIES_TABLE: Galleries
+  GALLERIES_PROJECT_GSI: projectId-index
+
+  # ---- WebSocket
+  CONNECTIONS_TABLE: Connections
+  CONNECTIONS_USER_GSI: userId-sessionId-index
+
+  # ---- Misc
+  SCANS_ALLOWED: "false"                     # flip to "true" only for dev scans

--- a/backend/user/serverless.yml
+++ b/backend/user/serverless.yml
@@ -1,13 +1,14 @@
 service: users
 frameworkVersion: '3'
 
-custom: ${file(../serverless.common.yml):custom}
+custom:
+  env: ${file(../serverless.common.yml):env}
 
 provider:
   name: aws
   runtime: nodejs18.x
   region: us-west-2
-  stage: ${self:custom.stage}
+  stage: ${opt:stage, 'dev'}
   memorySize: 256
   timeout: 15
   httpApi:
@@ -18,14 +19,8 @@ provider:
     CORS_WILDCARD_HOSTS: mylg.studio
     CORS_ALLOW_CREDENTIALS: "false"
 
-    # Users domain tables / indexes
-    USER_PROFILES_TABLE:        ${self:custom.tables.USERS_PROFILES}
-    INVITES_TABLE:              ${self:custom.tables.USERS_INVITES}
-    INVITES_BY_SENDER_INDEX:    senderId-index
-    INVITES_BY_RECIPIENT_INDEX: recipientId-index
-
-    # Dev toggle the router reads as a string
-    SCANS_ALLOWED: ${env:SCANS_ALLOWED, 'false'}
+    # Tables: pull from the shared file
+    ${self:custom.env}
 
   iam:
     role:
@@ -41,9 +36,9 @@ provider:
             - dynamodb:Query
             - dynamodb:Scan
           Resource:
-            - arn:aws:dynamodb:${self:provider.region}:${aws:accountId}:table/${self:provider.environment.USER_PROFILES_TABLE}
-            - arn:aws:dynamodb:${self:provider.region}:${aws:accountId}:table/${self:provider.environment.INVITES_TABLE}
-            - arn:aws:dynamodb:${self:provider.region}:${aws:accountId}:table/${self:provider.environment.INVITES_TABLE}/index/*
+            - arn:aws:dynamodb:${aws:region}:${aws:accountId}:table/${env:USER_PROFILES_TABLE}
+            - arn:aws:dynamodb:${aws:region}:${aws:accountId}:table/${env:INVITES_TABLE}
+            - arn:aws:dynamodb:${aws:region}:${aws:accountId}:table/${env:INVITES_TABLE}/index/*
 
 functions:
   usersRouter:

--- a/backend/ws/serverless.yml
+++ b/backend/ws/serverless.yml
@@ -1,22 +1,20 @@
 service: mylg-v2-websocket
 frameworkVersion: '3'
 
-custom: ${file(../serverless.common.yml):custom}
+custom:
+  env: ${file(../serverless.common.yml):env}
 
 provider:
   name: aws
   runtime: nodejs18.x
   region: us-west-2
-  stage: ${self:custom.stage}
+  stage: ${opt:stage, 'dev'}
   memorySize: 256
   timeout: 15
   environment:
-    # DynamoDB
-    CONNECTIONS_TABLE: ${self:custom.tables.WS_CONNECTIONS}  # ← your table name
-    CONNECTIONS_USER_GSI: userId-sessionId-index     # ← GSI used in code
-    # WebSocket Management API endpoint (HTTPS domain + stage)
-    # Example: https://abc123.execute-api.us-west-2.amazonaws.com/dev
     WEBSOCKET_ENDPOINT: ${env:WEBSOCKET_ENDPOINT}
+
+    ${self:custom.env}
 
   iam:
     role:
@@ -31,8 +29,8 @@ provider:
             - dynamodb:Scan
             - dynamodb:BatchWriteItem
           Resource:
-            - arn:aws:dynamodb:${aws:region}:${aws:accountId}:table/${self:provider.environment.CONNECTIONS_TABLE}
-            - arn:aws:dynamodb:${aws:region}:${aws:accountId}:table/${self:provider.environment.CONNECTIONS_TABLE}/index/*
+            - arn:aws:dynamodb:${aws:region}:${aws:accountId}:table/${env:CONNECTIONS_TABLE}
+            - arn:aws:dynamodb:${aws:region}:${aws:accountId}:table/${env:CONNECTIONS_TABLE}/index/*
         - Effect: Allow
           Action:
             - execute-api:ManageConnections


### PR DESCRIPTION
## Summary
- centralize DynamoDB table and index names in `backend/serverless.common.yml`
- import shared env block in service `serverless.yml`
- update IAM resources to reference shared env variables

## Testing
- `npm test` *(fails: npm: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0ccab27808324be72619cd5095b51