### PR TITLE
refactor: centralize file URL generation

### DIFF
--- a/backend/shared-layer/nodejs/utils/files.mjs
+++ b/backend/shared-layer/nodejs/utils/files.mjs
@@ -1,0 +1,18 @@
+export function getFileUrl(key) {
+  const bucket = process.env.FILE_BUCKET || 'mylg-files-v12';
+  const region = process.env.AWS_REGION || 'us-west-2';
+  const cloudfront = process.env.FILE_CDN;
+  if (cloudfront) {
+    return `${cloudfront.replace(/\/$/, '')}/${key}`;
+  }
+  return `https://${bucket}.s3.${region}.amazonaws.com/${key}`;
+}
+
+export function normalizeFileUrl(urlOrKey) {
+  if (!urlOrKey) return urlOrKey;
+  if (urlOrKey.startsWith('http')) {
+    const bucket = process.env.FILE_BUCKET || 'mylg-files-v12';
+    return urlOrKey.replace(/mylg-files-v\d+/, bucket);
+  }
+  return getFileUrl(urlOrKey);
+}

--- a/frontend/src/features/messages/MessageItem.tsx
+++ b/frontend/src/features/messages/MessageItem.tsx
@@ -4,7 +4,7 @@ import { useOnlineStatus } from '@/app/contexts/OnlineStatusContext';
 import { Trash2, Pencil, Smile } from "lucide-react";
 import ReactPlayer from "react-player";
 // import "../../../../index.css";
-import { S3_PUBLIC_BASE } from "../../shared/utils/api";
+import { normalizeFileUrl } from "../../shared/utils/api";
 import ReactionBar from "@/shared/ui/ReactionBar";
 import { ChatMessage, ChatFile, DMFile } from "@/shared/utils/messageUtils";
 
@@ -147,8 +147,9 @@ const MessageItem: React.FC<MessageItemProps> = ({
         </div>
       );
     }
