### PR TITLE
feat: derive dynamic project accent palette

### DIFF
--- a/frontend/src/features/budget/components/budget-header-summary.module.css
+++ b/frontend/src/features/budget/components/budget-header-summary.module.css
@@ -48,10 +48,13 @@
   position: absolute;
   top: 8px;
   right: 8px;
-  background: rgba(255,255,255,0.2);
+  background: var(--tag-bg, rgba(255,255,255,0.2));
   font-size: 0.6rem;
   padding: 2px 6px;
   border-radius: 4px;
+  color: var(--tag-color, inherit);
+  border: 1px solid var(--tag-border, transparent);
+  box-shadow: var(--tag-shadow, none);
 }
 .cardTitle {
   font-size: 0.8rem;

--- a/frontend/src/features/budget/pages/BudgetPage.tsx
+++ b/frontend/src/features/budget/pages/BudgetPage.tsx
@@ -32,6 +32,8 @@ import { useBudget } from "@/features/budget/context/BudgetContext";
 import { useData } from "@/app/contexts/useData";
 import type { Project, TimelineEvent } from "@/app/contexts/DataProvider";
 import { findProjectBySlug, slugify } from "@/shared/utils/slug";
+import { useProjectPalette } from "@/features/project/hooks/useProjectPalette";
+import { resolveProjectCoverUrl } from "@/features/project/utils/theme";
 import {
   fetchBudgetHeaders,
   updateBudgetItem,
@@ -86,6 +88,9 @@ const BudgetPageContent = () => {
   const [areaGroups, setAreaGroups] = useState([]);
   const [invoiceGroups, setInvoiceGroups] = useState([]);
   const [clients, setClients] = useState([]);
+
+  const coverImage = useMemo(() => resolveProjectCoverUrl(activeProject), [activeProject]);
+  const projectPalette = useProjectPalette(coverImage);
 
   useLayoutEffect(() => {
     const updateTableHeight = () => {
@@ -470,6 +475,7 @@ const BudgetPageContent = () => {
       `}</style>
       <ProjectPageLayout
         projectId={activeProject?.projectId}
+        theme={projectPalette}
         header={
           <ProjectHeader
             activeProject={activeProject as Project}

--- a/frontend/src/features/calendar/calendar.tsx
+++ b/frontend/src/features/calendar/calendar.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useMemo } from 'react';
 import ProjectPageLayout from '../project/components/ProjectPageLayout';
 import ProjectHeader from '@/features/project/components/ProjectHeader';
 import TimelineChart from '../project/components/TimelineChart';
@@ -12,6 +12,8 @@ import { findProjectBySlug, slugify } from '../../shared/utils/slug';
 import { BudgetProvider } from '@/features/budget/context/BudgetProvider';
 import type { Project } from '../../app/contexts/DataProvider';
 import type { QuickLinksRef } from '@/features/project/components/QuickLinksComponent';
+import { useProjectPalette } from '@/features/project/hooks/useProjectPalette';
+import { resolveProjectCoverUrl } from '@/features/project/utils/theme';
 
 type TimelineMode = 'overview' | 'agenda';
 
@@ -127,9 +129,13 @@ const CalendarPage: React.FC = () => {
     navigate(`/dashboard/projects/${projectSlug}`);
   };
 
+  const coverImage = useMemo(() => resolveProjectCoverUrl(activeProject), [activeProject]);
+  const projectPalette = useProjectPalette(coverImage);
+
   return (
     <ProjectPageLayout
       projectId={activeProject?.projectId}
+      theme={projectPalette}
       header={
         <ProjectHeader
           activeProject={activeProject}

--- a/frontend/src/features/dashboard/components/projects-panel.module.css
+++ b/frontend/src/features/dashboard/components/projects-panel.module.css
@@ -111,19 +111,22 @@
 }
 
 .chip {
-  border: 1px solid rgba(255, 255, 255, .16);
+  border: 1px solid var(--chip-border, rgba(255, 255, 255, .16));
   border-radius: 999px;
   padding: 6px 14px;
   font-size: 11.5px;
   line-height: 1;
   opacity: .85;
+  background: var(--chip-bg, transparent);
+  color: var(--chip-color, inherit);
+  box-shadow: var(--chip-shadow, none);
 }
 
 .dot {
   width: 4px;
   height: 4px;
   border-radius: 50%;
-  background: #FA3356;
+  background: var(--chip-dot, #FA3356);
   align-self: center;
   opacity: .9;
 }

--- a/frontend/src/features/dashboard/styles/components/timeline.css
+++ b/frontend/src/features/dashboard/styles/components/timeline.css
@@ -156,6 +156,48 @@
   color: var(--text-color-3);
 }
 
+[data-project-theme] .timeline-track .milestone-pill.active {
+  background-color: var(--accent-weak, var(--text-color-3));
+  color: var(--accent-on-color, #fff);
+  border-color: color-mix(
+    in srgb,
+    var(--accent-strong, #FA3356) 55%,
+    transparent
+  );
+  box-shadow: 0 0 0 1px
+    color-mix(in srgb, var(--accent-strong, #FA3356) 32%, transparent);
+}
+
+[data-project-theme] .timeline-track .milestone-pill.active .percentage-pill {
+  background-color: var(--accent-strong, #FA3356);
+  color: var(--accent-on-color, #fff);
+}
+
+[data-project-theme] .timeline-track .milestone-pill.upcoming {
+  border-color: color-mix(
+    in srgb,
+    var(--accent-weak, rgba(255, 255, 255, 0.32)) 40%,
+    transparent
+  );
+}
+
+[data-project-theme] .timeline-track .milestone-pill.passed {
+  border-color: color-mix(
+    in srgb,
+    var(--accent-strong, #FA3356) 28%,
+    transparent
+  );
+}
+
+[data-project-theme] .timeline-track .milestone-pill.passed .percentage-pill {
+  background-color: color-mix(
+    in srgb,
+    var(--accent-strong, #FA3356) 30%,
+    #0d0d0d 70%
+  );
+  color: #fff;
+}
+
 .milestone-pill.upcoming {
   background-color: var(--primary-color);
   color: rgba(255, 255, 255, 0.7);

--- a/frontend/src/features/editor/pages/editorpage.tsx
+++ b/frontend/src/features/editor/pages/editorpage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useCallback } from "react";
+import React, { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { useNavigate, useParams, useLocation } from "react-router-dom";
 import { AnimatePresence, motion } from "framer-motion";
 import ProjectPageLayout from "@/features/project/components/ProjectPageLayout";
@@ -14,6 +14,8 @@ import { Project } from "../../../app/contexts/DataProvider";
 import { useSocket } from "../../../app/contexts/useSocket";
 import { findProjectBySlug, slugify } from "../../../shared/utils/slug";
 import { notify } from "@/shared/ui/ToastNotifications";
+import { useProjectPalette } from "@/features/project/hooks/useProjectPalette";
+import { resolveProjectCoverUrl } from "@/features/project/utils/theme";
 
 const EditorPage: React.FC = () => {
   const { projectSlug } = useParams<{ projectSlug: string }>();
@@ -38,6 +40,8 @@ const EditorPage: React.FC = () => {
   const [filesOpen, setFilesOpen] = useState(false);
   const [briefToolbarActions, setBriefToolbarActions] = useState<Record<string, unknown>>({});
   const quickLinksRef = useRef<QuickLinksRef>(null);
+  const coverImage = useMemo(() => resolveProjectCoverUrl(activeProject), [activeProject]);
+  const projectPalette = useProjectPalette(coverImage);
   const designerRef = useRef<DesignerRef>(null);
   const [briefContent, setBriefContent] = useState<string>("");
   const [isBriefDirty, setIsBriefDirty] = useState(false);
@@ -198,6 +202,7 @@ const EditorPage: React.FC = () => {
   return (
     <ProjectPageLayout
       projectId={activeProject?.projectId}
+      theme={projectPalette}
       header={
         <ProjectHeader
           activeProject={activeProject}

--- a/frontend/src/features/project/components/ProjectHeader.tsx
+++ b/frontend/src/features/project/components/ProjectHeader.tsx
@@ -938,11 +938,13 @@ const ProjectHeader: React.FC<ProjectHeaderProps> = ({
                   rx="160"
                   ry="160"
                   fill="none"
-                  stroke="#fff"
                   strokeWidth="15"
                   strokeDasharray={`${
                     (parseStatusToNumber(localActiveProject.status) / 100) * 1002
                   }, 1004`}
+                  style={{
+                    stroke: "var(--progress-accent, var(--accent-strong, #FA3356))",
+                  }}
                 >
                   {parseStatusToNumber(localActiveProject.status) < 100 && (
                     <animate

--- a/frontend/src/features/project/components/ProjectPageLayout.tsx
+++ b/frontend/src/features/project/components/ProjectPageLayout.tsx
@@ -1,11 +1,13 @@
 import React from "react";
 import ProjectMessagesThread from "../../messages/ProjectMessagesThread";
 import ChatPanel from "./ChatPanel";
+import type { ProjectAccentPalette } from "@/features/project/hooks/useProjectPalette";
 
 type ProjectPageLayoutProps = {
-  projectId: string;
+  projectId?: string;
   header: React.ReactNode;
   children: React.ReactNode;
+  theme?: ProjectAccentPalette;
 };
 
 // Minimal prop typings for local components (adjust if your real components differ)
@@ -33,10 +35,38 @@ const MOBILE_BREAKPOINT = 768;
 const MIN_THREAD_WIDTH = 350;
 const MAX_THREAD_WIDTH = 800;
 
-const ProjectPageLayout: React.FC<ProjectPageLayoutProps> = ({ projectId, header, children }) => {
+const ProjectPageLayout: React.FC<ProjectPageLayoutProps> = ({
+  projectId,
+  header,
+  children,
+  theme,
+}) => {
   const projectHeaderRef = React.useRef<HTMLDivElement | null>(null);
   const layoutRef = React.useRef<HTMLDivElement | null>(null);
   const resizingRef = React.useRef<boolean>(false);
+
+  const themeStyle = React.useMemo<React.CSSProperties | undefined>(() => {
+    if (!theme) return undefined;
+    return {
+      "--accent": theme.accent,
+      "--accent-weak": theme.accentWeak,
+      "--accent-strong": theme.accentStrong,
+      "--accent-on-color": "#ffffff",
+      "--chip-bg": theme.accentWeak,
+      "--chip-border": theme.accentStrong,
+      "--chip-color": "#ffffff",
+      "--chip-dot": theme.accentStrong,
+      "--chip-shadow": "0 0 0 1px color-mix(in srgb, var(--accent-strong, #FA3356) 35%, transparent)",
+      "--tag-bg": theme.accentWeak,
+      "--tag-color": "#ffffff",
+      "--tag-border": theme.accentStrong,
+      "--tag-shadow": "0 0 0 1px color-mix(in srgb, var(--accent-strong, #FA3356) 25%, transparent)",
+      "--progress-accent": theme.accentStrong,
+      "--progress-accent-weak": theme.accentWeak,
+    } as React.CSSProperties;
+  }, [theme]);
+
+  const safeProjectId = projectId ?? "";
 
   const [threadWidth, setThreadWidth] = React.useState<number>(MIN_THREAD_WIDTH);
   const [headerHeights, setHeaderHeights] = React.useState<{ global: number; project: number }>({
@@ -122,7 +152,11 @@ const ProjectPageLayout: React.FC<ProjectPageLayoutProps> = ({ projectId, header
   const contentHeight = `calc(100vh - ${headerHeights.global + headerHeights.project}px)`;
 
   return (
-    <div className="dashboard-wrapper active-project-details">
+    <div
+      className="dashboard-wrapper active-project-details"
+      data-project-theme={theme ? "" : undefined}
+      style={themeStyle}
+    >
       <div
         ref={projectHeaderRef}
         style={{ position: "sticky", top: 0, zIndex: 5, backgroundColor: "#0c0c0c" }}
@@ -175,7 +209,7 @@ const ProjectPageLayout: React.FC<ProjectPageLayoutProps> = ({ projectId, header
               }}
             >
               <_ProjectMessagesThread
-                projectId={projectId}
+                projectId={safeProjectId}
                 open
                 setOpen={() => {}}
                 floating={false}
@@ -190,7 +224,7 @@ const ProjectPageLayout: React.FC<ProjectPageLayoutProps> = ({ projectId, header
 
       {floatingThread && (
         <_ChatPanel
-          projectId={projectId}
+          projectId={safeProjectId}
           initialFloating
           onFloatingChange={setFloatingThread}
         />

--- a/frontend/src/features/project/hooks/useProjectPalette.ts
+++ b/frontend/src/features/project/hooks/useProjectPalette.ts
@@ -1,0 +1,457 @@
+import { useEffect, useState } from "react";
+
+export type ProjectAccentPalette = {
+  accent: string;
+  accentWeak: string;
+  accentStrong: string;
+  source: "image" | "fallback";
+};
+
+const BRAND_ACCENT = "#FA3356";
+const BRAND_BG = "#0c0c0c";
+const WHITE = "#ffffff";
+
+type ContrastConstraint = {
+  reference: string;
+  min: number;
+  prefer?: "lighter" | "darker" | "auto";
+};
+
+type Bucket = {
+  r: number;
+  g: number;
+  b: number;
+  count: number;
+};
+
+const paletteCache = new Map<string, ProjectAccentPalette>();
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+function componentToHex(value: number): string {
+  const clamped = clamp(Math.round(value), 0, 255);
+  return clamped.toString(16).padStart(2, "0").toUpperCase();
+}
+
+function rgbToHex(r: number, g: number, b: number): string {
+  return `#${componentToHex(r)}${componentToHex(g)}${componentToHex(b)}`;
+}
+
+function hexToRgbNormalized(hex: string): { r: number; g: number; b: number } {
+  let value = hex.replace("#", "");
+  if (value.length === 3) {
+    value = value
+      .split("")
+      .map((c) => c + c)
+      .join("");
+  }
+  if (value.length !== 6) {
+    return { r: 0, g: 0, b: 0 };
+  }
+  return {
+    r: parseInt(value.slice(0, 2), 16) / 255,
+    g: parseInt(value.slice(2, 4), 16) / 255,
+    b: parseInt(value.slice(4, 6), 16) / 255,
+  };
+}
+
+function hexToRgb255(hex: string): { r: number; g: number; b: number } {
+  const { r, g, b } = hexToRgbNormalized(hex);
+  return { r: r * 255, g: g * 255, b: b * 255 };
+}
+
+function rgbToHslNormalized(r: number, g: number, b: number): {
+  h: number;
+  s: number;
+  l: number;
+} {
+  r /= 255;
+  g /= 255;
+  b /= 255;
+
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  let h = 0;
+  let s = 0;
+  const l = (max + min) / 2;
+
+  if (max !== min) {
+    const d = max - min;
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+
+    switch (max) {
+      case r:
+        h = (g - b) / d + (g < b ? 6 : 0);
+        break;
+      case g:
+        h = (b - r) / d + 2;
+        break;
+      default:
+        h = (r - g) / d + 4;
+        break;
+    }
+    h *= 60;
+  }
+
+  return { h, s, l };
+}
+
+function hslToRgbNormalized(h: number, s: number, l: number): {
+  r: number;
+  g: number;
+  b: number;
+} {
+  const hue = ((h % 360) + 360) % 360;
+  const c = (1 - Math.abs(2 * l - 1)) * s;
+  const x = c * (1 - Math.abs(((hue / 60) % 2) - 1));
+  const m = l - c / 2;
+  let r1 = 0;
+  let g1 = 0;
+  let b1 = 0;
+
+  if (hue < 60) {
+    r1 = c;
+    g1 = x;
+  } else if (hue < 120) {
+    r1 = x;
+    g1 = c;
+  } else if (hue < 180) {
+    g1 = c;
+    b1 = x;
+  } else if (hue < 240) {
+    g1 = x;
+    b1 = c;
+  } else if (hue < 300) {
+    r1 = x;
+    b1 = c;
+  } else {
+    r1 = c;
+    b1 = x;
+  }
+
+  return {
+    r: clamp(r1 + m, 0, 1),
+    g: clamp(g1 + m, 0, 1),
+    b: clamp(b1 + m, 0, 1),
+  };
+}
+
+function hslToHexNormalized(h: number, s: number, l: number): string {
+  const { r, g, b } = hslToRgbNormalized(h, s, l);
+  return rgbToHex(r * 255, g * 255, b * 255);
+}
+
+function mixColors(colorA: string, colorB: string, amount: number): string {
+  const t = clamp(amount, 0, 1);
+  const a = hexToRgbNormalized(colorA);
+  const b = hexToRgbNormalized(colorB);
+  return rgbToHex(
+    (a.r * (1 - t) + b.r * t) * 255,
+    (a.g * (1 - t) + b.g * t) * 255,
+    (a.b * (1 - t) + b.b * t) * 255
+  );
+}
+
+function clampSaturation(hex: string, min: number, max: number): string {
+  const { r, g, b } = hexToRgb255(hex);
+  const { h, s, l } = rgbToHslNormalized(r, g, b);
+  const nextS = clamp(s, min, max);
+  return hslToHexNormalized(h, nextS, l);
+}
+
+function getLuminance(hex: string): number {
+  const { r, g, b } = hexToRgbNormalized(hex);
+  const transform = (value: number) =>
+    value <= 0.03928 ? value / 12.92 : Math.pow((value + 0.055) / 1.055, 2.4);
+  return (
+    0.2126 * transform(r) + 0.7152 * transform(g) + 0.0722 * transform(b)
+  );
+}
+
+function contrastRatio(hexA: string, hexB: string): number {
+  const l1 = getLuminance(hexA);
+  const l2 = getLuminance(hexB);
+  const lighter = Math.max(l1, l2);
+  const darker = Math.min(l1, l2);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+function adjustLightness(
+  color: string,
+  reference: string,
+  minContrast: number,
+  prefer: "lighter" | "darker" | "auto" = "auto"
+): string {
+  const { r, g, b } = hexToRgb255(color);
+  let { h, s, l } = rgbToHslNormalized(r, g, b);
+  let bestColor = color;
+  let bestContrast = contrastRatio(color, reference);
+  if (bestContrast >= minContrast) return bestColor;
+
+  const referenceLum = getLuminance(reference);
+  const colorLum = getLuminance(color);
+  const directions: Array<"lighten" | "darken"> = [];
+  const preferLight =
+    prefer === "lighter" || (prefer === "auto" && colorLum <= referenceLum);
+
+  directions.push(preferLight ? "lighten" : "darken");
+  directions.push(preferLight ? "darken" : "lighten");
+
+  for (const direction of directions) {
+    let currentL = l;
+    for (let i = 0; i < 24; i += 1) {
+      currentL += direction === "lighten" ? 0.02 : -0.02;
+      currentL = clamp(currentL, 0.02, 0.98);
+      const candidate = hslToHexNormalized(h, s, currentL);
+      const ratio = contrastRatio(candidate, reference);
+      if (ratio > bestContrast) {
+        bestContrast = ratio;
+        bestColor = candidate;
+      }
+      if (ratio >= minContrast) {
+        return candidate;
+      }
+      if (currentL === 0.02 || currentL === 0.98) {
+        break;
+      }
+    }
+  }
+
+  return bestColor;
+}
+
+function applyContrastConstraints(
+  color: string,
+  constraints: ContrastConstraint[]
+): string {
+  let result = color;
+  for (let iteration = 0; iteration < 4; iteration += 1) {
+    let updated = result;
+    for (const constraint of constraints) {
+      updated = adjustLightness(
+        updated,
+        constraint.reference,
+        constraint.min,
+        constraint.prefer
+      );
+    }
+    if (updated === result) {
+      return result;
+    }
+    result = updated;
+  }
+  return result;
+}
+
+function addToBucket(bucket: Bucket, r: number, g: number, b: number): void {
+  bucket.r += r;
+  bucket.g += g;
+  bucket.b += b;
+  bucket.count += 1;
+}
+
+function bucketToHex(bucket: Bucket): string | null {
+  if (!bucket.count) return null;
+  return rgbToHex(bucket.r / bucket.count, bucket.g / bucket.count, bucket.b / bucket.count);
+}
+
+async function extractPaletteFromImage(
+  url: string
+): Promise<{ vibrant: string | null; muted: string | null }> {
+  return new Promise((resolve) => {
+    if (typeof window === "undefined") {
+      resolve({ vibrant: null, muted: null });
+      return;
+    }
+
+    const img = new Image();
+    img.crossOrigin = "anonymous";
+    img.decoding = "async";
+
+    const cleanup = () => {
+      img.onload = null;
+      img.onerror = null;
+    };
+
+    img.onload = () => {
+      try {
+        const naturalWidth = img.naturalWidth || img.width;
+        const naturalHeight = img.naturalHeight || img.height;
+        if (!naturalWidth || !naturalHeight) {
+          cleanup();
+          resolve({ vibrant: null, muted: null });
+          return;
+        }
+
+        const maxSize = 64;
+        const scale = Math.max(naturalWidth, naturalHeight) / maxSize;
+        const width = Math.max(1, Math.round(naturalWidth / (scale || 1)));
+        const height = Math.max(1, Math.round(naturalHeight / (scale || 1)));
+
+        const canvas = document.createElement("canvas");
+        canvas.width = width;
+        canvas.height = height;
+        const ctx = canvas.getContext("2d", { willReadFrequently: true });
+        if (!ctx) {
+          cleanup();
+          resolve({ vibrant: null, muted: null });
+          return;
+        }
+
+        ctx.drawImage(img, 0, 0, width, height);
+        const { data } = ctx.getImageData(0, 0, width, height);
+
+        const vibrant: Bucket = { r: 0, g: 0, b: 0, count: 0 };
+        const muted: Bucket = { r: 0, g: 0, b: 0, count: 0 };
+        const fallback: Bucket = { r: 0, g: 0, b: 0, count: 0 };
+
+        for (let i = 0; i < data.length; i += 4) {
+          const alpha = data[i + 3] / 255;
+          if (alpha < 0.3) continue;
+          const r = data[i];
+          const g = data[i + 1];
+          const b = data[i + 2];
+          const { s, l } = rgbToHslNormalized(r, g, b);
+          if (l <= 0.05 || l >= 0.97) continue;
+          if (s >= 0.45 && l >= 0.25 && l <= 0.75) {
+            addToBucket(vibrant, r, g, b);
+          } else if (s >= 0.2 && l >= 0.2 && l <= 0.8) {
+            addToBucket(muted, r, g, b);
+          } else {
+            addToBucket(fallback, r, g, b);
+          }
+        }
+
+        const vibrantHex = bucketToHex(vibrant) ?? bucketToHex(fallback);
+        const mutedHex = bucketToHex(muted) ?? bucketToHex(fallback);
+        cleanup();
+        resolve({ vibrant: vibrantHex, muted: mutedHex });
+      } catch {
+        cleanup();
+        resolve({ vibrant: null, muted: null });
+      }
+    };
+
+    img.onerror = () => {
+      cleanup();
+      resolve({ vibrant: null, muted: null });
+    };
+
+    img.src = url;
+  });
+}
+
+const DEFAULT_PALETTE: ProjectAccentPalette = {
+  accent: BRAND_ACCENT,
+  accentWeak: applyContrastConstraints(
+    mixColors(BRAND_ACCENT, BRAND_BG, 0.65),
+    [
+      { reference: WHITE, min: 4.5, prefer: "darker" },
+      { reference: BRAND_BG, min: 1.6, prefer: "lighter" },
+    ]
+  ),
+  accentStrong: applyContrastConstraints(BRAND_ACCENT, [
+    { reference: BRAND_BG, min: 4.5, prefer: "lighter" },
+    { reference: WHITE, min: 2.2, prefer: "darker" },
+  ]),
+  source: "fallback",
+};
+
+async function computePalette(imageUrl: string): Promise<ProjectAccentPalette> {
+  if (!imageUrl) return DEFAULT_PALETTE;
+  const cached = paletteCache.get(imageUrl);
+  if (cached) return cached;
+
+  const { vibrant, muted } = await extractPaletteFromImage(imageUrl);
+  const baseCandidate = vibrant ?? muted ?? BRAND_ACCENT;
+  const secondaryCandidate = muted ?? vibrant ?? BRAND_ACCENT;
+
+  let accent = clampSaturation(baseCandidate, 0.35, 0.9);
+  accent = applyContrastConstraints(accent, [
+    { reference: BRAND_BG, min: 3.6, prefer: "lighter" },
+    { reference: WHITE, min: 2.4, prefer: "darker" },
+  ]);
+
+  let accentStrong = clampSaturation(mixColors(accent, BRAND_ACCENT, 0.25), 0.4, 0.95);
+  accentStrong = applyContrastConstraints(accentStrong, [
+    { reference: BRAND_BG, min: 4.5, prefer: "lighter" },
+    { reference: WHITE, min: 2.2, prefer: "darker" },
+  ]);
+
+  let accentWeak = clampSaturation(mixColors(secondaryCandidate, BRAND_BG, 0.55), 0.2, 0.7);
+  accentWeak = applyContrastConstraints(accentWeak, [
+    { reference: WHITE, min: 4.5, prefer: "darker" },
+    { reference: BRAND_BG, min: 1.6, prefer: "lighter" },
+  ]);
+
+  if (contrastRatio(accentWeak, BRAND_BG) < 1.4) {
+    accentWeak = applyContrastConstraints(mixColors(accentWeak, accent, 0.25), [
+      { reference: WHITE, min: 4.5, prefer: "darker" },
+      { reference: BRAND_BG, min: 1.6, prefer: "lighter" },
+    ]);
+  }
+
+  if (contrastRatio(accentWeak, accentStrong) < 1.2) {
+    accentWeak = applyContrastConstraints(mixColors(accentStrong, BRAND_BG, 0.6), [
+      { reference: WHITE, min: 4.5, prefer: "darker" },
+      { reference: BRAND_BG, min: 1.6, prefer: "lighter" },
+    ]);
+  }
+
+  const palette: ProjectAccentPalette = {
+    accent,
+    accentWeak,
+    accentStrong,
+    source: vibrant || muted ? "image" : "fallback",
+  };
+  paletteCache.set(imageUrl, palette);
+  return palette;
+}
+
+function palettesEqual(a: ProjectAccentPalette, b: ProjectAccentPalette): boolean {
+  return (
+    a.accent === b.accent &&
+    a.accentWeak === b.accentWeak &&
+    a.accentStrong === b.accentStrong &&
+    a.source === b.source
+  );
+}
+
+export function useProjectPalette(imageUrl?: string | null): ProjectAccentPalette {
+  const [palette, setPalette] = useState<ProjectAccentPalette>(DEFAULT_PALETTE);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!imageUrl) {
+      setPalette((prev) => (palettesEqual(prev, DEFAULT_PALETTE) ? prev : DEFAULT_PALETTE));
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    computePalette(imageUrl)
+      .then((result) => {
+        if (!cancelled) {
+          setPalette((prev) => (palettesEqual(prev, result) ? prev : result));
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setPalette((prev) =>
+            palettesEqual(prev, DEFAULT_PALETTE) ? prev : DEFAULT_PALETTE
+          );
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [imageUrl]);
+
+  return palette;
+}
+
+export const PROJECT_BRAND_ACCENT = BRAND_ACCENT;
+export const PROJECT_BRAND_BG = BRAND_BG;

--- a/frontend/src/features/project/pages/project.tsx
+++ b/frontend/src/features/project/pages/project.tsx
@@ -19,6 +19,8 @@ import { useParams, useNavigate, useLocation } from "react-router-dom";
 import { AnimatePresence, motion } from "framer-motion";
 import { findProjectBySlug, slugify } from "@/shared/utils/slug";
 import type { Project } from "@/app/contexts/DataProvider";
+import { useProjectPalette } from "@/features/project/hooks/useProjectPalette";
+import { resolveProjectCoverUrl } from "@/features/project/utils/theme";
 
 interface QuickLinksRef {
   openModal: () => void;
@@ -61,6 +63,9 @@ const SingleProject: React.FC = () => {
     const num = parseFloat(str.replace("%", ""));
     return Number.isNaN(num) ? 0 : num;
   }, []);
+
+  const coverImage = useMemo(() => resolveProjectCoverUrl(activeProject), [activeProject]);
+  const projectPalette = useProjectPalette(coverImage);
 
   const showWelcome = useCallback(() => {
     navigate("/dashboard");
@@ -162,6 +167,7 @@ const SingleProject: React.FC = () => {
   return (
     <ProjectPageLayout
       projectId={activeProject?.projectId}
+      theme={projectPalette}
       header={
         <ProjectHeader
           activeProject={activeProject}

--- a/frontend/src/features/project/utils/theme.ts
+++ b/frontend/src/features/project/utils/theme.ts
@@ -1,0 +1,49 @@
+import type { Project } from "@/app/contexts/DataProvider";
+import { getFileUrl } from "@/shared/utils/api";
+
+const stringFromUnknown = (value: unknown): string | undefined => {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed ? trimmed : undefined;
+  }
+  return undefined;
+};
+
+export const resolveProjectCoverUrl = (
+  project?: Project | null
+): string | undefined => {
+  if (!project) return undefined;
+
+  const thumbnails = Array.isArray(project.thumbnails)
+    ? project.thumbnails
+    : [];
+  for (const entry of thumbnails) {
+    const candidate = stringFromUnknown(entry);
+    if (candidate) {
+      return getFileUrl(candidate);
+    }
+  }
+
+  const fallbackThumb = stringFromUnknown(
+    (project as Record<string, unknown>).thumbnail
+  );
+  if (fallbackThumb) {
+    return getFileUrl(fallbackThumb);
+  }
+
+  const preview = stringFromUnknown(project.previewUrl);
+  if (preview) {
+    return getFileUrl(preview);
+  }
+
+  const cover = stringFromUnknown(
+    (project as Record<string, unknown>).coverImageUrl ||
+      (project as Record<string, unknown>).coverImage ||
+      (project as Record<string, unknown>).heroImage
+  );
+  if (cover) {
+    return getFileUrl(cover);
+  }
+
+  return undefined;
+};


### PR DESCRIPTION
## Summary
- add a hook and helper to extract a per-project accent palette from the cover image and expose the values as CSS variables on project layouts
- update project-related pages and styles so chips, tags, and progress visuals use the derived accent colors while keeping brand outlines for focus states

## Testing
- npm run typecheck *(fails: existing type errors in WelcomeHeader.tsx and Squircle.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c8f99b8bd083248b882affce21d39b