### PR TITLE
Parameterize S3 base URL

### DIFF
--- a/backend/s3/serverless.yml
+++ b/backend/s3/serverless.yml
@@ -14,7 +14,7 @@ resources:
     S3Bucket:
       Type: AWS::S3::Bucket
       Properties:
-        BucketName: mylg-files-v12
+        BucketName: ${env:S3_BUCKET_NAME, 'mylg-files-v12'}
         CorsConfiguration:
           CorsRules:
             - AllowedHeaders:
@@ -55,13 +55,13 @@ resources:
               Principal: "*"
               Action:
                 - s3:GetObject
-              Resource: !Sub "arn:aws:s3:::mylg-files-v12/*"
+              Resource: arn:aws:s3:::${env:S3_BUCKET_NAME, 'mylg-files-v12'}/*
             - Sid: PublicListBucket
               Effect: Allow
               Principal: "*"
               Action:
                 - s3:ListBucket
-              Resource: !Sub "arn:aws:s3:::mylg-files-v12"
+              Resource: arn:aws:s3:::${env:S3_BUCKET_NAME, 'mylg-files-v12'}
 
   Outputs:
     S3BucketName:

--- a/backend/scripts/migrate-s3-content.mjs
+++ b/backend/scripts/migrate-s3-content.mjs
@@ -5,10 +5,12 @@ import { config } from "dotenv";
 // Load environment variables
 config();
 
-const OLD_BUCKET = "mylguserdata194416-dev";
-const NEW_BUCKET = "mylg-files-v12";
-const OLD_REGION = "us-west-1";
-const NEW_REGION = "us-west-2";
+// Allow overriding bucket names/regions via environment variables so this
+// script can be reused for future migrations without code changes.
+const OLD_BUCKET = process.env.OLD_BUCKET || "mylguserdata194416-dev";
+const NEW_BUCKET = process.env.NEW_BUCKET || "mylg-files-v12";
+const OLD_REGION = process.env.OLD_REGION || "us-west-1";
+const NEW_REGION = process.env.NEW_REGION || "us-west-2";
 
 async function migrateS3Content() {
   console.log("🚀 Starting S3 content migration using AWS CLI...");

--- a/frontend/src/features/budget/components/InvoicePreviewModal.tsx
+++ b/frontend/src/features/budget/components/InvoicePreviewModal.tsx
@@ -212,7 +212,7 @@ const InvoicePreviewModal: React.FC<InvoicePreviewModalProps> = ({
         .filter((item) => item.key && !String(item.key).endsWith("/"))
         .map((item) => ({
           name: String(item.key).split("/").pop() || "",
-          url: `${S3_PUBLIC_BASE}/${item.key}`,
+          url: `${S3_PUBLIC_BASE}${item.key}`,
         }));
     } catch (err) {
       console.error("Failed to list invoice files", err);
@@ -731,7 +731,7 @@ const InvoicePreviewModal: React.FC<InvoicePreviewModalProps> = ({
           metadata: { friendlyName: fileName },
         },
       });
-      const url = `${S3_PUBLIC_BASE}/${key}`;
+      const url = `${S3_PUBLIC_BASE}${key}`;
       setSavedInvoices((prev) => [...prev, { name: fileName, url }]);
       setInvoiceDirty(false);
       setCurrentFileName(fileName);
@@ -757,7 +757,7 @@ const InvoicePreviewModal: React.FC<InvoicePreviewModalProps> = ({
         const file = new File([blob], `logo.${ext}`, { type: blob.type });
         const filename = `userBranding/${userData.userId}/${file.name}`;
         await uploadData({ key: filename, data: file, options: { accessLevel: "public" } });
-        uploadedUrl = `${S3_PUBLIC_BASE}/${filename}`;
+        uploadedUrl = `${S3_PUBLIC_BASE}${filename}`;
       }
 
       const updated = {

--- a/frontend/src/features/dashboard/components/AdminUserManagement.tsx
+++ b/frontend/src/features/dashboard/components/AdminUserManagement.tsx
@@ -180,7 +180,7 @@ export default function AdminUserManagement() {
       options: { accessLevel: 'guest' },
     });
     console.log('Thumbnail uploaded:', result);
-    return `${S3_PUBLIC_BASE}/${filename}?t=${Date.now()}`;
+    return `${S3_PUBLIC_BASE}${filename}?t=${Date.now()}`;
   };
 
   const handleThumbnailChange: React.ChangeEventHandler<HTMLInputElement> = async (e) => {

--- a/frontend/src/features/dashboard/components/Collaborators.tsx
+++ b/frontend/src/features/dashboard/components/Collaborators.tsx
@@ -247,7 +247,7 @@ interface EditValues {
       data: file,
       options: { accessLevel: 'guest' },
     });
-    return `${S3_PUBLIC_BASE}/${filename}?t=${Date.now()}`;
+    return `${S3_PUBLIC_BASE}${filename}?t=${Date.now()}`;
   };
 
   const handleThumbnailChange = async (e, userId) => {

--- a/frontend/src/features/dashboard/components/Settings.tsx
+++ b/frontend/src/features/dashboard/components/Settings.tsx
@@ -107,7 +107,7 @@ const Settings: React.FC = () => {
       });
        
       console.log("Thumbnail uploaded:", result);
-      const completeUrl = `${S3_PUBLIC_BASE}/${filename}`;
+      const completeUrl = `${S3_PUBLIC_BASE}${filename}`;
       return `${completeUrl}?t=${Date.now()}`;
     } catch (error) {
        

--- a/frontend/src/features/editor/components/Brief/plugins/DragAndDropPlugin.tsx
+++ b/frontend/src/features/editor/components/Brief/plugins/DragAndDropPlugin.tsx
@@ -42,7 +42,7 @@ async function uploadFileToS3(
       data: file,
       options: { accessLevel: "public" },
     });
-    return `${S3_PUBLIC_BASE}/${key}`;
+    return `${S3_PUBLIC_BASE}${key}`;
   } catch (err) {
     console.error("Error uploading file:", err);
     return null;

--- a/frontend/src/features/editor/components/Brief/plugins/ImagePlugin.tsx
+++ b/frontend/src/features/editor/components/Brief/plugins/ImagePlugin.tsx
@@ -65,7 +65,7 @@ export default function ImagePlugin({ showToolbarButton = true }: Props) {
         options: { accessLevel: "public" },
       });
       console.log("Upload completed:", result);
-      return `${S3_PUBLIC_BASE}/${filename}`;
+      return `${S3_PUBLIC_BASE}${filename}`;
     } catch (error) {
       console.error("Error uploading file:", error);
       return null;

--- a/frontend/src/features/gallery/GalleryAdminEdit.test.tsx
+++ b/frontend/src/features/gallery/GalleryAdminEdit.test.tsx
@@ -265,7 +265,7 @@ describe("GalleryComponent admin edit", () => {
     expect(fileInput).toBeTruthy();
     await userEvent.upload(fileInput as HTMLInputElement, file);
 
-    const expectedUrl = `${S3_PUBLIC_BASE}/projects/1/galleries/g1/cover/cover.png?t=${fixedTime}`;
+    const expectedUrl = `${S3_PUBLIC_BASE}projects/1/galleries/g1/cover/cover.png?t=${fixedTime}`;
 
     await waitFor(() => {
       expect(updateGallery).toHaveBeenCalled();
@@ -312,7 +312,7 @@ describe("GalleryComponent admin edit", () => {
     expect(projectId).toBe("1");
 
     const img = document.querySelector("img") as HTMLImageElement | null;
-    const expectedSrc = `${S3_PUBLIC_BASE}/projects/1/galleries/legacy/cover/my%20cover.png?t=${fixedTime}`;
+    const expectedSrc = `${S3_PUBLIC_BASE}projects/1/galleries/legacy/cover/my%20cover.png?t=${fixedTime}`;
 
     expect(fields.gallery[0].coverImageUrl).toBe(expectedSrc);
     expect(img?.getAttribute("src")).toBe(expectedSrc);

--- a/frontend/src/features/messages/Messages.tsx
+++ b/frontend/src/features/messages/Messages.tsx
@@ -804,7 +804,7 @@ const fetchMessages = async () => {
       await uploadTask.result;
       // small delay for availability
       await new Promise((resolve) => setTimeout(resolve, 2000));
-      const fileUrl = `${S3_PUBLIC_BASE}/dms/${encodeURIComponent(
+      const fileUrl = `${S3_PUBLIC_BASE}dms/${encodeURIComponent(
         conversationId
       )}/${folderKey}/${encodeURIComponent(file.name)}`;
       return { fileName: file.name, url: fileUrl };

--- a/frontend/src/features/messages/ProjectMessagesThread.tsx
+++ b/frontend/src/features/messages/ProjectMessagesThread.tsx
@@ -597,7 +597,7 @@ const ProjectMessagesThread: React.FC<ProjectMessagesThreadProps> = ({
       });
       await uploadTask.result;
       await new Promise((resolve) => setTimeout(resolve, 2000)); // deliberate delay
-      const fileUrl = `${S3_PUBLIC_BASE}/${filename}`;
+      const fileUrl = `${S3_PUBLIC_BASE}${filename}`;
       return { fileName: file.name, url: fileUrl };
     } catch (error) {
       console.error("Error uploading file:", error);

--- a/frontend/src/features/project/components/FileManager.tsx
+++ b/frontend/src/features/project/components/FileManager.tsx
@@ -647,7 +647,7 @@ const FileManagerComponent = forwardRef<FileManagerRef, FileManagerProps>(
           });
           // small delay for edge consistency
           await new Promise((resolve) => setTimeout(resolve, 2000));
-          const fileUrl = `${S3_PUBLIC_BASE}/${encodeS3Key(filename)}`;
+          const fileUrl = `${S3_PUBLIC_BASE}${encodeS3Key(filename)}`;
           return { fileName: file.name, url: fileUrl };
         } catch (error) {
           console.error("Error uploading file:", error);

--- a/frontend/src/features/project/components/GalleryComponent.tsx
+++ b/frontend/src/features/project/components/GalleryComponent.tsx
@@ -755,7 +755,7 @@ const GalleryComponent: React.FC = () => {
         options: { accessLevel: "public" },
       });
       const encodedName = encodeURIComponent(file.name);
-      const url = `${S3_PUBLIC_BASE}/projects/${activeProject.projectId}/galleries/${galleryId}/cover/${encodedName}?t=${Date.now()}`;
+      const url = `${S3_PUBLIC_BASE}projects/${activeProject.projectId}/galleries/${galleryId}/cover/${encodedName}?t=${Date.now()}`;
       await applyCoverUrl(pendingCover.index, pendingCover.isLegacy, pendingCover.gallery, url);
     } catch (err) {
       console.error("Failed to upload cover image", err);

--- a/frontend/src/features/project/components/ProjectHeader.tsx
+++ b/frontend/src/features/project/components/ProjectHeader.tsx
@@ -700,7 +700,7 @@ const ProjectHeader: React.FC<ProjectHeaderProps> = ({
 
       const encodedProjectId = encodeURIComponent(activeProject.projectId);
       const encodedFileName = encodeURIComponent(selectedThumbnailFile.name);
-      const uploadedURL = `${S3_PUBLIC_BASE}/project-thumbnails/${encodedProjectId}/${encodedFileName}`;
+      const uploadedURL = `${S3_PUBLIC_BASE}project-thumbnails/${encodedProjectId}/${encodedFileName}`;
 
       const updatedLocal: Project = {
         ...localActiveProject,

--- a/frontend/src/features/project/pages/NewProject.tsx
+++ b/frontend/src/features/project/pages/NewProject.tsx
@@ -164,7 +164,7 @@ const NewProject: React.FC = () => {
           options: { accessLevel: "public" },
         });
 
-        const fileUrl = `${S3_PUBLIC_BASE}/${filename}`;
+        const fileUrl = `${S3_PUBLIC_BASE}${filename}`;
         uploadedFileUrls.push({ fileName: file.name, url: fileUrl });
 
         completed += 1;

--- a/frontend/src/shared/utils/api.ts
+++ b/frontend/src/shared/utils/api.ts
@@ -140,6 +140,16 @@ type MaybeItem<T> = { Item?: T } | T;
 
 const ENV = import.meta.env.VITE_APP_ENV || 'development';
 
+// Resolve the public S3 base URL dynamically. This allows overriding the full
+// URL via VITE_S3_PUBLIC_BASE while still supporting the legacy approach of
+// specifying the bucket/region separately. A trailing slash is maintained for
+// backwards compatibility with existing URL concatenations.
+const DEFAULT_S3_BUCKET = import.meta.env.VITE_S3_FILES_BUCKET || 'mylg-files-v12';
+const DEFAULT_S3_REGION = import.meta.env.VITE_S3_REGION || 'us-west-2';
+const DEFAULT_S3_PUBLIC_BASE =
+  import.meta.env.VITE_S3_PUBLIC_BASE ||
+  `https://${DEFAULT_S3_BUCKET}.s3.${DEFAULT_S3_REGION}.amazonaws.com/`;
+
 const BASE_ENDPOINTS = {
   development: {
     // Core v1.2 Services (us-west-2)
@@ -180,7 +190,7 @@ const BASE_ENDPOINTS = {
     
     // External services (unchanged)
     NOMINATIM_SEARCH_URL: 'https://nominatim.openstreetmap.org/search?format=json&q=',
-    S3_PUBLIC_BASE: 'https://mylg-files-v12.s3.us-west-2.amazonaws.com/',
+    S3_PUBLIC_BASE: DEFAULT_S3_PUBLIC_BASE,
     
     // Legacy endpoints that may need special handling or removal
     NEWSLETTER_SUBSCRIBE_URL: 'https://jmmn5p5yhe.execute-api.us-west-1.amazonaws.com/default/notifyNewSubscriber',


### PR DESCRIPTION
## Summary
- derive S3 public base URL from environment and remove hardcoded bucket reference
- use S3_PUBLIC_BASE consistently without redundant slashes across messages, projects, dashboards, and editor uploads
- allow backend S3 utilities and infrastructure to override bucket names via env

## Testing
- `npm test` *(fails: Form.useForm is not a function, useProjects must be used within DataProvider)*

------
https://chatgpt.com/codex/tasks/task_e_68c5cb3e01d88324b96cbff29fc48cae