### PR TITLE
Refine dashboard home layout with persistent navigation

### DIFF
--- a/frontend/src/app/layout/AppShell.tsx
+++ b/frontend/src/app/layout/AppShell.tsx
@@ -1,0 +1,119 @@
+/* eslint-disable react-refresh/only-export-components */
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useId,
+  useMemo,
+  useState,
+  type PropsWithChildren,
+} from "react";
+
+const DESKTOP_QUERY = "(min-width: 1280px)";
+
+type AppShellContextValue = {
+  isDesktop: boolean;
+  isDrawerOpen: boolean;
+  openDrawer: () => void;
+  closeDrawer: () => void;
+  drawerId: string;
+};
+
+const AppShellContext = createContext<AppShellContextValue | null>(null);
+
+export function useAppShell() {
+  return useContext(AppShellContext);
+}
+
+type OverlayRenderArgs = {
+  open: boolean;
+  onClose: () => void;
+  drawerId: string;
+};
+
+type AppShellProps = PropsWithChildren<{
+  drawer?: React.ReactNode;
+  renderOverlayDrawer?: (args: OverlayRenderArgs) => React.ReactNode;
+  className?: string;
+  contentClassName?: string;
+}>;
+
+const AppShell: React.FC<AppShellProps> = ({
+  drawer,
+  renderOverlayDrawer,
+  className,
+  contentClassName,
+  children,
+}) => {
+  const rawId = useId();
+  const drawerId = useMemo(
+    () => `app-shell-drawer-${rawId.replace(/[^a-zA-Z0-9_-]/g, "")}`,
+    [rawId]
+  );
+  const [isDesktop, setIsDesktop] = useState(() => {
+    if (typeof window === "undefined") return false;
+    return window.matchMedia(DESKTOP_QUERY).matches;
+  });
+  const [drawerOpen, setDrawerOpen] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const mediaQuery = window.matchMedia(DESKTOP_QUERY);
+
+    const handleChange = (event: MediaQueryListEvent) => {
+      setIsDesktop(event.matches);
+      if (event.matches) {
+        setDrawerOpen(false);
+      }
+    };
+
+    setIsDesktop(mediaQuery.matches);
+    mediaQuery.addEventListener("change", handleChange);
+    return () => mediaQuery.removeEventListener("change", handleChange);
+  }, []);
+
+  const openDrawer = useCallback(() => setDrawerOpen(true), []);
+  const closeDrawer = useCallback(() => setDrawerOpen(false), []);
+
+  const contextValue = useMemo<AppShellContextValue>(
+    () => ({
+      isDesktop,
+      isDrawerOpen: drawerOpen,
+      openDrawer,
+      closeDrawer,
+      drawerId,
+    }),
+    [isDesktop, drawerOpen, openDrawer, closeDrawer, drawerId]
+  );
+
+  const overlay = !isDesktop && renderOverlayDrawer
+    ? renderOverlayDrawer({ open: drawerOpen, onClose: closeDrawer, drawerId })
+    : null;
+
+  const rootClass = ["app-shell", className].filter(Boolean).join(" ");
+  const mainClass = ["app-shell__main", contentClassName].filter(Boolean).join(" ");
+
+  return (
+    <AppShellContext.Provider value={contextValue}>
+      <div className={rootClass}>
+        <div className="app-shell__inner">
+          <aside
+            id={drawerId}
+            className="app-shell__drawer"
+            aria-label="Main navigation"
+            aria-hidden={!isDesktop}
+            data-state={isDesktop ? "open" : "closed"}
+          >
+            {drawer}
+          </aside>
+
+          <div className={mainClass}>{children}</div>
+        </div>
+        {overlay}
+      </div>
+    </AppShellContext.Provider>
+  );
+};
+
+export default AppShell;

--- a/frontend/src/features/dashboard/components/WelcomeHeader.tsx
+++ b/frontend/src/features/dashboard/components/WelcomeHeader.tsx
@@ -4,18 +4,19 @@ import { useData } from '@/app/contexts/useData';
 import { useNavigate } from 'react-router-dom';
 import { useOnlineStatus } from '@/app/contexts/OnlineStatusContext';
 import NotificationsDrawer from '../../../shared/ui/NotificationsDrawer';
-import NavigationDrawer from '../../../shared/ui/NavigationDrawer';
 import { useNotifications } from "../../../app/contexts/useNotifications";
 import NavBadge from "../../../shared/ui/NavBadge";
 import { GridPlus } from "../../../shared/icons/GridPlus";
 import GlobalSearch from './GlobalSearch';
 import './GlobalSearch.css';
 import { getFileUrl } from '../../../shared/utils/api';
