### PR TITLE
Add squircle utilities and documentation

### DIFF
--- a/frontend/docs/design/squircle.md
+++ b/frontend/docs/design/squircle.md
@@ -1,0 +1,66 @@
+# Squircle Corners
+
+The squircle utilities provide a consistent corner treatment across the app that keeps the original 20px rounded look but smooths the inflection where straight edges meet. The approach is built around a reusable React wrapper and a lightweight CSS helper so teams can pick the right tool depending on whether they need dynamic measurements or static media styling.
+
+## Components
+
+### `<Squircle>` wrapper
+
+- **Location:** `src/shared/ui/Squircle.tsx`
+- **Purpose:** Wraps any block element, measures its size, and applies an SVG mask generated with `getSquirclePath`.
+- **Props:**
+  - `as`: host element/component. Defaults to `div`.
+  - `radius`: numeric radius in pixels (default `20`).
+  - `smoothing`: 0–1 float that controls how square the corner becomes (default `0.6`).
+  - `className`, `style`, and `children` pass straight through to the host.
+- **Fallbacks:** When masks or `ResizeObserver` are unavailable, the wrapper falls back to `border-radius` with `overflow: hidden` so older browsers still render rounded corners.
+- **Usage:**
+
+  ```tsx
+  import Squircle from '@/shared/ui/Squircle';
+
+  <Squircle as="button" radius={24} smoothing={0.5} className="primary-button">
+    Action
+  </Squircle>;
+  ```
+
+### CSS helper class
+
+- **Location:** `src/shared/ui/squircle/squircle.css`
+- **Usage:** Add the `.squircle` class for static media or markup where a wrapper component would be overkill.
+- **Customization:** Override the CSS variables `--shape-radius` and `--shape-smoothing` locally. For example:
+
+  ```css
+  .avatar.squircle {
+    --shape-radius: 16px;
+    --shape-smoothing: 0.7;
+  }
+  ```
+
+- **Fallback:** Uses `border-radius` by default, and switches to a `clip-path` powered squircle when the browser supports it.
+
+## Utility function
+
+`getSquirclePath(width, height, radius, smoothing)` generates a deterministic SVG path and caches repeated lookups. It is exported from `src/shared/ui/squircle/getSquirclePath.ts` and covered by unit tests.
+
+## Storybook
+
+`src/shared/ui/Squircle.stories.tsx` renders a radius/smoothing matrix so designers can compare shapes quickly. It is intended for the upcoming Storybook environment and uses inline styles only.
+
+## Codemod helper
+
+The repository includes `scripts/codemods/rounded20-to-squircle.ts`, a lightweight analyzer that surfaces the most common `border-radius: 20px` patterns. Run it in dry mode to see a report:
+
+```bash
+npm run tsx scripts/codemods/rounded20-to-squircle.ts -- --dry
+```
+
+Re-run without `--dry` to insert inline `TODO(squircle)` comments beside matches. The comments make it easier to wrap the affected markup with `<Squircle>` or to apply the `.squircle` utility during a follow-up sweep.
+
+## Dos and Don'ts
+
+- ✅ Prefer `<Squircle>` for interactive elements and any layout that changes size dynamically.
+- ✅ Use the `.squircle` class for static thumbnails, avatars, and images.
+- ✅ Keep `--shape-radius` and `--shape-smoothing` in sync with design tokens when theming.
+- ❌ Avoid wrapping elements that already manage their own clipping (videos, canvases) without testing.
+- ❌ Do not combine the squircle mask with additional `border-radius`; the component zeroes the native radius for you.

