### PR TITLE
Route file keys through getFileUrl helper

### DIFF
--- a/frontend/src/features/budget/components/InvoicePreviewModal.tsx
+++ b/frontend/src/features/budget/components/InvoicePreviewModal.tsx
@@ -26,6 +26,7 @@ import {
   DELETE_FILE_FROM_S3_URL,
   apiFetch,
   fileUrlsToKeys,
+  getFileUrl,
 } from "@/shared/utils/api";
 import { v4 as uuid } from "uuid";
 import { useData } from "@/app/contexts/useData";
@@ -1069,7 +1070,7 @@ const InvoicePreviewModal: React.FC<InvoicePreviewModalProps> = ({
                           aria-label="Company logo"
                         >
                           {logoDataUrl || brandLogoUrl ? (
-                            <img src={logoDataUrl || brandLogoUrl} alt="Company logo" />
+                            <img src={logoDataUrl || getFileUrl(brandLogoUrl || '')} alt="Company logo" />
                           ) : (
                             <span>Upload Logo</span>
                           )}
@@ -1371,7 +1372,7 @@ const InvoicePreviewModal: React.FC<InvoicePreviewModalProps> = ({
                             aria-label="Company logo"
                           >
                             {logoDataUrl || brandLogoUrl ? (
-                              <img src={logoDataUrl || brandLogoUrl} alt="Company logo" />
+                              <img src={logoDataUrl || getFileUrl(brandLogoUrl || '')} alt="Company logo" />
                             ) : (
                               <span>Upload Logo</span>
                             )}

--- a/frontend/src/features/dashboard/components/AdminUserManagement.tsx
+++ b/frontend/src/features/dashboard/components/AdminUserManagement.tsx
@@ -12,6 +12,7 @@ import {
   S3_PUBLIC_BASE,
   apiFetch,
   UserProfile,
+  getFileUrl,
 } from '../../../shared/utils/api';
 import UserProfilePicture from '../../../shared/ui/UserProfilePicture';
 import ProjectAvatar from '../../../shared/ui/ProjectAvatar';
@@ -491,7 +492,7 @@ export default function AdminUserManagement() {
                           onChange={() => toggleCollaboratorSelection(selectedUserId, u.userId)}
                         />
                         {u.thumbnail ? (
-                          <img src={u.thumbnail} alt="" className="collaborator-thumb" />
+                          <img src={getFileUrl(u.thumbnail)} alt="" className="collaborator-thumb" />
                         ) : (
                           <div className="collaborator-thumb" />
                         )}

--- a/frontend/src/features/dashboard/components/AllProjects.tsx
+++ b/frontend/src/features/dashboard/components/AllProjects.tsx
@@ -19,6 +19,7 @@ import {
   Pin,
 } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
+import { getFileUrl } from '../../../shared/utils/api';
 
 interface Project {
   projectId: string;
@@ -336,7 +337,7 @@ const AllProjects: React.FC = () => {
             project.thumbnails &&
             project.thumbnails.length > 0 ? (
               <img
-                src={project.thumbnails[0]}
+                src={getFileUrl(project.thumbnails[0])}
                 alt={`Thumbnail of ${
                   project.title?.trim() || 'Untitled project'
                 }`}
@@ -433,7 +434,7 @@ const AllProjects: React.FC = () => {
               project.thumbnails &&
               project.thumbnails.length > 0 ? (
                 <img
-                  src={project.thumbnails[0]}
+                  src={getFileUrl(project.thumbnails[0])}
                   alt={`Thumbnail of ${
                     project.title?.trim() || 'Untitled project'
                   }`}

--- a/frontend/src/features/dashboard/components/AllProjectsCalendar.tsx
+++ b/frontend/src/features/dashboard/components/AllProjectsCalendar.tsx
@@ -16,6 +16,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import type { TimelineEvent } from "@/shared/utils/api";
 import { faClock } from "@fortawesome/free-solid-svg-icons";
 import { WeekWidget } from "./WeekWidget";
+import { getFileUrl } from "../../../shared/utils/api";
 
 // --- Types ---
 type Project = {
@@ -385,7 +386,7 @@ const AllProjectsCalendar: React.FC = () => {
                 >
                   {item.thumbnail ? (
                     <img
-                      src={item.thumbnail}
+                      src={getFileUrl(item.thumbnail)}
                       alt={item.title ?? "thumbnail"}
                       className="tooltip-thumb"
                     />

--- a/frontend/src/features/dashboard/components/CollaboratorList.tsx
+++ b/frontend/src/features/dashboard/components/CollaboratorList.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { MessageCircle, ListPlus } from 'lucide-react';
 import ProjectAvatar from '../../../shared/ui/ProjectAvatar';
 import { slugify } from '../../../shared/utils/slug';
+import { getFileUrl } from '../../../shared/utils/api';
 import styles from './Collaborators.module.css';
 
 interface User {
@@ -51,7 +52,7 @@ const CollaboratorList: React.FC<CollaboratorListProps> = ({
             <div className={styles.cardInfo}>
               <div className={styles.cardLeft}>
                 {u.thumbnail ? (
-                  <img src={u.thumbnail} alt={u.firstName} className={styles.avatar} />
+                  <img src={getFileUrl(u.thumbnail)} alt={u.firstName} className={styles.avatar} />
                 ) : (
                   <div className={styles.avatarPlaceholder} />
                 )}

--- a/frontend/src/features/dashboard/components/Collaborators.tsx
+++ b/frontend/src/features/dashboard/components/Collaborators.tsx
@@ -24,6 +24,7 @@ import {
   POST_PROJECT_TO_USER_URL,
   S3_PUBLIC_BASE,
   apiFetch,
+  getFileUrl,
 } from "@/shared/utils/api";
 import UserProfilePicture from "@/shared/ui/UserProfilePicture";
 import styles from "./Collaborators.module.css";
@@ -759,7 +760,7 @@ interface EditValues {
                           onChange={() => toggleCollaboratorSelection(selectedUserId, u.userId)}
                         />
                         {u.thumbnail ? (
-                          <img src={u.thumbnail} alt="" className="collaborator-thumb" />
+                          <img src={getFileUrl(u.thumbnail)} alt="" className="collaborator-thumb" />
                         ) : (
                           <div className="collaborator-thumb" />
                         )}

--- a/frontend/src/features/dashboard/components/CurrentUserProfile.tsx
+++ b/frontend/src/features/dashboard/components/CurrentUserProfile.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import ProjectAvatar from '../../../shared/ui/ProjectAvatar';
+import { getFileUrl } from '../../../shared/utils/api';
 import styles from './Collaborators.module.css';
 
 interface CurrentUserProfileProps {
@@ -19,7 +20,7 @@ const CurrentUserProfile: React.FC<CurrentUserProfileProps> = ({
     <div className={styles.profileBlock}>
       <div className={styles.avatarWrapper}>
         {userData?.thumbnail ? (
-          <img src={userData.thumbnail} alt="Me" className={styles.avatar} />
+          <img src={getFileUrl(userData.thumbnail)} alt="Me" className={styles.avatar} />
         ) : (
           <div className={styles.avatarPlaceholder} />
         )}

--- a/frontend/src/features/dashboard/components/ProjectsPanel.tsx
+++ b/frontend/src/features/dashboard/components/ProjectsPanel.tsx
@@ -6,6 +6,7 @@ import { useData } from "@/app/contexts/useData";
 import SVGThumbnail from "./SvgThumbnail";
 import styles from "./projects-panel.module.css";
 import { useProjectKpis, type ProjectLike } from "../hooks/useProjectKpis";
+import { getFileUrl } from "../../../shared/utils/api";
 
 type Props = {
   onOpenProject: (projectId: string) => void;
@@ -227,7 +228,7 @@ const ProjectsPanel: React.FC<Props> = ({ onOpenProject }) => {
                       {thumb && !imgError[id] ? (
                         <img
                           className={styles.thumbSm}
-                          src={thumb}
+                          src={getFileUrl(thumb)}
                           alt=""
                           onError={() =>
                             setImgError((m) => ({ ...m, [id]: true }))
@@ -397,7 +398,7 @@ const ProjectsPanel: React.FC<Props> = ({ onOpenProject }) => {
                     {thumb && !imgError[id] ? (
                       <img
                         className={styles.thumb}
-                        src={thumb}
+                        src={getFileUrl(thumb)}
                         alt=""
                         onError={() =>
                           setImgError((m) => ({ ...m, [id]: true }))

--- a/frontend/src/features/dashboard/components/ProjectsRecentsCard.tsx
+++ b/frontend/src/features/dashboard/components/ProjectsRecentsCard.tsx
@@ -4,6 +4,7 @@ import { ChevronDown } from "lucide-react";
 import { Kebab } from "@/shared/icons/Kebab";
 import { useData } from "@/app/contexts/useData";
 import { ProjectCard } from "@/shared/icons/ProjectCard";
+import { getFileUrl } from "../../../shared/utils/api";
 
 type ProjectLike = {
   projectId: string;
@@ -162,7 +163,7 @@ const ProjectsRecentsCard: React.FC<Props> = ({ onOpenProject }) => {
                     {thumb && !imgError[id] ? (
                       <img
                         className="prc-thumb"
-                        src={thumb}
+                        src={getFileUrl(thumb)}
                         alt=""
                         onError={() => setImgError((m) => ({ ...m, [id]: true }))}
                       />

--- a/frontend/src/features/dashboard/components/WelcomeHeader.tsx
+++ b/frontend/src/features/dashboard/components/WelcomeHeader.tsx
@@ -10,6 +10,7 @@ import NavBadge from "../../../shared/ui/NavBadge";
 import { GridPlus } from "../../../shared/icons/GridPlus";
 import GlobalSearch from './GlobalSearch';
 import './GlobalSearch.css';
+import { getFileUrl } from '../../../shared/utils/api';
 
 const WelcomeHeader: React.FC<{ userName?: string; setActiveView?: (view: string) => void }> = ({ userName: propUserName, setActiveView }) => {
   const { userData } = useData();
@@ -150,7 +151,7 @@ const WelcomeHeader: React.FC<{ userName?: string; setActiveView?: (view: string
           <div style={{ position: 'relative' }}>
             {userThumbnail ? (
               <img
-                src={userThumbnail}
+                src={getFileUrl(userThumbnail)}
                 alt={`${userName}'s Thumbnail`}
                 style={{
                   width: isMobile ? '32px' : '40px',

--- a/frontend/src/features/dashboard/components/inbox.tsx
+++ b/frontend/src/features/dashboard/components/inbox.tsx
@@ -5,7 +5,7 @@ import { useData } from "@/app/contexts/useData";
 import { Thread } from "@/app/contexts/DataProvider";
 import { useSocket } from "../../../app/contexts/useSocket";
 import { User as UserIcon, Mail, Check } from "lucide-react";
-import { MESSAGES_INBOX_URL, MESSAGES_THREADS_URL, apiFetch } from "../../../shared/utils/api";
+import { MESSAGES_INBOX_URL, MESSAGES_THREADS_URL, apiFetch, getFileUrl } from "../../../shared/utils/api";
 import { slugify } from "../../../shared/utils/slug";
 
 type InboxProps = {
@@ -162,7 +162,7 @@ export default function Inbox({ setActiveView, setDmUserSlug }: InboxProps) {
                 }
               >
                 {thumb ? (
-                  <img src={thumb} alt={name} className="dm-avatar" />
+                  <img src={getFileUrl(thumb)} alt={name} className="dm-avatar" />
                 ) : (
                   <UserIcon className="dm-avatar" />
                 )}

--- a/frontend/src/features/dashboard/components/paymentsection.tsx
+++ b/frontend/src/features/dashboard/components/paymentsection.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Download } from "lucide-react";
+import { getFileUrl } from "../../../shared/utils/api";
 
 type Invoice = { url: string; fileName?: string };
 
@@ -36,7 +37,7 @@ const PaymentsSection: React.FC<PaymentsSectionProps> = ({
         {invoiceList.length > 0 ? (
           invoiceList.map((inv) => (
             <div className="invoice-item" key={inv.url}>
-              <a href={inv.url} download>
+              <a href={getFileUrl(inv.url)} download>
                 <Download size={16} /> {inv.fileName ?? "Invoice"}
               </a>
             </div>

--- a/frontend/src/features/editor/components/Brief/plugins/nodes/FileEmbedNode.jsx
+++ b/frontend/src/features/editor/components/Brief/plugins/nodes/FileEmbedNode.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { DecoratorNode } from 'lexical';
+import { getFileUrl } from '@/shared/utils/api';
 
 export class FileEmbedNode extends DecoratorNode {
   constructor(url, name, key) {
@@ -49,7 +50,7 @@ export class FileEmbedNode extends DecoratorNode {
   decorate() {
     const name = this.__name || this.__url.split('/').pop();
     return (
-      <a href={this.__url} target="_blank" rel="noopener noreferrer">
+      <a href={getFileUrl(this.__url)} target="_blank" rel="noopener noreferrer">
         {name}
       </a>
     );

--- a/frontend/src/features/editor/components/Brief/plugins/nodes/ImageNode.jsx
+++ b/frontend/src/features/editor/components/Brief/plugins/nodes/ImageNode.jsx
@@ -6,6 +6,7 @@ import Moveable from "react-moveable";
 import React, { useRef, useState, useEffect } from "react";
 import { useData } from "@/app/contexts/useData";
 import { useImageLocks } from "@/features/editor/components/Brief/plugins/ImageLockContext";
+import { getFileUrl } from "@/shared/utils/api";
 
 export class ImageNode extends DecoratorNode {
   constructor(src, altText, x = 0, y = 0, width = 300, height = 200, clipPath = "none", key) {
@@ -111,7 +112,7 @@ export class ImageNode extends DecoratorNode {
   decorate() {
     return (
       <MoveableImage
-        src={this.__src}
+        src={getFileUrl(this.__src)}
         altText={this.__altText}
         x={this.__x}
         y={this.__y}

--- a/frontend/src/features/editor/components/Brief/plugins/nodes/ResizableImageNode.jsx
+++ b/frontend/src/features/editor/components/Brief/plugins/nodes/ResizableImageNode.jsx
@@ -5,6 +5,7 @@ import { useLexicalNodeSelection } from "@lexical/react/useLexicalNodeSelection"
 import React, { useRef, useState, useEffect } from "react";
 import { useData } from "@/app/contexts/useData";
 import { useImageLocks } from "@/features/editor/components/Brief/plugins/ImageLockContext";
+import { getFileUrl } from "@/shared/utils/api";
 
 export class ResizableImageNode extends DecoratorNode {
   static getType() {
@@ -86,7 +87,7 @@ export class ResizableImageNode extends DecoratorNode {
   decorate() {
     return (
       <ResizableImageComponent
-        src={this.__src}
+        src={getFileUrl(this.__src)}
         altText={this.__altText}
         width={this.__width}
         height={this.__height}

--- a/frontend/src/features/gallery/GalleryMasonry.tsx
+++ b/frontend/src/features/gallery/GalleryMasonry.tsx
@@ -1,6 +1,7 @@
 import React, { type FC } from 'react';
 
 import styles from './gallery-masonry.module.css';
+import { getFileUrl } from '../../shared/utils/api';
 
 interface GalleryMasonryProps {
   imageUrls?: string[];
@@ -15,7 +16,7 @@ const GalleryMasonry: FC<GalleryMasonryProps> = ({
     {imageUrls.map((src, idx) => (
       <img
         key={idx}
-        src={src}
+        src={getFileUrl(src)}
         alt={`Gallery item ${idx + 1}`}
         className={styles.image}
         onClick={() => onImageClick(idx)}

--- a/frontend/src/features/gallery/GalleryPage.tsx
+++ b/frontend/src/features/gallery/GalleryPage.tsx
@@ -14,7 +14,7 @@ import { sha256 } from "../../shared/utils/hash";
 import useModalStack from "../../shared/utils/useModalStack";
 import { useData } from "@/app/contexts/useData";
 import { slugify, findProjectBySlug } from "../../shared/utils/slug";
-import { fetchGalleries } from "../../shared/utils/api";
+import { fetchGalleries, fileUrlsToKeys, getFileUrl } from "../../shared/utils/api";
 import Preloader from "../../shared/ui/Preloader";
 import * as pdfjsLibLocal from "pdfjs-dist/legacy/build/pdf";
 import GalleryMasonry from "./GalleryMasonry";
@@ -602,7 +602,7 @@ const GalleryPage: FC<GalleryPageProps> = ({ projectId: propProjectId }) => {
           {"\u276E"}
         </button>
         <img
-          src={imageUrls[currentIndex]}
+          src={getFileUrl(fileUrlsToKeys([imageUrls[currentIndex]])[0])}
           alt={`Gallery item ${currentIndex + 1}`}
           className={styles.modalImage}
         />

--- a/frontend/src/features/messages/MessageItem.tsx
+++ b/frontend/src/features/messages/MessageItem.tsx
@@ -4,7 +4,7 @@ import { useOnlineStatus } from '@/app/contexts/OnlineStatusContext';
 import { Trash2, Pencil, Smile } from "lucide-react";
 import ReactPlayer from "react-player";
 // import "../../../../index.css";
-import { normalizeFileUrl } from "../../shared/utils/api";
+import { normalizeFileUrl, getFileUrl } from "../../shared/utils/api";
 import ReactionBar from "@/shared/ui/ReactionBar";
 import { ChatMessage, ChatFile, DMFile } from "@/shared/utils/messageUtils";
 
@@ -173,7 +173,7 @@ const MessageItem: React.FC<MessageItemProps> = ({
         {!isCurrentUser && (
           <div className="avatar-wrapper">
             {senderThumbnail ? (
-              <img src={senderThumbnail} alt={senderName} className="avatar" />
+              <img src={getFileUrl(senderThumbnail)} alt={senderName} className="avatar" />
             ) : (
               <User className="avatar" />
             )}
@@ -252,7 +252,7 @@ const MessageItem: React.FC<MessageItemProps> = ({
         {isCurrentUser && (
           <div className="avatar-wrapper">
             {senderThumbnail ? (
-              <img src={senderThumbnail} alt="You" className="avatar avatar-right" />
+              <img src={getFileUrl(senderThumbnail)} alt="You" className="avatar avatar-right" />
             ) : (
               <User className="avatar avatar-right" />
             )}

--- a/frontend/src/features/messages/Messages.tsx
+++ b/frontend/src/features/messages/Messages.tsx
@@ -983,7 +983,7 @@ const fetchMessages = async () => {
       chatTitle = `Direct Message / ${dmUser.title}`;
       chatIcon = dmUser.profilePicture ? (
         <img
-          src={dmUser.profilePicture}
+          src={getFileUrl(dmUser.profilePicture)}
           alt={dmUser.title}
           style={{ width: 40, height: 40, borderRadius: "50%", objectFit: "cover" }}
         />
@@ -1062,7 +1062,7 @@ const fetchMessages = async () => {
                         <>
                           {conv.profilePicture ? (
                             <img
-                              src={conv.profilePicture}
+                              src={getFileUrl(conv.profilePicture)}
                               alt={conv.title}
                               style={{
                                 width: 32,
@@ -1293,7 +1293,7 @@ const fetchMessages = async () => {
                   if (["jpg", "jpeg", "png"].includes(ext)) {
                     return (
                       <img
-                        src={selectedPreviewFile.finalUrl || selectedPreviewFile.url}
+                        src={getFileUrl(fileUrlsToKeys([selectedPreviewFile.finalUrl || selectedPreviewFile.url])[0])}
                         alt={selectedPreviewFile.fileName}
                         style={{ maxWidth: "90vw", maxHeight: "80vh" }}
                       />
@@ -1305,7 +1305,7 @@ const fetchMessages = async () => {
                   <button onClick={closePreviewModal} className="modal-button secondary" aria-label="Close preview">
                     <FontAwesomeIcon icon={faTimes} />
                   </button>
-                  <a href={selectedPreviewFile.url} download style={{ color: "white" }}>
+                  <a href={getFileUrl(fileUrlsToKeys([selectedPreviewFile.url])[0])} download style={{ color: "white" }}>
                     <FontAwesomeIcon icon={faDownload} />
                   </a>
                 </div>

--- a/frontend/src/features/messages/ProjectMessagesThread.tsx
+++ b/frontend/src/features/messages/ProjectMessagesThread.tsx
@@ -1013,9 +1013,11 @@ const ProjectMessagesThread: React.FC<ProjectMessagesThreadProps> = ({
               if (["jpg", "jpeg", "png"].includes(ext)) {
                 return (
                   <img
-                    src={
-                      selectedPreviewFile.finalUrl || selectedPreviewFile.url
-                    }
+                    src={getFileUrl(
+                      fileUrlsToKeys([
+                        selectedPreviewFile.finalUrl || selectedPreviewFile.url,
+                      ])[0]
+                    )}
                     alt={selectedPreviewFile.fileName}
                     className="preview-image"
                   />
@@ -1041,7 +1043,9 @@ const ProjectMessagesThread: React.FC<ProjectMessagesThreadProps> = ({
                 <FontAwesomeIcon icon={faTimes} />
               </button>
               <a
-                href={selectedPreviewFile.url}
+                href={getFileUrl(
+                  fileUrlsToKeys([selectedPreviewFile.url])[0]
+                )}
                 download
                 style={{ color: "white" }}
                 aria-label="Download"

--- a/frontend/src/features/project/components/FileManager.tsx
+++ b/frontend/src/features/project/components/FileManager.tsx
@@ -704,7 +704,7 @@ const FileManagerComponent = forwardRef<FileManagerRef, FileManagerProps>(
         const thumbUrl = getThumbnailUrl(file.url, folderKey);
         return (
           <img
-            src={thumbUrl}
+            src={getFileUrl(fileUrlsToKeys([thumbUrl])[0])}
             alt={file.fileName}
             className={styles.previewImage}
             onError={(e) => {
@@ -1125,10 +1125,10 @@ const FileManagerComponent = forwardRef<FileManagerRef, FileManagerProps>(
                 if (ext && ["jpg", "jpeg", "png"].includes(ext)) {
                   return (
                     <img
-                      src={selectedImage}
+                      src={selectedImage ? getFileUrl(fileUrlsToKeys([selectedImage])[0]) : ''}
                       alt="Selected"
                       onError={(e) => {
-                        (e.target as HTMLImageElement).src = selectedImage;
+                        (e.target as HTMLImageElement).src = selectedImage || '';
                       }}
                       className={styles.fullImage}
                     />
@@ -1157,7 +1157,7 @@ const FileManagerComponent = forwardRef<FileManagerRef, FileManagerProps>(
                 <button onClick={closeImageModal} className={styles.iconButton} aria-label="Close image">
                   <FontAwesomeIcon icon={faXmark} />
                 </button>
-                <a href={selectedImage} download className={styles.iconButton} aria-label="Download image">
+                <a href={selectedImage ? getFileUrl(fileUrlsToKeys([selectedImage])[0]) : ''} download className={styles.iconButton} aria-label="Download image">
                   <FontAwesomeIcon icon={faDownload} />
                 </a>
               </div>

--- a/frontend/src/features/project/components/GalleryComponent.tsx
+++ b/frontend/src/features/project/components/GalleryComponent.tsx
@@ -26,6 +26,7 @@ import {
   updateGallery,
   apiFetch,
   S3_PUBLIC_BASE,
+  getFileUrl,
 } from "../../../shared/utils/api";
 import { uploadData } from "aws-amplify/storage";
 import styles from "./gallery-component.module.css";
@@ -834,7 +835,7 @@ const GalleryComponent: React.FC = () => {
               const previewUrl = getPreviewUrl(galleryItem);
               return previewUrl ? (
                 <img
-                  src={previewUrl}
+                  src={previewUrl ? getFileUrl(previewUrl) : ''}
                   alt=""
                   className={styles.previewThumbnail}
                   key={galleryItem.slug || idx}
@@ -1010,7 +1011,7 @@ const GalleryComponent: React.FC = () => {
                           >
                             {previewUrl ? (
                               <img
-                                src={previewUrl}
+                                src={previewUrl ? getFileUrl(previewUrl) : ''}
                                 className={`${styles.thumbnail} ${styles.listThumbnail}`}
                                 alt=""
                               />
@@ -1147,7 +1148,7 @@ const GalleryComponent: React.FC = () => {
 
                 {editingIndex !== null && galleries[editingIndex]?.svgUrl && (
                   <a
-                    href={galleries[editingIndex].svgUrl}
+                    href={getFileUrl(galleries[editingIndex].svgUrl)}
                     download
                     className={styles.originalLink}
                   >
@@ -1308,7 +1309,7 @@ const GalleryComponent: React.FC = () => {
               onClick={() => chooseCoverUrl(url)}
               key={`${startIndex + i}`}
             >
-              <img src={url} alt={`Cover option ${startIndex + i + 1}`} />
+              <img src={getFileUrl(url)} alt={`Cover option ${startIndex + i + 1}`} />
             </div>
           ))}
         </div>

--- a/frontend/src/features/project/components/ProjectHeader.tsx
+++ b/frontend/src/features/project/components/ProjectHeader.tsx
@@ -43,6 +43,7 @@ import {
   apiFetch,
   fetchUserProfilesBatch,
   type UserProfile,
+  getFileUrl,
 } from "@/shared/utils/api";
 import AvatarStack from "@/shared/ui/AvatarStack";
 import TeamModal from "@/features/project/components/TeamModal";
@@ -873,7 +874,7 @@ const ProjectHeader: React.FC<ProjectHeaderProps> = ({
               {localActiveProject?.thumbnails &&
               localActiveProject.thumbnails.length > 0 ? (
                 <img
-                  src={localActiveProject.thumbnails[0]}
+                  src={getFileUrl(localActiveProject.thumbnails[0])}
                   alt="Project Thumbnail"
                   className="project-logo"
                 />

--- a/frontend/src/features/project/components/TeamModal.tsx
+++ b/frontend/src/features/project/components/TeamModal.tsx
@@ -3,6 +3,7 @@ import Modal from "../../../shared/ui/ModalWithStack";
 import { X } from "lucide-react";
 import styles from "./team-modal.module.css";
 import { useOnlineStatus } from "@/app/contexts/OnlineStatusContext";
+import { getFileUrl } from "../../../shared/utils/api";
 
 type Member = {
   userId: string;
@@ -59,7 +60,7 @@ export default function TeamModal({
             <div className={styles.avatarWrapper}>
               {m.thumbnail ? (
                 <img
-                  src={m.thumbnail}
+                  src={getFileUrl(m.thumbnail)}
                   alt={m.firstName || "Member"}
                   className={styles.avatar}
                 />

--- a/frontend/src/shared/ui/AvatarStack.tsx
+++ b/frontend/src/shared/ui/AvatarStack.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import styles from './avatar-stack.module.css';
+import { getFileUrl } from '../utils/api';
 
 interface Member {
   userId: string;
@@ -63,7 +64,7 @@ const AvatarStack: React.FC<AvatarStackProps> = ({ members = [], onClick, size }
             aria-label={label}
           >
             {m.thumbnail ? (
-              <img src={m.thumbnail} alt={label} />
+              <img src={getFileUrl(m.thumbnail)} alt={label} />
             ) : (
               <span className={styles.initials}>{initials}</span>
             )}

--- a/frontend/src/shared/ui/BlogCard.tsx
+++ b/frontend/src/shared/ui/BlogCard.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import './blog-card.css';
 import { ScrambleButton } from './ScrambleButton';
+import { getFileUrl } from '../utils/api';
 
 export interface BlogCardProps {
   type?: 'blog' | 'project';
@@ -39,7 +40,7 @@ const BlogCard: React.FC<BlogCardProps> = ({
       {layout === 'row1' && (
         <>
           <div className="row1-image">
-            <img src={images[0]} alt={title} className="card-image" />
+            <img src={getFileUrl(images[0])} alt={title} className="card-image" />
           </div>
           <div className="row1-content">
             <div className="column1">
@@ -68,7 +69,7 @@ const BlogCard: React.FC<BlogCardProps> = ({
           </div>
           <div className="row2-image">
             <Link to={linkTarget}>
-              <img src={images[0]} alt={title} className="card-image" />
+              <img src={getFileUrl(images[0])} alt={title} className="card-image" />
             </Link>
           </div>
           <div className="content-row">
@@ -109,7 +110,7 @@ const BlogCard: React.FC<BlogCardProps> = ({
             </div>
           </div>
           <div className="image-column2">
-            <img src={images[0]} alt={title} className="card-image" />
+            <img src={getFileUrl(images[0])} alt={title} className="card-image" />
           </div>
         </>
       )}
@@ -118,7 +119,7 @@ const BlogCard: React.FC<BlogCardProps> = ({
         <>
           <div className="row1-image">
             <Link to={linkTarget}>
-              <img src={images[0]} alt={title} className="card-image" />
+              <img src={getFileUrl(images[0])} alt={title} className="card-image" />
             </Link>
           </div>
           <div className="row1-content">

--- a/frontend/src/shared/ui/LayoutPdfButtons.tsx
+++ b/frontend/src/shared/ui/LayoutPdfButtons.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { LayoutGrid, FileDown } from 'lucide-react';
 import styles from './layout-pdf-buttons.module.css';
+import { getFileUrl } from '../utils/api';
 
 interface LayoutPdfButtonsProps {
   useMasonryLayout?: boolean;
@@ -27,7 +28,7 @@ const LayoutPdfButtons: React.FC<LayoutPdfButtonsProps> = ({
       <span>{useMasonryLayout ? 'Grid Layout' : 'Masonry Layout'}</span>
     </button>
     {downloadUrl && (
-      <a href={downloadUrl} download className={styles.actionButton}>
+      <a href={getFileUrl(downloadUrl)} download className={styles.actionButton}>
         <FileDown size={16} />
         <span>{isPdf ? 'Download PDF' : 'Download SVG'}</span>
       </a>

--- a/frontend/src/shared/ui/OptimisticImage.tsx
+++ b/frontend/src/shared/ui/OptimisticImage.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, CSSProperties } from 'react';
+import { getFileUrl } from '../utils/api';
 
 interface OptimisticImageProps {
   tempUrl: string;
@@ -26,7 +27,7 @@ const OptimisticImage: React.FC<OptimisticImageProps> = ({
 
   return (
     <img
-      src={loaded && finalUrl ? finalUrl : tempUrl}
+      src={loaded && finalUrl ? getFileUrl(finalUrl) : tempUrl}
       alt={alt}
       className={className}
       style={{

--- a/frontend/src/shared/ui/PortfolioCard.tsx
+++ b/frontend/src/shared/ui/PortfolioCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { getFileUrl } from '../utils/api';
 
 import './portfolio-card.css';
 import CustomIcon from '../../assets/svg/angled-arrow.svg?react';
@@ -25,7 +26,7 @@ const PortfolioCard: React.FC<PortfolioCardProps> = ({
 }) => {
   return (
     <Link to={linkUrl} className={`portfolio-card ${className}`}>
-      <img src={imageSrc} alt={imageAlt} className="card-image" />
+      <img src={getFileUrl(imageSrc)} alt={imageAlt} className="card-image" />
       <div className="top-left title">
         <h3 className="title">{title}</h3>
         <h3 className="subtitle">{subtitle}</h3>

--- a/frontend/src/shared/ui/ProjectAvatar.tsx
+++ b/frontend/src/shared/ui/ProjectAvatar.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import SVGThumbnail from '../../features/dashboard/components/SvgThumbnail';
+import { getFileUrl } from '../utils/api';
 
 interface ProjectAvatarProps {
   thumb?: string;
@@ -15,7 +16,7 @@ const ProjectAvatar: React.FC<ProjectAvatarProps> = ({
   className = '',
 }) =>
   thumb ? (
-    <img src={thumb} alt={name} className={className} />
+    <img src={getFileUrl(thumb)} alt={name} className={className} />
   ) : (
     <SVGThumbnail
       initial={(initial || name.charAt(0)).toUpperCase()}

--- a/frontend/src/shared/ui/SlideShow.tsx
+++ b/frontend/src/shared/ui/SlideShow.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import { Navigation, Pagination, Mousewheel } from 'swiper/modules';
+import { getFileUrl } from '../utils/api';
 import 'swiper/css';
 import 'swiper/css/navigation';
 import 'swiper/css/pagination';
@@ -32,8 +33,8 @@ const Slideshow: React.FC<SlideshowProps> = ({ slides }) => {
         {slides.map((slide, index) => (
           <SwiperSlide key={index}>
             <div className="slide-content">
-              <a href={slide.url} target="_blank" rel="noopener noreferrer">
-                <img src={slide.imageUrl} alt={slide.title} />
+              <a href={getFileUrl(slide.url)} target="_blank" rel="noopener noreferrer">
+                <img src={getFileUrl(slide.imageUrl)} alt={slide.title} />
                 <h2>{slide.title}</h2>
                 <p>{slide.content}</p>
               </a>

--- a/frontend/src/shared/ui/UserProfilePicture.tsx
+++ b/frontend/src/shared/ui/UserProfilePicture.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import User from '@/assets/svg/user.svg?react';
+import { getFileUrl } from '../utils/api';
 
 export interface UserProfilePictureProps {
   thumbnail?: string | null;
@@ -18,7 +19,7 @@ const UserProfilePicture: React.FC<UserProfilePictureProps> = ({
     <label htmlFor="thumbnail" className="thumbnail-label">
       {localPreview || thumbnail ? (
         <img
-          src={localPreview || thumbnail || ''}
+          src={localPreview || (thumbnail ? getFileUrl(thumbnail) : '')}
           alt="Profile Thumbnail"
           className="profile-thumbnail"
         />


### PR DESCRIPTION
## Summary
- wrap user avatars and project thumbnails with getFileUrl
- normalize gallery images and file preview links via getFileUrl
- convert download anchors to use CDN-backed URLs

## Testing
- `npm test` *(fails: useProjects must be used within DataProvider)*

------
https://chatgpt.com/codex/tasks/task_e_68c5e4250100832493118534cde51ca9