### PR TITLE
feat: add textured project thumbnails

### DIFF
--- a/frontend/src/app/contexts/DataProvider.tsx
+++ b/frontend/src/app/contexts/DataProvider.tsx
@@ -58,6 +58,7 @@ export interface Project {
   finishline?: string;
   productionStart?: string;
   dateCreated?: string;
+  version?: string;
   invoiceBrandName?: string;
   invoiceBrandAddress?: string;
   invoiceBrandPhone?: string;

--- a/frontend/src/features/dashboard/components/AllProjects.tsx
+++ b/frontend/src/features/dashboard/components/AllProjects.tsx
@@ -4,7 +4,7 @@ import React, {
   useMemo,
   useRef,
 } from 'react';
-import SVGThumbnail from './SvgThumbnail';
+import ProjectThumb, { type ProjectThumbVariant } from './ProjectThumb';
 import { useData } from '@/app/contexts/useData';
 import Spinner from '../../../shared/ui/Spinner';
 import { useNavigate } from 'react-router-dom';
@@ -30,6 +30,7 @@ interface Project {
   title?: string; // <-- make optional
   description?: string;
   status?: string;
+  version?: string;
   thumbnails?: string[];
   dateCreated?: string;
   date?: string;
@@ -100,7 +101,6 @@ const AllProjects: React.FC = () => {
   const { projects, isLoading, fetchProjectDetails, projectsError, fetchProjects, allUsers } = useData();
   const navigate = useNavigate();
   const [filterQuery, setFilterQuery] = useState<string>('');
-  const [imageErrors, setImageErrors] = useState<Record<string, boolean>>({});
   const [sortOption, setSortOption] = useState<SortOption>('titleAsc');
   const [statusFilter, setStatusFilter] = useState<string>('');
   const [viewMode, setViewMode] = useState<'grid' | 'list'>('list');
@@ -128,16 +128,6 @@ const AllProjects: React.FC = () => {
       console.error('Error loading project', err);
     }
   };
-
-  // Preload project thumbnails
-  useEffect(() => {
-    projects.forEach((p: Project) => {
-      if (p.thumbnails && p.thumbnails[0]) {
-        const img = new Image();
-        img.src = p.thumbnails[0];
-      }
-    });
-  }, [projects]);
 
   // Quick map for user lookups (thumbnails/names)
   const usersById = useMemo(() => {
@@ -196,6 +186,73 @@ const AllProjects: React.FC = () => {
     const num = Number(cleaned);
     return cleaned !== '' && !Number.isNaN(num) && num >= 0 && num <= 100;
   };
+
+  const resolveProjectThumbSrc = (project: Project): string | undefined => {
+    const candidate = project.thumbnails && project.thumbnails[0];
+    if (!candidate) return undefined;
+    return getFileUrl(candidate);
+  };
+
+  const resolveProjectThumbLabel = (project: Project): string | undefined => {
+    if (project.version && project.version.trim()) {
+      return project.version.trim();
+    }
+    const rawStatus = project.status?.trim();
+    if (rawStatus && !isPercentageStatus(rawStatus)) {
+      return rawStatus;
+    }
+    return undefined;
+  };
+
+  const resolveProjectThumbVariant = (
+    project: Project,
+    label?: string,
+  ): ProjectThumbVariant => {
+    const text = (label || project.version || project.status || '').toLowerCase();
+    if (!text) return 'default';
+
+    const normalized = text.replace(/[-_/]/g, ' ');
+    if (
+      /\bwip\b/.test(normalized) ||
+      /\bin\s*progress\b/.test(normalized) ||
+      /\bprogress\b/.test(normalized) ||
+      /\bbuilding\b/.test(normalized) ||
+      /\bdrafting\b/.test(normalized) ||
+      /\bmaking\b/.test(normalized)
+    ) {
+      return 'wip';
+    }
+    if (
+      /\bprototype\b/.test(normalized) ||
+      /\bproto\b/.test(normalized) ||
+      /\bbeta\b/.test(normalized) ||
+      /\balpha\b/.test(normalized) ||
+      /\bconcept\b/.test(normalized) ||
+      /\bexploration\b/.test(normalized) ||
+      /\bdraft\b/.test(normalized)
+    ) {
+      return 'prototype';
+    }
+    if (
+      /\barchive(?:d)?\b/.test(normalized) ||
+      /\bpaused\b/.test(normalized) ||
+      /\bon\s*hold\b/.test(normalized) ||
+      /\bretired\b/.test(normalized)
+    ) {
+      return 'archived';
+    }
+    return 'default';
+  };
+
+  useEffect(() => {
+    projects.forEach((p: Project) => {
+      const src = resolveProjectThumbSrc(p);
+      if (src) {
+        const img = new Image();
+        img.src = src;
+      }
+    });
+  }, [projects]);
 
   const statusOptions = useMemo(() => {
     const statuses = projects
@@ -323,51 +380,42 @@ const AllProjects: React.FC = () => {
           isSingleProject ? 'single-item' : ''
         }`}
       >
-        {sortedProjects.map((project: Project) => (
-          <div
-            key={project.projectId}
-            className={`project-container-welcome ${
-              isSingleProject ? 'single-item' : ''
-            }`}
-            role="button"
-            tabIndex={0}
-            onClick={() => handleProjectClick(project)}
-            onKeyDown={(e) => handleKeyDown(e, project)}
-            aria-label={`Open project ${
-              project.title?.trim() || 'Untitled project'
-            }`}
-          >
-            {!imageErrors[project.projectId] &&
-            project.thumbnails &&
-            project.thumbnails.length > 0 ? (
-              <img
-                src={getFileUrl(project.thumbnails[0])}
+        {sortedProjects.map((project: Project) => {
+          const thumbSrc = resolveProjectThumbSrc(project);
+          const thumbLabel = resolveProjectThumbLabel(project);
+          const thumbVariant = resolveProjectThumbVariant(project, thumbLabel);
+          const fallbackInitial =
+            project.title?.trim()?.charAt(0)?.toUpperCase() || '#';
+          return (
+            <div
+              key={project.projectId}
+              className={`project-container-welcome ${
+                isSingleProject ? 'single-item' : ''
+              }`}
+              role="button"
+              tabIndex={0}
+              onClick={() => handleProjectClick(project)}
+              onKeyDown={(e) => handleKeyDown(e, project)}
+              aria-label={`Open project ${
+                project.title?.trim() || 'Untitled project'
+              }`}
+            >
+              <ProjectThumb
+                className="project-thumbnail"
+                src={thumbSrc}
                 alt={`Thumbnail of ${
                   project.title?.trim() || 'Untitled project'
                 }`}
-                className="project-thumbnail"
-                loading="lazy"
-                decoding="async"
-                onError={() =>
-                  setImageErrors((prev) => ({
-                    ...prev,
-                    [project.projectId]: true,
-                  }))
-                }
+                label={thumbLabel}
+                variant={thumbVariant}
+                fallbackInitial={fallbackInitial}
               />
-            ) : (
-              <SVGThumbnail
-                initial={
-                  project.title?.trim()?.charAt(0)?.toUpperCase() || '#'
-                }
-                className="project-thumbnail"
-              />
-            )}
-            <h6 className="project-title">
-              {project.title?.trim() || 'Untitled project'}
-            </h6>
-          </div>
-        ))}
+              <h6 className="project-title">
+                {project.title?.trim() || 'Untitled project'}
+              </h6>
+            </div>
+          );
+        })}
       </div>
     );
   } else {
@@ -422,6 +470,11 @@ const AllProjects: React.FC = () => {
             !Number.isNaN(progress) && progress >= 0 && progress <= 100;
           const dateLabel = formatShortDate(project.dateCreated || project.date);
           const isMenuOpen = menuOpenId === project.projectId;
+          const thumbSrc = resolveProjectThumbSrc(project);
+          const thumbLabel = resolveProjectThumbLabel(project);
+          const thumbVariant = resolveProjectThumbVariant(project, thumbLabel);
+          const fallbackInitial =
+            project.title?.trim()?.charAt(0)?.toUpperCase() || '#';
           return (
             <li
               key={project.projectId}
@@ -434,32 +487,15 @@ const AllProjects: React.FC = () => {
                 project.title?.trim() || 'Untitled project'
               }`}
             >
-              {!imageErrors[project.projectId] &&
-              project.thumbnails &&
-              project.thumbnails.length > 0 ? (
-                <img
-                  src={getFileUrl(project.thumbnails[0])}
-                  alt={`Thumbnail of ${
-                    project.title?.trim() || 'Untitled project'
-                  }`}
-                  className="project-list-thumb"
-                  loading="lazy"
-                  decoding="async"
-                  onError={() =>
-                    setImageErrors((prev) => ({
-                      ...prev,
-                      [project.projectId]: true,
-                    }))
-                  }
-                />
-              ) : (
-                <SVGThumbnail
-                  initial={
-                    project.title?.trim()?.charAt(0)?.toUpperCase() || '#'
-                  }
-                  className="project-list-thumb"
-                />
-              )}
+              <ProjectThumb
+                className="project-list-thumb"
+                src={thumbSrc}
+                alt={`Thumbnail of ${
+                  project.title?.trim() || 'Untitled project'
+                }`}
+                variant={thumbVariant}
+                fallbackInitial={fallbackInitial}
+              />
               <div className="project-list-info">
                 <div className="project-title-row">
                   <span className="project-list-title">

--- a/frontend/src/features/dashboard/components/ProjectThumb.tsx
+++ b/frontend/src/features/dashboard/components/ProjectThumb.tsx
@@ -1,0 +1,229 @@
+import React, {
+  forwardRef,
+  useEffect,
+  useId,
+  useMemo,
+  useState,
+} from "react";
+
+const cx = (...classes: Array<string | false | null | undefined>): string =>
+  classes.filter(Boolean).join(" ");
+
+export type ProjectThumbVariant = "default" | "wip" | "prototype" | "archived";
+
+export interface ProjectThumbProps
+  extends React.HTMLAttributes<HTMLDivElement> {
+  src?: string | null;
+  alt?: string;
+  label?: string;
+  variant?: ProjectThumbVariant;
+  grain?: boolean;
+  vignette?: boolean;
+  fallbackInitial?: string;
+  imageProps?: React.ImgHTMLAttributes<HTMLImageElement>;
+}
+
+interface PlaceholderIds {
+  maskId: string;
+  noiseId: string;
+  gradientId: string;
+  accentId: string;
+}
+
+const sanitizeForId = (value: string): string =>
+  value.replace(/[^a-zA-Z0-9_-]/g, "");
+
+const usePlaceholderIds = (): PlaceholderIds => {
+  const reactId = useId();
+  return useMemo(() => {
+    const sanitized = sanitizeForId(reactId) || "thumb";
+    const base = `thumb-${sanitized}`;
+    return {
+      maskId: `${base}-mask`,
+      noiseId: `${base}-noise`,
+      gradientId: `${base}-gradient`,
+      accentId: `${base}-accent`,
+    };
+  }, [reactId]);
+};
+
+const TornPaperPlaceholder: React.FC<{
+  initial?: string;
+  ids: PlaceholderIds;
+}> = ({ initial, ids }) => (
+  <svg
+    className="project-thumb__placeholder"
+    viewBox="0 0 400 300"
+    preserveAspectRatio="xMidYMid slice"
+    aria-hidden="true"
+    focusable="false"
+  >
+    <defs>
+      <linearGradient id={ids.gradientId} x1="0%" y1="0%" x2="100%" y2="100%">
+        <stop offset="0%" stopColor="#1c1c1f" />
+        <stop offset="45%" stopColor="#121214" />
+        <stop offset="100%" stopColor="#080808" />
+      </linearGradient>
+      <radialGradient id={ids.accentId} cx="78%" cy="18%" r="78%">
+        <stop offset="0%" stopColor="rgba(250, 51, 86, 0.38)" />
+        <stop offset="55%" stopColor="rgba(250, 51, 86, 0.14)" />
+        <stop offset="100%" stopColor="rgba(250, 51, 86, 0)" />
+      </radialGradient>
+      <filter id={ids.noiseId} x="-20%" y="-20%" width="140%" height="140%">
+        <feTurbulence
+          type="fractalNoise"
+          baseFrequency="0.9"
+          numOctaves="3"
+          seed="42"
+        />
+        <feComponentTransfer>
+          <feFuncA type="linear" slope="1.4" />
+        </feComponentTransfer>
+      </filter>
+      <mask id={ids.maskId} maskUnits="userSpaceOnUse">
+        <path
+          fill="#fff"
+          d="M0 38 Q 24 6 68 18 T 136 16 T 208 12 T 286 24 T 360 14 T 400 26 L400 268 Q 336 310 292 276 T 220 292 T 148 268 T 64 296 T 0 276 Z"
+        />
+      </mask>
+    </defs>
+    <g mask={`url(#${ids.maskId})`}>
+      <rect width="400" height="300" fill={`url(#${ids.gradientId})`} />
+      <rect
+        width="400"
+        height="300"
+        fill={`url(#${ids.accentId})`}
+        style={{ mixBlendMode: "screen", opacity: 0.32 }}
+      />
+      <rect
+        width="400"
+        height="300"
+        filter={`url(#${ids.noiseId})`}
+        fill="rgba(255, 255, 255, 0.4)"
+        style={{
+          mixBlendMode: "soft-light",
+          opacity: "var(--thumb-grain-opacity, 0.024)",
+        }}
+      />
+      <path
+        d="M-10 92 Q 120 70 214 94 T 410 66"
+        fill="none"
+        stroke="rgba(255, 255, 255, 0.05)"
+        strokeWidth="8"
+        strokeLinecap="round"
+      />
+      <path
+        d="M-36 214 Q 124 252 214 228 T 436 262"
+        fill="none"
+        stroke="rgba(0, 0, 0, 0.35)"
+        strokeWidth="12"
+        strokeLinecap="round"
+      />
+      <path
+        d="M28 126 C 46 118 66 120 84 134"
+        fill="none"
+        stroke="rgba(255, 255, 255, 0.08)"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        strokeDasharray="6 10"
+      />
+      <circle cx="56" cy="198" r="26" fill="rgba(255, 255, 255, 0.05)" />
+      <circle cx="334" cy="118" r="34" fill="rgba(250, 51, 86, 0.1)" />
+    </g>
+    {initial && (
+      <text
+        x="200"
+        y="178"
+        textAnchor="middle"
+        dominantBaseline="middle"
+        className="project-thumb__placeholder-initial"
+      >
+        {initial}
+      </text>
+    )}
+  </svg>
+);
+
+const ProjectThumb = forwardRef<HTMLDivElement, ProjectThumbProps>((props, ref) => {
+  const {
+    src,
+    alt = "Project thumbnail",
+    label,
+    variant = "default",
+    grain = true,
+    vignette = true,
+    fallbackInitial,
+    className,
+    imageProps,
+    ...rest
+  } = props;
+
+  const [imageError, setImageError] = useState(false);
+  useEffect(() => {
+    setImageError(false);
+  }, [src]);
+
+  const resolvedSrc = src && !imageError ? src : undefined;
+  const trimmedLabel = label?.trim();
+  const showLabel = Boolean(trimmedLabel);
+  const ids = usePlaceholderIds();
+  const placeholderInitial = useMemo(() => {
+    const first = fallbackInitial?.trim();
+    return first && first.length > 0 ? first.charAt(0).toUpperCase() : undefined;
+  }, [fallbackInitial]);
+
+  const {
+    className: imgClassName,
+    onError: imgOnError,
+    loading: loadingProp,
+    decoding: decodingProp,
+    ...imgRest
+  } = imageProps ?? {};
+
+  const { "aria-label": ariaLabelProp, role: roleProp, ...containerRest } = rest;
+  const resolvedRole = roleProp ?? (resolvedSrc ? undefined : "img");
+  const resolvedAriaLabel = ariaLabelProp ?? (resolvedSrc ? undefined : alt);
+
+  return (
+    <div
+      ref={ref}
+      className={cx("project-thumb", className)}
+      data-variant={variant}
+      data-empty={resolvedSrc ? undefined : "true"}
+      data-grain={grain ? "true" : undefined}
+      data-vignette={vignette ? "true" : undefined}
+      role={resolvedRole}
+      aria-label={resolvedAriaLabel}
+      {...containerRest}
+    >
+      {resolvedSrc ? (
+        <img
+          {...imgRest}
+          className={cx("project-thumb__image", imgClassName)}
+          src={resolvedSrc}
+          alt={alt}
+          loading={loadingProp ?? "lazy"}
+          decoding={decodingProp ?? "async"}
+          onError={(event) => {
+            setImageError(true);
+            imgOnError?.(event);
+          }}
+        />
+      ) : (
+        <TornPaperPlaceholder initial={placeholderInitial} ids={ids} />
+      )}
+      <span className="project-thumb__smudges" aria-hidden="true" />
+      {grain && <span className="project-thumb__grain" aria-hidden="true" />}
+      {vignette && <span className="project-thumb__vignette" aria-hidden="true" />}
+      {showLabel && (
+        <span className="project-thumb__label">
+          <span className="project-thumb__label-text">{trimmedLabel}</span>
+        </span>
+      )}
+    </div>
+  );
+});
+
+ProjectThumb.displayName = "ProjectThumb";
+
+export default ProjectThumb;

--- a/frontend/src/features/dashboard/styles/components/project-containers.css
+++ b/frontend/src/features/dashboard/styles/components/project-containers.css
@@ -46,16 +46,197 @@
 .project-thumbnail,
 .new-project-thumbnail {
   width: 100%;
-  border-radius: 12px; /* square with rounded corners */
+  border-radius: var(--radius-2xl);
   cursor: pointer;
   aspect-ratio: 1 / 1;
-  object-fit: cover;
-  transition: transform 0.25s ease, box-shadow 0.25s ease;
+  transition: transform 0.35s ease, box-shadow 0.35s ease, border-color 0.35s ease;
+  display: block;
 }
 
-.project-thumbnail:hover {
-  transform: scale(1.01);
-  box-shadow: 0 3px 12px rgba(255, 255, 255, 0.1);
+.project-thumbnail img,
+.new-project-thumbnail img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.project-thumbnail:hover,
+.project-thumb:hover {
+  transform: translateY(-2px) scale(1.01);
+  box-shadow: 0 22px 46px rgba(0, 0, 0, 0.35);
+}
+
+.project-thumb {
+  position: relative;
+  overflow: hidden;
+  border-radius: inherit;
+  background: linear-gradient(140deg, rgba(21, 21, 23, 0.95) 0%, rgba(8, 8, 8, 0.95) 100%);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  isolation: isolate;
+  display: block;
+  height: 100%;
+  width: 100%;
+  will-change: transform;
+}
+
+.project-thumb__image,
+.project-thumb__placeholder {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  z-index: 0;
+  transition: transform 0.4s ease;
+}
+
+.project-thumb:hover .project-thumb__image,
+.project-thumb:hover .project-thumb__placeholder {
+  transform: scale(1.04);
+}
+
+.project-thumb__placeholder {
+  background: linear-gradient(140deg, #151517 0%, #0a0a0a 100%);
+}
+
+.project-thumb[data-empty="true"] {
+  border-color: rgba(255, 255, 255, 0.08);
+  background: linear-gradient(140deg, rgba(22, 22, 22, 0.94) 0%, rgba(10, 10, 10, 0.94) 100%);
+}
+
+.project-thumb__smudges,
+.project-thumb__grain,
+.project-thumb__vignette {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+}
+
+.project-thumb__smudges {
+  background-image:
+    radial-gradient(120px 120px at 20% 24%, rgba(255, 255, 255, 0.08), transparent 70%),
+    radial-gradient(160px 160px at 78% 78%, rgba(250, 51, 86, 0.16), transparent 72%),
+    radial-gradient(90px 90px at 74% 30%, rgba(255, 255, 255, 0.05), transparent 78%);
+  mix-blend-mode: soft-light;
+  opacity: 0.75;
+  filter: saturate(0.85);
+  z-index: 2;
+}
+
+.project-thumb[data-empty="true"] .project-thumb__smudges {
+  opacity: 0.95;
+}
+
+.project-thumb__grain {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120' viewBox='0 0 120 120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='1.25' numOctaves='3' seed='7'/%3E%3C/filter%3E%3Crect width='120' height='120' filter='url(%23n)'/%3E%3C/svg%3E");
+  background-size: 120px 120px;
+  opacity: var(--thumb-grain-opacity, 0.024);
+  mix-blend-mode: soft-light;
+  z-index: 3;
+}
+
+.project-thumb[data-empty="true"] .project-thumb__grain {
+  opacity: 0.04;
+}
+
+.project-thumb__vignette {
+  box-shadow: var(--thumb-vignette, inset 0 0 120px rgba(0, 0, 0, 0.18));
+  z-index: 4;
+}
+
+.project-thumb[data-empty="true"] .project-thumb__vignette {
+  box-shadow: inset 0 0 140px rgba(0, 0, 0, 0.22);
+}
+
+.project-thumb__label {
+  position: absolute;
+  left: 16px;
+  bottom: 16px;
+  padding: 6px 14px 6px 12px;
+  background: var(--thumb-label-bg, rgba(12, 12, 12, 0.9));
+  color: rgba(255, 255, 255, 0.86);
+  text-transform: uppercase;
+  font-size: 0.65rem;
+  letter-spacing: 0.18em;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.35);
+  text-shadow: 0 1px 0 rgba(0, 0, 0, 0.45);
+  pointer-events: none;
+  z-index: 5;
+  max-width: calc(100% - 32px);
+  backdrop-filter: blur(3px);
+  white-space: nowrap;
+}
+
+.project-thumb__label::before {
+  content: "";
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--brand);
+  box-shadow: 0 0 0 2px rgba(250, 51, 86, 0.18);
+  flex-shrink: 0;
+}
+
+.project-thumb__label-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.project-thumb[data-empty="true"] .project-thumb__label {
+  color: rgba(255, 255, 255, 0.74);
+}
+
+.project-thumb[data-variant='wip'] .project-thumb__label {
+  background: linear-gradient(120deg, rgba(255, 226, 125, 0.95), rgba(255, 191, 90, 0.95));
+  color: #2c1b07;
+  border-color: rgba(255, 236, 175, 0.6);
+  text-shadow: none;
+}
+
+.project-thumb[data-variant='wip'] .project-thumb__label::before {
+  background: rgba(255, 153, 0, 0.92);
+  box-shadow: 0 0 0 2px rgba(255, 196, 104, 0.42);
+}
+
+.project-thumb[data-variant='prototype'] .project-thumb__label {
+  background: linear-gradient(120deg, rgba(147, 197, 253, 0.9), rgba(109, 186, 255, 0.9));
+  color: #06243d;
+  border-color: rgba(153, 209, 255, 0.55);
+  text-shadow: none;
+}
+
+.project-thumb[data-variant='prototype'] .project-thumb__label::before {
+  background: rgba(59, 130, 246, 0.9);
+  box-shadow: 0 0 0 2px rgba(147, 197, 253, 0.45);
+}
+
+.project-thumb[data-variant='archived'] .project-thumb__label {
+  background: linear-gradient(120deg, rgba(73, 73, 73, 0.88), rgba(47, 47, 47, 0.88));
+  color: rgba(255, 255, 255, 0.78);
+  border-color: rgba(255, 255, 255, 0.1);
+  text-shadow: none;
+}
+
+.project-thumb[data-variant='archived'] .project-thumb__label::before {
+  background: rgba(140, 140, 140, 0.9);
+  box-shadow: 0 0 0 2px rgba(120, 120, 120, 0.4);
+}
+
+.project-thumb__placeholder-initial {
+  font-family: var(--font-family-primary, "Helvetica Neue", Arial, sans-serif);
+  font-size: 120px;
+  font-weight: var(--font-weight-semibold, 600);
+  letter-spacing: 0.18em;
+  fill: rgba(255, 255, 255, 0.26);
+  text-transform: uppercase;
 }
 
 .all-projects-container-welcome.single-item .project-container-welcome {
@@ -100,6 +281,14 @@ svg .project-title {
   .new-project-thumbnail,
   .new-project-thumbnail svg {
     border-radius: 10px;
+  }
+
+  .project-thumb__label {
+    left: 12px;
+    bottom: 12px;
+    padding: 4px 12px;
+    font-size: 0.58rem;
+    letter-spacing: 0.14em;
   }
 }
 

--- a/frontend/src/features/dashboard/styles/components/projects-view.css
+++ b/frontend/src/features/dashboard/styles/components/projects-view.css
@@ -201,11 +201,47 @@
 .project-list-thumb {
   width: 48px;  /* align to 48px avatar size */
   height: 48px;
-  border-radius: 8px;
-  object-fit: cover;
-  display: block;
-  background: #0c0c0c;
-  border: 1px solid rgba(255,255,255,.16);
+  border-radius: 10px;
+  display: inline-flex;
+  align-items: stretch;
+  justify-content: stretch;
+  flex-shrink: 0;
+  position: relative;
+  overflow: hidden;
+}
+
+.project-list-thumb.project-thumb {
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: linear-gradient(135deg, rgba(20, 20, 20, 0.96) 0%, rgba(8, 8, 8, 0.94) 100%);
+  box-shadow: none;
+  transition: border-color 0.3s ease;
+}
+
+.project-list-thumb.project-thumb:hover {
+  transform: none;
+  box-shadow: none;
+}
+
+.project-list-thumb.project-thumb:hover .project-thumb__image,
+.project-list-thumb.project-thumb:hover .project-thumb__placeholder {
+  transform: none;
+}
+
+.project-list-thumb .project-thumb__label {
+  display: none;
+}
+
+.project-list-thumb .project-thumb__grain {
+  opacity: 0.018;
+}
+
+.project-list-thumb .project-thumb__smudges {
+  opacity: 0.55;
+}
+
+.project-list-thumb .project-thumb__vignette {
+  box-shadow: inset 0 0 48px rgba(0, 0, 0, 0.2);
 }
 
 .project-list-info {

--- a/frontend/src/shared/styles/components/projects.css
+++ b/frontend/src/shared/styles/components/projects.css
@@ -41,13 +41,198 @@
   border-radius: var(--radius-2xl);
   cursor: pointer;
   aspect-ratio: 1 / 1;
-  object-fit: cover;
-  transition: transform 0.25s ease, box-shadow 0.25s ease;
+  transition: transform 0.35s ease, box-shadow 0.35s ease, border-color 0.35s ease;
+  display: block;
 }
 
-.project-thumbnail:hover {
-  transform: scale(1.01);
-  box-shadow: 0 3px 12px rgba(255, 255, 255, 0.1);
+.project-thumbnail img,
+.new-project-thumbnail img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.project-thumbnail:hover,
+.project-thumb:hover {
+  transform: translateY(-2px) scale(1.01);
+  box-shadow: 0 22px 46px rgba(0, 0, 0, 0.35);
+}
+
+.project-thumb {
+  position: relative;
+  overflow: hidden;
+  border-radius: inherit;
+  background: linear-gradient(140deg, rgba(21, 21, 23, 0.95) 0%, rgba(8, 8, 8, 0.95) 100%);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  isolation: isolate;
+  display: block;
+  height: 100%;
+  width: 100%;
+  will-change: transform;
+}
+
+.project-thumb__image,
+.project-thumb__placeholder {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  z-index: 0;
+}
+
+.project-thumb__image,
+.project-thumb__placeholder {
+  transition: transform 0.4s ease;
+}
+
+.project-thumb:hover .project-thumb__image,
+.project-thumb:hover .project-thumb__placeholder {
+  transform: scale(1.04);
+}
+
+.project-thumb__placeholder {
+  background: linear-gradient(140deg, #151517 0%, #0a0a0a 100%);
+}
+
+.project-thumb[data-empty="true"] {
+  border-color: rgba(255, 255, 255, 0.08);
+  background: linear-gradient(140deg, rgba(22, 22, 22, 0.94) 0%, rgba(10, 10, 10, 0.94) 100%);
+}
+
+.project-thumb__smudges,
+.project-thumb__grain,
+.project-thumb__vignette {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+}
+
+.project-thumb__smudges {
+  background-image:
+    radial-gradient(120px 120px at 20% 24%, rgba(255, 255, 255, 0.08), transparent 70%),
+    radial-gradient(160px 160px at 78% 78%, rgba(250, 51, 86, 0.16), transparent 72%),
+    radial-gradient(90px 90px at 74% 30%, rgba(255, 255, 255, 0.05), transparent 78%);
+  mix-blend-mode: soft-light;
+  opacity: 0.75;
+  filter: saturate(0.85);
+  z-index: 2;
+}
+
+.project-thumb[data-empty="true"] .project-thumb__smudges {
+  opacity: 0.95;
+}
+
+.project-thumb__grain {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120' viewBox='0 0 120 120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='1.25' numOctaves='3' seed='7'/%3E%3C/filter%3E%3Crect width='120' height='120' filter='url(%23n)'/%3E%3C/svg%3E");
+  background-size: 120px 120px;
+  opacity: var(--thumb-grain-opacity, 0.024);
+  mix-blend-mode: soft-light;
+  z-index: 3;
+}
+
+.project-thumb[data-empty="true"] .project-thumb__grain {
+  opacity: 0.04;
+}
+
+.project-thumb__vignette {
+  box-shadow: var(--thumb-vignette, inset 0 0 120px rgba(0, 0, 0, 0.18));
+  z-index: 4;
+}
+
+.project-thumb[data-empty="true"] .project-thumb__vignette {
+  box-shadow: inset 0 0 140px rgba(0, 0, 0, 0.22);
+}
+
+.project-thumb__label {
+  position: absolute;
+  left: 16px;
+  bottom: 16px;
+  padding: 6px 14px 6px 12px;
+  background: var(--thumb-label-bg, rgba(12, 12, 12, 0.9));
+  color: rgba(255, 255, 255, 0.86);
+  text-transform: uppercase;
+  font-size: 0.65rem;
+  letter-spacing: 0.18em;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.35);
+  text-shadow: 0 1px 0 rgba(0, 0, 0, 0.45);
+  pointer-events: none;
+  z-index: 5;
+  max-width: calc(100% - 32px);
+  backdrop-filter: blur(3px);
+  white-space: nowrap;
+}
+
+.project-thumb__label::before {
+  content: "";
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--brand);
+  box-shadow: 0 0 0 2px rgba(250, 51, 86, 0.18);
+  flex-shrink: 0;
+}
+
+.project-thumb__label-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.project-thumb[data-empty="true"] .project-thumb__label {
+  color: rgba(255, 255, 255, 0.74);
+}
+
+.project-thumb[data-variant='wip'] .project-thumb__label {
+  background: linear-gradient(120deg, rgba(255, 226, 125, 0.95), rgba(255, 191, 90, 0.95));
+  color: #2c1b07;
+  border-color: rgba(255, 236, 175, 0.6);
+  text-shadow: none;
+}
+
+.project-thumb[data-variant='wip'] .project-thumb__label::before {
+  background: rgba(255, 153, 0, 0.92);
+  box-shadow: 0 0 0 2px rgba(255, 196, 104, 0.42);
+}
+
+.project-thumb[data-variant='prototype'] .project-thumb__label {
+  background: linear-gradient(120deg, rgba(147, 197, 253, 0.9), rgba(109, 186, 255, 0.9));
+  color: #06243d;
+  border-color: rgba(153, 209, 255, 0.55);
+  text-shadow: none;
+}
+
+.project-thumb[data-variant='prototype'] .project-thumb__label::before {
+  background: rgba(59, 130, 246, 0.9);
+  box-shadow: 0 0 0 2px rgba(147, 197, 253, 0.45);
+}
+
+.project-thumb[data-variant='archived'] .project-thumb__label {
+  background: linear-gradient(120deg, rgba(73, 73, 73, 0.88), rgba(47, 47, 47, 0.88));
+  color: rgba(255, 255, 255, 0.78);
+  border-color: rgba(255, 255, 255, 0.1);
+  text-shadow: none;
+}
+
+.project-thumb[data-variant='archived'] .project-thumb__label::before {
+  background: rgba(140, 140, 140, 0.9);
+  box-shadow: 0 0 0 2px rgba(120, 120, 120, 0.4);
+}
+
+.project-thumb__placeholder-initial {
+  font-family: var(--font-family-primary, "Helvetica Neue", Arial, sans-serif);
+  font-size: 120px;
+  font-weight: var(--font-weight-semibold, 600);
+  letter-spacing: 0.18em;
+  fill: rgba(255, 255, 255, 0.26);
+  text-transform: uppercase;
 }
 
 .all-projects-container-welcome.single-item .project-container-welcome {
@@ -123,9 +308,17 @@
     height: auto;
     aspect-ratio: 1 / 1;
   }
-  
+
   .project-title {
     font-size: var(--font-size-sm);
     margin-top: 4px;
+  }
+
+  .project-thumb__label {
+    left: 12px;
+    bottom: 12px;
+    padding: 4px 12px;
+    font-size: 0.58rem;
+    letter-spacing: 0.14em;
   }
 }

--- a/frontend/src/shared/styles/design-tokens/colors.css
+++ b/frontend/src/shared/styles/design-tokens/colors.css
@@ -25,6 +25,9 @@
 
   /* Overlay */
   --overlay-color: rgb(12 12 12 / 63%);
+  --thumb-grain-opacity: 0.024; /* 0.02 → 0.03 sweet spot */
+  --thumb-vignette: inset 0 0 120px rgba(0, 0, 0, 0.18);
+  --thumb-label-bg: #0c0c0c;
 
   /* Borders */
   --border-color: #2a2a2a;

--- a/frontend/src/shared/utils/api.ts
+++ b/frontend/src/shared/utils/api.ts
@@ -47,6 +47,7 @@ export interface Project {
   team?: TeamMember[];
   timelineEvents?: TimelineEvent[];
   thumbnails?: string[];
+  version?: string;
   color?: string;
   finishline?: string;
   productionStart?: string;


### PR DESCRIPTION
## Summary
- add a reusable ProjectThumb component with optional film grain, vignette and label overlays plus a textured SVG placeholder
- integrate ProjectThumb into the AllProjects grid and list views, deriving labels/variants from project metadata and preloading thumbnail URLs
- expand design tokens and styling to support the textured look, update list thumb styling, and expose project version on shared interfaces

## Testing
- npm run lint *(fails: pre-existing lint violations in unrelated test files)*
- npx eslint src/features/dashboard/components/AllProjects.tsx src/features/dashboard/components/ProjectThumb.tsx


------
https://chatgpt.com/codex/tasks/task_e_68c8f97282108324b9eeb5fc51904c4b