### PR TITLE
chore: centralize cors env vars

### DIFF
--- a/backend/auth/serverless.yml
+++ b/backend/auth/serverless.yml
@@ -14,16 +14,11 @@ provider:
   httpApi:
     cors: false  # dynamic CORS handled in Lambda
   environment:
-    # CORS (unchanged)
-    ALLOWED_ORIGINS: https://beta.mylg.studio,https://mylg.studio,http://localhost:3000
-    CORS_WILDCARD_HOSTS: mylg.studio
-    CORS_ALLOW_CREDENTIALS: "false"
-
     COGNITO_USER_POOL_ID: ${env:COGNITO_USER_POOL_ID}
     COGNITO_USER_POOL_NAME: ${env:COGNITO_USER_POOL_NAME}
     COGNITO_USER_CLIENT_ID: ${env:COGNITO_USER_CLIENT_ID}
 
-    # Tables: pull from the shared file
+    # Tables & shared config (CORS, etc.)
     ${self:custom.env}
 
   iam:

--- a/backend/messages/serverless.yml
+++ b/backend/messages/serverless.yml
@@ -14,12 +14,7 @@ provider:
   httpApi:
     cors: false  # dynamic CORS in Lambda
   environment:
-    # CORS (read by /opt layer)
-    ALLOWED_ORIGINS: https://beta.mylg.studio,https://mylg.studio,http://localhost:3000
-    CORS_WILDCARD_HOSTS: mylg.studio
-    CORS_ALLOW_CREDENTIALS: "false"
-
-    # Tables: pull from the shared file
+    # Tables & shared config (CORS, etc.)
     ${self:custom.env}
 
   iam:

--- a/backend/projects/serverless.yml
+++ b/backend/projects/serverless.yml
@@ -23,12 +23,7 @@ provider:
     Domain: projects
     Stage: ${sls:stage}
   environment:
-    # CORS (layer reads these)
-    ALLOWED_ORIGINS: https://beta.mylg.studio,https://mylg.studio,http://localhost:3000
-    CORS_WILDCARD_HOSTS: mylg.studio
-    CORS_ALLOW_CREDENTIALS: "false"
-
-    # Tables: pull from the shared file
+    # Tables & shared config (CORS, etc.)
     ${self:custom.env}
 
   iam:

--- a/backend/serverless.common.yml
+++ b/backend/serverless.common.yml
@@ -1,4 +1,10 @@
 env:
+  # ---- CORS
+  ALLOWED_ORIGINS: https://beta.mylg.studio,https://mylg.studio,http://localhost:3000
+  CORS_WILDCARD_HOSTS: mylg.studio
+  CORS_ALLOW_CREDENTIALS: "false"
+  CORS_DEFAULT_ORIGIN: https://beta.mylg.studio
+
   # ---- Users & invites
   USER_PROFILES_TABLE: UserProfiles
   INVITES_TABLE: ProjectInvitations          # or CollabInvites if that’s the one live

--- a/backend/user/serverless.yml
+++ b/backend/user/serverless.yml
@@ -14,12 +14,7 @@ provider:
   httpApi:
     cors: false   # dynamic CORS handled in /opt/nodejs/utils/cors.mjs
   environment:
-    # CORS (read by the shared layer)
-    ALLOWED_ORIGINS: https://beta.mylg.studio,https://mylg.studio,http://localhost:3000
-    CORS_WILDCARD_HOSTS: mylg.studio
-    CORS_ALLOW_CREDENTIALS: "false"
-
-    # Tables: pull from the shared file
+    # Tables & shared config (CORS, etc.)
     ${self:custom.env}
 
   iam:


### PR DESCRIPTION
## Summary
- add shared CORS env vars to serverless.common.yml
- reference shared env in auth, messages, projects, and user services

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx serverless print --stage dev` *(fails: cannot parse serverless.yml: cannot read an implicit mapping pair)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c49264148324b8325d1c5c2249d8