### PR TITLE
Fix S3 file deletion by sending correct object keys

### DIFF
--- a/frontend/src/features/budget/components/InvoicePreviewModal.tsx
+++ b/frontend/src/features/budget/components/InvoicePreviewModal.tsx
@@ -25,6 +25,7 @@ import {
   S3_PUBLIC_BASE,
   DELETE_FILE_FROM_S3_URL,
   apiFetch,
+  fileUrlsToKeys,
 } from "@/shared/utils/api";
 import { v4 as uuid } from "uuid";
 import { useData } from "@/app/contexts/useData";
@@ -239,7 +240,8 @@ const InvoicePreviewModal: React.FC<InvoicePreviewModalProps> = ({
 
   const performDeleteInvoices = async () => {
     const fileUrls = Array.from(selectedInvoices);
-    if (!fileUrls.length || !project?.projectId) return;
+    const fileKeys = fileUrlsToKeys(fileUrls);
+    if (!fileKeys.length || !project?.projectId) return;
     setIsConfirmingDelete(false);
     const toastId = toast.loading("Deleting invoices...");
     try {
@@ -249,7 +251,7 @@ const InvoicePreviewModal: React.FC<InvoicePreviewModalProps> = ({
         body: JSON.stringify({
           projectId: project.projectId,
           field: "invoices",
-          fileKeys: fileUrls,
+          fileKeys,
         }),
       });
       setSavedInvoices((prev) => prev.filter((inv) => !fileUrls.includes(inv.url)));

--- a/frontend/src/features/messages/Messages.tsx
+++ b/frontend/src/features/messages/Messages.tsx
@@ -52,6 +52,7 @@ import {
   apiFetch,
   getFileUrl,
   normalizeFileUrl,
+  fileUrlsToKeys,
 } from "@/shared/utils/api";
 import MessageItem, { ChatMessage } from "@/features/messages/MessageItem";
 import "@/features/messages/project-messages-thread.css";
@@ -824,13 +825,14 @@ const fetchMessages = async () => {
       const fileUrl = message.file?.url ?? message.attachments?.[0]?.url;
       if (fileUrl) {
         try {
+          const fileKeys = fileUrlsToKeys([fileUrl]);
           await apiFetch(DELETE_FILE_FROM_S3_URL, {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({
               projectId: selectedConversation,
               field: folderKey,
-              fileKeys: [fileUrl],
+              fileKeys,
             }),
           });
         } catch (err) {

--- a/frontend/src/features/messages/ProjectMessagesThread.tsx
+++ b/frontend/src/features/messages/ProjectMessagesThread.tsx
@@ -48,6 +48,7 @@ import {
   apiFetch,
   getFileUrl,
   normalizeFileUrl,
+  fileUrlsToKeys,
 } from "../../shared/utils/api";
 
 /* =============================================================================
@@ -748,14 +749,15 @@ const ProjectMessagesThread: React.FC<ProjectMessagesThreadProps> = ({
         ...(message.attachments?.map((a) => a.url) ?? []),
         ...(message.file?.url ? [message.file.url] : []),
       ];
-      if (fileUrls.length) {
+      const fileKeys = fileUrlsToKeys(fileUrls);
+      if (fileKeys.length) {
         await apiFetch<DeleteS3FilesResponse>(DELETE_FILE_FROM_S3_URL, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             projectId,
             field: folderKey,
-            fileKeys: fileUrls,
+            fileKeys,
           }),
         });
       }

--- a/frontend/src/features/project/components/FileManager.test.tsx
+++ b/frontend/src/features/project/components/FileManager.test.tsx
@@ -60,6 +60,7 @@ vi.mock("../../../../utils/api", () => ({
   EDIT_MESSAGE_URL: "editMsg",
   getFileUrl: (key: string) => `https://s3/${key}`,
   normalizeFileUrl: (u: string) => u,
+  fileUrlsToKeys: (urls: string[]) => urls.map((u) => u.replace('https://s3/', '')),
   apiFetch: vi.fn(() =>
     Promise.resolve({ ok: true, json: vi.fn().mockResolvedValue([]) })
   ),

--- a/frontend/src/features/project/components/FileManager.tsx
+++ b/frontend/src/features/project/components/FileManager.tsx
@@ -35,6 +35,7 @@ import {
   apiFetch,
   getFileUrl,
   normalizeFileUrl,
+  fileUrlsToKeys,
 } from "../../../shared/utils/api";
 import Spinner from "../../../shared/ui/Spinner";
 import styles from "./file-manager.module.css";
@@ -452,6 +453,7 @@ const FileManagerComponent = forwardRef<FileManagerRef, FileManagerProps>(
 
     const performDelete = async () => {
       const fileUrlsToDelete = Array.from(selectedItems);
+      const fileKeysToDelete = fileUrlsToKeys(fileUrlsToDelete);
       setIsConfirmingDelete(false);
 
       const messages = projectMessages[activeProject.projectId] || [];
@@ -464,7 +466,7 @@ const FileManagerComponent = forwardRef<FileManagerRef, FileManagerProps>(
           body: JSON.stringify({
             projectId: activeProject.projectId,
             field: folderKey,
-            fileKeys: fileUrlsToDelete,
+            fileKeys: fileKeysToDelete,
           }),
           headers: { "Content-Type": "application/json" },
         });
@@ -528,12 +530,7 @@ const FileManagerComponent = forwardRef<FileManagerRef, FileManagerProps>(
 
     const getZippedFiles = async (fileUrls: string[]): Promise<string> => {
       try {
-        const fileKeys = fileUrls
-          .map((url) => {
-            const matches = url.match(/amazonaws\.com\/(.+)$/);
-            return matches ? decodeURIComponent(matches[1]) : null;
-          })
-          .filter((key): key is string => key !== null);
+        const fileKeys = fileUrlsToKeys(fileUrls);
 
         const response = await apiFetch<{ zipFileUrl: string }>(apiGatewayEndpoint, {
           method: "POST",

--- a/frontend/src/shared/utils/api.ts
+++ b/frontend/src/shared/utils/api.ts
@@ -161,6 +161,18 @@ export function normalizeFileUrl(urlOrKey: string): string {
   return getFileUrl(urlOrKey);
 }
 
+export function fileUrlsToKeys(urls: string[]): string[] {
+  return urls.map((url) => {
+    try {
+      const parsed = new URL(url);
+      const path = parsed.pathname.startsWith('/') ? parsed.pathname.slice(1) : parsed.pathname;
+      return decodeURIComponent(path);
+    } catch {
+      return url;
+    }
+  });
+}
+
 export const S3_PUBLIC_BASE = `${FILE_CDN || `https://${FILE_BUCKET}.s3.${FILE_REGION}.amazonaws.com`}/`;
 
 const BASE_ENDPOINTS = {


### PR DESCRIPTION
## Summary
- derive S3 object keys from file URLs before calling deletion APIs
- update file manager and related components to use `fileUrlsToKeys`
- reuse conversion when zipping files for download

## Testing
- `npm test` *(fails: useProjects must be used within DataProvider, Form.useForm is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68c5da4f7e7083249ba68446a73cd9c7