--- a/frontend/scripts/codemods/rounded20-to-squircle.ts
+++ b/frontend/scripts/codemods/rounded20-to-squircle.ts
@@ -1,0 +1,127 @@
+#!/usr/bin/env tsx
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+interface Finding {
+  file: string;
+  line: number;
+  preview: string;
+  hint: string;
+}
+
+const cwd = process.cwd();
+const repoRoot = fs.existsSync(path.join(cwd, 'src')) ? cwd : path.join(cwd, 'frontend');
+const srcRoot = path.join(repoRoot, 'src');
+
+const argv = process.argv.slice(2);
+const isDryRun = argv.includes('--dry') || argv.includes('-d');
+
+const findings: Finding[] = [];
+
+const jsPattern = /borderRadius\s*:\s*(?:20|['"]20px['"])/g;
+const cssPattern = /border-radius\s*:\s*20px/g;
+const classPattern = /(rounded-\[20px\]|rounded-2xl)/g;
+
+const visited = new Set<string>();
+
+function walk(dir: string) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name.startsWith('.')) continue;
+    const absolute = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(absolute);
+      continue;
+    }
+
+    const ext = path.extname(entry.name);
+    if (!['.ts', '.tsx', '.js', '.jsx', '.css', '.scss', '.less'].includes(ext)) {
+      continue;
+    }
+
+    analyzeFile(absolute);
+  }
+}
+
+function analyzeFile(filePath: string) {
+  if (visited.has(filePath)) return;
+  visited.add(filePath);
+  const content = fs.readFileSync(filePath, 'utf8');
+
+  const matches: Finding[] = [];
+
+  if (filePath.endsWith('.css') || filePath.endsWith('.scss') || filePath.endsWith('.less')) {
+    for (const match of content.matchAll(cssPattern)) {
+      const line = content.slice(0, match.index ?? 0).split(/\n/).length;
+      matches.push({
+        file: filePath,
+        line,
+        preview: content.split(/\n/)[line - 1]?.trim() ?? '',
+        hint: 'Replace selector with .squircle helper or migrate container to <Squircle>.',
+      });
+    }
+  } else {
+    for (const match of content.matchAll(jsPattern)) {
+      const line = content.slice(0, match.index ?? 0).split(/\n/).length;
+      matches.push({
+        file: filePath,
+        line,
+        preview: content.split(/\n/)[line - 1]?.trim() ?? '',
+        hint: 'Wrap element with <Squircle radius={20}> and remove inline borderRadius.',
+      });
+    }
+
+    for (const match of content.matchAll(classPattern)) {
+      const line = content.slice(0, match.index ?? 0).split(/\n/).length;
+      matches.push({
+        file: filePath,
+        line,
+        preview: content.split(/\n/)[line - 1]?.trim() ?? '',
+        hint: 'Swap Tailwind radius for squircle class or wrapper.',
+      });
+    }
+  }
+
+  if (matches.length === 0) {
+    return;
+  }
+
+  findings.push(...matches);
+
+  if (!isDryRun) {
+    // Add TODO comment for manual follow-up.
+    const lines = content.split(/\n/);
+    let offset = 0;
+    for (const match of matches) {
+      const insertAt = match.line - 1 + offset;
+      lines.splice(insertAt, 0, '/* TODO(squircle): migrate rounded corners to <Squircle> or .squircle */');
+      offset += 1;
+    }
+
+    fs.writeFileSync(filePath, lines.join('\n'), 'utf8');
+  }
+}
+
+if (!fs.existsSync(srcRoot)) {
+  console.error('Unable to locate src directory from', repoRoot);
+  process.exit(1);
+}
+
+walk(srcRoot);
+
+if (findings.length === 0) {
+  console.log('No 20px rounded corners detected.');
+  process.exit(0);
+}
+
+console.log(`Found ${findings.length} rounded corner occurrences${isDryRun ? ' (dry run)' : ''}:`);
+for (const finding of findings) {
+  console.log(`- ${path.relative(repoRoot, finding.file)}:${finding.line} -> ${finding.preview}`);
+  console.log(`    hint: ${finding.hint}`);
+}
+
+if (!isDryRun) {
+  console.log('\nTODO comments were inserted to flag migrations. Re-run with --dry to inspect without edits.');
+} else {
+  console.log('\nRun without --dry to insert migration TODO markers.');
+}

--- a/frontend/src/shared/styles/index.css
+++ b/frontend/src/shared/styles/index.css
@@ -27,6 +27,7 @@
 @import './components/video-containers.css';
 @import './components/grid-layouts.css';
 @import './components/work-layouts.css';
+@import '../ui/squircle/squircle.css';
 
 @import './components/blog-row-layouts.css';
 