-    if (text && text.includes(S3_PUBLIC_BASE)) {
-      const file: ChatFile = { fileName: getFileNameFromUrl(text), url: text };
+    if (text && /mylg-files-v\d+/.test(text)) {
+      const url = normalizeFileUrl(text);
+      const file: ChatFile = { fileName: getFileNameFromUrl(url), url };
       return (
         <div
           onClick={() => openPreviewModal(file)}

--- a/frontend/src/features/messages/Messages.tsx
+++ b/frontend/src/features/messages/Messages.tsx
@@ -49,8 +49,9 @@ import {
   MESSAGES_THREADS_URL,
   DELETE_FILE_FROM_S3_URL,
   EDIT_MESSAGE_URL,
-  S3_PUBLIC_BASE,
   apiFetch,
+  getFileUrl,
+  normalizeFileUrl,
 } from "@/shared/utils/api";
 import MessageItem, { ChatMessage } from "@/features/messages/MessageItem";
 import "@/features/messages/project-messages-thread.css";
@@ -101,8 +102,9 @@ const renderFilePreview = (file: DMFile, folderKey = "chat_uploads") => {
   };
 
   if (["jpg", "jpeg", "png"].includes(extension)) {
-    const thumbnailUrl = getThumbnailUrl(file.url, folderKey);
-    const finalUrl = file.finalUrl || file.url;
+    const normalizedUrl = normalizeFileUrl(file.url);
+    const thumbnailUrl = getThumbnailUrl(normalizedUrl, folderKey);
+    const finalUrl = normalizeFileUrl(file.finalUrl || file.url);
     return <OptimisticImage tempUrl={thumbnailUrl} finalUrl={finalUrl} alt={file.fileName} />;
   }
   if (extension === "pdf") {
@@ -804,10 +806,10 @@ const fetchMessages = async () => {
       await uploadTask.result;
       // small delay for availability
       await new Promise((resolve) => setTimeout(resolve, 2000));
-      const fileUrl = `${S3_PUBLIC_BASE}dms/${encodeURIComponent(
-        conversationId
-      )}/${folderKey}/${encodeURIComponent(file.name)}`;
-      return { fileName: file.name, url: fileUrl };
+      const fileUrl = getFileUrl(
+        `dms/${encodeURIComponent(conversationId)}/${folderKey}/${encodeURIComponent(file.name)}`
+      );
+      return { fileName: file.name, url: normalizeFileUrl(fileUrl) };
     } catch (error) {
       console.error("Error uploading file:", error);
     }

--- a/frontend/src/features/messages/ProjectMessagesThread.tsx
+++ b/frontend/src/features/messages/ProjectMessagesThread.tsx
@@ -45,8 +45,9 @@ import {
   DELETE_PROJECT_MESSAGE_URL,
   DELETE_FILE_FROM_S3_URL,
   EDIT_MESSAGE_URL,
-  S3_PUBLIC_BASE,
   apiFetch,
+  getFileUrl,
+  normalizeFileUrl,
 } from "../../shared/utils/api";
 
 /* =============================================================================
@@ -139,8 +140,9 @@ const renderFilePreview = (file: FileObj, folderKey = "chat_uploads") => {
   };
 
   if (["jpg", "jpeg", "png"].includes(extension)) {
-    const thumbnailUrl = getThumbnailUrl(file.url, folderKey);
-    const finalUrl = file.finalUrl || file.url;
+    const normalizedUrl = normalizeFileUrl(file.url);
+    const thumbnailUrl = getThumbnailUrl(normalizedUrl, folderKey);
+    const finalUrl = normalizeFileUrl(file.finalUrl || file.url);
     return (
       <OptimisticImage
         tempUrl={thumbnailUrl}
@@ -597,7 +599,7 @@ const ProjectMessagesThread: React.FC<ProjectMessagesThreadProps> = ({
       });
       await uploadTask.result;
       await new Promise((resolve) => setTimeout(resolve, 2000)); // deliberate delay
-      const fileUrl = `${S3_PUBLIC_BASE}${filename}`;
+      const fileUrl = getFileUrl(filename);
       return { fileName: file.name, url: fileUrl };
     } catch (error) {
       console.error("Error uploading file:", error);

--- a/frontend/src/features/project/components/FileManager.test.tsx
+++ b/frontend/src/features/project/components/FileManager.test.tsx
@@ -58,7 +58,8 @@ vi.mock("../../../../utils/api", () => ({
   DELETE_PROJECT_MESSAGE_URL: "delMsg",
   GET_PROJECT_MESSAGES_URL: "getMsgs",
   EDIT_MESSAGE_URL: "editMsg",
-  S3_PUBLIC_BASE: "https://s3",
+  getFileUrl: (key: string) => `https://s3/${key}`,
+  normalizeFileUrl: (u: string) => u,
   apiFetch: vi.fn(() =>
     Promise.resolve({ ok: true, json: vi.fn().mockResolvedValue([]) })
   ),

--- a/frontend/src/features/project/components/FileManager.tsx
+++ b/frontend/src/features/project/components/FileManager.tsx
@@ -32,8 +32,9 @@ import {
   ZIP_FILES_URL,
   DELETE_FILE_FROM_S3_URL,
   EDIT_MESSAGE_URL,
-  S3_PUBLIC_BASE,
   apiFetch,
+  getFileUrl,
+  normalizeFileUrl,
 } from "../../../shared/utils/api";
 import Spinner from "../../../shared/ui/Spinner";
 import styles from "./file-manager.module.css";
@@ -647,7 +648,7 @@ const FileManagerComponent = forwardRef<FileManagerRef, FileManagerProps>(
           });
           // small delay for edge consistency
           await new Promise((resolve) => setTimeout(resolve, 2000));
-          const fileUrl = `${S3_PUBLIC_BASE}${encodeS3Key(filename)}`;
+          const fileUrl = getFileUrl(encodeS3Key(filename));
           return { fileName: file.name, url: fileUrl };
         } catch (error) {
           console.error("Error uploading file:", error);
@@ -761,10 +762,10 @@ const FileManagerComponent = forwardRef<FileManagerRef, FileManagerProps>(
             const name: string = key.split("/").pop()!;
             // Add public/ prefix since files are stored in public/ but Amplify keys don't include it
             const fullKey = key.startsWith('public/') ? key : `public/${key}`;
-            const url = `${S3_PUBLIC_BASE}${encodeS3Key(fullKey)}`;
+            const url = getFileUrl(encodeS3Key(fullKey));
             return {
               fileName: name,
-              url,
+              url: normalizeFileUrl(url),
               lastModified: (item as { lastModified?: string | Date }).lastModified ? new Date((item as { lastModified?: string | Date }).lastModified!).getTime() : 0,
               kind: getFileKind(name),
             };

--- a/frontend/src/shared/utils/api.ts
+++ b/frontend/src/shared/utils/api.ts
@@ -140,15 +140,28 @@ type MaybeItem<T> = { Item?: T } | T;
 
 const ENV = import.meta.env.VITE_APP_ENV || 'development';
 
-// Resolve the public S3 base URL dynamically. This allows overriding the full
-// URL via VITE_S3_PUBLIC_BASE while still supporting the legacy approach of
-// specifying the bucket/region separately. A trailing slash is maintained for
-// backwards compatibility with existing URL concatenations.
-const DEFAULT_S3_BUCKET = import.meta.env.VITE_S3_FILES_BUCKET || 'mylg-files-v12';
-const DEFAULT_S3_REGION = import.meta.env.VITE_S3_REGION || 'us-west-2';
-const DEFAULT_S3_PUBLIC_BASE =
-  import.meta.env.VITE_S3_PUBLIC_BASE ||
-  `https://${DEFAULT_S3_BUCKET}.s3.${DEFAULT_S3_REGION}.amazonaws.com/`;
+const FILE_BUCKET = import.meta.env.VITE_FILE_BUCKET ||
+  import.meta.env.VITE_S3_FILES_BUCKET ||
+  'mylg-files-v12';
+const FILE_REGION = import.meta.env.VITE_AWS_REGION ||
+  import.meta.env.VITE_S3_REGION ||
+  'us-west-2';
+const FILE_CDN = import.meta.env.VITE_FILE_CDN || import.meta.env.VITE_S3_PUBLIC_BASE || '';
+
+export function getFileUrl(key: string): string {
+  const base = FILE_CDN || `https://${FILE_BUCKET}.s3.${FILE_REGION}.amazonaws.com`;
+  return `${base.replace(/\/$/, '')}/${key}`;
+}
+
+export function normalizeFileUrl(urlOrKey: string): string {
+  if (!urlOrKey) return urlOrKey;
+  if (urlOrKey.startsWith('http')) {
+    return urlOrKey.replace(/mylg-files-v\d+/, FILE_BUCKET);
+  }
+  return getFileUrl(urlOrKey);
+}
+
+export const S3_PUBLIC_BASE = `${FILE_CDN || `https://${FILE_BUCKET}.s3.${FILE_REGION}.amazonaws.com`}/`;
 
 const BASE_ENDPOINTS = {
   development: {
@@ -190,7 +203,7 @@ const BASE_ENDPOINTS = {
     
     // External services (unchanged)
     NOMINATIM_SEARCH_URL: 'https://nominatim.openstreetmap.org/search?format=json&q=',
-    S3_PUBLIC_BASE: DEFAULT_S3_PUBLIC_BASE,
+    S3_PUBLIC_BASE,
     
     // Legacy endpoints that may need special handling or removal
     NEWSLETTER_SUBSCRIBE_URL: 'https://jmmn5p5yhe.execute-api.us-west-1.amazonaws.com/default/notifyNewSubscriber',


### PR DESCRIPTION
## Summary
- add reusable helpers for building and normalizing file URLs
- use helper in message and file-manager features to avoid hardcoded bucket paths

## Testing
- `npm test` *(fails: Form.useForm is not a function)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c5d3a55a608324977fe1d0375e374b