### PR TITLE
Use user-centric project listing

### DIFF
--- a/frontend/src/app/contexts/DataProvider.test.tsx
+++ b/frontend/src/app/contexts/DataProvider.test.tsx
@@ -66,7 +66,8 @@ import type { AuthContextValue } from './AuthContext';
 import React from 'react';
 import { act, render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { DataProvider, useData } from './DataProvider';
+import DataProvider from './DataProvider';
+import { useData } from './useData';
 import type { TimelineEvent } from './DataProvider';
 
 const ErrProbe: React.FC = () => {

--- a/frontend/src/shared/utils/api.ts
+++ b/frontend/src/shared/utils/api.ts
@@ -472,8 +472,10 @@ export async function updateUserRole(userId: string, role: string): Promise<User
 // Projects
 // ───────────────────────────────────────────────────────────────────────────────
 
-export async function fetchProjectsFromApi(): Promise<Project[]> {
-  const data = await apiFetch<MaybeItems<Project>>(`${PROJECTS_SERVICE_URL}/projects`);
+export async function fetchProjectsFromApi(userId: string): Promise<Project[]> {
+  if (!userId) return [];
+  const url = `${PROJECTS_SERVICE_URL}/projects?userId=${encodeURIComponent(userId)}`;
+  const data = await apiFetch<MaybeItems<Project>>(url);
   return extractItems<Project>(data);
 }
 

--- a/frontend/test/setupTests.ts
+++ b/frontend/test/setupTests.ts
@@ -108,6 +108,17 @@ vi.mock('@/app/contexts/DataProvider', () => ({
   DataProvider: ({ children }: { children: any }) => children,
 }));
 
+vi.mock('@/app/contexts/useUser', () => ({
+  useUser: vi.fn(() => ({
+    isAdmin: false,
+    isBuilder: false,
+    isDesigner: false,
+    isVendor: false,
+    isClient: false,
+    userId: 'test-user-id',
+  })),
+}));
+
 vi.mock('@/app/contexts/AuthContext', () => ({
   useAuth: vi.fn(() => ({
     user: { firstName: 'Test User', email: 'test@example.com' },


### PR DESCRIPTION
## Summary
- Fetch projects by user ID to leverage profile-based lookups
- Simplify ProjectsProvider by removing client-side filtering and rely on backend visibility
- Mock user context in tests for useData consumer compatibility

## Testing
- `npm test` *(fails: useProjects must be used within DataProvider)*

------
https://chatgpt.com/codex/tasks/task_e_68c33fc50ae083249f4ca39c33f33827