--- a/frontend/src/shared/ui/Squircle.stories.tsx
+++ b/frontend/src/shared/ui/Squircle.stories.tsx
@@ -1,0 +1,65 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+
+import Squircle from './Squircle';
+
+const radii = [12, 16, 20, 24];
+const smoothness = [0.4, 0.6, 0.8];
+
+const meta: Meta<typeof Squircle> = {
+  title: 'Shared/Squircle',
+  component: Squircle,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Squircle>;
+
+export const RadiusSmoothingMatrix: Story = {
+  render: () => (
+    <div
+      style={{
+        display: 'grid',
+        gap: '1.5rem',
+        gridTemplateColumns: `repeat(${smoothness.length + 1}, minmax(0, 1fr))`,
+        alignItems: 'center',
+        justifyItems: 'center',
+        maxWidth: 'min(900px, 100%)',
+      }}
+    >
+      <div />
+      {smoothness.map((value) => (
+        <strong key={`header-${value}`}>smoothing {value}</strong>
+      ))}
+      {radii.map((radius) => (
+        <React.Fragment key={`row-${radius}`}>
+          <strong>radius {radius}px</strong>
+          {smoothness.map((value) => (
+            <Squircle
+              key={`${radius}-${value}`}
+              radius={radius}
+              smoothing={value}
+              style={{
+                width: 120,
+                height: 80,
+                background:
+                  'linear-gradient(135deg, rgba(120, 82, 255, 0.85), rgba(0, 200, 255, 0.85))',
+                color: '#fff',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                fontWeight: 600,
+              }}
+            >
+              {radius}/{value}
+            </Squircle>
+          ))}
+        </React.Fragment>
+      ))}
+    </div>
+  ),
+};

--- a/frontend/src/shared/ui/Squircle.tsx
+++ b/frontend/src/shared/ui/Squircle.tsx
@@ -1,0 +1,234 @@
+import React from 'react';
+
+import { getSquirclePath } from './squircle/getSquirclePath';
+
+const hasWindow = typeof window !== 'undefined';
+const hasResizeObserver = hasWindow && 'ResizeObserver' in window;
+
+let cachedMaskSupport: boolean | null = null;
+const supportsMask = (): boolean => {
+  if (cachedMaskSupport !== null) {
+    return cachedMaskSupport;
+  }
+
+  if (!hasWindow || typeof document === 'undefined') {
+    cachedMaskSupport = false;
+    return cachedMaskSupport;
+  }
+
+  const style = document.createElement('div').style as CSSStyleDeclaration & {
+    webkitMaskImage?: string;
+  };
+  cachedMaskSupport =
+    typeof style.maskImage !== 'undefined' || typeof style.webkitMaskImage !== 'undefined';
+  return cachedMaskSupport;
+};
+
+const useIsomorphicLayoutEffect = hasWindow ? React.useLayoutEffect : React.useEffect;
+
+type ElementType = keyof JSX.IntrinsicElements | React.ComponentType<any>;
+
+export type SquircleProps<T extends React.ElementType = 'div'> = {
+  as?: T;
+  radius?: number;
+  smoothing?: number;
+  className?: string;
+  style?: React.CSSProperties;
+  children?: React.ReactNode;
+} & Omit<React.ComponentPropsWithoutRef<T>, 'as' | 'style' | 'className'>;
+
+type ElementRef<T extends React.ElementType> = React.ComponentPropsWithRef<T> extends {
+  ref?: React.Ref<infer R>;
+}
+  ? R
+  : never;
+
+function encodeSvg(svg: string): string {
+  return encodeURIComponent(svg)
+    .replace(/%0A/g, '')
+    .replace(/%20/g, ' ')
+    .replace(/%3D/g, '=')
+    .replace(/%3A/g, ':')
+    .replace(/%2F/g, '/')
+    .replace(/%22/g, "'");
+}
+
+const defaultGetRect = (node: Element) => node.getBoundingClientRect();
+
+const SquircleInner = <T extends React.ElementType = 'div'>(
+  {
+    as,
+    radius = 20,
+    smoothing = 0.6,
+    className,
+    style,
+    children,
+    ...rest
+  }: SquircleProps<T>,
+  forwardedRef: React.ForwardedRef<ElementRef<T>>,
+): React.ReactElement | null => {
+  const Component = (as ?? 'div') as ElementType;
+  const localRef = React.useRef<Element | null>(null);
+  const [size, setSize] = React.useState({ width: 0, height: 0 });
+  const [prefersReducedTransparency, setPrefersReducedTransparency] = React.useState<boolean>(() => {
+    if (!hasWindow || typeof window.matchMedia !== 'function') {
+      return false;
+    }
+
+    return window.matchMedia('(prefers-reduced-transparency: reduce)').matches;
+  });
+
+  const combinedRef = React.useCallback(
+    (node: Element | null) => {
+      localRef.current = node;
+      if (typeof forwardedRef === 'function') {
+        forwardedRef(node as ElementRef<T> | null);
+      } else if (forwardedRef) {
+        (forwardedRef as React.MutableRefObject<ElementRef<T> | null>).current = node as ElementRef<T> | null;
+      }
+    },
+    [forwardedRef],
+  );
+
+  useIsomorphicLayoutEffect(() => {
+    const node = localRef.current;
+    if (!node) {
+      return;
+    }
+
+    const updateSize = () => {
+      const { width, height } = defaultGetRect(node);
+      setSize((prev) =>
+        prev.width === width && prev.height === height ? prev : { width, height },
+      );
+    };
+
+    updateSize();
+
+    if (!hasResizeObserver) {
+      if (hasWindow) {
+        window.addEventListener('resize', updateSize);
+        return () => {
+          window.removeEventListener('resize', updateSize);
+        };
+      }
+
+      return;
+    }
+
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        if (entry.target !== node) {
+          continue;
+        }
+
+        const boxSize = Array.isArray(entry.contentBoxSize)
+          ? entry.contentBoxSize[0]
+          : entry.contentBoxSize;
+        const width = boxSize ? boxSize.inlineSize : entry.contentRect.width;
+        const height = boxSize ? boxSize.blockSize : entry.contentRect.height;
+        setSize((prev) =>
+          prev.width === width && prev.height === height ? prev : { width, height },
+        );
+      }
+    });
+
+    observer.observe(node);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+
+  React.useEffect(() => {
+    if (!hasWindow || typeof window.matchMedia !== 'function') {
+      return;
+    }
+
+    const mediaQuery = window.matchMedia('(prefers-reduced-transparency: reduce)');
+    const listener = (event: MediaQueryListEvent) => {
+      setPrefersReducedTransparency(event.matches);
+    };
+
+    if ('addEventListener' in mediaQuery) {
+      mediaQuery.addEventListener('change', listener);
+    } else {
+      mediaQuery.addListener(listener);
+    }
+
+    return () => {
+      if ('removeEventListener' in mediaQuery) {
+        mediaQuery.removeEventListener('change', listener);
+      } else {
+        mediaQuery.removeListener(listener);
+      }
+    };
+  }, []);
+
+  const maskReady = supportsMask() && !prefersReducedTransparency;
+  const canMask = maskReady && size.width > 0 && size.height > 0;
+
+  const maskValue = React.useMemo(() => {
+    if (!canMask) {
+      return null;
+    }
+
+    const path = getSquirclePath(size.width, size.height, radius, smoothing);
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${size.width}" height="${size.height}" viewBox="0 0 ${size.width} ${size.height}"><path fill="white" d="${path}" /></svg>`;
+    const dataUrl = `url("data:image/svg+xml,${encodeSvg(svg)}")`;
+    return dataUrl;
+  }, [canMask, radius, size.height, size.width, smoothing]);
+
+  const mergedStyle = React.useMemo(() => {
+    const next: React.CSSProperties = {
+      borderRadius: canMask ? 0 : radius,
+      ...(style ?? {}),
+    };
+
+    if (canMask && maskValue) {
+      next.WebkitMaskImage = maskValue;
+      next.maskImage = maskValue;
+      next.WebkitMaskRepeat = 'no-repeat';
+      next.maskRepeat = 'no-repeat';
+      next.WebkitMaskSize = '100% 100%';
+      next.maskSize = '100% 100%';
+    } else if (next.overflow === undefined) {
+      next.overflow = 'hidden';
+    }
+
+    return next;
+  }, [canMask, maskValue, radius, style]);
+
+  if (Component === React.Fragment) {
+    console.warn('Squircle cannot render as a React.Fragment. Falling back to a div.');
+    return React.createElement(
+      'div',
+      {
+        ...rest,
+        ref: combinedRef as React.Ref<HTMLDivElement>,
+        className,
+        style: mergedStyle,
+      },
+      children,
+    );
+  }
+
+  return React.createElement(
+    Component,
+    {
+      ...rest,
+      ref: combinedRef,
+      className,
+      style: mergedStyle,
+    },
+    children,
+  );
+};
+
+const Squircle = React.forwardRef(SquircleInner) as <
+  T extends React.ElementType = 'div',
+>(
+  props: SquircleProps<T> & { ref?: React.Ref<ElementRef<T>> },
+) => React.ReactElement | null;
+
+export default Squircle;

