### PR TITLE
feat: centralize default CORS origin

### DIFF
--- a/backend/auth/serverless.yml
+++ b/backend/auth/serverless.yml
@@ -3,6 +3,7 @@ frameworkVersion: '3'
 
 custom:
   env: ${file(../serverless.common.yml):env}
+  cors: ${file(../serverless.common.yml):cors}
 
 provider:
   name: aws
@@ -18,6 +19,7 @@ provider:
     ALLOWED_ORIGINS: https://beta.mylg.studio,https://mylg.studio,http://localhost:3000
     CORS_WILDCARD_HOSTS: mylg.studio
     CORS_ALLOW_CREDENTIALS: "false"
+    CORS_DEFAULT_ORIGIN: ${self:custom.cors.CORS_DEFAULT_ORIGIN}
 
     COGNITO_USER_POOL_ID: ${env:COGNITO_USER_POOL_ID}
     COGNITO_USER_POOL_NAME: ${env:COGNITO_USER_POOL_NAME}

--- a/backend/messages/serverless.yml
+++ b/backend/messages/serverless.yml
@@ -3,6 +3,7 @@ frameworkVersion: '3'
 
 custom:
   env: ${file(../serverless.common.yml):env}
+  cors: ${file(../serverless.common.yml):cors}
 
 provider:
   name: aws
@@ -18,6 +19,7 @@ provider:
     ALLOWED_ORIGINS: https://beta.mylg.studio,https://mylg.studio,http://localhost:3000
     CORS_WILDCARD_HOSTS: mylg.studio
     CORS_ALLOW_CREDENTIALS: "false"
+    CORS_DEFAULT_ORIGIN: ${self:custom.cors.CORS_DEFAULT_ORIGIN}
 
     # Tables: pull from the shared file
     ${self:custom.env}

--- a/backend/projects/serverless.yml
+++ b/backend/projects/serverless.yml
@@ -5,6 +5,7 @@ custom:
   app: mylg
   ver: v12
   env: ${file(../serverless.common.yml):env}
+  cors: ${file(../serverless.common.yml):cors}
 
 provider:
   name: aws
@@ -27,6 +28,7 @@ provider:
     ALLOWED_ORIGINS: https://beta.mylg.studio,https://mylg.studio,http://localhost:3000
     CORS_WILDCARD_HOSTS: mylg.studio
     CORS_ALLOW_CREDENTIALS: "false"
+    CORS_DEFAULT_ORIGIN: ${self:custom.cors.CORS_DEFAULT_ORIGIN}
 
     # Tables: pull from the shared file
     ${self:custom.env}

--- a/backend/serverless.common.yml
+++ b/backend/serverless.common.yml
@@ -1,3 +1,6 @@
+cors:
+  CORS_DEFAULT_ORIGIN: https://beta.mylg.studio
+
 env:
   # ---- Users & invites
   USER_PROFILES_TABLE: UserProfiles

--- a/backend/shared-layer/nodejs/utils/cors.mjs
+++ b/backend/shared-layer/nodejs/utils/cors.mjs
@@ -14,8 +14,6 @@ const ENV_ALLOWED = (process.env.ALLOWED_ORIGINS || "")
 const DEFAULT_ALLOWED = [
   "http://localhost:3000",
   "http://192.168.1.200:3000",
-  "https://mylg.studio",
-  "https://www.mylg.studio",
 ];
 
 const EXPLICIT_ALLOW = new Set([...DEFAULT_ALLOWED, ...ENV_ALLOWED]);

--- a/backend/user/serverless.yml
+++ b/backend/user/serverless.yml
@@ -3,6 +3,7 @@ frameworkVersion: '3'
 
 custom:
   env: ${file(../serverless.common.yml):env}
+  cors: ${file(../serverless.common.yml):cors}
 
 provider:
   name: aws
@@ -18,6 +19,7 @@ provider:
     ALLOWED_ORIGINS: https://beta.mylg.studio,https://mylg.studio,http://localhost:3000
     CORS_WILDCARD_HOSTS: mylg.studio
     CORS_ALLOW_CREDENTIALS: "false"
+    CORS_DEFAULT_ORIGIN: ${self:custom.cors.CORS_DEFAULT_ORIGIN}
 
     # Tables: pull from the shared file
     ${self:custom.env}

--- a/backend/ws/serverless.yml
+++ b/backend/ws/serverless.yml
@@ -3,6 +3,7 @@ frameworkVersion: '3'
 
 custom:
   env: ${file(../serverless.common.yml):env}
+  cors: ${file(../serverless.common.yml):cors}
 
 provider:
   name: aws
@@ -13,6 +14,7 @@ provider:
   timeout: 15
   environment:
     WEBSOCKET_ENDPOINT: ${env:WEBSOCKET_ENDPOINT}
+    CORS_DEFAULT_ORIGIN: ${self:custom.cors.CORS_DEFAULT_ORIGIN}
 
     ${self:custom.env}
 


### PR DESCRIPTION
## Summary
- add shared CORS_DEFAULT_ORIGIN in serverless.common.yml
- expose CORS_DEFAULT_ORIGIN to all services
- read default origin from env and drop hard-coded production URLs in cors.mjs

## Testing
- `npm test` *(fails: Missing script "test"?)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c49dd6a08324abb587379f20e8de