### PR TITLE
feat: add GSI-based project queries

### DIFF
--- a/backend/projects/serverless.yml
+++ b/backend/projects/serverless.yml
@@ -44,6 +44,7 @@ provider:
           Resource:
             # Projects core
             - arn:aws:dynamodb:${aws:region}:${aws:accountId}:table/${env:PROJECTS_TABLE}
+            - arn:aws:dynamodb:${aws:region}:${aws:accountId}:table/${env:PROJECTS_TABLE}/index/*
 
             # Tasks
             - arn:aws:dynamodb:${aws:region}:${aws:accountId}:table/${env:TASKS_TABLE}

--- a/backend/serverless.common.yml
+++ b/backend/serverless.common.yml
@@ -30,6 +30,8 @@ env:
 
   # ---- Projects / workflow
   PROJECTS_TABLE: Projects
+  PROJECTS_VISIBILITY_INDEX: visibility-index
+  PROJECTS_TEAMUSERIDS_INDEX: teamUserIds-index
   TASKS_TABLE: Tasks
   EVENTS_TABLE: Events
   EVENTS_STARTAT_INDEX: ""                   # leave blank if you don’t have projectId-startAt-index


### PR DESCRIPTION
## Summary
- replace project scans with role-based GSI queries
- store collaborator ids and visibility on project records
- update team management to keep `teamUserIds`

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c32eadecb48324a4c487e05e485c3f