--- a/frontend/src/shared/ui/index.ts
+++ b/frontend/src/shared/ui/index.ts
@@ -46,4 +46,5 @@ export { default as Slideshow } from "./SlideShow";
 export { default as SmoothScroll } from "./SmoothScroll";
 export { default as Spinner } from "./Spinner";
 export { default as Ticker } from "./Ticker";
+export { default as Squircle } from "./Squircle";
 

--- a/frontend/src/shared/ui/squircle/getSquirclePath.test.ts
+++ b/frontend/src/shared/ui/squircle/getSquirclePath.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+
+import { clearSquirclePathCache, getSquirclePath } from './getSquirclePath';
+
+describe('getSquirclePath', () => {
+  beforeEach(() => {
+    clearSquirclePathCache();
+  });
+
+  it('creates a rounded path for default radius and smoothing', () => {
+    const path = getSquirclePath(200, 120, 20, 0.6);
+
+    expect(path).toMatchInlineSnapshot(
+      '"M 20 0 L 180 0 C 196.4183 0 200 3.5817 200 20 L 200 100 C 200 116.4183 196.4183 120 180 120 L 20 120 C 3.5817 120 0 116.4183 0 100 L 0 20 C 0 3.5817 3.5817 0 20 0 Z"',
+    );
+  });
+
+  it('clamps radius when larger than half the dimension', () => {
+    const path = getSquirclePath(60, 40, 80, 0.6);
+
+    expect(path).toMatchInlineSnapshot(
+      '"M 20 0 L 40 0 C 56.4183 0 60 3.5817 60 20 L 60 20 C 60 36.4183 56.4183 40 40 40 L 20 40 C 3.5817 40 0 36.4183 0 20 L 0 20 C 0 3.5817 3.5817 0 20 0 Z"',
+    );
+  });
+
+  it('falls back to rectangle when radius is zero', () => {
+    const path = getSquirclePath(100, 50, 0, 0.6);
+
+    expect(path).toBe('M 0 0 L 100 0 L 100 50 L 0 50 Z');
+  });
+
+  it('returns cached value on repeated calls', () => {
+    const pathA = getSquirclePath(150, 90, 16, 0.4);
+    const pathB = getSquirclePath(150, 90, 16, 0.4);
+
+    expect(pathA).toBe(pathB);
+  });
+});

