### PR TITLE
Enhance global search project results

### DIFF
--- a/frontend/src/features/dashboard/components/GlobalSearch.css
+++ b/frontend/src/features/dashboard/components/GlobalSearch.css
@@ -95,6 +95,11 @@
   border-bottom: 1px solid rgba(255, 255, 255, 0.1);
 }
 
+.global-search-result.project-result {
+  gap: 16px;
+  align-items: center;
+}
+
 .global-search-result:last-child {
   border-bottom: none;
 }
@@ -125,9 +130,41 @@
   margin-top: 2px;
 }
 
+.global-search-thumbnail {
+  width: 48px;
+  height: 48px;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.08);
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.global-search-thumbnail-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.global-search-thumbnail-placeholder {
+  width: 48px;
+  height: 48px;
+  display: block;
+}
+
 .global-search-result-content {
   flex: 1;
   min-width: 0;
+}
+
+.global-search-title-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 4px;
 }
 
 .global-search-result-title {
@@ -139,6 +176,13 @@
   white-space: nowrap;
 }
 
+.global-search-result-title mark {
+  background: rgba(255, 255, 255, 0.2);
+  color: inherit;
+  padding: 0 2px;
+  border-radius: 2px;
+}
+
 .global-search-result-subtitle {
   font-size: 12px;
   color: rgba(255, 255, 255, 0.6);
@@ -148,8 +192,69 @@
   white-space: nowrap;
 }
 
+.global-search-status {
+  font-size: 11px;
+  line-height: 1.2;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.16);
+  color: rgba(255, 255, 255, 0.9);
+  text-transform: capitalize;
+  flex-shrink: 0;
+}
+
+.global-search-status--completed {
+  background: rgba(46, 125, 50, 0.22);
+  color: #b9f6ca;
+}
+
+.global-search-status--in-progress {
+  background: rgba(30, 136, 229, 0.22);
+  color: #bbdefb;
+}
+
+.global-search-status--pending,
+.global-search-status--awaiting,
+.global-search-status--awaiting-approval {
+  background: rgba(255, 193, 7, 0.28);
+  color: #ffe082;
+}
+
+.global-search-status--on-hold {
+  background: rgba(229, 115, 115, 0.28);
+  color: #ffcccb;
+}
+
+.global-search-status--archived {
+  background: rgba(158, 158, 158, 0.24);
+  color: #eeeeee;
+}
+
+.global-search-meta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.6);
+  margin-bottom: 4px;
+}
+
+.global-search-meta-label {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.global-search-meta-value {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.85);
+}
+
 .global-search-result-snippet,
-.global-search-result-description {
+.global-search-result-description,
+.global-search-result-excerpt {
   font-size: 12px;
   color: rgba(255, 255, 255, 0.7);
   line-height: 1.4;
@@ -161,6 +266,14 @@
 
 .global-search-result-snippet {
   font-style: italic;
+}
+
+.global-search-result-excerpt {
+  -webkit-line-clamp: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-style: normal;
 }
 
 /* Responsive design */
@@ -186,14 +299,30 @@
     padding: 10px 12px;
     gap: 10px;
   }
-  
+
+  .global-search-thumbnail,
+  .global-search-thumbnail-placeholder {
+    width: 40px;
+    height: 40px;
+  }
+
+  .global-search-status {
+    font-size: 10px;
+    padding: 2px 6px;
+  }
+
+  .global-search-meta {
+    font-size: 11px;
+  }
+
   .global-search-result-title {
     font-size: 13px;
   }
-  
+
   .global-search-result-subtitle,
   .global-search-result-snippet,
-  .global-search-result-description {
+  .global-search-result-description,
+  .global-search-result-excerpt {
     font-size: 11px;
   }
 }
@@ -257,7 +386,8 @@
   }
   
   .global-search-result-snippet,
-  .global-search-result-description {
+  .global-search-result-description,
+  .global-search-result-excerpt {
     color: rgba(0, 0, 0, 0.7);
   }
 }

