### PR TITLE
Replace gradient washes with textured surfaces

### DIFF
--- a/frontend/src/features/projects/ProjectsPanelDesktop.module.css
+++ b/frontend/src/features/projects/ProjectsPanelDesktop.module.css
@@ -6,17 +6,16 @@
   gap: var(--space-2, 16px);
   padding: clamp(20px, 2.2vw, 28px);
   color: rgba(255, 255, 255, 0.95);
-  background:
-    radial-gradient(140% 120% at 0% -10%, rgba(250, 51, 86, 0.22) 0%, rgba(250, 51, 86, 0) 62%),
-    linear-gradient(180deg, rgba(255, 255, 255, 0.08) 0%, rgba(255, 255, 255, 0) 68%),
-    var(--bg2, #111213);
+  background: var(--bg-surface-elevated, var(--bg2, #111213));
   border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: var(--radius-squircle, var(--radius-lg, 24px));
   box-shadow:
     inset 0 0 0 1px rgba(255, 255, 255, 0.02),
+    inset 0 0 120px rgba(0, 0, 0, 0.18),
     0 18px 48px rgba(0, 0, 0, 0.45);
   overflow: hidden;
   isolation: isolate;
+  --thumb-grain-opacity: 0.025;
 }
 
 @supports (color: color-mix(in srgb, white 50%, black 50%)) {
@@ -28,6 +27,7 @@
     );
     box-shadow:
       inset 0 0 0 1px color-mix(in srgb, rgba(255, 255, 255, 0.08) 55%, transparent 45%),
+      inset 0 0 120px rgba(0, 0, 0, 0.18),
       0 18px 48px rgba(0, 0, 0, 0.45);
   }
 }
