### PR TITLE
fix: normalize message file URLs

### DIFF
--- a/frontend/src/features/messages/MessageItem.tsx
+++ b/frontend/src/features/messages/MessageItem.tsx
@@ -4,7 +4,7 @@ import { useOnlineStatus } from '@/app/contexts/OnlineStatusContext';
 import { Trash2, Pencil, Smile } from "lucide-react";
 import ReactPlayer from "react-player";
 // import "../../../../index.css";
-import { S3_PUBLIC_BASE } from "../../shared/utils/api";
+import { S3_PUBLIC_BASE, ensureS3Url } from "../../shared/utils/api";
 import ReactionBar from "@/shared/ui/ReactionBar";
 import { ChatMessage, ChatFile, DMFile } from "@/shared/utils/messageUtils";
 
@@ -147,16 +147,19 @@ const MessageItem: React.FC<MessageItemProps> = ({
         </div>
       );
     }
-    if (text && text.includes(S3_PUBLIC_BASE)) {
-      const file: ChatFile = { fileName: getFileNameFromUrl(text), url: text };
-      return (
-        <div
-          onClick={() => openPreviewModal(file)}
-          style={{ cursor: "pointer" }}
-        >
-          {renderFilePreview(file, folderKey)}
-        </div>
-      );
+    if (text) {
+      const normalized = ensureS3Url(text);
+      if (normalized !== text || text.includes(S3_PUBLIC_BASE)) {
+        const file: ChatFile = {
+          fileName: getFileNameFromUrl(normalized),
+          url: normalized,
+        };
+        return (
+          <div onClick={() => openPreviewModal(file)} style={{ cursor: "pointer" }}>
+            {renderFilePreview(file, folderKey)}
+          </div>
+        );
+      }
     }
     if (matchedUrl) {
       return <RenderLinkContent url={matchedUrl} />;

--- a/frontend/src/shared/utils/api.ts
+++ b/frontend/src/shared/utils/api.ts
@@ -248,6 +248,26 @@ export const {
 // Helpers
 // ───────────────────────────────────────────────────────────────────────────────
 
+/**
+ * Ensures that a provided URL points to the currently configured public S3
+ * bucket. If the URL references any previous `mylg-files*` bucket or region,
+ * it will be rewritten to use {@link S3_PUBLIC_BASE} while preserving the
+ * original path.
+ */
+export function ensureS3Url(url: string): string {
+  if (!url) return url;
+  try {
+    const pattern = /^https?:\/\/[^/]*mylg-files[^/]*\.s3\.[^/]+\.amazonaws\.com\//;
+    if (pattern.test(url)) {
+      const path = url.replace(pattern, "");
+      return `${S3_PUBLIC_BASE.replace(/\/$/, "")}/${path}`;
+    }
+  } catch {
+    // Ignore parsing errors and fall back to the original URL
+  }
+  return url;
+}
+
 /** Extracts array results from either `{ Items: T[] }`, `{ items: T[] }`, `{ notifications: T[] }`, or `T[]`. */
 function extractItems<T>(data: MaybeItems<T> | JsonRecord): T[] {
   if (Array.isArray(data)) return data as T[];


### PR DESCRIPTION
## Summary
- add helper to normalize S3 URLs to current bucket
- ensure messages and project messages use normalized S3 file links

## Testing
- `npm test` *(fails: useProjects must be used within DataProvider)*

------
https://chatgpt.com/codex/tasks/task_e_68c4bd5bbae0832480ba297082289013