### PR TITLE
refactor: unify inbox table and conversation messaging

### DIFF
--- a/backend/messages/serverless.yml
+++ b/backend/messages/serverless.yml
@@ -36,8 +36,8 @@ provider:
             - dynamodb:Query
             - dynamodb:Scan
           Resource:
-            # Threads
-            - arn:aws:dynamodb:${aws:region}:${aws:accountId}:table/${env:THREADS_TABLE}
+            # Inbox entries
+            - arn:aws:dynamodb:${aws:region}:${aws:accountId}:table/${env:INBOX_TABLE}
 
             # Messages + GSIs (messageId-index)
             - arn:aws:dynamodb:${aws:region}:${aws:accountId}:table/${env:MESSAGES_TABLE}

--- a/backend/serverless.common.yml
+++ b/backend/serverless.common.yml
@@ -6,8 +6,7 @@ env:
   INVITES_BY_RECIPIENT_INDEX: recipientId-index
 
   # ---- Messaging & notifications (v1.1 compat)
-  THREADS_TABLE: Inbox                  # used only if we ever read per-thread info
-  THREAD_MEMBERS_TABLE: Inbox           # membership lives here (PK userId, SK conversationId)
+  INBOX_TABLE: Inbox                    # PK userId, SK conversationId
   MESSAGES_TABLE: Messages
   MESSAGES_BY_ID_INDEX: messageId-index
   PROJECT_MESSAGES_TABLE: ProjectMessages


### PR DESCRIPTION
## Summary
- replace thread and membership tables with unified `INBOX_TABLE`
- create conversation inbox entries per participant and query inbox by user
- use `conversationId` as partition key for message CRUD operations

## Testing
- `npm test` *(fails: Missing script)*
- `node -e "import('./messages/router.mjs')..."` *(fails: Cannot find module '/opt/nodejs/utils/cors.mjs')*

------
https://chatgpt.com/codex/tasks/task_e_68c1c55779d48324bf98f8375517723d