+import { useAppShell } from '@/app/layout/AppShell';
 
 const WelcomeHeader: React.FC<{ userName?: string; setActiveView?: (view: string) => void }> = ({ userName: propUserName, setActiveView }) => {
   const { userData } = useData();
   const { isOnline } = useOnlineStatus(); // <-- only need this now
   const navigate = useNavigate();
+  const appShell = useAppShell();
 
   const userName = propUserName || userData?.firstName || userData?.email || 'User';
   const userThumbnail = userData?.thumbnail;
@@ -25,15 +26,16 @@ const WelcomeHeader: React.FC<{ userName?: string; setActiveView?: (view: string
   const [notificationsOpen, setNotificationsOpen] = useState(false);
   const [notificationsPinned, setNotificationsPinned] = useState(false);
 
-  // navigation drawer
-  const [navigationOpen, setNavigationOpen] = useState(false);
-
   // notifications count
   const { notifications } = useNotifications();
   const unreadNotifications = notifications.filter((n) => !n.read).length;
 
   // online status (derived from presenceChanged events via OnlineStatusContext)
   const isUserOnline = !!userId && isOnline(String(userId));
+
+  const drawerId = appShell?.drawerId;
+  const isDrawerOpen = appShell?.isDrawerOpen ?? false;
+  const showHamburger = !!setActiveView && !!appShell && !appShell.isDesktop;
 
   const [isMobile, setIsMobile] = useState(false);
   useEffect(() => {
@@ -46,7 +48,11 @@ const WelcomeHeader: React.FC<{ userName?: string; setActiveView?: (view: string
   const handleHomeClick = () => navigate('/');
   const handleNotificationsToggle = () => setNotificationsOpen(!notificationsOpen);
   const handleNotificationsPinToggle = () => setNotificationsPinned(!notificationsPinned);
-  const handleNavigationToggle = () => setNavigationOpen(!navigationOpen);
+  const handleNavigationToggle = () => {
+    if (appShell && !appShell.isDesktop) {
+      appShell.openDrawer();
+    }
+  };
 
   const handleAvatarKeyDown: React.KeyboardEventHandler<HTMLDivElement | SVGElement | HTMLImageElement> = (e) => {
     if (e.key === 'Enter' || e.key === ' ') {
@@ -108,17 +114,20 @@ const WelcomeHeader: React.FC<{ userName?: string; setActiveView?: (view: string
             </div>
           </div>
 
-          <div
-            className="header-icon-btn"
-            onClick={handleNavigationToggle}
-            role="button"
-            tabIndex={0}
-            aria-label="Open navigation menu"
-            onKeyDown={handleMenuKeyDown}
-            style={{ cursor: 'pointer' }}
-          >
-            <Menu size={isMobile ? 20 : 24} color="white" />
-          </div>
+          {showHamburger && (
+            <button
+              type="button"
+              className="header-icon-btn"
+              onClick={handleNavigationToggle}
+              aria-label="Open navigation menu"
+              aria-controls={drawerId}
+              aria-expanded={isDrawerOpen}
+              onKeyDown={handleMenuKeyDown}
+              style={{ cursor: 'pointer' }}
+            >
+              <Menu size={isMobile ? 20 : 24} color="white" />
+            </button>
+          )}
         </div>
 
         {/* Center: Global Search */}
@@ -209,14 +218,6 @@ const WelcomeHeader: React.FC<{ userName?: string; setActiveView?: (view: string
         pinned={notificationsPinned}
         onTogglePin={handleNotificationsPinToggle}
       />
-
-      {setActiveView && (
-        <NavigationDrawer
-          open={navigationOpen}
-          onClose={() => setNavigationOpen(false)}
-          setActiveView={setActiveView}
-        />
-      )}
     </>
   );
 };

--- a/frontend/src/features/dashboard/components/week-widget.css
+++ b/frontend/src/features/dashboard/components/week-widget.css
@@ -3,7 +3,7 @@
   margin:  0;
   background: var(--bg2, #111111);
   border: 2px solid rgba(255, 255, 255, 0.10);
-  border-radius: 20px;
+  border-radius: var(--radius-squircle, var(--radius-lg, 24px));
   overflow: visible;
   padding: 10px;
 }

--- a/frontend/src/features/dashboard/pages/DashboardHome.tsx
+++ b/frontend/src/features/dashboard/pages/DashboardHome.tsx
@@ -5,9 +5,7 @@ import { UserLite } from "@/app/contexts/DataProvider";
 import { slugify } from "@/shared/utils/slug";
 import { prefetchBudgetData } from "@/features/budget/context/useBudget";
 import WelcomeHeader from "@/features/dashboard/components/WelcomeHeader";
-import WelcomeWidget from "@/features/dashboard/components/WelcomeWidget";
 import TopBar from "@/features/dashboard/components/TopBar";
-
 import AllProjects from "@/features/dashboard/components/AllProjects";
 import ProjectsPanel from "@/features/dashboard/components/ProjectsPanel";
 import NotificationsPage from "@/features/dashboard/components/NotificationsPage";
@@ -16,8 +14,12 @@ import Settings from "@/features/dashboard/components/Settings";
 import Collaborators from "@/features/dashboard/components/Collaborators";
 import SpinnerScreen from "@/shared/ui/SpinnerScreen";
 import PendingApprovalScreen from "@/shared/ui/PendingApprovalScreen";
-import AllProjectsCalendar from "@/features/dashboard/components/AllProjectsCalendar";
 import AllProjectsWeekWidget from "@/features/dashboard/components/AllProjectsWeekWidget";
+import NavigationDrawer from "@/shared/ui/NavigationDrawer";
+import DashboardNavPanel from "@/shared/ui/DashboardNavPanel";
+import AppShell from "@/app/layout/AppShell";
+import ProjectsPanelDesktop from "@/features/projects/ProjectsPanelDesktop";
+import WeekWidgetCard from "@/features/schedule/WeekWidgetCard";
 
 import "./dashboard-styles.css";
 
@@ -61,9 +63,14 @@ const WelcomeScreen: React.FC = () => {
   const [activeView, setActiveView] = useState<string>(initialView);
   const [dmUserSlug, setDmUserSlug] = useState<string | null>(initialDMUserSlug);
   const [isMobile, setIsMobile] = useState(false);
+  const [isDesktop, setIsDesktop] = useState(false);
 
   useEffect(() => {
-    const handleResize = () => setIsMobile(window.innerWidth < 768);
+    const handleResize = () => {
+      const width = window.innerWidth;
+      setIsMobile(width < 768);
+      setIsDesktop(width >= 1280);
+    };
     if (typeof window !== "undefined") {
       handleResize();
       window.addEventListener("resize", handleResize);
@@ -139,66 +146,84 @@ const WelcomeScreen: React.FC = () => {
   const isFullWidthView = ["projects", "notifications", "messages", "settings", "collaborators"].includes(
     activeView
   );
-  const showTopBar = !isFullWidthView;
+  const showTopBar = !isFullWidthView && !isDesktop; // TODO: Remove legacy desktop bento tiles after mobile parity update.
+
+  const renderWelcomeView = () => {
+    if (isDesktop) {
+      return (
+        <div className="dashboard-home-grid">
+          <ProjectsPanelDesktop
+            onOpenProject={(projectId) => handleNavigateToProject({ projectId })}
+          />
+          <WeekWidgetCard />
+        </div>
+      );
+    }
+
+    return (
+      <div className="mobile-welcome-layout">
+        <div className="mobile-projects-section">
+          <ProjectsPanel
+            onOpenProject={(projectId) => handleNavigateToProject({ projectId })}
+          />
+        </div>
+        <div className="mobile-calendar-section">
+          <AllProjectsWeekWidget />
+        </div>
+      </div>
+    );
+  };
+
+  const renderActiveView = () => {
+    switch (activeView) {
+      case "welcome":
+        return renderWelcomeView();
+      case "projects":
+        return <AllProjects />;
+      case "notifications":
+        return (
+          <NotificationsPage
+            onNavigateToProject={(projectId: string) =>
+              handleNavigateToProject({ projectId })
+            }
+          />
+        );
+      case "messages":
+        return <Messages initialUserSlug={dmUserSlug || undefined} />;
+      case "settings":
+        return <Settings />;
+      case "collaborators":
+        return <Collaborators />;
+      default:
+        return null;
+    }
+  };
 
   return (
-    <div className="dashboard-wrapper welcome-screen no-vertical-center">
-      <WelcomeHeader userName={userName} setActiveView={setActiveView} />
+    <AppShell
+      drawer={<DashboardNavPanel variant="persistent" setActiveView={setActiveView} />}
+      renderOverlayDrawer={({ open, onClose }) => (
+        <NavigationDrawer open={open} onClose={onClose} setActiveView={setActiveView} />
+      )}
+    >
+      <div className="dashboard-wrapper welcome-screen no-vertical-center">
+        <WelcomeHeader userName={userName} setActiveView={setActiveView} />
 
-      <div className="row-layout">
-        <div className="welcome-screen-details">
-          {showTopBar && !isMobile && <TopBar setActiveView={setActiveView} />}
+        <div className="row-layout">
+          <div className="welcome-screen-details">
+            {showTopBar && !isMobile && <TopBar setActiveView={setActiveView} />}
 
-          <div
-            className={`dashboard-content ${
-              isFullWidthView ? "full-width" : ""
-            }`}
-          >
-            {!isFullWidthView && (
-              <div className="quickstats-sidebar">
-                <WelcomeWidget
-                  setActiveView={setActiveView}
-                  setDmUserSlug={setDmUserSlug}
-                />
-              </div>
-            )}
-
-            <div className="main-content">
-              {{
-                welcome: isMobile ? (
-                  <>
-                    {/* DashboardHome.tsx (mobile welcome layout) */}
-                    <div className="mobile-welcome-layout">
-                      <div className="mobile-projects-section">
-                        <ProjectsPanel onOpenProject={(projectId) => handleNavigateToProject({ projectId })} />
-                      </div>
-                      <div className="mobile-calendar-section">
-                        <AllProjectsWeekWidget />
-                      </div>
-                    </div>
-                  </>
-                ) : (
-                  <AllProjectsCalendar />
-                ),
-                projects: <AllProjects />,
-                notifications: (
-                  <NotificationsPage
-                    onNavigateToProject={(projectId: string) =>
-                      handleNavigateToProject({ projectId })
-                    }
-                  />
-                ),
-                messages: (
-                  <Messages initialUserSlug={dmUserSlug || undefined} />
-                ),
-                settings: <Settings />,
-                collaborators: <Collaborators />,
-              }[activeView] || null}
+            <div
+              className={`dashboard-content ${
+                isFullWidthView ? "full-width" : ""
+              }`}
+            >
+              <div className="main-content">{renderActiveView()}</div>
             </div>
           </div>
         </div>
       </div>
-    </div>
+    </AppShell>
   );
 };
 

--- a/frontend/src/features/projects/ProjectsPanelDesktop.module.css
+++ b/frontend/src/features/projects/ProjectsPanelDesktop.module.css
@@ -1,0 +1,204 @@
+.card {
+  background: var(--bg, #0c0c0c);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--radius-squircle, var(--radius-lg, 24px));
+  color: rgba(255, 255, 255, 0.92);
+  padding: var(--space-3, 24px);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2, 16px);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.35);
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2, 16px);
+}
+
+.headerTop {
+  display: flex;
+  gap: var(--space-2, 16px);
+  align-items: flex-start;
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+
+.viewToggle {
+  display: inline-flex;
+  align-items: center;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 999px;
+  padding: 4px;
+  gap: 4px;
+}
+
+.toggleButton {
+  border: none;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.72);
+  font-size: 13px;
+  font-weight: 600;
+  padding: 6px 14px;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.toggleButton[aria-pressed="true"] {
+  background: rgba(250, 51, 86, 0.18);
+  color: #fff;
+}
+
+.tableWrap {
+  overflow-x: auto;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 640px;
+}
+
+.table th,
+.table td {
+  text-align: left;
+  padding: 12px 16px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  font-size: 14px;
+  vertical-align: middle;
+}
+
+.table th {
+  font-size: 12px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.table tbody tr {
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.table tbody tr:hover,
+.table tbody tr:focus-within {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.projectCell {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.thumb {
+  width: 38px;
+  height: 38px;
+  border-radius: 12px;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.08);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.projectName {
+  font-weight: 600;
+  color: inherit;
+}
+
+.statusBadge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.9);
+  font-size: 12px;
+  font-weight: 600;
+  min-width: 48px;
+}
+
+.deadline {
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.owner {
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.unreadPill {
+  display: inline-flex;
+  min-width: 36px;
+  justify-content: center;
+  padding: 4px 12px;
+  border-radius: 999px;
+  background: rgba(250, 51, 86, 0.18);
+  color: #fff;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.emptyState,
+.errorState {
+  padding: 24px 0;
+  text-align: center;
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.footer {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.footerButton {
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: transparent;
+  color: rgba(255, 255, 255, 0.9);
+  font-weight: 600;
+  padding: 8px 18px;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.footerButton:hover {
+  background: rgba(250, 51, 86, 0.18);
+  border-color: rgba(250, 51, 86, 0.6);
+  color: #fff;
+}
+
+.gridWrap {
+  border-radius: var(--radius-squircle, var(--radius-lg, 24px));
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  padding: var(--space-2, 16px);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.gridWrap :global(.list) {
+  max-height: none;
+}
+
+.gridWrap :global(.row) {
+  border-radius: 12px;
+}
+
+.gridWrap :global(.listScrollable) {
+  max-height: 420px;
+}
+
+@media (max-width: 1440px) {
+  .table {
+    min-width: 560px;
+  }
+}

--- a/frontend/src/features/projects/ProjectsPanelDesktop.tsx
+++ b/frontend/src/features/projects/ProjectsPanelDesktop.tsx
@@ -1,0 +1,626 @@
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { useNavigate } from "react-router-dom";
+import { ChevronDown } from "lucide-react";
+import { useData } from "@/app/contexts/useData";
+import type { UserLite } from "@/app/contexts/DataProvider";
+import { useProjectKpis, type ProjectLike } from "@/features/dashboard/hooks/useProjectKpis";
+import SVGThumbnail from "@/features/dashboard/components/SvgThumbnail";
+import { Kebab } from "@/shared/icons/Kebab";
+import { getFileUrl } from "@/shared/utils/api";
+import desktopStyles from "./ProjectsPanelDesktop.module.css";
+import mobileStyles from "@/features/dashboard/components/projects-panel.module.css";
+
+const DEFAULT_DESKTOP_ROWS = 6;
+
+export type ProjectsPanelDesktopProps = {
+  onOpenProject?: (projectId: string) => void;
+};
+
+type SortOption = "titleAsc" | "titleDesc" | "dateNewest" | "dateOldest";
+
+type ProjectWithMeta = ProjectLike & {
+  _activity: number;
+  _created: number;
+  team?: Array<{ userId?: string; firstName?: string; lastName?: string; email?: string }>;
+  unreadCount?: number;
+};
+
+const formatShortDate = (iso?: string): string | undefined => {
+  if (!iso) return undefined;
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return undefined;
+  return d.toLocaleString(undefined, { month: "short", day: "numeric" });
+};
+
+const getProjectActivityTs = (p: ProjectLike): number => {
+  const candidates: (string | undefined)[] = [
+    p.updatedAt,
+    p.dateUpdated,
+    p.lastModified,
+    p.date,
+    p.dateCreated,
+  ];
+  if (Array.isArray(p.timelineEvents)) {
+    for (const ev of p.timelineEvents) {
+      if (ev?.timestamp) candidates.push(ev.timestamp);
+      if (ev?.date) candidates.push(ev.date);
+    }
+  }
+  const timestamps = candidates
+    .filter(Boolean)
+    .map((s) => new Date(s as string).getTime())
+    .filter((n) => Number.isFinite(n));
+  return timestamps.length ? Math.max(...timestamps) : 0;
+};
+
+function sanitizeId(raw: string) {
+  return raw.replace(/[^a-zA-Z0-9_-]/g, "");
+}
+
+const ProjectsPanelDesktop: React.FC<ProjectsPanelDesktopProps> = ({ onOpenProject }) => {
+  const {
+    projects = [],
+    isLoading,
+    projectsError,
+    fetchProjects,
+    allUsers,
+  } = useData() as {
+    projects: ProjectLike[];
+    isLoading: boolean;
+    projectsError: boolean;
+    fetchProjects: () => Promise<void> | void;
+    allUsers: UserLite[];
+  };
+  const navigate = useNavigate();
+
+  const [menuOpenId, setMenuOpenId] = useState<string | null>(null);
+  const menuRefs = useRef<Record<string, HTMLDivElement | null>>({});
+  const [imgError, setImgError] = useState<Record<string, boolean>>({});
+  const [filtersOpen, setFiltersOpen] = useState(false);
+  const filtersRef = useRef<HTMLDivElement | null>(null);
+  const filtersIdRef = useRef(`projects-filters-${sanitizeId(Math.random().toString(36).slice(2))}`);
+
+  const [sortOption, setSortOption] = useState<SortOption>("dateNewest");
+  const [statusFilter, setStatusFilter] = useState<string>("");
+  const [query, setQuery] = useState<string>("");
+  const [scope, setScope] = useState<"recents" | "all">("recents");
+  const [viewMode, setViewMode] = useState<"table" | "grid">("table");
+
+  useEffect(() => {
+    if (!isLoading && projects.length === 0 && !projectsError) {
+      fetchProjects();
+    }
+  }, [isLoading, projects.length, projectsError, fetchProjects]);
+
+  useEffect(() => {
+    const onDocClick = (e: MouseEvent) => {
+      if (!menuOpenId) return;
+      const el = menuRefs.current[menuOpenId];
+      if (el && e.target instanceof Node && !el.contains(e.target)) {
+        setMenuOpenId(null);
+      }
+    };
+    document.addEventListener("click", onDocClick);
+    return () => document.removeEventListener("click", onDocClick);
+  }, [menuOpenId]);
+
+  useEffect(() => {
+    const onDocClick = (e: MouseEvent) => {
+      if (!filtersOpen) return;
+      if (
+        filtersRef.current &&
+        e.target instanceof Node &&
+        !filtersRef.current.contains(e.target)
+      ) {
+        setFiltersOpen(false);
+      }
+    };
+    document.addEventListener("click", onDocClick);
+    return () => document.removeEventListener("click", onDocClick);
+  }, [filtersOpen]);
+
+  const statuses = useMemo(() => {
+    try {
+      return Array.from(
+        new Set(
+          projects
+            .map((p) => String(p.status || "").toLowerCase())
+            .filter(Boolean)
+        )
+      );
+    } catch {
+      return [] as string[];
+    }
+  }, [projects]);
+
+  const items = useMemo(() => {
+    const list: ProjectWithMeta[] = (projects as ProjectLike[]).map((p) => ({
+      ...(p as ProjectWithMeta),
+      _activity: getProjectActivityTs(p),
+      _created: new Date(p.dateCreated || p.date || 0).getTime() || 0,
+    }));
+
+    let ordered = list.slice();
+    if (scope === "recents") {
+      ordered.sort((a, b) => b._activity - a._activity);
+    }
+
+    const q = query.trim().toLowerCase();
+    if (q) {
+      ordered = ordered.filter((p) => (p.title || "").toLowerCase().includes(q));
+    }
+    if (statusFilter) {
+      ordered = ordered.filter(
+        (p) => String(p.status || "").toLowerCase() === statusFilter
+      );
+    }
+
+    const byTitle = (a: ProjectLike, b: ProjectLike) =>
+      (a.title || "").localeCompare(b.title || "", undefined, {
+        sensitivity: "base",
+      });
+    const byCreated = (a: ProjectWithMeta, b: ProjectWithMeta) => b._created - a._created;
+    const byCreatedAsc = (a: ProjectWithMeta, b: ProjectWithMeta) => a._created - b._created;
+
+    switch (sortOption) {
+      case "titleAsc":
+        ordered.sort(byTitle);
+        break;
+      case "titleDesc":
+        ordered.sort((a, b) => -byTitle(a, b));
+        break;
+      case "dateOldest":
+        ordered.sort(byCreatedAsc);
+        break;
+      case "dateNewest":
+      default:
+        ordered.sort(byCreated);
+        break;
+    }
+
+    if (scope === "recents") {
+      return ordered.slice(0, DEFAULT_DESKTOP_ROWS);
+    }
+    return ordered;
+  }, [projects, scope, query, statusFilter, sortOption]);
+
+  const kpis = useProjectKpis(projects as ProjectLike[]);
+
+  const usersById = useMemo(() => {
+    const map = new Map<string, UserLite>();
+    (Array.isArray(allUsers) ? allUsers : []).forEach((u: UserLite) => {
+      if (u?.userId) map.set(u.userId, u);
+    });
+    return map;
+  }, [allUsers]);
+
+  const handleOpen = useCallback(
+    (projectId: string) => {
+      if (onOpenProject) {
+        onOpenProject(projectId);
+      } else {
+        navigate("/dashboard/projects");
+      }
+    },
+    [onOpenProject, navigate]
+  );
+
+  const handleRowKeyDown = (e: React.KeyboardEvent<HTMLTableRowElement>, id: string) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      handleOpen(id);
+    }
+  };
+
+  const toggleMenu = (id: string) =>
+    setMenuOpenId((prev) => (prev === id ? null : id));
+
+  const onAction = (
+    action: "open" | "pin" | "unpin" | "archive",
+    id: string
+  ) => {
+    if (action === "open") {
+      handleOpen(id);
+    }
+    console.log(`Project ${id}: ${action}`);
+    setMenuOpenId(null);
+  };
+
+  const getOwnerName = (project: ProjectWithMeta): string => {
+    const team = Array.isArray(project.team) ? project.team : [];
+    if (team.length === 0) return "—";
+    const primary = team[0];
+    const user = primary?.userId ? usersById.get(primary.userId) : undefined;
+    const first = user?.firstName ?? primary?.firstName ?? "";
+    const last = user?.lastName ?? primary?.lastName ?? "";
+    const full = `${first} ${last}`.trim();
+    if (full) return full;
+    return user?.email || user?.username || primary?.email || primary?.userId || "—";
+  };
+
+  const renderIconsStrip = () => {
+    const allProjects = projects as ProjectLike[];
+    const maxIcons = 7;
+    const shown = allProjects.slice(0, maxIcons);
+    const more = Math.max(0, allProjects.length - shown.length);
+
+    return (
+      <div className={mobileStyles.iconsStrip} aria-label="Quick projects">
+        {shown.map((p) => {
+          const id = p.projectId;
+          const title = (p.title || "Untitled project").trim();
+          const thumb = Array.isArray(p.thumbnails) && p.thumbnails[0] ? p.thumbnails[0] : undefined;
+          return (
+            <button
+              key={`icon-${id}`}
+              type="button"
+              className={mobileStyles.iconBtnSm}
+              aria-label={`Open project ${title}`}
+              title={title}
+              onClick={() => handleOpen(id)}
+            >
+              {thumb && !imgError[id] ? (
+                <img
+                  className={mobileStyles.thumbSm}
+                  src={getFileUrl(thumb)}
+                  alt=""
+                  onError={() => setImgError((m) => ({ ...m, [id]: true }))}
+                />
+              ) : (
+                <SVGThumbnail
+                  initial={title.charAt(0).toUpperCase() || "#"}
+                  className={mobileStyles.thumbSm}
+                />
+              )}
+            </button>
+          );
+        })}
+        {more > 0 && (
+          <span className={mobileStyles.iconsMore} aria-hidden>
+            +{more}
+          </span>
+        )}
+      </div>
+    );
+  };
+
+  const tableRows = items.map((p) => {
+    const id = p.projectId;
+    const title = (p.title || "Untitled project").trim();
+    const thumb = Array.isArray(p.thumbnails) && p.thumbnails[0] ? p.thumbnails[0] : undefined;
+    const deadline = formatShortDate(p.finishline);
+    const status = p.status ? String(p.status) : "—";
+    const unread = Number.isFinite(p.unreadCount as number) ? Number(p.unreadCount) : Number((p as { unreadCount?: number }).unreadCount ?? 0);
+    const owner = getOwnerName(p);
+
+    return (
+      <tr
+        key={id}
+        tabIndex={0}
+        onClick={() => handleOpen(id)}
+        onKeyDown={(event) => handleRowKeyDown(event, id)}
+        aria-label={`Open project ${title}`}
+      >
+        <td>
+          <div className={desktopStyles.projectCell}>
+            <span className={desktopStyles.thumb} aria-hidden>
+              {thumb && !imgError[id] ? (
+                <img
+                  className={mobileStyles.thumb}
+                  src={getFileUrl(thumb)}
+                  alt=""
+                  onError={() => setImgError((m) => ({ ...m, [id]: true }))}
+                />
+              ) : (
+                <SVGThumbnail
+                  initial={title.charAt(0).toUpperCase() || "#"}
+                  className={mobileStyles.thumb}
+                />
+              )}
+            </span>
+            <span className={desktopStyles.projectName}>{title}</span>
+          </div>
+        </td>
+        <td>
+          <span className={desktopStyles.statusBadge}>{status}</span>
+        </td>
+        <td>
+          <span className={desktopStyles.deadline}>{deadline ?? "—"}</span>
+        </td>
+        <td>
+          <span className={desktopStyles.owner}>{owner}</span>
+        </td>
+        <td>
+          <span className={desktopStyles.unreadPill}>{unread}</span>
+        </td>
+      </tr>
+    );
+  });
+
+  const renderGrid = () => (
+    <div className={desktopStyles.gridWrap}>
+      <div
+        className={`${mobileStyles.list} ${
+          scope === "all" ? mobileStyles.listScrollable : ""
+        }`}
+        role="list"
+      >
+        {items.map((p) => {
+          const dateIso =
+            p.updatedAt || p.dateUpdated || p.lastModified || p.date || p.dateCreated;
+          const dateLabel = formatShortDate(dateIso);
+          const id = p.projectId;
+          const title = (p.title || "Untitled project").trim();
+          const isMenuOpen = menuOpenId === id;
+          const thumb = Array.isArray(p.thumbnails) && p.thumbnails[0] ? p.thumbnails[0] : undefined;
+          const onKey = (e: React.KeyboardEvent) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              handleOpen(id);
+            }
+          };
+          return (
+            <div key={id} className={mobileStyles.row} role="listitem">
+              <div
+                className={mobileStyles.rowMain}
+                role="button"
+                tabIndex={0}
+                onClick={() => handleOpen(id)}
+                onKeyDown={onKey}
+                aria-label={`Open project ${title}`}
+              >
+                <div className={mobileStyles.icon} aria-hidden>
+                  {thumb && !imgError[id] ? (
+                    <img
+                      className={mobileStyles.thumb}
+                      src={getFileUrl(thumb)}
+                      alt=""
+                      onError={() => setImgError((m) => ({ ...m, [id]: true }))}
+                    />
+                  ) : (
+                    <SVGThumbnail
+                      initial={title.charAt(0).toUpperCase() || "#"}
+                      className={mobileStyles.thumb}
+                    />
+                  )}
+                </div>
+                <div className={mobileStyles.meta}>
+                  <div className={mobileStyles.titleRow}>
+                    <div className={mobileStyles.titleLeft}>
+                      <span className={mobileStyles.name}>{title}</span>
+                    </div>
+                    {dateLabel ? (
+                      <span className={mobileStyles.dateInline}>{dateLabel}</span>
+                    ) : null}
+                  </div>
+                </div>
+              </div>
+
+              <div
+                className={`${mobileStyles.menu} ${
+                  isMenuOpen ? mobileStyles.menuOpen : ""
+                }`}
+                ref={(el) => {
+                  menuRefs.current[id] = el;
+                }}
+              >
+                <button
+                  type="button"
+                  className={mobileStyles.menuBtn}
+                  aria-label="Project actions"
+                  aria-haspopup="menu"
+                  aria-expanded={isMenuOpen}
+                  onClick={() => toggleMenu(id)}
+                >
+                  <Kebab size={20} aria-hidden />
+                </button>
+                {isMenuOpen && (
+                  <div className={mobileStyles.menuPop} role="menu">
+                    <button
+                      className={mobileStyles.menuItem}
+                      role="menuitem"
+                      onClick={() => onAction("open", id)}
+                    >
+                      Open
+                    </button>
+                    <button
+                      className={mobileStyles.menuItem}
+                      role="menuitem"
+                      onClick={() => onAction("pin", id)}
+                    >
+                      Pin
+                    </button>
+                    <button
+                      className={mobileStyles.menuItem}
+                      role="menuitem"
+                      onClick={() => onAction("archive", id)}
+                    >
+                      Archive
+                    </button>
+                  </div>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+
+  const errorText = projectsError ? "Failed to load projects." : undefined;
+
+  return (
+    <section aria-label="Projects overview" className={desktopStyles.card}>
+      <header className={desktopStyles.header}>
+        <div className={desktopStyles.headerTop}>
+          <div className={mobileStyles.titleWrap}>
+            <h3 className={mobileStyles.title}>Projects</h3>
+            {renderIconsStrip()}
+          </div>
+          <div className={desktopStyles.viewToggle} role="group" aria-label="Select projects layout">
+            <button
+              type="button"
+              className={desktopStyles.toggleButton}
+              aria-pressed={viewMode === "table"}
+              onClick={() => setViewMode("table")}
+              aria-label="Show projects table"
+            >
+              Table
+            </button>
+            <button
+              type="button"
+              className={desktopStyles.toggleButton}
+              aria-pressed={viewMode === "grid"}
+              onClick={() => setViewMode("grid")}
+              aria-label="Show project cards"
+            >
+              Cards
+            </button>
+          </div>
+        </div>
+
+        <div className={mobileStyles.recentsWrap} ref={filtersRef}>
+          <button
+            type="button"
+            className={mobileStyles.recents}
+            aria-expanded={filtersOpen}
+            aria-haspopup="menu"
+            aria-controls={filtersIdRef.current}
+            onClick={() => setFiltersOpen((v) => !v)}
+          >
+            {scope === "recents" ? "Recents" : "All projects"} <ChevronDown size={14} aria-hidden />
+          </button>
+          {filtersOpen && (
+            <div className={mobileStyles.filterPop} role="menu" id={filtersIdRef.current}>
+              <div className={mobileStyles.filterSection}>
+                <div
+                  className={mobileStyles.scopeBtns}
+                  role="group"
+                  aria-label="Scope"
+                >
+                  <button
+                    type="button"
+                    className={`${mobileStyles.scopeBtn} ${
+                      scope === "recents" ? mobileStyles.scopeBtnActive : ""
+                    }`}
+                    onClick={() => setScope("recents")}
+                  >
+                    Recents
+                  </button>
+                  <button
+                    type="button"
+                    className={`${mobileStyles.scopeBtn} ${
+                      scope === "all" ? mobileStyles.scopeBtnActive : ""
+                    }`}
+                    onClick={() => setScope("all")}
+                  >
+                    All projects
+                  </button>
+                </div>
+
+                <input
+                  className={mobileStyles.input}
+                  placeholder="Filter projects..."
+                  value={query}
+                  onChange={(e) => setQuery(e.target.value)}
+                  aria-label="Filter projects"
+                />
+
+                {statuses.length > 0 && (
+                  <select
+                    className={mobileStyles.select}
+                    value={statusFilter}
+                    onChange={(e) => setStatusFilter(e.target.value)}
+                    aria-label="Filter by status"
+                  >
+                    <option value="">All statuses</option>
+                    {statuses.map((s) => (
+                      <option key={s} value={s}>
+                        {s}
+                      </option>
+                    ))}
+                  </select>
+                )}
+
+                <select
+                  className={mobileStyles.select}
+                  value={sortOption}
+                  onChange={(e) => setSortOption(e.target.value as SortOption)}
+                  aria-label="Sort projects"
+                >
+                  <option value="titleAsc">Title (A-Z)</option>
+                  <option value="titleDesc">Title (Z-A)</option>
+                  <option value="dateNewest">Date (Newest)</option>
+                  <option value="dateOldest">Date (Oldest)</option>
+                </select>
+              </div>
+            </div>
+          )}
+        </div>
+
+        <div className={mobileStyles.kpis}>
+          <span className={mobileStyles.chip}>{kpis.totalProjects} Projects</span>
+          <span className={mobileStyles.dot} />
+          <span className={mobileStyles.chip}>{kpis.pendingProjects} Pending</span>
+          <span className={mobileStyles.dot} />
+          <span className={mobileStyles.chip}>
+            {kpis.nextProject
+              ? `Next: ${kpis.nextProject.title} ${kpis.nextProject.date}`
+              : "No upcoming projects"}
+          </span>
+        </div>
+      </header>
+
+      {errorText && <div className={desktopStyles.errorState}>{errorText}</div>}
+
+      {!errorText && viewMode === "table" && (
+        <div className={desktopStyles.tableWrap}>
+          {isLoading ? (
+            <div className={desktopStyles.emptyState}>Loading projects…</div>
+          ) : items.length === 0 ? (
+            <div className={desktopStyles.emptyState}>No projects match filters.</div>
+          ) : (
+            <table className={desktopStyles.table} aria-label="Projects table">
+              <thead>
+                <tr>
+                  <th scope="col">Project</th>
+                  <th scope="col">Status</th>
+                  <th scope="col">Deadline</th>
+                  <th scope="col">Owner</th>
+                  <th scope="col">Unread</th>
+                </tr>
+              </thead>
+              <tbody>{tableRows}</tbody>
+            </table>
+          )}
+        </div>
+      )}
+
+      {!errorText && viewMode === "grid" && (isLoading ? (
+        <div className={desktopStyles.emptyState}>Loading projects…</div>
+      ) : items.length === 0 ? (
+        <div className={desktopStyles.emptyState}>No projects match filters.</div>
+      ) : (
+        renderGrid()
+      ))}
+
+      <div className={desktopStyles.footer}>
+        <button
+          type="button"
+          className={desktopStyles.footerButton}
+          onClick={() => navigate("/dashboard/projects")}
+        >
+          See all projects
+        </button>
+      </div>
+    </section>
+  );
+};
+
+export default ProjectsPanelDesktop;

--- a/frontend/src/features/schedule/WeekWidgetCard.module.css
+++ b/frontend/src/features/schedule/WeekWidgetCard.module.css
@@ -1,0 +1,53 @@
+.card {
+  background: var(--bg, #0c0c0c);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--radius-squircle, var(--radius-lg, 24px));
+  color: rgba(255, 255, 255, 0.92);
+  padding: var(--space-3, 24px);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2, 16px);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.35);
+}
+
+.header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-2, 16px);
+}
+
+.titleWrap {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.title {
+  font-size: 18px;
+  font-weight: 600;
+  margin: 0;
+}
+
+.subtitle {
+  margin: 0;
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.morePill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: rgba(250, 51, 86, 0.18);
+  color: #fff;
+  font-size: 12px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.widget {
+  margin-top: 8px;
+}

--- a/frontend/src/features/schedule/WeekWidgetCard.tsx
+++ b/frontend/src/features/schedule/WeekWidgetCard.tsx
@@ -1,0 +1,127 @@
+import React, { useMemo, useState } from "react";
+import WeekWidget, { type Track, type Dot } from "@/features/dashboard/components/WeekWidget";
+import { useData } from "@/app/contexts/useData";
+import { getColor } from "@/shared/utils/colorUtils";
+import styles from "./WeekWidgetCard.module.css";
+
+type TimelineEvent = { date?: string; description?: string; [k: string]: unknown };
+type Project = {
+  projectId: string;
+  title?: string;
+  color?: string;
+  dateCreated?: string;
+  finishline?: string;
+  timelineEvents?: TimelineEvent[];
+};
+
+const MAX_VISIBLE_TRACKS = 3;
+
+type WeekWidgetCardProps = {
+  className?: string;
+};
+
+function toDay(d?: string | Date | number) {
+  if (!d) return null;
+  const v = d instanceof Date ? d : new Date(d);
+  return Number.isNaN(v.getTime()) ? null : new Date(v.getFullYear(), v.getMonth(), v.getDate());
+}
+
+function sameDay(a: Date | null, b: Date | null) {
+  return !!(a && b) &&
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate();
+}
+
+const WeekWidgetCard: React.FC<WeekWidgetCardProps> = ({ className }) => {
+  const { projects = [] } = useData() as { projects: Project[] };
+  const [weekOf, setWeekOf] = useState<Date>(new Date());
+
+  const colorMap = useMemo(() => {
+    const m: Record<string, string> = {};
+    for (const p of projects) m[p.projectId] = p.color || getColor(p.projectId);
+    return m;
+  }, [projects]);
+
+  const tracks: Track[] = useMemo(() => {
+    return projects
+      .map((p) => {
+        const start = toDay(p.dateCreated);
+        const end = toDay(p.finishline);
+        if (!start || !end || end < start) return null;
+        return { id: p.projectId, color: colorMap[p.projectId] || "#FA3356", start, end };
+      })
+      .filter(Boolean) as Track[];
+  }, [projects, colorMap]);
+
+  const dots: Dot[] = useMemo(() => {
+    const out: Dot[] = [];
+    for (const p of projects) {
+      for (const ev of p.timelineEvents ?? []) {
+        const d = toDay(ev.date);
+        if (d) out.push({ date: d, color: colorMap[p.projectId] || "#FA3356" });
+      }
+    }
+    return out;
+  }, [projects, colorMap]);
+
+  const moreCount = Math.max(0, tracks.length - MAX_VISIBLE_TRACKS);
+
+  const getTooltipItems = (date: Date) => {
+    const day = toDay(date)!;
+    const items: { id: string; title?: string; color?: string; note?: string }[] = [];
+
+    for (const p of projects) {
+      const color = colorMap[p.projectId] || "#FA3356";
+      const start = toDay(p.dateCreated);
+      const end = toDay(p.finishline);
+
+      if (start && end && day >= start && day <= end) {
+        items.push({ id: p.projectId, title: p.title || p.projectId, color });
+      }
+      for (const ev of p.timelineEvents ?? []) {
+        const d = toDay(ev.date);
+        if (sameDay(d, day)) {
+          const note = (ev.description as string) || undefined;
+          const hit = items.find((i) => i.id === p.projectId);
+          if (hit) hit.note ??= note;
+          else items.push({ id: p.projectId, title: p.title || p.projectId, color, note });
+        }
+      }
+    }
+    return items;
+  };
+
+  return (
+    <section className={`${styles.card} ${className ?? ""}`.trim()} aria-label="Week overview">
+      <header className={styles.header}>
+        <div className={styles.titleWrap}>
+          <h3 className={styles.title}>This Week</h3>
+          <p className={styles.subtitle}>Timeline snapshots across your projects.</p>
+        </div>
+        {moreCount > 0 && (
+          <span
+            className={styles.morePill}
+            aria-label={`${moreCount} more active projects this week`}
+          >
+            +{moreCount} more
+          </span>
+        )}
+      </header>
+
+      <WeekWidget
+        weekOf={weekOf}
+        tracks={tracks}
+        dots={dots}
+        className={styles.widget}
+        onPrevWeek={(d) => setWeekOf(d)}
+        onNextWeek={(d) => setWeekOf(d)}
+        onSelectDate={(d) => setWeekOf(d)}
+        getTooltipItems={getTooltipItems}
+        isMobile
+      />
+    </section>
+  );
+};
+
+export default WeekWidgetCard;

--- a/frontend/src/shared/styles/index.css
+++ b/frontend/src/shared/styles/index.css
@@ -12,6 +12,7 @@
 @import './base/reset.css';
 
 /* Layout Styles */
+@import './layout.css';
 @import './layouts/dashboard.css';
 @import './layouts/marketing.css';
 

--- a/frontend/src/shared/styles/layout.css
+++ b/frontend/src/shared/styles/layout.css
@@ -1,0 +1,90 @@
+.app-shell {
+  min-height: 100vh;
+  background: var(--bg, #0c0c0c);
+  color: rgba(255, 255, 255, 0.92);
+}
+
+.app-shell__inner {
+  display: flex;
+  min-height: 100vh;
+}
+
+.app-shell__drawer {
+  display: none;
+  width: 280px;
+  background: rgba(12, 12, 12, 0.94);
+  border-right: 1px solid rgba(255, 255, 255, 0.08);
+  padding: var(--space-3, 24px) 0;
+  box-shadow: inset -1px 0 0 rgba(255, 255, 255, 0.06);
+}
+
+@media (min-width: 1280px) {
+  .app-shell__drawer {
+    display: flex;
+    flex-direction: column;
+    position: sticky;
+    top: 0;
+    height: 100vh;
+    overflow-y: auto;
+  }
+}
+
+.app-shell__main {
+  flex: 1;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.dashboard-nav-panel {
+  width: 100%;
+}
+
+.dashboard-nav-panel__logo {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.32);
+  background: transparent;
+  color: #fff;
+  font-weight: 700;
+  font-size: 18px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.dashboard-nav-panel__logo:hover {
+  border-color: var(--brand, #FA3356);
+}
+
+.dashboard-nav-panel--persistent .navigation-drawer-header {
+  padding: 24px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.dashboard-nav-panel--persistent .navigation-drawer-content {
+  padding: 16px 0 24px;
+  gap: 16px;
+}
+
+.dashboard-nav-panel--persistent .navigation-items,
+.dashboard-nav-panel--persistent .navigation-items-bottom {
+  padding: 0 24px;
+}
+
+.dashboard-home-grid {
+  display: grid;
+  gap: var(--space-3, 24px);
+}
+
+.dashboard-home-grid > * {
+  width: 100%;
+}
+
+@media (min-width: 1280px) {
+  .dashboard-home-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}

--- a/frontend/src/shared/ui/DashboardNavPanel.tsx
+++ b/frontend/src/shared/ui/DashboardNavPanel.tsx
@@ -1,0 +1,114 @@
+import React from "react";
+import { X } from "lucide-react";
+import NavBadge from "./NavBadge";
+import useDashboardNavigation, {
+  type DashboardNavItem,
+  type UseDashboardNavigationArgs,
+} from "./useDashboardNavigation";
+import "./navigation-drawer.css";
+
+type Variant = "persistent" | "overlay";
+
+type DashboardNavPanelProps = UseDashboardNavigationArgs & {
+  variant?: Variant;
+  className?: string;
+};
+
+function renderNavItem(item: DashboardNavItem) {
+  const hasBadge = typeof item.badgeCount === "number" && item.badgeCount > 0 && item.badgeLabel;
+  const inner = (
+    <>
+      <div className="nav-drawer-icon" aria-hidden>
+        {item.icon}
+        {hasBadge ? (
+          <NavBadge
+            count={item.badgeCount ?? 0}
+            label={item.badgeLabel ?? "item"}
+            className="nav-drawer-badge"
+          />
+        ) : null}
+      </div>
+      <span className="nav-drawer-label">{item.label}</span>
+    </>
+  );
+
+  if (item.href) {
+    return (
+      <a
+        key={item.key}
+        className={`nav-drawer-item ${item.isAction ? "nav-drawer-action" : ""}`.trim()}
+        href={item.href}
+        target={item.external ? "_blank" : undefined}
+        rel={item.external ? "noopener noreferrer" : undefined}
+        onClick={item.onClick}
+      >
+        {inner}
+      </a>
+    );
+  }
+
+  return (
+    <button
+      key={item.key}
+      type="button"
+      className={`nav-drawer-item ${item.isAction ? "nav-drawer-action" : ""}`.trim()}
+      onClick={item.onClick}
+    >
+      {inner}
+    </button>
+  );
+}
+
+const DashboardNavPanel: React.FC<DashboardNavPanelProps> = ({
+  setActiveView,
+  onClose,
+  variant = "persistent",
+  className,
+}) => {
+  const { navItems, bottomItems, handleLogoClick } = useDashboardNavigation({ setActiveView, onClose });
+  const showClose = variant === "overlay";
+
+  const containerClass = [
+    "dashboard-nav-panel",
+    `dashboard-nav-panel--${variant}`,
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <div className={containerClass}>
+      <div className="navigation-drawer-header">
+        <button
+          type="button"
+          className="dashboard-nav-panel__logo"
+          onClick={handleLogoClick}
+          aria-label="Go to Home"
+        >
+          M!
+        </button>
+        {showClose && (
+          <button
+            type="button"
+            className="close-button"
+            onClick={onClose}
+            aria-label="Close navigation"
+          >
+            <X size={24} color="white" />
+          </button>
+        )}
+      </div>
+
+      <div className="navigation-drawer-content">
+        <div className="navigation-items">
+          {navItems.map((item) => renderNavItem(item))}
+        </div>
+        <div className="navigation-items-bottom">
+          {bottomItems.map((item) => renderNavItem(item))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DashboardNavPanel;

--- a/frontend/src/shared/ui/NavigationDrawer.tsx
+++ b/frontend/src/shared/ui/NavigationDrawer.tsx
@@ -1,15 +1,7 @@
-import React from 'react';
-import { AnimatePresence, motion } from 'framer-motion';
-import { Home, Folder, Bell, MessageSquare, Settings, LogOut, Shield, Users, X } from 'lucide-react';
-import { useAuth } from '@/app/contexts/useAuth';
-import { useData } from '@/app/contexts/useData';
-import { useNotifications } from '../../app/contexts/useNotifications';
-import NavBadge from './NavBadge';
-import { useNavigate } from 'react-router-dom';
-import { signOut } from 'aws-amplify/auth';
-import Cookies from 'js-cookie';
-import './navigation-drawer.css';
-import { GridPlus } from '../icons/GridPlus';
+import React from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import DashboardNavPanel from "./DashboardNavPanel";
+import "./navigation-drawer.css";
 
 interface NavigationDrawerProps {
   open: boolean;
@@ -21,199 +13,37 @@ const NavigationDrawer: React.FC<NavigationDrawerProps> = ({
   open,
   onClose,
   setActiveView,
-}) => {
-  const { setIsAuthenticated, setCognitoUser } = useAuth();
-  const { inbox } = useData();
-  const { notifications } = useNotifications() as { notifications: Array<{ read?: boolean }>; };
-  const navigate = useNavigate();
+}) => (
+  <AnimatePresence>
+    {open && (
+      <>
+        <motion.div
+          className="navigation-drawer-backdrop"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          onClick={onClose}
+        />
 
-  const unreadNotifications = notifications.filter((n) => !n.read).length;
-  const unreadMessages = inbox.filter((t) => t.read === false).length;
-
-  const handleNavigation = (view: string) => {
-    setActiveView(view);
-    const base = "/dashboard";
-    const path = view === "welcome" ? base : `${base}/${view}`;
-    navigate(path);
-    onClose(); // Close drawer after navigation
-  };
-
-  const handleCreateProject = () => {
-    navigate("/dashboard/new");
-    onClose();
-  };
-
-  const handleSignOut = async () => {
-    try {
-      await signOut();
-      setIsAuthenticated(false);
-      setCognitoUser(null);
-      navigate("/login");
-      Cookies.remove("myCookie");
-      onClose();
-    } catch (error) {
-      console.error("Error during sign out:", error);
-    }
-  };
-
-  const navigationItems = [
-    {
-      icon: <GridPlus size={24} color="white" />,
-      label: "Create New Project",
-      onClick: handleCreateProject,
-      isAction: true,
-    },
-    {
-      icon: <Home size={24} color="white" />,
-      label: "Home",
-      onClick: () => handleNavigation("welcome"),
-    },
-    {
-      icon: <Folder size={24} color="white" />,
-      label: "Projects",
-      onClick: () => handleNavigation("projects"),
-    },
-    {
-      icon: (
-        <div className="nav-icon-wrapper">
-          <Bell size={24} color="white" />
-          <NavBadge count={unreadNotifications} label="notification" className="nav-drawer-badge" />
-        </div>
-      ),
-      label: "Notifications",
-      onClick: () => handleNavigation("notifications"),
-      badge: unreadNotifications,
-    },
-    {
-      icon: (
-        <div className="nav-icon-wrapper">
-          <MessageSquare size={24} color="white" />
-          <NavBadge count={unreadMessages} label="message" className="nav-drawer-badge" />
-        </div>
-      ),
-      label: "Messages",
-      onClick: () => handleNavigation("messages"),
-      badge: unreadMessages,
-    },
-    {
-      icon: <Users size={24} color="white" />,
-      label: "Collaborators",
-      onClick: () => handleNavigation("collaborators"),
-    },
-  ];
-
-  const bottomItems = [
-    {
-      icon: (
-        <a
-          href="/terms-and-privacy"
-          target="_blank"
-          rel="noopener noreferrer"
-          style={{ textDecoration: "none" }}
+        <motion.div
+          className="navigation-drawer"
+          initial={{ x: "-100%" }}
+          animate={{ x: 0 }}
+          exit={{ x: "-100%" }}
+          transition={{ type: "spring", damping: 25, stiffness: 300 }}
+          role="dialog"
+          aria-modal="true"
+          aria-label="Navigation"
         >
-          <Shield size={24} color="white" />
-        </a>
-      ),
-      label: "Terms & Privacy",
-      onClick: () => {},
-    },
-    {
-      icon: <Settings size={24} color="white" />,
-      label: "Settings",
-      onClick: () => handleNavigation("settings"),
-    },
-    {
-      icon: <LogOut size={24} color="white" />,
-      label: "Sign Out",
-      onClick: handleSignOut,
-    },
-  ];
-
-  return (
-    <AnimatePresence>
-      {open && (
-        <>
-          {/* Backdrop */}
-          <motion.div
-            className="navigation-drawer-backdrop"
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            onClick={onClose}
+          <DashboardNavPanel
+            variant="overlay"
+            setActiveView={setActiveView}
+            onClose={onClose}
           />
-          
-          {/* Drawer */}
-          <motion.div
-            className="navigation-drawer"
-            initial={{ x: '-100%' }}
-            animate={{ x: 0 }}
-            exit={{ x: '-100%' }}
-            transition={{ type: 'spring', damping: 25, stiffness: 300 }}
-          >
-            <div className="navigation-drawer-header">
-              <div
-                style={{
-                  width: '40px',
-                  height: '40px',
-                  borderRadius: '50%',
-                  border: '2px solid white',
-                  backgroundColor: 'transparent',
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  color: 'white',
-                  fontWeight: 'bold',
-                  fontSize: '18px',
-                  cursor: 'pointer',
-                }}
-                onClick={() => navigate('/')}
-                role="button"
-                tabIndex={0}
-                aria-label="Go to Home"
-              >
-                M!
-              </div>
-              <button className="close-button" onClick={onClose}>
-                <X size={24} color="white" />
-              </button>
-            </div>
-
-            <div className="navigation-drawer-content">
-              <div className="navigation-items">
-                {navigationItems.map((item, index) => (
-                  <div
-                    key={index}
-                    className={`nav-drawer-item ${item.isAction ? 'nav-drawer-action' : ''}`}
-                    onClick={item.onClick}
-                  >
-                    <div className="nav-drawer-icon">
-                      {item.icon}
-                    </div>
-                    <span className="nav-drawer-label">{item.label}</span>
-                  </div>
-                ))}
-              </div>
-
-              <div className="navigation-items-bottom">
-                {bottomItems.map((item, index) => (
-                  <div
-                    key={index}
-                    className="nav-drawer-item"
-                    onClick={item.onClick}
-                  >
-                    <div className="nav-drawer-icon">
-                      {item.icon}
-                    </div>
-                    <span className="nav-drawer-label">{item.label}</span>
-                  </div>
-                ))}
-              </div>
-            </div>
-          </motion.div>
-        </>
-      )}
-    </AnimatePresence>
-  );
-};
+        </motion.div>
+      </>
+    )}
+  </AnimatePresence>
+);
 
 export default NavigationDrawer;

--- a/frontend/src/shared/ui/useDashboardNavigation.tsx
+++ b/frontend/src/shared/ui/useDashboardNavigation.tsx
@@ -1,0 +1,161 @@
+import { useCallback, useMemo, type ReactNode } from "react";
+import { useNavigate } from "react-router-dom";
+import { Home, Folder, Bell, MessageSquare, Settings, LogOut, Shield, Users } from "lucide-react";
+import { signOut } from "aws-amplify/auth";
+import Cookies from "js-cookie";
+import { useAuth } from "@/app/contexts/useAuth";
+import { useData } from "@/app/contexts/useData";
+import { useNotifications } from "@/app/contexts/useNotifications";
+import { GridPlus } from "@/shared/icons/GridPlus";
+
+export type DashboardNavItem = {
+  key: string;
+  label: string;
+  icon: ReactNode;
+  onClick?: () => void;
+  href?: string;
+  external?: boolean;
+  isAction?: boolean;
+  badgeCount?: number;
+  badgeLabel?: string;
+};
+
+export type UseDashboardNavigationArgs = {
+  setActiveView: (view: string) => void;
+  onClose?: () => void;
+};
+
+export function useDashboardNavigation({ setActiveView, onClose }: UseDashboardNavigationArgs) {
+  const { setIsAuthenticated, setCognitoUser } = useAuth();
+  const { inbox } = useData();
+  const { notifications } = useNotifications() as { notifications: Array<{ read?: boolean }> };
+  const navigate = useNavigate();
+
+  const unreadNotifications = useMemo(
+    () => notifications.filter((n) => !n.read).length,
+    [notifications]
+  );
+  const unreadMessages = useMemo(
+    () => inbox.filter((t) => t.read === false).length,
+    [inbox]
+  );
+
+  const close = useCallback(() => {
+    if (onClose) onClose();
+  }, [onClose]);
+
+  const handleNavigation = useCallback(
+    (view: string) => {
+      setActiveView(view);
+      const base = "/dashboard";
+      const path = view === "welcome" ? base : `${base}/${view}`;
+      navigate(path);
+      close();
+    },
+    [setActiveView, navigate, close]
+  );
+
+  const handleCreateProject = useCallback(() => {
+    navigate("/dashboard/new");
+    close();
+  }, [navigate, close]);
+
+  const handleSignOut = useCallback(async () => {
+    try {
+      await signOut();
+      setIsAuthenticated(false);
+      setCognitoUser(null);
+      navigate("/login");
+      Cookies.remove("myCookie");
+      close();
+    } catch (error) {
+      console.error("Error during sign out:", error);
+    }
+  }, [setIsAuthenticated, setCognitoUser, navigate, close]);
+
+  const handleLogoClick = useCallback(() => {
+    navigate("/");
+    close();
+  }, [navigate, close]);
+
+  const navItems: DashboardNavItem[] = useMemo(
+    () => [
+      {
+        key: "create",
+        icon: <GridPlus size={24} color="white" />, // icon colors handled in CSS
+        label: "Create New Project",
+        onClick: handleCreateProject,
+        isAction: true,
+      },
+      {
+        key: "home",
+        icon: <Home size={24} color="white" />,
+        label: "Home",
+        onClick: () => handleNavigation("welcome"),
+      },
+      {
+        key: "projects",
+        icon: <Folder size={24} color="white" />,
+        label: "Projects",
+        onClick: () => handleNavigation("projects"),
+      },
+      {
+        key: "notifications",
+        icon: <Bell size={24} color="white" />,
+        label: "Notifications",
+        onClick: () => handleNavigation("notifications"),
+        badgeCount: unreadNotifications,
+        badgeLabel: "notification",
+      },
+      {
+        key: "messages",
+        icon: <MessageSquare size={24} color="white" />,
+        label: "Messages",
+        onClick: () => handleNavigation("messages"),
+        badgeCount: unreadMessages,
+        badgeLabel: "message",
+      },
+      {
+        key: "collaborators",
+        icon: <Users size={24} color="white" />,
+        label: "Collaborators",
+        onClick: () => handleNavigation("collaborators"),
+      },
+    ],
+    [handleCreateProject, handleNavigation, unreadNotifications, unreadMessages]
+  );
+
+  const bottomItems: DashboardNavItem[] = useMemo(
+    () => [
+      {
+        key: "terms",
+        icon: <Shield size={24} color="white" />,
+        label: "Terms & Privacy",
+        href: "/terms-and-privacy",
+        external: true,
+        onClick: close,
+      },
+      {
+        key: "settings",
+        icon: <Settings size={24} color="white" />,
+        label: "Settings",
+        onClick: () => handleNavigation("settings"),
+      },
+      {
+        key: "sign-out",
+        icon: <LogOut size={24} color="white" />,
+        label: "Sign Out",
+        onClick: handleSignOut,
+      },
+    ],
+    [close, handleNavigation, handleSignOut]
+  );
+
+  return {
+    navItems,
+    bottomItems,
+    handleLogoClick,
+  };
+}
+
+export default useDashboardNavigation;


### PR DESCRIPTION
## Summary
- add an AppShell layout that keeps the dashboard drawer pinned on desktop while still supporting the overlay drawer on smaller viewports
- replace the desktop welcome view with a projects table/grid toggle and a week widget card that mirror the mobile experience, and clean up the old notification/invoice tiles
- refactor shared navigation utilities and update the home header, navigation drawer, and styling to align with the refreshed layout

## Testing
- `npx eslint src/app/layout/AppShell.tsx src/shared/ui/useDashboardNavigation.tsx src/shared/ui/DashboardNavPanel.tsx src/features/dashboard/pages/DashboardHome.tsx src/features/projects/ProjectsPanelDesktop.tsx src/features/schedule/WeekWidgetCard.tsx src/features/dashboard/components/WelcomeHeader.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c8a0b0c174832485f43c9b032179db