--- a/frontend/src/features/dashboard/components/GlobalSearch.test.tsx
+++ b/frontend/src/features/dashboard/components/GlobalSearch.test.tsx
@@ -6,7 +6,7 @@ import '@testing-library/jest-dom';
 
 // Mock the required hooks and modules
 vi.mock('@/app/contexts/useData', () => ({
-  useData: vi.fn()
+  useData: () => mockUseData
 }));
 
 vi.mock('@/shared/utils/slug', () => ({
@@ -15,7 +15,8 @@ vi.mock('@/shared/utils/slug', () => ({
 
 vi.mock('@/shared/utils/api', () => ({
   apiFetch: vi.fn(),
-  GET_PROJECT_MESSAGES_URL: 'http://test.com/messages'
+  GET_PROJECT_MESSAGES_URL: 'http://test.com/messages',
+  getFileUrl: vi.fn((value: string) => value)
 }));
 
 const mockNavigate = vi.fn();
@@ -33,13 +34,16 @@ const mockProjects = [
     projectId: 'project-1',
     title: 'Test Project One',
     description: 'A test project for searching',
-    status: 'in-progress'
+    status: 'in-progress',
+    finishline: '2024-01-10',
+    thumbnails: ['https://example.com/thumb-1.jpg']
   },
   {
     projectId: 'project-2',
     title: 'Demo Application',
     description: 'Another project to test search functionality',
-    status: 'completed'
+    status: 'completed',
+    finishline: '2024-03-15'
   }
 ];
 
@@ -75,6 +79,9 @@ const mockUseData = {
 describe('GlobalSearch', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUseData.projects = mockProjects.map(project => ({ ...project }));
+    mockUseData.projectMessages = JSON.parse(JSON.stringify(mockProjectMessages));
+    mockNavigate.mockReset();
   });
 
   const renderGlobalSearch = () => {
@@ -196,6 +203,57 @@ describe('GlobalSearch', () => {
     fireEvent.keyDown(input, { key: 'Enter' });
 
     expect(mockUseData.fetchProjectDetails).toHaveBeenCalledWith('project-1');
+  });
+
+  it('renders project metadata with status and due date', async () => {
+    renderGlobalSearch();
+    const input = screen.getByPlaceholderText('Search projects and messages...');
+
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: 'test' } });
+
+    const statusPill = await screen.findByText('In Progress');
+    expect(statusPill).toBeInTheDocument();
+
+    const dueLabel = await screen.findByText('Due');
+    expect(dueLabel.parentElement).toHaveTextContent(/Due.*2024/);
+  });
+
+  it('shows plain text excerpts for lexical descriptions', async () => {
+    const lexicalDescription = JSON.stringify({
+      root: {
+        children: [
+          {
+            type: 'paragraph',
+            children: [
+              { type: 'text', text: 'Lexical summary text' }
+            ]
+          }
+        ]
+      }
+    });
+
+    mockUseData.projects = [
+      {
+        projectId: 'project-lexical',
+        title: 'Lexical Project',
+        description: lexicalDescription,
+        status: 'pending',
+        finishline: '2024-06-01'
+      }
+    ];
+
+    renderGlobalSearch();
+    const input = screen.getByPlaceholderText('Search projects and messages...');
+
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: 'lexical' } });
+
+    await waitFor(() => {
+      expect(screen.getByText('Lexical summary text')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText(lexicalDescription)).not.toBeInTheDocument();
   });
 
   it('closes search results on Escape key', async () => {

--- a/frontend/src/features/dashboard/components/GlobalSearch.tsx
+++ b/frontend/src/features/dashboard/components/GlobalSearch.tsx
@@ -4,6 +4,13 @@ import { useData } from '@/app/contexts/useData';
 import { useNavigate } from 'react-router-dom';
 import { slugify } from '@/shared/utils/slug';
 import type { Project, Message } from '@/app/contexts/DataProvider';
+import { getFileUrl } from '@/shared/utils/api';
+import SVGThumbnail from './SvgThumbnail';
+
+interface HighlightPart {
+  text: string;
+  isMatch: boolean;
+}
 
 interface SearchResult {
   id: string;
@@ -14,7 +21,186 @@ interface SearchResult {
   projectId?: string;
   messageId?: string;
   snippet?: string;
+  excerpt?: string;
+  thumbnailUrl?: string;
+  thumbnailInitial?: string;
+  status?: string;
+  statusLabel?: string;
+  statusClassName?: string;
+  dueDate?: string;
+  dueDateLabel?: string;
+  highlightParts?: HighlightPart[];
 }
+
+const EXCERPT_MAX_LENGTH = 140;
+
+const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const buildHighlightParts = (text: string, rawQuery: string): HighlightPart[] | undefined => {
+  const trimmedQuery = rawQuery.trim();
+  if (!trimmedQuery) return undefined;
+
+  const regex = new RegExp(`(${escapeRegExp(trimmedQuery)})`, 'ig');
+  const parts = text.split(regex);
+
+  if (parts.length <= 1) {
+    return undefined;
+  }
+
+  const lowerQuery = trimmedQuery.toLowerCase();
+
+  return parts
+    .filter(part => part.length > 0)
+    .map(part => ({
+      text: part,
+      isMatch: part.toLowerCase() === lowerQuery,
+    }));
+};
+
+const toSingleLine = (value: string) => value.replace(/\s+/g, ' ').trim();
+
+const truncate = (value: string, length = EXCERPT_MAX_LENGTH) => {
+  if (!value) return value;
+  if (value.length <= length) return value;
+  return `${value.slice(0, length - 1).trimEnd()}…`;
+};
+
+const collectLexicalText = (node: unknown): string => {
+  if (!node) return '';
+
+  if (typeof node === 'string') {
+    return node;
+  }
+
+  if (Array.isArray(node)) {
+    return toSingleLine(
+      node
+        .map(child => collectLexicalText(child))
+        .filter(Boolean)
+        .join(' ')
+    );
+  }
+
+  if (typeof node !== 'object') {
+    return '';
+  }
+
+  const obj = node as Record<string, unknown>;
+  const parts: string[] = [];
+
+  if (typeof obj.text === 'string') {
+    parts.push(obj.text);
+  }
+
+  if (Array.isArray(obj.children)) {
+    parts.push(collectLexicalText(obj.children));
+  }
+
+  if (Array.isArray(obj.rows)) {
+    parts.push(collectLexicalText(obj.rows));
+  }
+
+  if (Array.isArray(obj.cells)) {
+    parts.push(collectLexicalText(obj.cells));
+  }
+
+  if (typeof obj.value === 'string') {
+    parts.push(obj.value);
+  }
+
+  return toSingleLine(parts.filter(Boolean).join(' '));
+};
+
+const extractPlainText = (input: unknown): string => {
+  if (!input) return '';
+
+  if (typeof input === 'string') {
+    const trimmed = input.trim();
+    if (!trimmed) return '';
+
+    if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+      try {
+        const parsed = JSON.parse(trimmed);
+        const fromLexical = collectLexicalText((parsed as Record<string, unknown>).root ?? parsed);
+        if (fromLexical) {
+          return fromLexical;
+        }
+      } catch {
+        // fall through to HTML stripping below
+      }
+    }
+
+    return toSingleLine(trimmed.replace(/<[^>]+>/g, ''));
+  }
+
+  if (typeof input === 'object') {
+    const fromLexical = collectLexicalText((input as Record<string, unknown>).root ?? input);
+    if (fromLexical) {
+      return fromLexical;
+    }
+  }
+
+  return '';
+};
+
+const createExcerpt = (description: unknown): string | undefined => {
+  const plain = extractPlainText(description);
+  if (!plain) return undefined;
+  return truncate(toSingleLine(plain));
+};
+
+const formatDueDate = (value?: string | null) => {
+  if (!value) return undefined;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return undefined;
+  }
+  return date.toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+};
+
+const getStatusMetadata = (status?: string) => {
+  if (!status) return {};
+
+  const normalized = status.toLowerCase();
+  const label = toSingleLine(
+    normalized
+      .split(/[-_\s]+/)
+      .filter(Boolean)
+      .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+      .join(' ')
+  );
+
+  const className = `global-search-status--${normalized.replace(/[^a-z0-9]+/g, '-')}`;
+
+  return {
+    statusLabel: label || status,
+    statusClassName: className,
+  };
+};
+
+const getProjectThumbnail = (project: Project) => {
+  const initial = (project.title || 'Untitled project').trim().charAt(0).toUpperCase() || '#';
+  const thumbnails = Array.isArray(project.thumbnails) ? project.thumbnails : [];
+  const firstThumb = thumbnails.find((thumb): thumb is string => typeof thumb === 'string' && thumb.trim().length > 0);
+
+  if (!firstThumb) {
+    return { initial };
+  }
+
+  try {
+    return {
+      initial,
+      thumbnailUrl: getFileUrl(firstThumb),
+    };
+  } catch (error) {
+    console.warn('Failed to resolve thumbnail URL', error);
+    return { initial };
+  }
+};
 
 interface GlobalSearchProps {
   className?: string;
@@ -26,12 +212,20 @@ const GlobalSearch: React.FC<GlobalSearchProps> = ({ className = '' }) => {
   const [results, setResults] = useState<SearchResult[]>([]);
   const [loading, setLoading] = useState(false);
   const [selectedIndex, setSelectedIndex] = useState(-1);
-  
+  const [imageErrors, setImageErrors] = useState<Record<string, boolean>>({});
+
   const inputRef = useRef<HTMLInputElement>(null);
   const searchBoxRef = useRef<HTMLDivElement>(null);
   const navigate = useNavigate();
-  
-  const { projects, projectMessages, fetchProjectDetails } = useData();
+
+  const data = useData();
+  const projects = (Array.isArray(data?.projects) ? data.projects : []) as Project[];
+  const projectMessages = (data?.projectMessages && typeof data.projectMessages === 'object'
+    ? data.projectMessages
+    : {}) as Record<string, Message[]>;
+  const fetchProjectDetails = data?.fetchProjectDetails as
+    | ((projectId: string) => Promise<unknown>)
+    | undefined;
 
   // Close search when clicking outside
   useEffect(() => {
@@ -89,19 +283,30 @@ const GlobalSearch: React.FC<GlobalSearchProps> = ({ className = '' }) => {
           const title = (project.title || '').toLowerCase();
           const description = (project.description || '').toLowerCase();
           const status = (project.status || '').toLowerCase();
-          
+
           if (
             title.includes(normalizedQuery) ||
             description.includes(normalizedQuery) ||
             status.includes(normalizedQuery)
           ) {
+            const { thumbnailUrl, initial } = getProjectThumbnail(project);
+            const excerpt = createExcerpt(project.description);
+            const dueDateLabel = formatDueDate(project.finishline);
+            const statusMeta = getStatusMetadata(project.status);
             searchResults.push({
               id: `project-${project.projectId}`,
               type: 'project',
               title: project.title || 'Untitled Project',
-              subtitle: project.status ? `Status: ${project.status}` : undefined,
-              description: project.description,
               projectId: project.projectId,
+              excerpt,
+              thumbnailUrl,
+              thumbnailInitial: initial,
+              status: project.status,
+              statusLabel: statusMeta.statusLabel,
+              statusClassName: statusMeta.statusClassName,
+              dueDate: project.finishline,
+              dueDateLabel: dueDateLabel,
+              highlightParts: buildHighlightParts(project.title || 'Untitled Project', searchQuery),
             });
           }
         });
@@ -113,19 +318,21 @@ const GlobalSearch: React.FC<GlobalSearchProps> = ({ className = '' }) => {
           if (Array.isArray(messages)) {
             messages.forEach((message: Message) => {
               const messageText = (message.text || message.body || message.content || '').toLowerCase();
-              
+
               if (messageText.includes(normalizedQuery)) {
                 const project = projects?.find((p: Project) => p.projectId === projectId);
                 const projectTitle = project?.title || 'Unknown Project';
-                
+
                 // Create a snippet of the message
                 const fullText = message.text || message.body || message.content || '';
                 const index = fullText.toLowerCase().indexOf(normalizedQuery);
                 const start = Math.max(0, index - 30);
                 const end = Math.min(fullText.length, index + normalizedQuery.length + 30);
-                const snippet = (start > 0 ? '...' : '') + 
-                               fullText.slice(start, end) + 
-                               (end < fullText.length ? '...' : '');
+                const snippet = toSingleLine(
+                  ((start > 0 ? '...' : '') +
+                    fullText.slice(start, end) +
+                    (end < fullText.length ? '...' : '')).trim()
+                );
 
                 searchResults.push({
                   id: `message-${message.messageId || message.optimisticId || Date.now()}`,
@@ -135,6 +342,7 @@ const GlobalSearch: React.FC<GlobalSearchProps> = ({ className = '' }) => {
                   snippet,
                   projectId,
                   messageId: message.messageId || message.optimisticId,
+                  highlightParts: buildHighlightParts(`Message in ${projectTitle}`, searchQuery),
                 });
               }
             });
@@ -186,7 +394,9 @@ const GlobalSearch: React.FC<GlobalSearchProps> = ({ className = '' }) => {
 
     if (result.type === 'project' && result.projectId) {
       try {
-        await fetchProjectDetails(result.projectId);
+        if (fetchProjectDetails) {
+          await fetchProjectDetails(result.projectId);
+        }
         const project = projects?.find((p: Project) => p.projectId === result.projectId);
         const slug = slugify(project?.title || result.title);
         navigate(`/dashboard/projects/${slug}`);
@@ -195,11 +405,13 @@ const GlobalSearch: React.FC<GlobalSearchProps> = ({ className = '' }) => {
       }
     } else if (result.type === 'message' && result.projectId) {
       try {
-        await fetchProjectDetails(result.projectId);
+        if (fetchProjectDetails) {
+          await fetchProjectDetails(result.projectId);
+        }
         const project = projects?.find((p: Project) => p.projectId === result.projectId);
         const slug = slugify(project?.title || 'project');
-        navigate(`/dashboard/projects/${slug}`, { 
-          state: { highlightMessage: result.messageId } 
+        navigate(`/dashboard/projects/${slug}`, {
+          state: { highlightMessage: result.messageId }
         });
       } catch (error) {
         console.error('Error navigating to message:', error);
@@ -281,29 +493,78 @@ const GlobalSearch: React.FC<GlobalSearchProps> = ({ className = '' }) => {
             </div>
           )}
 
-          {!loading && results.map((result, index) => (
-            <button
-              key={result.id}
-              onClick={() => handleResultClick(result)}
-              className={`global-search-result ${index === selectedIndex ? 'selected' : ''}`}
-            >
-              <div className="global-search-result-icon">
-                {getResultIcon(result.type)}
-              </div>
-              <div className="global-search-result-content">
-                <div className="global-search-result-title">{result.title}</div>
-                {result.subtitle && (
-                  <div className="global-search-result-subtitle">{result.subtitle}</div>
+          {!loading && results.map((result, index) => {
+            const isProject = result.type === 'project';
+            const titleParts = result.highlightParts && result.highlightParts.length > 0
+              ? result.highlightParts
+              : [{ text: result.title, isMatch: false }];
+
+            return (
+              <button
+                key={result.id}
+                type="button"
+                onClick={() => handleResultClick(result)}
+                className={`global-search-result ${isProject ? 'project-result' : ''} ${index === selectedIndex ? 'selected' : ''}`}
+              >
+                {isProject ? (
+                  <div className="global-search-thumbnail" aria-hidden>
+                    {result.thumbnailUrl && !imageErrors[result.id] ? (
+                      <img
+                        src={result.thumbnailUrl}
+                        alt=""
+                        className="global-search-thumbnail-image"
+                        onError={() =>
+                          setImageErrors(prev => ({ ...prev, [result.id]: true }))
+                        }
+                      />
+                    ) : (
+                      <SVGThumbnail
+                        initial={result.thumbnailInitial || '#'}
+                        className="global-search-thumbnail-placeholder"
+                      />
+                    )}
+                  </div>
+                ) : (
+                  <div className="global-search-result-icon" aria-hidden>
+                    {getResultIcon(result.type)}
+                  </div>
                 )}
-                {result.snippet && (
-                  <div className="global-search-result-snippet">{result.snippet}</div>
-                )}
-                {result.description && !result.snippet && (
-                  <div className="global-search-result-description">{result.description}</div>
-                )}
-              </div>
-            </button>
-          ))}
+                <div className="global-search-result-content">
+                  <div className="global-search-title-row">
+                    <div className="global-search-result-title">
+                      {titleParts.map((part, partIndex) =>
+                        part.isMatch ? (
+                          <mark key={`${result.id}-part-${partIndex}`}>{part.text}</mark>
+                        ) : (
+                          <span key={`${result.id}-part-${partIndex}`}>{part.text}</span>
+                        )
+                      )}
+                    </div>
+                    {isProject && result.statusLabel && (
+                      <span className={`global-search-status ${result.statusClassName || ''}`}>
+                        {result.statusLabel}
+                      </span>
+                    )}
+                  </div>
+                  {isProject && result.dueDateLabel && (
+                    <div className="global-search-meta">
+                      <span className="global-search-meta-label">Due</span>
+                      <span className="global-search-meta-value">{result.dueDateLabel}</span>
+                    </div>
+                  )}
+                  {!isProject && result.subtitle && (
+                    <div className="global-search-result-subtitle">{result.subtitle}</div>
+                  )}
+                  {result.snippet && (
+                    <div className="global-search-result-snippet">{result.snippet}</div>
+                  )}
+                  {isProject && result.excerpt && (
+                    <div className="global-search-result-excerpt">{result.excerpt}</div>
+                  )}
+                </div>
+              </button>
+            );
+          })}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- render project results in global search with thumbnails, status pills, due dates, and clean excerpts
- add utilities to normalize project metadata, plain-text excerpts, and title highlighting
- adjust global search styling and tests for the richer project presentation

## Testing
- `node verify-global-search.cjs`
- `npx vitest run src/features/dashboard/components/GlobalSearch.test.tsx` *(hangs; Vitest queueing issue observed, unable to complete despite multiple attempts)*

------
https://chatgpt.com/codex/tasks/task_e_68c86e0e94948324afad6b79eb87d5c1