### PR TITLE
Add ADRs for CDN, DM IDs, and centralized CORS

### DIFF
--- a/docs/adrs/ADR-001.md
+++ b/docs/adrs/ADR-001.md
@@ -1,0 +1,66 @@
+# ADR-001: CDN File URL Strategy
+
+- **Status**: Accepted
+- **Date**: 2025-09-15
+- **Owner**: Platform Engineering
+- **Stakeholders**: Backend Services, Frontend Web, Infrastructure/DevOps
+- **Related PRs**:
+  - [PR TBD](https://github.com/jazbelrose/v1.2-mylg/pull/XXXX)
+
+## Context
+The application currently serves user-generated files and static assets from multiple entry points, mixing direct Amazon S3 object
+URLs with legacy CloudFront links. That fragmentation makes cache invalidation harder, complicates URL signing, and creates
+inconsistent security postures between public and private assets. We need a predictable CDN URL pattern that works for both
+unsigned (public) assets and signed (authenticated) downloads while letting clients compose paths deterministically.
+
+## Decision
+We will standardize on a single CloudFront distribution (base URL `https://cdn.mylg.app`) for all externally shared files.
+
+1. **Public objects** will be published under `https://cdn.mylg.app/public/...` and will not require CloudFront signed URLs.
+2. **Restricted objects** will be exposed under `https://cdn.mylg.app/secure/...` and will require signed URLs generated with the
+   CloudFront key pair managed by the shared layer utilities.
+3. Backend services are responsible for generating deterministic paths of the form
+   `/{visibility}/{tenantId}/{entity}/{objectKey}`, where `visibility` is either `public` or `secure`.
+4. Upload flows will continue to write to S3 buckets, but all persisted metadata will store the canonical CloudFront path
+   (not raw S3 URLs) so that clients always request assets through the CDN.
+
+The shared layer will surface helpers for generating signed URLs (`secure`) and plain paths (`public`) so each service can adopt
+this convention without duplicating signing logic.
+
+## Alternatives Considered
+- **Keep mixing S3 and CDN URLs** – Discarded because it perpetuates cache fragmentation and creates inconsistent client code.
+- **Multiple CloudFront distributions** – Discarded because it introduces unnecessary configuration drift and complicates
+  invalidation/instrumentation.
+
+## Pros
+- Consistent base URL simplifies client rendering logic and reduces the risk of leaking raw S3 endpoints.
+- Single distribution improves cache hit ratios and gives Ops a focused surface for monitoring and invalidations.
+- Deterministic path structure makes it easier to trace an object’s provenance (tenant, entity) from logs.
+- Shared signing helper reduces implementation errors across services.
+
+## Cons
+- Requires re-writing existing metadata that still stores S3 URLs before clients benefit fully from the change.
+- Signed URL generation adds slight latency overhead for secure downloads and depends on CloudFront key management hygiene.
+- A single distribution concentrates blast radius; misconfiguration affects both public and secure assets simultaneously.
+
+## Operations / Telemetry
+- Track CloudFront metrics (cache hit rate, 4xx/5xx error counts, total bytes served) with an alarm when 5xx errors exceed
+  baseline thresholds.
+- Enable CloudFront access logs to S3 and pipe them into a Kinesis Firehose stream for Athena-based investigations on latency
+  outliers or unusual access patterns.
+- Add shared-layer instrumentation to increment a custom metric (`SecureUrlGenerationFailures`) whenever signing fails so Ops can
+  detect credential drift quickly.
+- Integrate CDN request IDs into application logs to tie backend responses to CDN behaviors during incident reviews.
+
+## Implementation Plan
+1. Update the shared layer utilities to expose `buildPublicCdnPath` and `signSecureCdnUrl` helpers that embed the CloudFront base.
+2. Migrate existing services to store the canonical CDN path in DynamoDB/S3 metadata and backfill historical records where
+   feasible.
+3. Update frontend download/upload flows to expect `public` vs `secure` paths and request signed URLs when necessary.
+4. Configure infrastructure (CloudFront behaviors, origin policies) to map `/public/*` to public S3 origins and `/secure/*`
+   to origins requiring Origin Access Control.
+5. Document cache invalidation runbooks so Ops understands how to purge stale assets per visibility tier.
+
+## Follow-Up Questions
+- Do we need a transitional alias (e.g., `https://files.mylg.app`) for clients that still reference legacy URLs?
+- Should we add an automated job to verify that stored CDN paths resolve after deployment (synthetic download test)?

--- a/docs/adrs/ADR-002.md
+++ b/docs/adrs/ADR-002.md
@@ -1,0 +1,60 @@
+# ADR-002: Direct Message Conversation Identifier Format
+
+- **Status**: Accepted
+- **Date**: 2025-09-15
+- **Owner**: Product Messaging Team
+- **Stakeholders**: Messaging Service, WebSocket Gateway, Frontend Inbox
+- **Related PRs**:
+  - [PR TBD](https://github.com/jazbelrose/v1.2-mylg/pull/YYYY)
+
+## Context
+Direct messages currently allow multiple divergent identifiers (database PKs, composite keys, and WebSocket channels) which makes
+it hard to reconcile notifications, unread counts, and idempotent message storage. We need a single canonical conversation ID for
+a pair of users that is deterministic, sortable, and portable across storage layers (DynamoDB, Redis, client caches).
+
+## Decision
+Adopt the format `dm#<lowerUserId>___<higherUserId>` for all two-party direct message threads. Implementation specifics:
+
+1. Collect both user IDs, cast them to strings, and sort lexicographically. The first value becomes `<lowerUserId>` and the
+   second becomes `<higherUserId>`.
+2. Join the two parts using the delimiter string `___` (three underscores) and prefix the composite with `dm#`.
+3. Use the resulting identifier as the partition key for DynamoDB DM tables, the WebSocket subscription identifier, and the
+   inbox cache key on the frontend.
+4. Store participant metadata separately if needed, but never rely on array order in payloads; the ID encodes the ordering rule.
+
+## Alternatives Considered
+- **Database-generated UUIDs** – Discarded because they cannot be reconstructed deterministically on clients, complicating
+  optimistic rendering and duplicate detection.
+- **Hashing both user IDs** – Discarded because hashes are opaque during debugging and add collision risk without strong
+  hashing discipline.
+- **User-order-dependent IDs** – Discarded because they require clients to know who initiated the conversation, causing duplicate
+  threads when both participants start a DM.
+
+## Pros
+- Deterministic ID guarantees that the same pair of users always maps to the same conversation, preventing duplicates.
+- Prefixed namespace (`dm#`) prevents collisions with future thread types (projects, groups) that may share persistence tables.
+- IDs remain human-inspectable for debugging while staying URL-safe and storage-friendly.
+- Sorting logic is trivial to replicate across backend languages and frontend TypeScript.
+
+## Cons
+- Format only supports two participants; group chat IDs will need a separate strategy to avoid overly long concatenations.
+- Lexicographic sorting requires consistent normalization (e.g., lowercasing UUID strings) or else mismatches could occur.
+- Existing records that stored unsorted pairs must be migrated, requiring data backfills and update scripts.
+
+## Operations / Telemetry
+- Emit a metric (`DuplicateDmIdDetected`) when a write observes an existing conversation with reversed participant order to
+  measure migration completeness.
+- Log the generated conversation ID alongside message write operations to ease incident forensics and cross-layer tracing.
+- Add integration tests in the messaging CI pipeline that validate round-trip ID generation across languages (Node.js layer and
+  any auxiliary services) to catch delimiter or sorting regressions.
+- Update data quality dashboards to alert if a conversation ID lacks exactly two user IDs when split on `___`.
+
+## Implementation Plan
+1. Add shared-layer helper `buildDmConversationId(userA, userB)` used by HTTP APIs, WebSocket handlers, and background workers.
+2. Backfill existing DynamoDB and cache records to rename legacy keys into the new format, logging before/after values.
+3. Update frontend state managers to derive DM IDs via the same helper and migrate persisted cache entries.
+4. Document the ordering rule in API schemas and publish test fixtures for contract testing with partner teams.
+
+## Follow-Up Questions
+- Should we reserve additional prefixes (`dm_group#`, `dm_system#`) now to avoid future breaking changes?
+- Do we need a scheduled audit job to flag any DM thread where the stored participants do not match the ID encoding?

--- a/docs/adrs/ADR-003.md
+++ b/docs/adrs/ADR-003.md
@@ -1,0 +1,64 @@
+# ADR-003: Centralized CORS Configuration via Shared Layer Environment
+
+- **Status**: Accepted
+- **Date**: 2025-09-15
+- **Owner**: Platform Engineering
+- **Stakeholders**: API Gateway Services, Shared Layer Maintainers, Frontend Developers
+- **Related PRs**:
+  - [PR TBD](https://github.com/jazbelrose/v1.2-mylg/pull/ZZZZ)
+
+## Context
+Each backend service currently defines its own CORS settings inside individual Serverless configuration files, leading to
+inconsistent allowed-origin lists and duplicated environment variables. Rolling out a new domain or staging host requires
+editing every service, increasing risk of drift and accidental production exposure. The shared Lambda layer already provides
+CORS helper utilities, but we lack a single source of truth for origin allowlists.
+
+## Decision
+Centralize all CORS configuration in the shared layer by relying on two environment variables exported through
+`serverless.common.yml`:
+
+1. `ALLOWED_ORIGINS` – A comma-delimited list of exact origins that should receive `Access-Control-Allow-Origin` responses.
+2. `CORS_WILDCARD_HOSTS` – A comma-delimited list of host patterns (`*.mylg.app`, `*.mylg.dev`) that the helper interprets with
+   wildcard matching for preview builds and ephemeral environments.
+
+All services will consume the shared layer helper `resolveCorsOrigin(event)` which reads the environment variables, applies the
+matching logic (exact first, then wildcard), and returns CORS headers or rejects the request. Service-specific overrides are
+removed in favor of centrally managed values defined per stage.
+
+## Alternatives Considered
+- **Service-local environment variables** – Discarded because they require manual synchronization and increase the risk of
+  forgetting to update a service during domain changes.
+- **API Gateway default wildcard (`*`)** – Discarded because it violates security requirements by allowing credentialed requests
+  from untrusted origins.
+- **Secrets Manager configuration** – Discarded as overkill; secrets rotation is unnecessary for public origin lists and would add
+  latency to cold starts.
+
+## Pros
+- Guarantees consistent CORS enforcement across HTTP and WebSocket services without copy/paste configuration.
+- Stage-specific overrides can be applied once in `serverless.common.yml`, reducing deployment toil.
+- Wildcard host support enables ephemeral preview environments while maintaining strict production allowlists.
+- Simplifies documentation and onboarding because developers reference one place for allowed origins.
+
+## Cons
+- A misconfigured shared variable propagates immediately to every service, increasing blast radius for mistakes.
+- Changes to the allowlist require redeploying services that consume the shared layer to pick up new environment values.
+- Wildcard parsing logic must be carefully tested to avoid unexpected matches or regex injection issues.
+
+## Operations / Telemetry
+- Extend the shared CORS helper to emit a structured log entry (`cors_decision`) containing the request origin, match result, and
+  reason whenever an origin is rejected.
+- Publish a custom metric (`CorsRejectionCount`) per stage to CloudWatch so Ops can detect spikes when a new domain launches.
+- Add synthetic health checks that execute OPTIONS requests from representative origins to verify header responses post-deploy.
+- Include the resolved origin in API tracing spans (e.g., X-Ray annotations) to correlate user reports with infrastructure data.
+
+## Implementation Plan
+1. Update `serverless.common.yml` to define `ALLOWED_ORIGINS` and `CORS_WILDCARD_HOSTS` for each stage and surface them to all
+   services via the shared layer exports.
+2. Refactor the shared CORS utility to parse the comma-delimited values once and cache the compiled matchers across invocations.
+3. Remove per-service CORS env variables and wire HTTP/WebSocket handlers to use the shared helper for header computation.
+4. Add integration tests validating that known good/bad origins return the expected headers using the centralized config.
+5. Document the process for updating origin lists and include change-management steps in the deployment runbook.
+
+## Follow-Up Questions
+- Should we back the environment variables with SSM Parameter Store for audit trails and stage-specific overrides managed via IaC?
+- Do we need a tooling command to preview how a given origin maps to the allowlist for faster troubleshooting?


### PR DESCRIPTION
## Summary
- add ADR describing the CDN file URL strategy using a unified CloudFront base for public and signed paths
- document the deterministic DM conversation identifier format using sorted user IDs
- capture the centralized shared-layer CORS configuration approach and its operations guidance

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68c89a45841c83248a357e5d15c2d91d