@@ -35,13 +35,14 @@
 .card::before {
   content: "";
   position: absolute;
-  inset: 0;
+  top: 14px;
+  bottom: 14px;
+  left: 16px;
+  width: 4px;
+  border-radius: 999px;
   pointer-events: none;
-  background:
-    radial-gradient(120% 160% at 90% -40%, rgba(120, 172, 255, 0.18) 0%, rgba(120, 172, 255, 0) 60%),
-    radial-gradient(120% 160% at 10% -30%, rgba(250, 51, 86, 0.26) 0%, rgba(250, 51, 86, 0) 62%);
-  opacity: 0.85;
-  mix-blend-mode: screen;
+  background: var(--panel-accent, transparent);
+  opacity: 0.65;
 }
 
 .card::after {
@@ -50,18 +51,17 @@
   inset: 0;
   pointer-events: none;
   background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='96' height='96'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='.85' numOctaves='3' stitchTiles='stitch'/></filter><rect width='96' height='96' filter='url(%23n)' opacity='.08'/></svg>");
-  background-size: 180px 180px;
+  background-size: 120px 120px;
   mix-blend-mode: soft-light;
-  opacity: 0.5;
+  opacity: var(--thumb-grain-opacity, 0.025);
 }
 
 @media (prefers-reduced-transparency: reduce) {
   .card {
-    background: var(--bg2, #111213);
+    background: var(--bg-surface-elevated, var(--bg2, #111213));
     box-shadow: 0 18px 48px rgba(0, 0, 0, 0.45);
   }
 
-  .card::before,
   .card::after {
     display: none;
   }
@@ -76,6 +76,9 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-2, 16px);
+  padding-bottom: 12px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  margin-bottom: var(--space-2, 16px);
 }
 
 .headerTop {
@@ -89,11 +92,11 @@
 .viewToggle {
   display: inline-flex;
   align-items: center;
-  background: rgba(255, 255, 255, 0.06);
-  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: 999px;
-  padding: 4px;
-  gap: 4px;
+  padding: 2px;
+  gap: 0;
 }
 
 .toggleButton {
@@ -105,12 +108,17 @@
   padding: 6px 14px;
   border-radius: 999px;
   cursor: pointer;
-  transition: background-color 0.2s ease, color 0.2s ease;
+  transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.toggleButton + .toggleButton {
+  border-left: 1px solid rgba(255, 255, 255, 0.08);
 }
 
 .toggleButton[aria-pressed="true"] {
-  background: rgba(250, 51, 86, 0.18);
+  background: rgba(255, 255, 255, 0.06);
   color: #fff;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.14);
 }
 
 .tableWrap {
@@ -235,8 +243,8 @@
 }
 
 .footerButton:hover {
-  background: rgba(250, 51, 86, 0.18);
-  border-color: rgba(250, 51, 86, 0.6);
+  background: rgba(255, 255, 255, 0.06);
+  border-color: rgba(255, 255, 255, 0.2);
   color: #fff;
 }
 

--- a/frontend/src/features/projects/ProjectsPanelDesktop.tsx
+++ b/frontend/src/features/projects/ProjectsPanelDesktop.tsx
@@ -13,6 +13,7 @@ import { useProjectKpis, type ProjectLike } from "@/features/dashboard/hooks/use
 import SVGThumbnail from "@/features/dashboard/components/SvgThumbnail";
 import { Kebab } from "@/shared/icons/Kebab";
 import { getFileUrl } from "@/shared/utils/api";
+import { getColor } from "@/shared/utils/colorUtils";
 import Squircle from "@/shared/ui/Squircle";
 import desktopStyles from "./ProjectsPanelDesktop.module.css";
 import mobileStyles from "@/features/dashboard/components/projects-panel.module.css";
@@ -193,6 +194,19 @@ const ProjectsPanelDesktop: React.FC<ProjectsPanelDesktopProps> = ({ onOpenProje
     }
     return ordered;
   }, [projects, scope, query, statusFilter, sortOption]);
+
+  const accentColor = useMemo(() => {
+    const first = items[0] as (ProjectWithMeta & {
+      color?: string;
+      accentColor?: string;
+    }) | undefined;
+    if (!first) return undefined;
+    const paletteColor = first.accentColor || first.color;
+    if (paletteColor && typeof paletteColor === "string") {
+      return paletteColor;
+    }
+    return getColor(first.projectId);
+  }, [items]);
 
   const kpis = useProjectKpis(projects as ProjectLike[]);
 
@@ -464,6 +478,7 @@ const ProjectsPanelDesktop: React.FC<ProjectsPanelDesktopProps> = ({ onOpenProje
       as="section"
       aria-label="Projects overview"
       className={desktopStyles.card}
+      style={accentColor ? ({ "--panel-accent": accentColor } as React.CSSProperties) : undefined}
       radius={PANEL_RADIUS}
       smoothing={0.6}
       cornerRadii={PANEL_CORNER_RADII}

--- a/frontend/src/features/schedule/WeekWidgetCard.module.css
+++ b/frontend/src/features/schedule/WeekWidgetCard.module.css
@@ -5,17 +5,16 @@
   gap: var(--space-2, 16px);
   padding: clamp(20px, 2.2vw, 28px);
   color: rgba(255, 255, 255, 0.95);
-  background:
-    radial-gradient(140% 120% at 0% -10%, rgba(250, 51, 86, 0.22) 0%, rgba(250, 51, 86, 0) 62%),
-    linear-gradient(180deg, rgba(255, 255, 255, 0.08) 0%, rgba(255, 255, 255, 0) 68%),
-    var(--bg2, #111213);
+  background: var(--bg-surface-elevated, var(--bg2, #111213));
   border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: var(--radius-squircle, var(--radius-lg, 24px));
   box-shadow:
     inset 0 0 0 1px rgba(255, 255, 255, 0.02),
+    inset 0 0 120px rgba(0, 0, 0, 0.18),
     0 18px 48px rgba(0, 0, 0, 0.45);
   overflow: hidden;
   isolation: isolate;
+  --thumb-grain-opacity: 0.025;
 }
 
 @supports (color: color-mix(in srgb, white 50%, black 50%)) {
@@ -27,6 +26,7 @@
     );
     box-shadow:
       inset 0 0 0 1px color-mix(in srgb, rgba(255, 255, 255, 0.08) 55%, transparent 45%),
+      inset 0 0 120px rgba(0, 0, 0, 0.18),
       0 18px 48px rgba(0, 0, 0, 0.45);
   }
 }
@@ -34,13 +34,14 @@
 .card::before {
   content: "";
   position: absolute;
-  inset: 0;
+  top: 14px;
+  bottom: 14px;
+  left: 16px;
+  width: 4px;
+  border-radius: 999px;
   pointer-events: none;
-  background:
-    radial-gradient(120% 160% at 90% -40%, rgba(120, 172, 255, 0.18) 0%, rgba(120, 172, 255, 0) 60%),
-    radial-gradient(120% 160% at 10% -30%, rgba(250, 51, 86, 0.26) 0%, rgba(250, 51, 86, 0) 62%);
-  opacity: 0.85;
-  mix-blend-mode: screen;
+  background: var(--panel-accent, transparent);
+  opacity: 0.65;
 }
 
 .card::after {
@@ -49,18 +50,17 @@
   inset: 0;
   pointer-events: none;
   background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='96' height='96'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='.85' numOctaves='3' stitchTiles='stitch'/></filter><rect width='96' height='96' filter='url(%23n)' opacity='.08'/></svg>");
-  background-size: 180px 180px;
+  background-size: 120px 120px;
   mix-blend-mode: soft-light;
-  opacity: 0.5;
+  opacity: var(--thumb-grain-opacity, 0.025);
 }
 
 @media (prefers-reduced-transparency: reduce) {
   .card {
-    background: var(--bg2, #111213);
+    background: var(--bg-surface-elevated, var(--bg2, #111213));
     box-shadow: 0 18px 48px rgba(0, 0, 0, 0.45);
   }
 
-  .card::before,
   .card::after {
     display: none;
   }
@@ -76,6 +76,9 @@
   align-items: flex-start;
   justify-content: space-between;
   gap: var(--space-2, 16px);
+  padding-bottom: 12px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  margin-bottom: var(--space-2, 16px);
 }
 
 .titleWrap {

--- a/frontend/src/features/schedule/WeekWidgetCard.tsx
+++ b/frontend/src/features/schedule/WeekWidgetCard.tsx
@@ -58,6 +58,8 @@ const WeekWidgetCard: React.FC<WeekWidgetCardProps> = ({ className }) => {
       .filter(Boolean) as Track[];
   }, [projects, colorMap]);
 
+  const accentColor = tracks[0]?.color;
+
   const dots: Dot[] = useMemo(() => {
     const out: Dot[] = [];
     for (const p of projects) {
@@ -103,6 +105,7 @@ const WeekWidgetCard: React.FC<WeekWidgetCardProps> = ({ className }) => {
       smoothing={0.6}
       cornerRadii={CARD_CORNER_RADII}
       className={`${styles.card} ${className ?? ""}`.trim()}
+      style={accentColor ? ({ "--panel-accent": accentColor } as React.CSSProperties) : undefined}
       aria-label="Week overview"
     >
       <header className={styles.header}>


### PR DESCRIPTION
## Summary
- replace the desktop projects panel and week widget gradient washes with a neutral surface plus micro-grain and vignette
- introduce an optional accent strip driven by project data and make headers use light dividers instead of slab backgrounds
- tone down control styling so toggles and buttons avoid accent washes while keeping chips for status emphasis

## Testing
- npm run lint *(fails: pre-existing lint errors in unrelated test files)*

------
https://chatgpt.com/codex/tasks/task_e_68c8f97cc2b88324912f3a7009e1e5da