### PR TITLE
refactor: use custom cognito userId

### DIFF
--- a/backend/auth/cognitoAuthorizer.mjs
+++ b/backend/auth/cognitoAuthorizer.mjs
@@ -85,7 +85,7 @@ export const handler = async (event) => {
         ],
       },
       context: {
-        userId: String(verified.sub),
+        userId: String(verified['custom:userId'] || verified.sub),
         email: String(verified.email),
         role: String(verified.role),
       },

--- a/backend/auth/preTokenGeneration.mjs
+++ b/backend/auth/preTokenGeneration.mjs
@@ -6,7 +6,9 @@ const tableName = process.env.USER_PROFILES_TABLE || 'UserProfiles';
 
 export const handler = async (event) => {
   console.log('PreTokenGeneration event:', JSON.stringify(event, null, 2));
-  const userId = event.request.userAttributes?.sub;
+  const userId =
+    event.request.userAttributes?.['custom:userId'] ||
+    event.request.userAttributes?.sub;
   let role = 'user';
 
   if (userId) {
@@ -19,7 +21,7 @@ export const handler = async (event) => {
       console.error('Error fetching user role:', err);
     }
   } else {
-    console.warn('No user sub in event.request.userAttributes');
+    console.warn('No user identifier in event.request.userAttributes');
   }
 
   event.response = event.response || {};

--- a/frontend/src/app/contexts/AuthContext.tsx
+++ b/frontend/src/app/contexts/AuthContext.tsx
@@ -50,7 +50,10 @@ export const AuthProvider: React.FC<PropsWithChildren> = ({ children }) => {
 
       const cognitoUserData = await amplifyGetCurrentUser();
       const role = (idToken.payload?.role as Role) ?? undefined;
-      const userId = (idToken.payload?.sub as string) ?? cognitoUserData?.username;
+      const userId =
+        (idToken.payload?.['custom:userId'] as string) ||
+        (idToken.payload?.sub as string) ||
+        cognitoUserData?.username;
 
       // For auth context, we only care about Cognito identity
       setIsAuthenticated(true);

--- a/frontend/src/features/auth/email-verification/EmailVerification.tsx
+++ b/frontend/src/features/auth/email-verification/EmailVerification.tsx
@@ -82,8 +82,11 @@ const EmailVerification: React.FC<EmailVerificationProps> = ({ registrationData,
           await signIn({ username: derivedEmail, password: registrationData.password });
           const session = await fetchAuthSession();
           const sub = session.tokens?.idToken?.payload?.sub as string | undefined;
+          const userId =
+            (session.tokens?.idToken?.payload?.['custom:userId'] as string | undefined) ||
+            sub;
           const { password: _unusedPassword, ...pendingData } = registrationData; // eslint-disable-line @typescript-eslint/no-unused-vars
-          const profileData = { ...pendingData, userId: sub, cognitoSub: sub };
+          const profileData = { ...pendingData, userId, cognitoSub: sub };
           await updateUserProfile(profileData);
           await validateAndSetUserSession();
         }
@@ -103,8 +106,11 @@ const EmailVerification: React.FC<EmailVerificationProps> = ({ registrationData,
               await signIn({ username: derivedEmail, password: registrationData.password });
               const session = await fetchAuthSession();
               const sub = session.tokens?.idToken?.payload?.sub as string | undefined;
+              const userId =
+                (session.tokens?.idToken?.payload?.['custom:userId'] as string | undefined) ||
+                sub;
               const { password: _unusedPassword, ...pendingData } = registrationData; // eslint-disable-line @typescript-eslint/no-unused-vars
-              const profileData = { ...pendingData, userId: sub, cognitoSub: sub };
+              const profileData = { ...pendingData, userId, cognitoSub: sub };
               await updateUserProfile(profileData);
               await validateAndSetUserSession();
             } catch {

--- a/frontend/src/features/auth/email-verification/EmailVerifications.test.tsx
+++ b/frontend/src/features/auth/email-verification/EmailVerifications.test.tsx
@@ -15,7 +15,7 @@ vi.mock('aws-amplify/auth', () => ({
   resendSignUpCode: vi.fn(),
   signIn: vi.fn(),
   fetchAuthSession: vi.fn().mockResolvedValue({
-    tokens: { idToken: { payload: { sub: 'sub123' } } },
+    tokens: { idToken: { payload: { sub: 'sub123', 'custom:userId': 'user123' } } },
   }),
 }));
 
@@ -47,7 +47,9 @@ describe('EmailVerification', () => {
   beforeEach(() => {
     mockedConfirmSignUp.mockResolvedValue({ isSignUpComplete: true });
     mockedFetchAuthSession.mockResolvedValue({
-      tokens: { idToken: { payload: { sub: 'sub123' } } },
+      tokens: {
+        idToken: { payload: { sub: 'sub123', 'custom:userId': 'user123' } },
+      },
     } as Awaited<ReturnType<typeof fetchAuthSession>>);
     mockedSignIn.mockResolvedValue({} as Awaited<ReturnType<typeof signIn>>);
   });


### PR DESCRIPTION
## Summary
- use Cognito custom:userId to lookup roles during pre-token generation
- propagate custom:userId in authorizer context
- reference custom:userId from front-end AuthContext and email verification
- update email verification tests

## Testing
- `npm test` *(fails: useUser must be used within <UserProvider>)*

------
https://chatgpt.com/codex/tasks/task_e_68c326d24a4c8324bea4fec73347a28a