### PR TITLE
Adjust dashboard branding placement

### DIFF
--- a/frontend/src/features/dashboard/components/WelcomeHeader.tsx
+++ b/frontend/src/features/dashboard/components/WelcomeHeader.tsx
@@ -35,7 +35,9 @@ const WelcomeHeader: React.FC<{ userName?: string; setActiveView?: (view: string
 
   const baseDrawerId = appShell?.drawerId;
   const isDrawerOpen = appShell?.isDrawerOpen ?? false;
-  const showHamburger = !!setActiveView && !!appShell && !appShell.isDesktop;
+  const isDesktopShell = appShell?.isDesktop ?? false;
+  const showHamburger = Boolean(setActiveView && appShell && !appShell.isDesktop);
+  const showBrandInHeader = !isDesktopShell;
 
   const [isMobile, setIsMobile] = useState(false);
   useEffect(() => {
@@ -95,16 +97,18 @@ const WelcomeHeader: React.FC<{ userName?: string; setActiveView?: (view: string
       <div className="welcome-header-desktop">
         {/* Left: Logo + Hamburger */}
         <div className="welcome-header-left">
-          <div
-            className="header-icon-btn welcome-header__brand-button"
-            onClick={handleHomeClick}
-            role="button"
-            tabIndex={0}
-            aria-label="Go to Home"
-            onKeyDown={handleLogoKeyDown}
-          >
-            <span className={brandClassName}>M!</span>
-          </div>
+          {showBrandInHeader ? (
+            <div
+              className="header-icon-btn welcome-header__brand-button"
+              onClick={handleHomeClick}
+              role="button"
+              tabIndex={0}
+              aria-label="Go to Home"
+              onKeyDown={handleLogoKeyDown}
+            >
+              <span className={brandClassName}>M!</span>
+            </div>
+          ) : null}
 
           {showHamburger && (
             <button

--- a/frontend/src/shared/ui/DashboardNavPanel.tsx
+++ b/frontend/src/shared/ui/DashboardNavPanel.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { X } from "lucide-react";
+import { Link } from "react-router-dom";
 import NavBadge from "./NavBadge";
 import useDashboardNavigation, {
   type DashboardNavItem,
@@ -67,7 +68,8 @@ const DashboardNavPanel: React.FC<DashboardNavPanelProps> = ({
   className,
 }) => {
   const { navItems, bottomItems } = useDashboardNavigation({ setActiveView, onClose });
-  const showClose = variant === "overlay";
+  const isOverlay = variant === "overlay";
+  const isPersistent = variant === "persistent";
 
   const containerClass = [
     "dashboard-nav-panel",
@@ -79,9 +81,8 @@ const DashboardNavPanel: React.FC<DashboardNavPanelProps> = ({
 
   return (
     <div className={containerClass}>
-      {showClose ? (
-        <div className="navigation-drawer-header">
-          <span className="navigation-drawer-title">Menu</span>
+      {isOverlay ? (
+        <div className="navigation-drawer-header navigation-drawer-header--overlay">
           <button
             type="button"
             className="close-button"
@@ -94,6 +95,19 @@ const DashboardNavPanel: React.FC<DashboardNavPanelProps> = ({
       ) : null}
 
       <div className="navigation-drawer-content">
+        {isPersistent ? (
+          <div className="dashboard-nav-panel__brand-row">
+            <Link
+              to="/"
+              className="dashboard-nav-panel__brand-button"
+              aria-label="Go to marketing home"
+            >
+              <span className="dashboard-nav-panel__brand-mark">M!</span>
+              <span className="dashboard-nav-panel__brand-text">MYLG</span>
+            </Link>
+          </div>
+        ) : null}
+
         <ul className="nav-list nav-list--primary">
           {navItems.map((item) => renderNavItem(item))}
         </ul>

--- a/frontend/src/shared/ui/navigation-drawer.css
+++ b/frontend/src/shared/ui/navigation-drawer.css
@@ -38,6 +38,60 @@
   color: var(--text, #eaecee);
 }
 
+.dashboard-nav-panel__brand-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 4px 14px 0;
+}
+
+.dashboard-nav-panel__brand-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: inherit;
+  text-decoration: none;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.dashboard-nav-panel__brand-button:hover .dashboard-nav-panel__brand-mark {
+  border-color: var(--accent, #FA3356);
+  box-shadow: 0 10px 32px rgba(250, 51, 86, 0.22);
+}
+
+.dashboard-nav-panel__brand-button:focus-visible {
+  outline: 2px solid var(--accent, #FA3356);
+  outline-offset: 3px;
+}
+
+.dashboard-nav-panel__brand-mark {
+  --shape-radius: 18px;
+  display: grid;
+  place-items: center;
+  width: 40px;
+  height: 40px;
+  font-weight: 700;
+  font-size: 18px;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--text, #eaecee);
+  background: radial-gradient(circle at top, rgba(255, 255, 255, 0.18), rgba(255, 255, 255, 0.02));
+  border: 1px solid var(--line, rgba(255, 255, 255, 0.06));
+  border-radius: 14px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
+}
+
+.dashboard-nav-panel__brand-text {
+  font-size: 0.85rem;
+  letter-spacing: 0.26em;
+  color: var(--muted, #9aa0a6);
+}
+
 .navigation-drawer {
   position: fixed;
   top: 0;
@@ -62,6 +116,11 @@
   justify-content: space-between;
   padding-bottom: 12px;
   border-bottom: 1px solid var(--line, rgba(255, 255, 255, 0.06));
+}
+
+.navigation-drawer-header--overlay {
+  justify-content: flex-end;
+  padding-bottom: 8px;
 }
 
 .navigation-drawer-title {


### PR DESCRIPTION
## Summary
- move the dashboard brand logo into the persistent navigation panel with styling and marketing home link while removing the mobile drawer "Menu" label
- hide the dashboard header logo on desktop so the icon only appears in the drawer on smaller viewports and keep marketing navigation on logo clicks

## Testing
- npx eslint src/shared/ui/DashboardNavPanel.tsx src/features/dashboard/components/WelcomeHeader.tsx

------
https://chatgpt.com/codex/tasks/task_e_68c8db81bd908324a1528191ef14ba74