### PR TITLE
refactor: rename dmThreads to inbox

### DIFF
--- a/frontend/src/app/contexts/MessagesContextValue.ts
+++ b/frontend/src/app/contexts/MessagesContextValue.ts
@@ -3,8 +3,8 @@ import type { Thread, Message } from "./DataProvider";
 export type ProjectMessagesMap = Record<string, Message[]>;
 
 export interface MessagesValue {
-  dmThreads: Thread[];
-  setDmThreads: React.Dispatch<React.SetStateAction<Thread[]>>;
+  inbox: Thread[];
+  setInbox: React.Dispatch<React.SetStateAction<Thread[]>>;
   projectMessages: ProjectMessagesMap;
   setProjectMessages: React.Dispatch<React.SetStateAction<ProjectMessagesMap>>;
   deletedMessageIds: Set<string>;

--- a/frontend/src/app/contexts/MessagesProvider.tsx
+++ b/frontend/src/app/contexts/MessagesProvider.tsx
@@ -17,8 +17,8 @@ export const MessagesProvider: React.FC<PropsWithChildren> = ({ children }) => {
   const { userId } = useAuth();
 
   const [projectMessages, setProjectMessages] = useState<ProjectMessagesMap>({});
-  const [dmThreads, setDmThreads] = useState<Thread[]>(() => {
-    const stored = getWithTTL("dmThreads");
+  const [inbox, setInbox] = useState<Thread[]>(() => {
+    const stored = getWithTTL("inbox");
     return Array.isArray(stored) ? (stored as Thread[]) : [];
   });
 
@@ -80,12 +80,12 @@ export const MessagesProvider: React.FC<PropsWithChildren> = ({ children }) => {
     }
   };
 
-  // Persist DM threads
+  // Persist inbox threads
   useEffect(() => {
-    setWithTTL("dmThreads", dmThreads, DEFAULT_TTL);
-  }, [dmThreads]);
+    setWithTTL("inbox", inbox, DEFAULT_TTL);
+  }, [inbox]);
 
-  // Load DM threads
+  // Load inbox threads
   useEffect(() => {
     if (!userId) return;
     const fetchThreads = async () => {
@@ -96,7 +96,7 @@ export const MessagesProvider: React.FC<PropsWithChildren> = ({ children }) => {
         const threads = Array.isArray(data)
           ? data
           : (data as { inbox?: Thread[] })?.inbox || [];
-        setDmThreads(threads as Thread[]);
+        setInbox(threads as Thread[]);
       } catch (err) {
         console.error("Failed to fetch threads", err);
       }
@@ -106,8 +106,8 @@ export const MessagesProvider: React.FC<PropsWithChildren> = ({ children }) => {
 
   const messagesValue = useMemo<MessagesValue>(
     () => ({
-      dmThreads,
-      setDmThreads,
+      inbox,
+      setInbox,
       projectMessages,
       setProjectMessages,
       deletedMessageIds: deletedMessageIdsRef.current,
@@ -115,7 +115,7 @@ export const MessagesProvider: React.FC<PropsWithChildren> = ({ children }) => {
       clearDeletedMessageId,
       toggleReaction,
     }),
-    [dmThreads, projectMessages]
+    [inbox, projectMessages]
   );
 
   return (

--- a/frontend/src/app/contexts/SocketContext.test.tsx
+++ b/frontend/src/app/contexts/SocketContext.test.tsx
@@ -67,7 +67,7 @@ describe("SocketContext collaborator updates", () => {
 
     (useData as ReturnType<typeof vi.fn>).mockReturnValue({
       setUserData: vi.fn(),
-      setDmThreads: vi.fn(),
+      setInbox: vi.fn(),
       userId: "u1",
       setProjects: vi.fn(),
       setUserProjects: vi.fn(),

--- a/frontend/src/app/contexts/SocketProvider.tsx
+++ b/frontend/src/app/contexts/SocketProvider.tsx
@@ -18,7 +18,7 @@ export const SocketProvider: React.FC<React.PropsWithChildren> = ({ children }) 
   const { getAuthTokens } = useAuth();
   const {
     setUserData,
-    setDmThreads,
+    setInbox,
     userId,
     setProjects,
     setUserProjects,
@@ -162,7 +162,7 @@ export const SocketProvider: React.FC<React.PropsWithChildren> = ({ children }) 
                 return { ...prev, messages: merged };
               });
 
-              setDmThreads((prev) => {
+              setInbox((prev) => {
                 const idx = prev.findIndex((t) => t.conversationId === data.conversationId);
                 if (idx !== -1) {
                   const shouldBeRead = viewing || isSelf;
@@ -209,7 +209,7 @@ export const SocketProvider: React.FC<React.PropsWithChildren> = ({ children }) 
                 const newSnippet = lastMsg?.text || "";
                 const newTs = lastMsg?.timestamp || new Date().toISOString();
 
-                setDmThreads((prevThreads) =>
+                setInbox((prevThreads) =>
                   prevThreads.map((t) =>
                     t.conversationId === data.conversationId
                       ? { ...t, snippet: newSnippet, lastMsgTs: newTs, read: viewing ? true : t.read }
@@ -230,7 +230,7 @@ export const SocketProvider: React.FC<React.PropsWithChildren> = ({ children }) 
                   ),
                 };
               });
-              setDmThreads((prev) =>
+              setInbox((prev) =>
                 prev.map((t) =>
                   t.conversationId === data.conversationId && t.lastMsgTs === data.timestamp
                     ? { ...t, snippet: data.text, lastMsgTs: data.timestamp }

--- a/frontend/src/features/dashboard/components/inbox.tsx
+++ b/frontend/src/features/dashboard/components/inbox.tsx
@@ -14,7 +14,7 @@ type InboxProps = {
 };
 
 export default function Inbox({ setActiveView, setDmUserSlug }: InboxProps) {
-  const { userId, allUsers, dmThreads, setDmThreads } = useData();
+  const { userId, allUsers, inbox, setInbox } = useData();
 
   const { ws } = useSocket() as { ws?: WebSocket | null };
 
@@ -30,22 +30,22 @@ export default function Inbox({ setActiveView, setDmUserSlug }: InboxProps) {
       // Optional: sanity check in dev
       console.debug("[Inbox] fetched threads:", data);
       const threads = Array.isArray(data) ? data : data?.inbox || [];
-      setDmThreads(threads as Thread[]);
+      setInbox(threads as Thread[]);
     } catch (err) {
       console.error("❌ inbox refresh failed", err);
-      setDmThreads([]); // keep UI consistent on error
+      setInbox([]); // keep UI consistent on error
     }
-  }, [userId, setDmThreads]); // :contentReference[oaicite:1]{index=1}
+  }, [userId, setInbox]); // :contentReference[oaicite:1]{index=1}
 
-  const inbox = useMemo<Thread[]>(
+  const sortedInbox = useMemo<Thread[]>(
     () =>
-      [...(dmThreads || [])].sort((a, b) => {
+      [...(inbox || [])].sort((a, b) => {
         const ta = Date.parse(a?.lastMsgTs as string);
         const tb = Date.parse(b?.lastMsgTs as string);
         // Fallback to 0 if invalid date
         return (isNaN(tb) ? 0 : tb) - (isNaN(ta) ? 0 : ta);
       }),
-    [dmThreads]
+    [inbox]
   );
 
   const handleNavigation = useCallback(
@@ -67,12 +67,12 @@ export default function Inbox({ setActiveView, setDmUserSlug }: InboxProps) {
   // 2) (Updates pushed via SocketContext elsewhere)
 
   // 3) helpers
-  const totalUnread = inbox.filter((item) => !item.read).length;
+  const totalUnread = sortedInbox.filter((item) => !item.read).length;
 
   const markReadAndNav = useCallback(
     async (otherUserId: string, convId: string) => {
       // 1) locally mark read
-      setDmThreads((prev) =>
+      setInbox((prev) =>
         prev.map((m) =>
           m.conversationId === convId ? { ...m, read: true } : m
         )
@@ -123,7 +123,7 @@ export default function Inbox({ setActiveView, setDmUserSlug }: InboxProps) {
       setActiveView,
       setDmUserSlug,
       allUsers,
-      setDmThreads,
+      setInbox,
     ]
   );
 
@@ -142,11 +142,11 @@ export default function Inbox({ setActiveView, setDmUserSlug }: InboxProps) {
         </div>
       </div>
 
-      {inbox.length === 0 ? (
+      {sortedInbox.length === 0 ? (
         <div className="progress-text">No messages</div>
       ) : (
         <div className="unread-dm-list">
-          {inbox.map((item) => {
+          {sortedInbox.map((item) => {
             const user = allUsers.find((u) => u.userId === item.otherUserId);
             const name = user?.firstName
               ? `${user.firstName} ${user.lastName ?? ""}`.trim()

--- a/frontend/src/features/dashboard/pages/DashboardHome.tsx
+++ b/frontend/src/features/dashboard/pages/DashboardHome.tsx
@@ -35,7 +35,7 @@ const WelcomeScreen: React.FC = () => {
     userData,
     userName,
     loadingProfile,
-    dmThreads,
+    inbox,
     allUsers,
     projects,
     fetchProjectDetails,
@@ -105,11 +105,11 @@ const WelcomeScreen: React.FC = () => {
       !isMobile &&
       activeView === "messages" &&
       !dmUserSlug &&
-      dmThreads &&
-      dmThreads.length > 0 &&
+      inbox &&
+      inbox.length > 0 &&
       userData
     ) {
-      const sorted = [...dmThreads].sort(
+      const sorted = [...inbox].sort(
         (a, b) => new Date(b.lastMsgTs).getTime() - new Date(a.lastMsgTs).getTime()
       );
       const lastThread = sorted[0];
@@ -130,7 +130,7 @@ const WelcomeScreen: React.FC = () => {
         }
       }
     }
-  }, [activeView, dmUserSlug, dmThreads, userData, allUsers, navigate, isMobile]);
+  }, [activeView, dmUserSlug, inbox, userData, allUsers, navigate, isMobile]);
 
   if (loadingProfile) return <SpinnerScreen />;
   if (userData?.pending) return <PendingApprovalScreen />;

--- a/frontend/src/features/messages/Messages.tsx
+++ b/frontend/src/features/messages/Messages.tsx
@@ -202,18 +202,18 @@ const Messages: React.FC<MessagesProps> = ({ initialUserSlug = null }) => {
     isAdmin,
     setUserData,
     setDmReadStatus,
-    setDmThreads,
+    setInbox,
     deletedMessageIds,
     markMessageDeleted,
     toggleReaction,
-    dmThreads,
+    inbox,
   } = useData() as unknown as {
     userData: AppUser;
     allUsers: AppUser[];
     isAdmin: boolean;
-    dmThreads: Thread[];
+    inbox: Thread[];
     setUserData: React.Dispatch<React.SetStateAction<AppUser>>;
-    setDmThreads: React.Dispatch<React.SetStateAction<Thread[]>>;
+    setInbox: React.Dispatch<React.SetStateAction<Thread[]>>;
     setDmReadStatus: React.Dispatch<React.SetStateAction<Record<string, string>>>;
     deletedMessageIds: Set<string>;
     markMessageDeleted: (id: string) => void;
@@ -254,11 +254,11 @@ const Messages: React.FC<MessagesProps> = ({ initialUserSlug = null }) => {
   // map for unread badge
   const threadMap = useMemo<Record<string, boolean>>(
     () =>
-      dmThreads.reduce((acc, t) => {
+      inbox.reduce((acc, t) => {
         acc[t.conversationId] = t.read === false;
         return acc;
       }, {} as Record<string, boolean>),
-    [dmThreads]
+    [inbox]
   );
 
   // Local state
@@ -365,7 +365,7 @@ const Messages: React.FC<MessagesProps> = ({ initialUserSlug = null }) => {
     if (isMobile) setShowConversation(true);
 
     // mark read locally
-    setDmThreads((prev) =>
+    setInbox((prev) =>
       prev.map((t) => (t.conversationId === conversationId ? { ...t, read: true } : t))
     );
     markConversationAsRead(conversationId);
@@ -373,7 +373,7 @@ const Messages: React.FC<MessagesProps> = ({ initialUserSlug = null }) => {
 
   const handleMarkRead = (conversationId: string | null) => {
     if (!conversationId) return;
-    setDmThreads((prev) =>
+    setInbox((prev) =>
       prev.map((t) => (t.conversationId === conversationId ? { ...t, read: true } : t))
     );
     markConversationAsRead(conversationId);
@@ -623,7 +623,7 @@ const fetchMessages = async () => {
         }
 
         // update thread list
-        setDmThreads((prev) => {
+        setInbox((prev) => {
           const idx = prev.findIndex((t) => t.conversationId === selectedConversation);
           if (idx !== -1) {
             const updated = [...prev];
@@ -787,7 +787,7 @@ const fetchMessages = async () => {
           }).catch((err) => console.error("Thread update failed:", err));
         }
 
-        setDmThreads((prev) => {
+        setInbox((prev) => {
           const idx = prev.findIndex((t) => t.conversationId === selectedConversation);
           if (idx !== -1) {
             const updated = [...prev];
@@ -904,7 +904,7 @@ const fetchMessages = async () => {
       const newSnippet = lastMsg?.text || "";
       const newTs = String(lastMsg?.timestamp || new Date().toISOString());
 
-      setDmThreads((prev) =>
+      setInbox((prev) =>
         prev.map((t) =>
           t.conversationId === selectedConversation
             ? { ...t, snippet: newSnippet, lastMsgTs: newTs, read: true }

--- a/frontend/src/shared/ui/NavigationDrawer.tsx
+++ b/frontend/src/shared/ui/NavigationDrawer.tsx
@@ -23,12 +23,12 @@ const NavigationDrawer: React.FC<NavigationDrawerProps> = ({
   setActiveView,
 }) => {
   const { setIsAuthenticated, setCognitoUser } = useAuth();
-  const { dmThreads } = useData();
+  const { inbox } = useData();
   const { notifications } = useNotifications() as { notifications: Array<{ read?: boolean }>; };
   const navigate = useNavigate();
 
   const unreadNotifications = notifications.filter((n) => !n.read).length;
-  const unreadMessages = dmThreads.filter((t) => t.read === false).length;
+  const unreadMessages = inbox.filter((t) => t.read === false).length;
 
   const handleNavigation = (view: string) => {
     setActiveView(view);


### PR DESCRIPTION
## Summary
- rename `dmThreads` references to `inbox`
- update socket provider and tests for new inbox naming
- adjust components to read/write inbox data

## Testing
- `npm test` *(fails: useProjects must be used within DataProvider; Form.useForm is not a function)*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c63344f33c832499cbef8b3ab50fac