### PR TITLE
Refine dashboard shell and navigation styling

### DIFF
--- a/frontend/src/app/layout/AppShell.tsx
+++ b/frontend/src/app/layout/AppShell.tsx
@@ -10,7 +10,7 @@ import React, {
   type PropsWithChildren,
 } from "react";
 
-const DESKTOP_QUERY = "(min-width: 1280px)";
+const DESKTOP_QUERY = "(min-width: 1024px)";
 
 type AppShellContextValue = {
   isDesktop: boolean;
@@ -88,27 +88,35 @@ const AppShell: React.FC<AppShellProps> = ({
   );
 
   const overlay = !isDesktop && renderOverlayDrawer
-    ? renderOverlayDrawer({ open: drawerOpen, onClose: closeDrawer, drawerId })
+    ? renderOverlayDrawer({
+        open: drawerOpen,
+        onClose: closeDrawer,
+        drawerId: `${drawerId}-overlay`,
+      })
     : null;
 
   const rootClass = ["app-shell", className].filter(Boolean).join(" ");
-  const mainClass = ["app-shell__main", contentClassName].filter(Boolean).join(" ");
+  const mainClass = ["app-shell__main", contentClassName]
+    .filter(Boolean)
+    .join(" ");
 
   return (
     <AppShellContext.Provider value={contextValue}>
-      <div className={rootClass}>
+      <div className={rootClass} data-desktop={isDesktop}>
         <div className="app-shell__inner">
-          <aside
-            id={drawerId}
-            className="app-shell__drawer"
-            aria-label="Main navigation"
-            aria-hidden={!isDesktop}
-            data-state={isDesktop ? "open" : "closed"}
-          >
-            {drawer}
-          </aside>
+          <div className={mainClass} data-layout={isDesktop ? "desktop" : "mobile"}>
+            <aside
+              id={drawerId}
+              className="app-shell__drawer app-drawer"
+              aria-label="Primary navigation"
+              aria-hidden={!isDesktop}
+              data-state={isDesktop ? "open" : "closed"}
+            >
+              {drawer}
+            </aside>
 
-          <div className={mainClass}>{children}</div>
+            <div className="app-shell__content">{children}</div>
+          </div>
         </div>
         {overlay}
       </div>

--- a/frontend/src/features/dashboard/components/WelcomeHeader.tsx
+++ b/frontend/src/features/dashboard/components/WelcomeHeader.tsx
@@ -33,7 +33,7 @@ const WelcomeHeader: React.FC<{ userName?: string; setActiveView?: (view: string
   // online status (derived from presenceChanged events via OnlineStatusContext)
   const isUserOnline = !!userId && isOnline(String(userId));
 
-  const drawerId = appShell?.drawerId;
+  const baseDrawerId = appShell?.drawerId;
   const isDrawerOpen = appShell?.isDrawerOpen ?? false;
   const showHamburger = !!setActiveView && !!appShell && !appShell.isDesktop;
 
@@ -82,36 +82,28 @@ const WelcomeHeader: React.FC<{ userName?: string; setActiveView?: (view: string
     }
   };
 
+  const brandClassName = [
+    'welcome-header__brand',
+    'squircle',
+    isMobile ? 'welcome-header__brand--compact' : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
   return (
     <>
       <div className="welcome-header-desktop">
         {/* Left: Logo + Hamburger */}
-        <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+        <div className="welcome-header-left">
           <div
-            className="header-icon-btn"
+            className="header-icon-btn welcome-header__brand-button"
             onClick={handleHomeClick}
             role="button"
             tabIndex={0}
             aria-label="Go to Home"
             onKeyDown={handleLogoKeyDown}
           >
-            <div
-              style={{
-                width: isMobile ? '32px' : '40px',
-                height: isMobile ? '32px' : '40px',
-                borderRadius: '50%',
-                border: '1px solid white',
-                backgroundColor: 'transparent',
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                color: 'white',
-                fontWeight: 'bold',
-                fontSize: isMobile ? '14px' : '18px',
-              }}
-            >
-              M!
-            </div>
+            <span className={brandClassName}>M!</span>
           </div>
 
           {showHamburger && (
@@ -119,8 +111,14 @@ const WelcomeHeader: React.FC<{ userName?: string; setActiveView?: (view: string
               type="button"
               className="header-icon-btn"
               onClick={handleNavigationToggle}
-              aria-label="Open navigation menu"
-              aria-controls={drawerId}
+              aria-label="Toggle navigation"
+              aria-controls={
+                baseDrawerId
+                  ? appShell?.isDesktop
+                    ? baseDrawerId
+                    : `${baseDrawerId}-overlay`
+                  : undefined
+              }
               aria-expanded={isDrawerOpen}
               onKeyDown={handleMenuKeyDown}
               style={{ cursor: 'pointer' }}

--- a/frontend/src/features/dashboard/pages/DashboardHome.tsx
+++ b/frontend/src/features/dashboard/pages/DashboardHome.tsx
@@ -69,7 +69,7 @@ const WelcomeScreen: React.FC = () => {
     const handleResize = () => {
       const width = window.innerWidth;
       setIsMobile(width < 768);
-      setIsDesktop(width >= 1280);
+      setIsDesktop(width >= 1024);
     };
     if (typeof window !== "undefined") {
       handleResize();
@@ -202,8 +202,13 @@ const WelcomeScreen: React.FC = () => {
   return (
     <AppShell
       drawer={<DashboardNavPanel variant="persistent" setActiveView={setActiveView} />}
-      renderOverlayDrawer={({ open, onClose }) => (
-        <NavigationDrawer open={open} onClose={onClose} setActiveView={setActiveView} />
+      renderOverlayDrawer={({ open, onClose, drawerId }) => (
+        <NavigationDrawer
+          open={open}
+          onClose={onClose}
+          setActiveView={setActiveView}
+          drawerId={drawerId}
+        />
       )}
     >
       <div className="dashboard-wrapper welcome-screen no-vertical-center">

--- a/frontend/src/features/dashboard/styles/components/welcome-header.css
+++ b/frontend/src/features/dashboard/styles/components/welcome-header.css
@@ -3,11 +3,21 @@
 .welcome-header-desktop {
   display: flex;
   align-items: center;
-  justify-content: space-between; /* Space items evenly */
-  padding: 4px 8px;
-  margin-bottom: 0;
+  justify-content: space-between;
   width: 100%;
-  gap: 12px; /* Add spacing between sections */
+  gap: 16px;
+  min-height: var(--topbar-h, 64px);
+  padding: 12px clamp(16px, 4vw, 28px);
+  margin-bottom: 0;
+  border-bottom: 1px solid var(--line, rgba(255, 255, 255, 0.06));
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.03), transparent 70%),
+    var(--bg, #0c0c0c);
+}
+
+.welcome-header-left {
+  display: flex;
+  align-items: center;
+  gap: 12px;
 }
 
 .welcome-header-center {
@@ -28,10 +38,57 @@
 
 /* Small, consistent icon button hit area */
 .header-icon-btn {
-  display: flex;
+  display: inline-flex;
   align-items: center;
+  justify-content: center;
   cursor: pointer;
-  padding: 4px 6px;
+  padding: 6px;
+  gap: 8px;
+  border-radius: 12px;
+  background: transparent;
+  border: none;
+  color: inherit;
+  transition: background-color 0.16s ease, transform 0.16s ease;
+}
+
+.header-icon-btn:hover {
+  transform: translateY(-1px);
+}
+
+.header-icon-btn:focus-visible {
+  outline: 2px solid var(--accent, #FA3356);
+  outline-offset: 2px;
+}
+
+.welcome-header__brand-button {
+  padding: 0;
+}
+
+.welcome-header__brand {
+  --shape-radius: 18px;
+  display: grid;
+  place-items: center;
+  width: 40px;
+  height: 40px;
+  font-weight: 700;
+  font-size: 18px;
+  letter-spacing: 0.02em;
+  color: var(--text, #eaecee);
+  background: radial-gradient(circle at top, rgba(255, 255, 255, 0.18), rgba(255, 255, 255, 0.02));
+  border: 1px solid var(--line, rgba(255, 255, 255, 0.06));
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
+  text-transform: uppercase;
+}
+
+.welcome-header__brand--compact {
+  width: 32px;
+  height: 32px;
+  font-size: 14px;
+}
+
+.welcome-header__brand-button:hover .welcome-header__brand {
+  border-color: var(--accent, #FA3356);
+  box-shadow: 0 10px 32px rgba(250, 51, 86, 0.22);
 }
 
 /* Notification/nav badges used in header */
@@ -71,8 +128,15 @@
 
 
 @media (max-width: 768px) {
-  .welcome-header-desktop { padding: 2px 6px; margin-bottom: 4px; }
-  .header-icon-btn { padding: 2px 4px; }
+  .welcome-header-desktop {
+    padding: 8px 12px;
+    gap: 12px;
+  }
+  .welcome-header__brand {
+    width: 34px;
+    height: 34px;
+    font-size: 16px;
+  }
 }
 
 @media (max-width: 760px) {

--- a/frontend/src/shared/styles/design-tokens/colors.css
+++ b/frontend/src/shared/styles/design-tokens/colors.css
@@ -7,19 +7,21 @@
 
   /* Backgrounds */
   --bg: #0c0c0c;
-  --bg2: #111111; /* your JAJ pref */
-  --bg3: #1a1a1a;
+  --bg2: #111213;
+  --bg3: #181a1b;
   --bg-color: var(--bg);
   --primary-color: #0d0d0d;
   --bg-secondary: rgba(255, 255, 255, 0.02);
 
   /* Text */
-  --text-color: #fff;
-  --text-color-2: #fff;
+  --text: #eaecee;
+  --text-color: var(--text);
+  --text-color-2: var(--text);
   --text-color-3: var(--brand); /* emphasis */
-  --secondary-color: #fff;
+  --secondary-color: var(--text);
   --text-color-secondary: #666;
-  --text-color-muted: #777;
+  --text-color-muted: #9aa0a6;
+  --muted: #9aa0a6;
 
   /* Overlay */
   --overlay-color: rgb(12 12 12 / 63%);
@@ -28,6 +30,7 @@
   --border-color: #2a2a2a;
   --border-color-light: #3a3a3a;
   --border-color-dark: #1d1d1d;
+  --line: rgba(255, 255, 255, 0.06);
 
   /* Status (keep neutral) */
   --color-success: #4caf50;
@@ -39,6 +42,7 @@
   --color-hover: #ff4b70;    /* slightly brighter brand */
   --color-active: #ffffff;
   --color-focus: var(--brand);  /* 🔴 was purple; now brand */
+  --accent: var(--brand);
 
   /* Code/Editor */
   --code-bg: #0f0f10;
@@ -49,4 +53,8 @@
   --brand-08: rgba(250, 51, 86, 0.08);
   --brand-12: rgba(250, 51, 86, 0.12);
   --brand-20: rgba(250, 51, 86, 0.20);
+
+  /* Layout */
+  --sidebar-w: 268px;
+  --topbar-h: 64px;
 }

--- a/frontend/src/shared/styles/layout.css
+++ b/frontend/src/shared/styles/layout.css
@@ -1,77 +1,56 @@
 .app-shell {
   min-height: 100vh;
+  min-height: 100svh;
   background: var(--bg, #0c0c0c);
-  color: rgba(255, 255, 255, 0.92);
+  color: var(--text, rgba(255, 255, 255, 0.92));
 }
 
 .app-shell__inner {
-  display: flex;
+  width: 100%;
+}
+
+.app-shell__main {
+  box-sizing: border-box;
+  width: 100%;
+  max-width: var(--container-max-width, 1920px);
+  margin: 0 auto;
   min-height: 100vh;
+  min-height: 100svh;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(20px, 3vw, 32px);
+  padding: clamp(16px, 4vw, 32px);
 }
 
 .app-shell__drawer {
   display: none;
-  width: 280px;
-  background: rgba(12, 12, 12, 0.94);
-  border-right: 1px solid rgba(255, 255, 255, 0.08);
-  padding: var(--space-3, 24px) 0;
-  box-shadow: inset -1px 0 0 rgba(255, 255, 255, 0.06);
 }
 
-@media (min-width: 1280px) {
-  .app-shell__drawer {
-    display: flex;
-    flex-direction: column;
-    position: sticky;
-    top: 0;
-    height: 100vh;
-    overflow-y: auto;
-  }
-}
-
-.app-shell__main {
-  flex: 1;
-  min-height: 100vh;
+.app-shell__content {
   display: flex;
   flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+  gap: clamp(20px, 3vw, 32px);
 }
 
-.dashboard-nav-panel {
-  width: 100%;
-}
+@media (min-width: 1024px) {
+  .app-shell__main {
+    display: grid;
+    align-items: flex-start;
+    grid-template-columns: var(--sidebar-w, 268px) minmax(0, 1fr);
+    gap: clamp(24px, 4vw, 48px);
+    padding: clamp(24px, 4vw, 48px);
+  }
 
-.dashboard-nav-panel__logo {
-  width: 40px;
-  height: 40px;
-  border-radius: 50%;
-  border: 1px solid rgba(255, 255, 255, 0.32);
-  background: transparent;
-  color: #fff;
-  font-weight: 700;
-  font-size: 18px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-}
+  .app-shell__drawer {
+    display: block;
+    width: var(--sidebar-w, 268px);
+  }
 
-.dashboard-nav-panel__logo:hover {
-  border-color: var(--brand, #FA3356);
-}
-
-.dashboard-nav-panel--persistent .navigation-drawer-header {
-  padding: 24px;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
-}
-
-.dashboard-nav-panel--persistent .navigation-drawer-content {
-  padding: 16px 0 24px;
-  gap: 16px;
-}
-
-.dashboard-nav-panel--persistent .navigation-items,
-.dashboard-nav-panel--persistent .navigation-items-bottom {
-  padding: 0 24px;
+  .app-shell__content {
+    min-height: calc(100svh - var(--topbar-h, 64px));
+  }
 }
 
 .dashboard-home-grid {
@@ -83,7 +62,7 @@
   width: 100%;
 }
 
-@media (min-width: 1280px) {
+@media (min-width: 1024px) {
   .dashboard-home-grid {
     grid-template-columns: minmax(0, 1fr);
   }

--- a/frontend/src/shared/ui/DashboardNavPanel.tsx
+++ b/frontend/src/shared/ui/DashboardNavPanel.tsx
@@ -16,46 +16,47 @@ type DashboardNavPanelProps = UseDashboardNavigationArgs & {
 
 function renderNavItem(item: DashboardNavItem) {
   const hasBadge = typeof item.badgeCount === "number" && item.badgeCount > 0 && item.badgeLabel;
+  const className = ["nav-item", item.isAction ? "nav-item--action" : ""]
+    .filter(Boolean)
+    .join(" ");
   const inner = (
     <>
-      <div className="nav-drawer-icon" aria-hidden>
+      <span className="nav-item__icon" aria-hidden>
         {item.icon}
         {hasBadge ? (
           <NavBadge
             count={item.badgeCount ?? 0}
             label={item.badgeLabel ?? "item"}
-            className="nav-drawer-badge"
+            className="nav-item__badge"
           />
         ) : null}
-      </div>
-      <span className="nav-drawer-label">{item.label}</span>
+      </span>
+      <span className="nav-item__label">{item.label}</span>
     </>
   );
 
   if (item.href) {
     return (
-      <a
-        key={item.key}
-        className={`nav-drawer-item ${item.isAction ? "nav-drawer-action" : ""}`.trim()}
-        href={item.href}
-        target={item.external ? "_blank" : undefined}
-        rel={item.external ? "noopener noreferrer" : undefined}
-        onClick={item.onClick}
-      >
-        {inner}
-      </a>
+      <li key={item.key}>
+        <a
+          className={className}
+          href={item.href}
+          target={item.external ? "_blank" : undefined}
+          rel={item.external ? "noopener noreferrer" : undefined}
+          onClick={item.onClick}
+        >
+          {inner}
+        </a>
+      </li>
     );
   }
 
   return (
-    <button
-      key={item.key}
-      type="button"
-      className={`nav-drawer-item ${item.isAction ? "nav-drawer-action" : ""}`.trim()}
-      onClick={item.onClick}
-    >
-      {inner}
-    </button>
+    <li key={item.key}>
+      <button type="button" className={className} onClick={item.onClick}>
+        {inner}
+      </button>
+    </li>
   );
 }
 
@@ -65,7 +66,7 @@ const DashboardNavPanel: React.FC<DashboardNavPanelProps> = ({
   variant = "persistent",
   className,
 }) => {
-  const { navItems, bottomItems, handleLogoClick } = useDashboardNavigation({ setActiveView, onClose });
+  const { navItems, bottomItems } = useDashboardNavigation({ setActiveView, onClose });
   const showClose = variant === "overlay";
 
   const containerClass = [
@@ -78,16 +79,9 @@ const DashboardNavPanel: React.FC<DashboardNavPanelProps> = ({
 
   return (
     <div className={containerClass}>
-      <div className="navigation-drawer-header">
-        <button
-          type="button"
-          className="dashboard-nav-panel__logo"
-          onClick={handleLogoClick}
-          aria-label="Go to Home"
-        >
-          M!
-        </button>
-        {showClose && (
+      {showClose ? (
+        <div className="navigation-drawer-header">
+          <span className="navigation-drawer-title">Menu</span>
           <button
             type="button"
             className="close-button"
@@ -96,16 +90,16 @@ const DashboardNavPanel: React.FC<DashboardNavPanelProps> = ({
           >
             <X size={24} color="white" />
           </button>
-        )}
-      </div>
+        </div>
+      ) : null}
 
       <div className="navigation-drawer-content">
-        <div className="navigation-items">
+        <ul className="nav-list nav-list--primary">
           {navItems.map((item) => renderNavItem(item))}
-        </div>
-        <div className="navigation-items-bottom">
+        </ul>
+        <ul className="nav-list nav-list--secondary">
           {bottomItems.map((item) => renderNavItem(item))}
-        </div>
+        </ul>
       </div>
     </div>
   );

--- a/frontend/src/shared/ui/NavigationDrawer.tsx
+++ b/frontend/src/shared/ui/NavigationDrawer.tsx
@@ -7,12 +7,14 @@ interface NavigationDrawerProps {
   open: boolean;
   onClose: () => void;
   setActiveView: (view: string) => void;
+  drawerId?: string;
 }
 
 const NavigationDrawer: React.FC<NavigationDrawerProps> = ({
   open,
   onClose,
   setActiveView,
+  drawerId,
 }) => (
   <AnimatePresence>
     {open && (
@@ -26,6 +28,7 @@ const NavigationDrawer: React.FC<NavigationDrawerProps> = ({
         />
 
         <motion.div
+          id={drawerId}
           className="navigation-drawer"
           initial={{ x: "-100%" }}
           animate={{ x: 0 }}
@@ -33,7 +36,7 @@ const NavigationDrawer: React.FC<NavigationDrawerProps> = ({
           transition={{ type: "spring", damping: 25, stiffness: 300 }}
           role="dialog"
           aria-modal="true"
-          aria-label="Navigation"
+          aria-label="Primary navigation"
         >
           <DashboardNavPanel
             variant="overlay"

--- a/frontend/src/shared/ui/navigation-drawer.css
+++ b/frontend/src/shared/ui/navigation-drawer.css
@@ -2,150 +2,244 @@
 
 .navigation-drawer-backdrop {
   position: fixed;
-  top: 0;
-  left: 0;
+  inset: 0;
   width: 100vw;
   height: 100vh;
-  background-color: rgba(0, 0, 0, 0.5);
+  height: 100svh;
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(6px);
   z-index: 999;
+}
+
+.app-drawer {
+  position: sticky;
+  top: var(--topbar-h, 64px);
+  height: calc(100svh - var(--topbar-h, 64px));
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.02), transparent 60%),
+    var(--bg2, #111213);
+  border: 1px solid var(--line, rgba(255, 255, 255, 0.06));
+  border-radius: 20px;
+  padding: 14px;
+  overflow: hidden;
+}
+
+@media (min-width: 1024px) {
+  .app-drawer {
+    display: flex;
+    flex-direction: column;
+  }
+}
+
+.dashboard-nav-panel {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  gap: 16px;
+  color: var(--text, #eaecee);
 }
 
 .navigation-drawer {
   position: fixed;
   top: 0;
   left: 0;
-  width: 350px;
+  width: min(340px, 88vw);
   height: 100vh;
-  background-color: #0c0c0c;
-  
+  height: 100svh;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.02), transparent 60%),
+    var(--bg2, #111213);
+  border-right: 1px solid var(--line, rgba(255, 255, 255, 0.06));
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.45);
   z-index: 1000;
   display: flex;
   flex-direction: column;
-  overflow-y: auto;
+  gap: 16px;
+  padding: 20px 18px;
 }
 
 .navigation-drawer-header {
   display: flex;
-  justify-content: space-between;
   align-items: center;
-  padding: 20px;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  justify-content: space-between;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--line, rgba(255, 255, 255, 0.06));
 }
 
-.navigation-drawer-header h2 {
-  color: white;
-  margin: 0;
-  font-size: 20px;
+.navigation-drawer-title {
+  font-size: 0.75rem;
   font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--muted, #9aa0a6);
 }
 
 .close-button {
-  background: none;
-  border: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: 1px solid var(--line, rgba(255, 255, 255, 0.06));
+  background: transparent;
+  color: var(--text, #eaecee);
   cursor: pointer;
-  padding: 4px;
-  border-radius: 4px;
-  transition: background-color 0.2s;
+  transition: border-color 0.16s ease, background-color 0.16s ease, transform 0.16s ease;
 }
 
 .close-button:hover {
-  background-color: rgba(255, 255, 255, 0.1);
+  background: rgba(250, 51, 86, 0.12);
+  border-color: var(--accent, #FA3356);
+  transform: translateY(-1px);
+}
+
+.close-button:focus-visible {
+  outline: 2px solid var(--accent, #FA3356);
+  outline-offset: 2px;
 }
 
 .navigation-drawer-content {
   flex: 1;
   display: flex;
   flex-direction: column;
-  padding: 20px 0;
+  gap: 24px;
+  overflow-y: auto;
+  padding-block: 8px;
+  padding-inline-end: 4px;
 }
 
-.navigation-items {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
+.nav-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 8px;
 }
 
-.navigation-items-bottom {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  margin-top: 20px;
-  border-top: 1px solid rgba(255, 255, 255, 0.1);
-  padding-top: 20px;
+.nav-list--secondary {
+  margin-top: auto;
+  padding-top: 16px;
+  border-top: 1px solid var(--line, rgba(255, 255, 255, 0.06));
 }
 
-.nav-drawer-item {
-  display: flex;
+.nav-item {
+  display: grid;
+  grid-template-columns: 36px minmax(0, 1fr);
   align-items: center;
-  gap: 16px;
-  padding: 12px 20px;
-  color: white;
-  cursor: pointer;
-  transition: background-color 0.2s;
+  column-gap: 12px;
+  min-height: 44px;
+  padding: 0 14px;
+  border-radius: 12px;
+  border: 1px solid var(--line, rgba(255, 255, 255, 0.06));
+  background: var(--bg3, #181a1b);
+  color: var(--text, #eaecee);
   text-decoration: none;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  appearance: none;
+  transition: border-color 0.16s ease, transform 0.16s ease, box-shadow 0.16s ease,
+    background-color 0.16s ease;
+  text-align: left;
+  outline: none;
 }
 
-.nav-drawer-item:hover {
-  background-color: rgba(255, 255, 255, 0.1);
+.nav-item:hover {
+  border-color: var(--accent, #FA3356);
+  box-shadow: 0 0 0 2px rgba(250, 51, 86, 0.25);
+  transform: translateY(-1px);
 }
 
-
-.nav-drawer-action:hover {
-  background-color: rgba(250, 51, 86, 0.2);
-  border-color: var(--brand, #FA3356);
-}
-
-.nav-drawer-icon {
-  position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 24px;
-  height: 24px;
-}
-
-.nav-drawer-label {
-  font-size: 16px;
-  font-weight: 500;
-  color: white;
-}
-
-.nav-drawer-badge {
-  position: absolute;
-  top: -8px;
-  right: -8px;
-  min-width: 16px;
-  height: 16px;
-  font-size: 10px;
-  line-height: 16px;
-  border-radius: 50%;
-  background: #E50017;
-  color: #fff;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0 4px;
-}
-
-.nav-icon-wrapper {
-  position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-/* Mobile adjustments */
-@media (max-width: 768px) {
-  .navigation-drawer {
-    width: 90vw;
-    max-width: 320px;
+@supports (color: color-mix(in oklab, white 50%, black 50%)) {
+  .nav-item:hover {
+    border-color: color-mix(in oklab, var(--accent) 35%, white 0%);
   }
 }
 
-/* Small mobile adjustments */
+.nav-item:focus-visible {
+  outline: 2px solid var(--accent, #FA3356);
+  outline-offset: 2px;
+}
+
+.nav-item--action {
+  background: linear-gradient(135deg, rgba(250, 51, 86, 0.16), rgba(250, 51, 86, 0.06));
+  border-color: color-mix(in oklab, var(--accent, #FA3356) 40%, var(--line, rgba(255, 255, 255, 0.06)) 60%);
+}
+
+@supports not (color: color-mix(in oklab, white 50%, black 50%)) {
+  .nav-item--action {
+    border-color: var(--accent, #FA3356);
+  }
+}
+
+.nav-item--action:hover {
+  background: linear-gradient(135deg, rgba(250, 51, 86, 0.2), rgba(250, 51, 86, 0.1));
+}
+
+.nav-item__icon {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.05);
+  color: inherit;
+}
+
+.nav-item__label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.nav-item__badge {
+  position: absolute;
+  top: -6px;
+  right: -6px;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 4px;
+  border-radius: 999px;
+  background: var(--accent, #FA3356);
+  color: #fff;
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 18px;
+  border: 1px solid rgba(12, 12, 12, 0.6);
+}
+
+button.nav-item {
+  background: var(--bg3, #181a1b);
+  border: 1px solid var(--line, rgba(255, 255, 255, 0.06));
+}
+
+button.nav-item:disabled {
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+button.nav-item,
+.nav-item {
+  font: inherit;
+}
+
+.navigation-drawer::-webkit-scrollbar,
+.navigation-drawer-content::-webkit-scrollbar,
+.app-drawer::-webkit-scrollbar {
+  width: 6px;
+}
+
+.navigation-drawer::-webkit-scrollbar-thumb,
+.navigation-drawer-content::-webkit-scrollbar-thumb,
+.app-drawer::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.12);
+  border-radius: 999px;
+}
+
 @media (max-width: 480px) {
   .navigation-drawer {
-    width: 100vw;
+    width: min(100vw, 22rem);
+    padding: 18px 16px;
   }
 }

--- a/frontend/src/shared/ui/useDashboardNavigation.tsx
+++ b/frontend/src/shared/ui/useDashboardNavigation.tsx
@@ -73,11 +73,6 @@ export function useDashboardNavigation({ setActiveView, onClose }: UseDashboardN
     }
   }, [setIsAuthenticated, setCognitoUser, navigate, close]);
 
-  const handleLogoClick = useCallback(() => {
-    navigate("/");
-    close();
-  }, [navigate, close]);
-
   const navItems: DashboardNavItem[] = useMemo(
     () => [
       {
@@ -154,7 +149,6 @@ export function useDashboardNavigation({ setActiveView, onClose }: UseDashboardN
   return {
     navItems,
     bottomItems,
-    handleLogoClick,
   };
 }
 


### PR DESCRIPTION
## Summary
- extend the shared design tokens with the updated dark palette values and layout constants the new dashboard shell requires
- restructure the AppShell grid so the persistent drawer resides inside the main content at ≥1024px while keeping the overlay drawer accessible
- rebuild the dashboard navigation markup/CSS and top bar branding to deliver the new dark drawer without the duplicate logo

## Testing
- `npm run lint` *(fails: existing lint issues in unrelated test files)*

------
https://chatgpt.com/codex/tasks/task_e_68c8d146726c8324a553dd195dfae31a