--- a/frontend/src/shared/ui/squircle/getSquirclePath.ts
+++ b/frontend/src/shared/ui/squircle/getSquirclePath.ts
@@ -1,0 +1,79 @@
+const PATH_CACHE = new Map<string, string>();
+
+const CIRCLE_APPROXIMATION = 0.5522847498;
+const HANDLE_EXTRA = 1 - CIRCLE_APPROXIMATION;
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+function formatNumber(value: number): string {
+  return Number.parseFloat(value.toFixed(4)).toString();
+}
+
+export function getSquirclePath(
+  width: number,
+  height: number,
+  r = 20,
+  k = 0.6,
+): string {
+  if (!Number.isFinite(width) || !Number.isFinite(height)) {
+    throw new TypeError('Width and height must be finite numbers.');
+  }
+
+  const safeWidth = Math.max(0, width);
+  const safeHeight = Math.max(0, height);
+
+  if (safeWidth === 0 || safeHeight === 0) {
+    return 'M 0 0';
+  }
+
+  const radius = clamp(r, 0, Math.min(safeWidth, safeHeight) / 2);
+  const smoothing = clamp(k, 0, 1);
+
+  if (radius === 0) {
+    const rectPath = [
+      'M 0 0',
+      `L ${formatNumber(safeWidth)} 0`,
+      `L ${formatNumber(safeWidth)} ${formatNumber(safeHeight)}`,
+      `L 0 ${formatNumber(safeHeight)}`,
+      'Z',
+    ].join(' ');
+
+    return rectPath;
+  }
+
+  const cacheKey = `${safeWidth}x${safeHeight}-r${radius}-k${smoothing}`;
+  const cached = PATH_CACHE.get(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
+  const handle = radius * (CIRCLE_APPROXIMATION + HANDLE_EXTRA * smoothing);
+
+  const topStartX = radius;
+  const topEndX = safeWidth - radius;
+  const rightStartY = radius;
+  const rightEndY = safeHeight - radius;
+
+  const pathSegments = [
+    `M ${formatNumber(topStartX)} 0`,
+    `L ${formatNumber(topEndX)} 0`,
+    `C ${formatNumber(topEndX + handle)} 0 ${formatNumber(safeWidth)} ${formatNumber(rightStartY - handle)} ${formatNumber(safeWidth)} ${formatNumber(rightStartY)}`,
+    `L ${formatNumber(safeWidth)} ${formatNumber(rightEndY)}`,
+    `C ${formatNumber(safeWidth)} ${formatNumber(rightEndY + handle)} ${formatNumber(topEndX + handle)} ${formatNumber(safeHeight)} ${formatNumber(topEndX)} ${formatNumber(safeHeight)}`,
+    `L ${formatNumber(topStartX)} ${formatNumber(safeHeight)}`,
+    `C ${formatNumber(topStartX - handle)} ${formatNumber(safeHeight)} 0 ${formatNumber(rightEndY + handle)} 0 ${formatNumber(rightEndY)}`,
+    `L 0 ${formatNumber(rightStartY)}`,
+    `C 0 ${formatNumber(rightStartY - handle)} ${formatNumber(topStartX - handle)} 0 ${formatNumber(topStartX)} 0`,
+    'Z',
+  ];
+
+  const path = pathSegments.join(' ');
+  PATH_CACHE.set(cacheKey, path);
+  return path;
+}
+
+export function clearSquirclePathCache(): void {
+  PATH_CACHE.clear();
+}

--- a/frontend/src/shared/ui/squircle/squircle.css
+++ b/frontend/src/shared/ui/squircle/squircle.css
@@ -1,0 +1,31 @@
+:root {
+  --shape-radius: 20px;
+  --shape-smoothing: 0.6;
+}
+
+.squircle {
+  --shape-radius-effective: min(var(--shape-radius), 50%);
+  --squircle-handle: calc(
+    var(--shape-radius-effective) *
+      (0.5522847498 + 0.4477152502 * var(--shape-smoothing))
+  );
+  position: relative;
+  border-radius: var(--shape-radius);
+  overflow: hidden;
+  isolation: isolate;
+}
+
+.squircle::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+@supports (clip-path: path('M 20px 0 L calc(100% - 20px) 0')) {
+  .squircle {
+    clip-path: path(
+      'M var(--shape-radius-effective) 0 L calc(100% - var(--shape-radius-effective)) 0 C calc(100% - var(--shape-radius-effective) + var(--squircle-handle)) 0 100% calc(var(--shape-radius-effective) - var(--squircle-handle)) 100% var(--shape-radius-effective) L 100% calc(100% - var(--shape-radius-effective)) C 100% calc(100% - var(--shape-radius-effective) + var(--squircle-handle)) calc(100% - var(--shape-radius-effective) + var(--squircle-handle)) 100% calc(100% - var(--shape-radius-effective)) 100% L var(--shape-radius-effective) 100% C calc(var(--shape-radius-effective) - var(--squircle-handle)) 100% 0 calc(100% - var(--shape-radius-effective) + var(--squircle-handle)) 0 calc(100% - var(--shape-radius-effective)) L 0 var(--shape-radius-effective) C 0 calc(var(--shape-radius-effective) - var(--squircle-handle)) calc(var(--shape-radius-effective) - var(--squircle-handle)) 0 var(--shape-radius-effective) 0 Z'
+    );
+  }
+}

--- a/frontend/src/types/storybook.d.ts
+++ b/frontend/src/types/storybook.d.ts
@@ -1,0 +1,18 @@
+declare module '@storybook/react' {
+  import type { ComponentType, ReactElement } from 'react';
+
+  export type Meta<T> = {
+    title: string;
+    component?: T;
+    tags?: string[];
+    parameters?: Record<string, unknown>;
+    decorators?: Array<(story: () => ReactElement) => ReactElement>;
+  };
+
+  export type StoryObj<T> = {
+    args?: Partial<T extends ComponentType<infer P> ? P : Record<string, unknown>>;
+    render?: (args: T extends ComponentType<infer P> ? P : Record<string, unknown>) => ReactElement;
+    name?: string;
+    parameters?: Record<string, unknown>;
+  };
+}


### PR DESCRIPTION
## Summary
- add `getSquirclePath` helper with caching and tests
- introduce a polymorphic `<Squircle>` wrapper plus global `.squircle` CSS helper
- document the squircle pattern, add a Storybook matrix, and ship a scanning codemod script

## Testing
- `npm test` *(fails: existing gallery suite assertion and two Vitest suites unrelated to the new squircle files)*

------
https://chatgpt.com/codex/tasks/task_e_68c8a2ff0b288324bf8123d1d8b6f60a