### PR TITLE
Handle undefined URLs in file name utility

### DIFF
--- a/frontend/src/features/messages/MessageItem.tsx
+++ b/frontend/src/features/messages/MessageItem.tsx
@@ -26,7 +26,7 @@ interface MessageItemProps {
   openPreviewModal: (file: ChatFile | DMFile) => void;
   folderKey: string;
   renderFilePreview: (file: ChatFile | DMFile, folderKey: string) => React.ReactNode;
-  getFileNameFromUrl: (url: string) => string;
+  getFileNameFromUrl: (url?: string) => string;
   onDelete?: (msg: ChatMessage) => void;
   onEditRequest?: (msg: ChatMessage) => void;
   onReact?: (messageId: string, emoji: Emoji) => void;

--- a/frontend/src/features/messages/Messages.tsx
+++ b/frontend/src/features/messages/Messages.tsx
@@ -54,6 +54,7 @@ import {
   normalizeFileUrl,
   fileUrlsToKeys,
 } from "@/shared/utils/api";
+import { getFileNameFromUrl } from "@/shared/utils/fileUtils";
 import MessageItem, { ChatMessage } from "@/features/messages/MessageItem";
 import "@/features/messages/project-messages-thread.css";
 
@@ -91,8 +92,6 @@ const msgKey = (convId: string) => `messages_${convId}`;
 
 const getThumbnailUrl = (url: string, folderKey = "chat_uploads") =>
   url.replace(`/${folderKey}/`, `/${folderKey}_thumbnails/`);
-
-const getFileNameFromUrl = (url: string) => url.split("/").pop() || "";
 
 const renderFilePreview = (file: DMFile, folderKey = "chat_uploads") => {
   const extension = file.fileName.split(".").pop()?.toLowerCase() || "";

--- a/frontend/src/features/messages/ProjectMessagesThread.tsx
+++ b/frontend/src/features/messages/ProjectMessagesThread.tsx
@@ -50,6 +50,7 @@ import {
   normalizeFileUrl,
   fileUrlsToKeys,
 } from "../../shared/utils/api";
+import { getFileNameFromUrl } from "../../shared/utils/fileUtils";
 
 /* =============================================================================
    Types
@@ -122,9 +123,6 @@ if (typeof document !== "undefined") {
 // Use "chat_uploads" folder key for previews
 const getThumbnailUrl = (url: string, folderKey = "chat_uploads") =>
   url.replace(`/${folderKey}/`, `/${folderKey}_thumbnails/`);
-
-// Extract filename from URL.
-const getFileNameFromUrl = (url: string) => url.split("/").pop() || url;
 
 // Custom preview renderer for files
 const renderFilePreview = (file: FileObj, folderKey = "chat_uploads") => {

--- a/frontend/src/shared/utils/fileUtils.test.ts
+++ b/frontend/src/shared/utils/fileUtils.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { getFileNameFromUrl } from './fileUtils';
+
+describe('getFileNameFromUrl', () => {
+  it('returns the filename for a valid URL', () => {
+    const url = 'https://example.com/path/to/file.txt';
+    expect(getFileNameFromUrl(url)).toBe('file.txt');
+  });
+
+  it('returns an empty string for an empty URL', () => {
+    expect(getFileNameFromUrl('')).toBe('');
+  });
+
+  it('returns an empty string for an undefined URL', () => {
+    expect(getFileNameFromUrl(undefined)).toBe('');
+  });
+});

--- a/frontend/src/shared/utils/fileUtils.ts
+++ b/frontend/src/shared/utils/fileUtils.ts
@@ -1,0 +1,6 @@
+export const getFileNameFromUrl = (url?: string): string => {
+  if (!url) return "";
+  return url.split("/").pop() || "";
+};
+
+export default getFileNameFromUrl;


### PR DESCRIPTION
## Summary
- centralize `getFileNameFromUrl` utility and handle empty/undefined URLs safely
- update message components to use the shared helper and allow optional URLs
- add unit tests for filename extraction edge cases

## Testing
- `npm test` *(fails: Form.useForm is not a function; useProjects must be used within DataProvider)*

------
https://chatgpt.com/codex/tasks/task_e_68c5f9502ef08324a39dfd372a0b0064