### PR TITLE
feat: add moodboard sticker canvas

### DIFF
--- a/frontend/src/app/routes.tsx
+++ b/frontend/src/app/routes.tsx
@@ -25,6 +25,7 @@ const DashboardSingleProject = React.lazy(() => import("@/features/project/pages
 const DashboardBudgetPage = React.lazy(() => import("../features/budget/pages/BudgetPage"));
 const DashboardCalendarPage = React.lazy(() => import("@/features/calendar/calendar"));
 const DashboardEditorPage = React.lazy(() => import("@/features/editor/pages/editorpage"));
+const DashboardMoodboardPage = React.lazy(() => import("@/features/moodboard/pages/MoodboardPage"));
 
 const ScrollToTop: React.FC = () => {
   const { pathname } = useLocation();
@@ -175,6 +176,7 @@ const ActualRoutes: React.FC<ActualRoutesProps> = ({ location }) => {
           <Route path="projects/:projectSlug" element={<DashboardSingleProject />} />
           <Route path="projects/:projectSlug/budget" element={<DashboardBudgetPage />} />
           <Route path="projects/:projectSlug/calendar" element={<DashboardCalendarPage />} />
+          <Route path="projects/:projectSlug/moodboard" element={<DashboardMoodboardPage />} />
           <Route path="projects/:projectSlug/editor" element={<DashboardEditorPage />} />
           <Route path="new" element={<DashboardNewProject />} />
           <Route path="welcome/*" element={<Navigate to=".." replace />} />

--- a/frontend/src/features/moodboard/components/MoodboardCanvas.tsx
+++ b/frontend/src/features/moodboard/components/MoodboardCanvas.tsx
@@ -1,0 +1,290 @@
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { Plus, RefreshCw, Trash2 } from "lucide-react";
+import StickerCard from "./StickerCard";
+import QuickInsertPalette from "./QuickInsertPalette";
+import { useMoodboardStore } from "../hooks/useMoodboardStore";
+import type { Sticker, StickerDraft } from "../types";
+import styles from "../moodboard.module.css";
+
+const GRID_STEP = 8;
+
+export interface MoodboardCanvasProps {
+  projectId?: string;
+  userId?: string;
+}
+
+type DragState = {
+  id: string;
+  pointerStart: { x: number; y: number };
+  stickerStart: { x: number; y: number };
+};
+
+const MoodboardCanvas: React.FC<MoodboardCanvasProps> = ({ projectId, userId }) => {
+  const { stickers, addSticker, updateSticker, removeSticker, bringToFront, clear } =
+    useMoodboardStore({ projectId, userId });
+  const boardRef = useRef<HTMLDivElement | null>(null);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [dragState, setDragState] = useState<DragState | null>(null);
+  const [dragOffset, setDragOffset] = useState<{ x: number; y: number } | null>(null);
+  const [paletteOpen, setPaletteOpen] = useState(false);
+
+  const selectedSticker = useMemo<Sticker | null>(() => {
+    if (!selectedId) return null;
+    return stickers.find((item) => item.id === selectedId) ?? null;
+  }, [selectedId, stickers]);
+
+  const cleanupDrag = useCallback(() => {
+    setDragState(null);
+    setDragOffset(null);
+  }, []);
+
+  useEffect(() => {
+    if (!dragState) return;
+
+    const handlePointerMove = (event: PointerEvent) => {
+      setDragOffset({
+        x: event.clientX - dragState.pointerStart.x,
+        y: event.clientY - dragState.pointerStart.y,
+      });
+    };
+
+    const handlePointerUp = (event: PointerEvent) => {
+      const deltaX = event.clientX - dragState.pointerStart.x;
+      const deltaY = event.clientY - dragState.pointerStart.y;
+      const nextX = dragState.stickerStart.x + deltaX;
+      const nextY = dragState.stickerStart.y + deltaY;
+      updateSticker(dragState.id, {
+        x: nextX,
+        y: nextY,
+      });
+      cleanupDrag();
+    };
+
+    const handlePointerCancel = () => {
+      cleanupDrag();
+    };
+
+    window.addEventListener("pointermove", handlePointerMove);
+    window.addEventListener("pointerup", handlePointerUp, { once: true });
+    window.addEventListener("pointercancel", handlePointerCancel, { once: true });
+
+    return () => {
+      window.removeEventListener("pointermove", handlePointerMove);
+      window.removeEventListener("pointerup", handlePointerUp);
+      window.removeEventListener("pointercancel", handlePointerCancel);
+    };
+  }, [cleanupDrag, dragState, updateSticker]);
+
+  const handleStickerPointerDown = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>, id: string) => {
+      event.preventDefault();
+      event.stopPropagation();
+      const sticker = stickers.find((item) => item.id === id);
+      if (!sticker) return;
+      bringToFront(id);
+      setSelectedId(id);
+      setDragState({
+        id,
+        pointerStart: { x: event.clientX, y: event.clientY },
+        stickerStart: { x: sticker.x, y: sticker.y },
+      });
+      setDragOffset({ x: 0, y: 0 });
+    },
+    [bringToFront, stickers]
+  );
+
+  const handleBoardPointerDown = useCallback(() => {
+    setSelectedId(null);
+    boardRef.current?.focus();
+  }, []);
+
+  const handleBoardKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (paletteOpen) {
+        if (event.key === "Escape") {
+          setPaletteOpen(false);
+        }
+        return;
+      }
+
+      if (event.key === "+" || event.key === "=" || event.key === "/") {
+        event.preventDefault();
+        setPaletteOpen(true);
+        return;
+      }
+
+      if (!selectedSticker) return;
+
+      const step = event.shiftKey ? GRID_STEP * 3 : GRID_STEP;
+      if (event.key === "ArrowUp") {
+        event.preventDefault();
+        updateSticker(selectedSticker.id, { y: selectedSticker.y - step });
+      } else if (event.key === "ArrowDown") {
+        event.preventDefault();
+        updateSticker(selectedSticker.id, { y: selectedSticker.y + step });
+      } else if (event.key === "ArrowLeft") {
+        event.preventDefault();
+        updateSticker(selectedSticker.id, { x: selectedSticker.x - step });
+      } else if (event.key === "ArrowRight") {
+        event.preventDefault();
+        updateSticker(selectedSticker.id, { x: selectedSticker.x + step });
+      } else if (event.key === "Delete" || event.key === "Backspace") {
+        event.preventDefault();
+        removeSticker(selectedSticker.id);
+        setSelectedId(null);
+      }
+    },
+    [paletteOpen, removeSticker, selectedSticker, updateSticker]
+  );
+
+  const focusBoard = useCallback(() => {
+    boardRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    focusBoard();
+  }, [focusBoard]);
+
+  const handleAddSticker = useCallback(
+    (draft: StickerDraft) => {
+      const rect = boardRef.current?.getBoundingClientRect();
+      const basePosition = rect
+        ? {
+            x: rect.width / 2 - 80,
+            y: rect.height / 2 - 80,
+          }
+        : { x: 64, y: 64 };
+      const created = addSticker(draft, basePosition);
+      if (created) {
+        setSelectedId(created.id);
+        bringToFront(created.id);
+        setTimeout(focusBoard, 0);
+      }
+    },
+    [addSticker, bringToFront, focusBoard]
+  );
+
+  const handleDeleteSelected = useCallback(() => {
+    if (!selectedSticker) return;
+    removeSticker(selectedSticker.id);
+    setSelectedId(null);
+    focusBoard();
+  }, [focusBoard, removeSticker, selectedSticker]);
+
+  const showEmptyState = stickers.length === 0;
+
+  return (
+    <div className={styles.moodboardPage}>
+      <div className={styles.toolbar}>
+        <div className={styles.toolbarButtons}>
+          <button
+            type="button"
+            className={styles.iconButton}
+            onClick={() => setPaletteOpen(true)}
+          >
+            <Plus size={16} />
+            Add sticker
+          </button>
+          <button
+            type="button"
+            className={styles.iconButton}
+            onClick={() => {
+              setPaletteOpen(true);
+            }}
+            aria-label="Open quick insert"
+          >
+            <span style={{ fontWeight: 700, fontSize: "1rem" }}>/</span>
+            Quick insert
+          </button>
+        </div>
+
+        <div className={styles.keyboardHint}>
+          <span>
+            <kbd>/</kbd> Quick insert
+          </span>
+          <span>
+            <kbd>+</kbd> Add
+          </span>
+          <span>
+            <kbd>↑↓←→</kbd> Nudge
+          </span>
+        </div>
+
+        <div className={styles.toolbarButtons}>
+          <button
+            type="button"
+            className={styles.iconButton}
+            onClick={handleDeleteSelected}
+            disabled={!selectedSticker}
+          >
+            <Trash2 size={16} />
+            Remove
+          </button>
+          <button
+            type="button"
+            className={styles.iconButton}
+            onClick={() => {
+              clear();
+              setSelectedId(null);
+              focusBoard();
+            }}
+            disabled={!stickers.length}
+          >
+            <RefreshCw size={16} />
+            Reset
+          </button>
+        </div>
+      </div>
+
+      <div className={styles.canvasWrapper}>
+        <div
+          ref={boardRef}
+          className={styles.canvas}
+          tabIndex={0}
+          role="application"
+          aria-label="Moodboard canvas"
+          onPointerDown={handleBoardPointerDown}
+          onKeyDown={handleBoardKeyDown}
+        >
+          {showEmptyState && (
+            <div className={styles.emptyState}>
+              Press <kbd>+</kbd> or <kbd>/</kbd> to drop your first sticker.
+            </div>
+          )}
+
+          {stickers.map((sticker) => (
+            <StickerCard
+              key={sticker.id}
+              sticker={sticker}
+              isSelected={selectedId === sticker.id}
+              isActiveDrag={dragState?.id === sticker.id}
+              offset={dragState?.id === sticker.id ? dragOffset : null}
+              onPointerDown={handleStickerPointerDown}
+              onFocus={setSelectedId}
+              onRemove={removeSticker}
+            />
+          ))}
+        </div>
+      </div>
+
+      <QuickInsertPalette
+        open={paletteOpen}
+        onClose={() => {
+          setPaletteOpen(false);
+          focusBoard();
+        }}
+        onSubmit={(draft) => {
+          handleAddSticker(draft);
+        }}
+      />
+    </div>
+  );
+};
+
+export default MoodboardCanvas;

--- a/frontend/src/features/moodboard/components/QuickInsertPalette.tsx
+++ b/frontend/src/features/moodboard/components/QuickInsertPalette.tsx
@@ -1,0 +1,273 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { X, StickyNote, Image as ImageIcon, Link2 } from "lucide-react";
+import styles from "../moodboard.module.css";
+import type {
+  LinkStickerContent,
+  NoteStickerContent,
+  PhotoStickerContent,
+  StickerDraft,
+  StickerType,
+} from "../types";
+
+type QuickInsertPaletteProps = {
+  open: boolean;
+  onClose: () => void;
+  onSubmit: (draft: StickerDraft) => void;
+};
+
+type DraftState = {
+  note: NoteStickerContent;
+  photo: PhotoStickerContent;
+  link: LinkStickerContent;
+};
+
+const createEmptyDraftState = (): DraftState => ({
+  note: { text: "", color: "" },
+  photo: { url: "", alt: "" },
+  link: { label: "", url: "" },
+});
+
+const typeMeta: Record<StickerType, { icon: React.ReactNode; title: string; description: string }> = {
+  note: {
+    icon: <StickyNote size={18} />,
+    title: "Note",
+    description: "Add a sticky note with quick copy or highlights.",
+  },
+  photo: {
+    icon: <ImageIcon size={18} />,
+    title: "Photo",
+    description: "Drop in an inspiration shot, render, or reference.",
+  },
+  link: {
+    icon: <Link2 size={18} />,
+    title: "Link",
+    description: "Pin a URL for vendors, shoppable picks, or docs.",
+  },
+};
+
+const QuickInsertPalette: React.FC<QuickInsertPaletteProps> = ({ open, onClose, onSubmit }) => {
+  const [activeType, setActiveType] = useState<StickerType>("note");
+  const [draftState, setDraftState] = useState<DraftState>(() => createEmptyDraftState());
+  const inputRef = useRef<HTMLInputElement | HTMLTextAreaElement | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      setTimeout(() => inputRef.current?.focus(), 0);
+    }
+  }, [open, activeType]);
+
+  useEffect(() => {
+    if (!open) {
+      setDraftState(createEmptyDraftState());
+      setActiveType("note");
+    }
+  }, [open]);
+
+  const handleKey = useCallback(
+    (event: KeyboardEvent) => {
+      if (!open) return;
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+      }
+    },
+    [onClose, open]
+  );
+
+  useEffect(() => {
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [handleKey]);
+
+  const handleChange = useCallback(
+    (type: StickerType, field: string, value: string) => {
+      setDraftState((prev) => {
+        switch (type) {
+          case "note":
+            return {
+              ...prev,
+              note: {
+                ...prev.note,
+                [field as keyof NoteStickerContent]: value,
+              },
+            };
+          case "photo":
+            return {
+              ...prev,
+              photo: {
+                ...prev.photo,
+                [field as keyof PhotoStickerContent]: value,
+              },
+            };
+          case "link":
+          default:
+            return {
+              ...prev,
+              link: {
+                ...prev.link,
+                [field as keyof LinkStickerContent]: value,
+              },
+            };
+        }
+      });
+    },
+    []
+  );
+
+  const isReady = useMemo(() => {
+    switch (activeType) {
+      case "note":
+        return draftState.note.text.trim().length > 0;
+      case "photo":
+        return draftState.photo.url.trim().length > 0;
+      case "link":
+        return draftState.link.url.trim().length > 0;
+      default:
+        return false;
+    }
+  }, [activeType, draftState]);
+
+  const submit = useCallback(
+    (event?: React.FormEvent) => {
+      event?.preventDefault();
+      if (!isReady) return;
+      const data = draftState[activeType];
+      onSubmit({ type: activeType, content: data } as StickerDraft);
+      onClose();
+      setDraftState(createEmptyDraftState());
+    },
+    [activeType, draftState, isReady, onClose, onSubmit]
+  );
+
+  if (!open) return null;
+
+  const meta = typeMeta[activeType];
+
+  return (
+    <div className={styles.paletteOverlay} role="dialog" aria-modal>
+      <form className={styles.palette} onSubmit={submit}>
+        <div className={styles.paletteHeader}>
+          <h2>
+            {meta.icon} Quick insert
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close quick insert"
+            className={styles.iconButton}
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        <p className={styles.paletteDescription}>{meta.description}</p>
+
+        <div className={styles.paletteBody}>
+          <div className={styles.typeToggleRow} role="radiogroup" aria-label="Sticker type">
+            {(Object.keys(typeMeta) as StickerType[]).map((type) => (
+              <button
+                key={type}
+                type="button"
+                onClick={() => setActiveType(type)}
+                className={styles.typeButton}
+                aria-pressed={type === activeType}
+              >
+                {typeMeta[type].icon}
+                <span>{typeMeta[type].title}</span>
+              </button>
+            ))}
+          </div>
+
+          {activeType === "note" && (
+            <div className={styles.fieldGroup}>
+              <label htmlFor="note-text">Note text</label>
+              <textarea
+                id="note-text"
+                ref={(node) => {
+                  if (node) inputRef.current = node;
+                }}
+                placeholder="What's the vibe?"
+                value={draftState.note.text}
+                onChange={(event) => handleChange("note", "text", event.target.value)}
+              />
+            </div>
+          )}
+
+          {activeType === "photo" && (
+            <>
+              <div className={styles.fieldGroup}>
+                <label htmlFor="photo-url">Image URL</label>
+                <input
+                  id="photo-url"
+                  type="url"
+                  ref={(node) => {
+                    if (node) inputRef.current = node;
+                  }}
+                  placeholder="https://..."
+                  value={draftState.photo.url}
+                  onChange={(event) => handleChange("photo", "url", event.target.value)}
+                  required
+                />
+              </div>
+              <div className={styles.fieldGroup}>
+                <label htmlFor="photo-alt">Caption</label>
+                <input
+                  id="photo-alt"
+                  type="text"
+                  placeholder="Optional context"
+                  value={draftState.photo.alt || ""}
+                  onChange={(event) => handleChange("photo", "alt", event.target.value)}
+                />
+              </div>
+            </>
+          )}
+
+          {activeType === "link" && (
+            <>
+              <div className={styles.fieldGroup}>
+                <label htmlFor="link-label">Label</label>
+                <input
+                  id="link-label"
+                  type="text"
+                  ref={(node) => {
+                    if (node) inputRef.current = node;
+                  }}
+                  placeholder="Vendor, SKU, article..."
+                  value={draftState.link.label}
+                  onChange={(event) => handleChange("link", "label", event.target.value)}
+                />
+              </div>
+              <div className={styles.fieldGroup}>
+                <label htmlFor="link-url">URL</label>
+                <input
+                  id="link-url"
+                  type="url"
+                  placeholder="https://..."
+                  value={draftState.link.url}
+                  onChange={(event) => handleChange("link", "url", event.target.value)}
+                  required
+                />
+              </div>
+            </>
+          )}
+        </div>
+
+        <div className={styles.paletteFooter}>
+          <button type="button" className={styles.secondaryButton} onClick={onClose}>
+            Cancel
+          </button>
+          <button type="submit" className={styles.primaryButton} disabled={!isReady}>
+            Drop sticker
+          </button>
+        </div>
+
+        <div className={styles.quickInsertHint}>
+          <span>Pro tip</span>
+          <span>Hit Enter to drop fast</span>
+        </div>
+      </form>
+    </div>
+  );
+};
+
+export default QuickInsertPalette;

--- a/frontend/src/features/moodboard/components/StickerCard.tsx
+++ b/frontend/src/features/moodboard/components/StickerCard.tsx
@@ -1,0 +1,143 @@
+import React, { useCallback, useMemo } from "react";
+import styles from "../moodboard.module.css";
+import type { Sticker } from "../types";
+
+type StickerCardProps = {
+  sticker: Sticker;
+  isSelected: boolean;
+  isActiveDrag: boolean;
+  offset: { x: number; y: number } | null;
+  onPointerDown: (event: React.PointerEvent<HTMLDivElement>, id: string) => void;
+  onFocus: (id: string) => void;
+  onRemove: (id: string) => void;
+};
+
+const formatTimestamp = (iso: string) => {
+  try {
+    const date = new Date(iso);
+    return date.toLocaleDateString(undefined, {
+      month: "short",
+      day: "numeric",
+    });
+  } catch (error) {
+    return "";
+  }
+};
+
+const StickerCard: React.FC<StickerCardProps> = ({
+  sticker,
+  isSelected,
+  isActiveDrag,
+  offset,
+  onPointerDown,
+  onFocus,
+  onRemove,
+}) => {
+  const { id } = sticker;
+
+  const transform = useMemo(() => {
+    const dx = offset?.x ?? 0;
+    const dy = offset?.y ?? 0;
+    return `translate3d(${sticker.x + dx}px, ${sticker.y + dy}px, 0) rotate(${sticker.rotation}deg)`;
+  }, [offset?.x, offset?.y, sticker.rotation, sticker.x, sticker.y]);
+
+  const stickerStyle = useMemo(() => {
+    const base: React.CSSProperties = {
+      transform,
+      zIndex: sticker.z,
+      touchAction: "none",
+      MozUserSelect: "none",
+    };
+
+    if (sticker.type === "note" && sticker.content.color) {
+      (base as React.CSSProperties & { [key: string]: string })["--note-color"] =
+        sticker.content.color;
+    }
+
+    return base;
+  }, [sticker.content, sticker.type, sticker.z, transform]);
+
+  const handlePointerDown = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      onPointerDown(event, id);
+    },
+    [id, onPointerDown]
+  );
+
+  const handleClick = useCallback(() => {
+    onFocus(id);
+  }, [id, onFocus]);
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (event.key === "Delete" || event.key === "Backspace") {
+        event.preventDefault();
+        onRemove(id);
+      }
+      if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        onFocus(id);
+      }
+    },
+    [id, onFocus, onRemove]
+  );
+
+  const className = [
+    styles.sticker,
+    isSelected ? styles.stickerSelected : "",
+    isActiveDrag ? styles.stickerDragging : "",
+    sticker.type === "note"
+      ? styles.noteSticker
+      : sticker.type === "photo"
+        ? styles.photoSticker
+        : styles.linkSticker,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      aria-pressed={isSelected}
+      className={className}
+      style={stickerStyle}
+      onPointerDown={handlePointerDown}
+      onClick={handleClick}
+      onFocus={() => onFocus(id)}
+      onKeyDown={handleKeyDown}
+    >
+      {sticker.type === "note" && (
+        <div style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: "0.75rem",
+        }}>
+          <strong>Note</strong>
+          <p style={{ margin: 0, whiteSpace: "pre-wrap" }}>{sticker.content.text}</p>
+          <span className={styles.stickerMeta}>{formatTimestamp(sticker.createdAt)}</span>
+        </div>
+      )}
+
+      {sticker.type === "photo" && (
+        <div style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
+          <img src={sticker.content.url} alt={sticker.content.alt || "Moodboard sticker"} />
+          {sticker.content.alt && (
+            <span className={styles.stickerMeta}>{sticker.content.alt}</span>
+          )}
+        </div>
+      )}
+
+      {sticker.type === "link" && (
+        <div style={{ display: "flex", flexDirection: "column", gap: "0.75rem" }}>
+          <span className={styles.stickerMeta}>Link</span>
+          <a href={sticker.content.url} target="_blank" rel="noopener noreferrer">
+            {sticker.content.label || sticker.content.url}
+          </a>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default StickerCard;

--- a/frontend/src/features/moodboard/hooks/useMoodboardStore.ts
+++ b/frontend/src/features/moodboard/hooks/useMoodboardStore.ts
@@ -1,0 +1,237 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { v4 as uuid } from "uuid";
+import type { Sticker, StickerDraft } from "../types";
+
+type StickerUpdate = Partial<Pick<Sticker, "x" | "y" | "rotation" | "z">>;
+
+const GRID_SIZE = 8;
+const STORAGE_PREFIX = "mylg:moodboard:";
+
+const snapToGrid = (value: number) => Math.round(value / GRID_SIZE) * GRID_SIZE;
+const clamp = (value: number, min = 0, max = Number.POSITIVE_INFINITY) =>
+  Math.min(max, Math.max(min, value));
+
+const randomRotation = () => {
+  const magnitude = 1 + Math.random();
+  const direction = Math.random() > 0.5 ? 1 : -1;
+  return Number((magnitude * direction).toFixed(2));
+};
+
+const randomNoteColor = () => {
+  const palette = ["#fef3c7", "#fee2e2", "#e0f2fe", "#dcfce7", "#ede9fe", "#fce7f3"];
+  return palette[Math.floor(Math.random() * palette.length)];
+};
+
+const withDefaults = (draft: StickerDraft): StickerDraft => {
+  if (draft.type === "note") {
+    return {
+      ...draft,
+      content: {
+        color: draft.content.color || randomNoteColor(),
+        text: draft.content.text,
+      },
+    };
+  }
+
+  return draft;
+};
+
+const buildSticker = (
+  draft: StickerDraft,
+  createdBy: string,
+  basePosition: { x: number; y: number }
+): Sticker => {
+  const base = {
+    id: uuid(),
+    x: snapToGrid(basePosition.x),
+    y: snapToGrid(basePosition.y),
+    rotation: randomRotation(),
+    z: 1,
+    createdBy,
+    createdAt: new Date().toISOString(),
+  };
+
+  if (draft.type === "note") {
+    return {
+      ...base,
+      type: "note" as const,
+      content: { ...draft.content },
+    };
+  }
+
+  if (draft.type === "photo") {
+    return {
+      ...base,
+      type: "photo" as const,
+      content: { ...draft.content },
+    };
+  }
+
+  return {
+    ...base,
+    type: "link" as const,
+    content: { ...draft.content },
+  };
+};
+
+const getStorageKey = (projectId?: string) =>
+  projectId ? `${STORAGE_PREFIX}${projectId}` : undefined;
+
+const readFromStorage = (projectId?: string): Sticker[] => {
+  const key = getStorageKey(projectId);
+  if (!key || typeof window === "undefined") return [];
+  try {
+    const stored = window.localStorage.getItem(key);
+    if (!stored) return [];
+    const parsed = JSON.parse(stored) as Sticker[];
+    if (!Array.isArray(parsed)) return [];
+    return parsed.map((item) => ({
+      ...item,
+      x: snapToGrid(item.x),
+      y: snapToGrid(item.y),
+      rotation: typeof item.rotation === "number" ? item.rotation : randomRotation(),
+      z: typeof item.z === "number" ? item.z : 1,
+    }));
+  } catch (error) {
+    console.error("Failed to parse moodboard stickers", error);
+    return [];
+  }
+};
+
+const persistToStorage = (projectId: string | undefined, stickers: Sticker[]): void => {
+  const key = getStorageKey(projectId);
+  if (!key || typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(key, JSON.stringify(stickers));
+  } catch (error) {
+    console.warn("Unable to persist moodboard stickers", error);
+  }
+};
+
+export interface UseMoodboardStoreOptions {
+  projectId?: string;
+  userId?: string;
+}
+
+export interface UseMoodboardStore {
+  stickers: Sticker[];
+  addSticker: (draft: StickerDraft, position?: { x: number; y: number }) => Sticker | null;
+  updateSticker: (id: string, updater: StickerUpdate | ((sticker: Sticker) => StickerUpdate)) => void;
+  removeSticker: (id: string) => void;
+  bringToFront: (id: string) => void;
+  clear: () => void;
+  nextStackIndex: number;
+  snap: (value: number) => number;
+}
+
+export const useMoodboardStore = ({ projectId, userId }: UseMoodboardStoreOptions): UseMoodboardStore => {
+  const [stickers, setStickers] = useState<Sticker[]>(() => readFromStorage(projectId));
+  const latestProject = useRef(projectId);
+
+  useEffect(() => {
+    if (projectId === latestProject.current) return;
+    latestProject.current = projectId;
+    setStickers(readFromStorage(projectId));
+  }, [projectId]);
+
+  const persist = useCallback(
+    (items: Sticker[]) => {
+      setStickers(items);
+      if (projectId) {
+        persistToStorage(projectId, items);
+      }
+    },
+    [projectId]
+  );
+
+  const nextStackIndex = useMemo(() => {
+    if (!stickers.length) return 1;
+    return Math.max(...stickers.map((item) => item.z)) + 1;
+  }, [stickers]);
+
+  const addSticker = useCallback<UseMoodboardStore["addSticker"]>(
+    (rawDraft, position) => {
+      const draft = withDefaults(rawDraft);
+      const owner = userId || "anonymous";
+      const basePosition = position || {
+        x: 48 + stickers.length * 24,
+        y: 48 + stickers.length * 16,
+      };
+
+      const sticker = buildSticker(draft, owner, basePosition);
+      sticker.z = nextStackIndex;
+
+      const updated = [...stickers, sticker];
+      persist(updated);
+      return sticker;
+    },
+    [persist, nextStackIndex, stickers, userId]
+  );
+
+  const updateSticker = useCallback<UseMoodboardStore["updateSticker"]>(
+    (id, updater) => {
+      persist(
+        stickers.map((item) => {
+          if (item.id !== id) return item;
+          const patch = typeof updater === "function" ? updater(item) : updater;
+          const next: Sticker = { ...item };
+
+          if (typeof patch.x === "number") {
+            next.x = clamp(snapToGrid(patch.x));
+          }
+          if (typeof patch.y === "number") {
+            next.y = clamp(snapToGrid(patch.y));
+          }
+          if (typeof patch.rotation === "number") {
+            next.rotation = patch.rotation;
+          }
+          if (typeof patch.z === "number") {
+            next.z = patch.z;
+          }
+          return next;
+        })
+      );
+    },
+    [persist, stickers]
+  );
+
+  const removeSticker = useCallback(
+    (id: string) => {
+      persist(stickers.filter((item) => item.id !== id));
+    },
+    [persist, stickers]
+  );
+
+  const bringToFront = useCallback(
+    (id: string) => {
+      persist(
+        stickers.map((item) =>
+          item.id === id
+            ? {
+                ...item,
+                z: nextStackIndex,
+              }
+            : item
+        )
+      );
+    },
+    [persist, nextStackIndex, stickers]
+  );
+
+  const clear = useCallback(() => {
+    persist([]);
+  }, [persist]);
+
+  return {
+    stickers,
+    addSticker,
+    updateSticker,
+    removeSticker,
+    bringToFront,
+    clear,
+    nextStackIndex,
+    snap: snapToGrid,
+  };
+};
+
+export const useGrid = () => ({ GRID_SIZE, snapToGrid });

--- a/frontend/src/features/moodboard/moodboard.module.css
+++ b/frontend/src/features/moodboard/moodboard.module.css
@@ -1,0 +1,376 @@
+.moodboardPage {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 1.5rem;
+  min-height: 100%;
+  background: radial-gradient(circle at top, rgba(255, 255, 255, 0.02), transparent 55%),
+    #0f1014;
+  color: #f8fafc;
+}
+
+.toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.toolbarButtons {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.iconButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.5rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: rgba(15, 16, 20, 0.9);
+  color: inherit;
+  gap: 0.5rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 120ms ease, border-color 120ms ease, transform 120ms ease;
+}
+
+.iconButton:hover,
+.iconButton:focus-visible {
+  background: rgba(30, 41, 59, 0.85);
+  border-color: rgba(148, 163, 184, 0.8);
+}
+
+.iconButton:active {
+  transform: translateY(1px);
+}
+
+.iconButton:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+.keyboardHint {
+  display: flex;
+  gap: 0.75rem;
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.72);
+}
+
+.keyboardHint kbd {
+  padding: 0.25rem 0.5rem;
+  border-radius: 6px;
+  background: rgba(148, 163, 184, 0.15);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  font-family: "JetBrains Mono", "Fira Mono", monospace;
+  font-size: 0.75rem;
+  color: inherit;
+}
+
+.canvasWrapper {
+  position: relative;
+  flex: 1;
+  min-height: 520px;
+  border-radius: 24px;
+  overflow: hidden;
+  border: 1px solid rgba(51, 65, 85, 0.4);
+  background-image: linear-gradient(rgba(226, 232, 240, 0.04) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(226, 232, 240, 0.04) 1px, transparent 1px);
+  background-size: 8px 8px;
+  background-color: rgba(15, 23, 42, 0.65);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.1);
+}
+
+.canvas {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  outline: none;
+}
+
+.canvas:focus-visible {
+  box-shadow: inset 0 0 0 2px rgba(96, 165, 250, 0.35);
+}
+
+.emptyState {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  color: rgba(226, 232, 240, 0.75);
+  pointer-events: none;
+  padding: 2rem;
+  font-size: 1rem;
+}
+
+.sticker {
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  min-width: 160px;
+  max-width: 240px;
+  padding: 1rem;
+  border-radius: 18px;
+  transform-origin: center;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.4);
+  transition: box-shadow 150ms ease, transform 150ms ease;
+  cursor: grab;
+  user-select: none;
+}
+
+.sticker:active {
+  cursor: grabbing;
+}
+
+.sticker:hover {
+  animation: shadowJitter 220ms ease-in-out infinite alternate;
+}
+
+@keyframes shadowJitter {
+  from {
+    box-shadow: 0 14px 28px rgba(15, 23, 42, 0.45);
+  }
+  to {
+    box-shadow: 0 18px 32px rgba(15, 23, 42, 0.55);
+  }
+}
+
+.stickerSelected {
+  box-shadow: 0 16px 34px rgba(59, 130, 246, 0.45), 0 0 0 2px rgba(96, 165, 250, 0.35);
+}
+
+.stickerDragging {
+  opacity: 0.92;
+  box-shadow: 0 18px 40px rgba(59, 130, 246, 0.55);
+}
+
+.noteSticker {
+  color: #0f172a;
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.4;
+  background: var(--note-color, #fef3c7);
+}
+
+.noteSticker strong {
+  display: block;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(15, 23, 42, 0.55);
+}
+
+.photoSticker {
+  padding: 0.5rem;
+  background: rgba(15, 23, 42, 0.9);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+}
+
+.photoSticker img {
+  width: 100%;
+  height: auto;
+  border-radius: 14px;
+  object-fit: cover;
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.4);
+}
+
+.linkSticker {
+  background: rgba(96, 165, 250, 0.15);
+  border: 1px solid rgba(96, 165, 250, 0.4);
+  color: rgba(191, 219, 254, 0.95);
+}
+
+.linkSticker a {
+  color: inherit;
+  font-weight: 600;
+  text-decoration: none;
+  word-break: break-word;
+}
+
+.linkSticker a:hover,
+.linkSticker a:focus {
+  text-decoration: underline;
+}
+
+.stickerMeta {
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.6;
+}
+
+.paletteOverlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.72);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 2000;
+  padding: 1.5rem;
+}
+
+.palette {
+  width: min(520px, 100%);
+  background: rgba(15, 16, 20, 0.98);
+  border-radius: 24px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  box-shadow: 0 30px 60px rgba(15, 23, 42, 0.55);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  padding: 1.75rem;
+}
+
+.paletteHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.paletteHeader h2 {
+  margin: 0;
+  font-size: 1.15rem;
+  letter-spacing: 0.02em;
+}
+
+.paletteBody {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.typeToggleRow {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.typeButton {
+  flex: 1;
+  border-radius: 14px;
+  padding: 0.75rem 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(30, 41, 59, 0.55);
+  color: inherit;
+  cursor: pointer;
+  font-weight: 600;
+  transition: background 120ms ease, border-color 120ms ease, transform 120ms ease;
+}
+
+.typeButton[aria-pressed="true"] {
+  background: rgba(96, 165, 250, 0.25);
+  border-color: rgba(96, 165, 250, 0.65);
+  box-shadow: 0 0 0 1px rgba(59, 130, 246, 0.4);
+}
+
+.typeButton:hover,
+.typeButton:focus-visible {
+  background: rgba(148, 163, 184, 0.25);
+  border-color: rgba(148, 163, 184, 0.55);
+}
+
+.fieldGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.fieldGroup label {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  opacity: 0.7;
+}
+
+.fieldGroup input,
+.fieldGroup textarea {
+  width: 100%;
+  padding: 0.75rem 0.85rem;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.75);
+  color: inherit;
+  font-size: 0.95rem;
+  line-height: 1.45;
+}
+
+.fieldGroup textarea {
+  min-height: 128px;
+  resize: vertical;
+}
+
+.paletteFooter {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.secondaryButton,
+.primaryButton {
+  padding: 0.75rem 1.25rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 120ms ease, box-shadow 120ms ease, background 120ms ease;
+}
+
+.secondaryButton {
+  background: rgba(15, 23, 42, 0.75);
+  border-color: rgba(148, 163, 184, 0.35);
+}
+
+.secondaryButton:hover,
+.secondaryButton:focus-visible {
+  background: rgba(30, 41, 59, 0.85);
+  border-color: rgba(148, 163, 184, 0.55);
+}
+
+.primaryButton {
+  background: linear-gradient(135deg, rgba(96, 165, 250, 0.8), rgba(129, 140, 248, 0.85));
+  color: #0b1120;
+  box-shadow: 0 12px 32px rgba(59, 130, 246, 0.35);
+}
+
+.primaryButton:hover,
+.primaryButton:focus-visible {
+  box-shadow: 0 14px 36px rgba(59, 130, 246, 0.45);
+  transform: translateY(-1px);
+}
+
+.paletteDescription {
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.72);
+}
+
+.quickInsertHint {
+  display: flex;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.65;
+}
+
+.listPreview {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.75rem;
+}
+
+.previewChip {
+  padding: 0.5rem 0.75rem;
+  border-radius: 12px;
+  background: rgba(148, 163, 184, 0.12);
+  border: 1px dashed rgba(148, 163, 184, 0.3);
+  font-size: 0.8rem;
+  color: rgba(226, 232, 240, 0.85);
+}

--- a/frontend/src/features/moodboard/pages/MoodboardPage.tsx
+++ b/frontend/src/features/moodboard/pages/MoodboardPage.tsx
@@ -1,0 +1,123 @@
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { AnimatePresence, motion } from "framer-motion";
+import ProjectPageLayout from "@/features/project/components/ProjectPageLayout";
+import ProjectHeader from "@/features/project/components/ProjectHeader";
+import MoodboardCanvas from "../components/MoodboardCanvas";
+import { useData } from "@/app/contexts/useData";
+import { findProjectBySlug, slugify } from "@/shared/utils/slug";
+import type { Project } from "@/app/contexts/DataProvider";
+
+const MoodboardPage: React.FC = () => {
+  const { projectSlug = "" } = useParams<{ projectSlug: string }>();
+  const navigate = useNavigate();
+  const {
+    activeProject: initialProject,
+    projects,
+    fetchProjectDetails,
+    setProjects,
+    setSelectedProjects,
+    userId,
+  } = useData();
+
+  const [activeProject, setActiveProject] = useState<Project | null>(initialProject ?? null);
+
+  useEffect(() => {
+    setActiveProject(initialProject ?? null);
+  }, [initialProject]);
+
+  useEffect(() => {
+    if (!projectSlug) return;
+    const matchesSlug =
+      activeProject?.title && slugify(activeProject.title) === projectSlug;
+    if (matchesSlug) return;
+    const fromList = findProjectBySlug(projects, projectSlug);
+    if (fromList && fromList.projectId) {
+      void fetchProjectDetails(fromList.projectId);
+    } else if (initialProject?.title) {
+      navigate(`/dashboard/projects/${slugify(initialProject.title)}/moodboard`, {
+        replace: true,
+      });
+    } else {
+      navigate("/dashboard/projects");
+    }
+  }, [
+    activeProject?.title,
+    fetchProjectDetails,
+    initialProject?.title,
+    navigate,
+    projectSlug,
+    projects,
+  ]);
+
+  useEffect(() => {
+    if (!activeProject?.projectId) return;
+    void fetchProjectDetails(activeProject.projectId);
+  }, [activeProject?.projectId, fetchProjectDetails]);
+
+  const parseStatusToNumber = useCallback((status: string | number | undefined | null) => {
+    if (status === undefined || status === null) return 0;
+    const str = typeof status === "string" ? status : String(status);
+    const num = parseFloat(str.replace("%", ""));
+    return Number.isNaN(num) ? 0 : num;
+  }, []);
+
+  const handleProjectDeleted = useCallback(
+    (projectId: string) => {
+      setProjects((prev) => prev.filter((item) => item.projectId !== projectId));
+      setSelectedProjects((prev) => prev.filter((id) => id !== projectId));
+      navigate("/dashboard/projects");
+    },
+    [navigate, setProjects, setSelectedProjects]
+  );
+
+  const handleActiveProjectChange = useCallback((project: Project) => {
+    setActiveProject(project);
+  }, []);
+
+  const showWelcomeScreen = useCallback(() => {
+    navigate("/dashboard");
+  }, [navigate]);
+
+  const projectId = activeProject?.projectId ?? "";
+  const currentUserId = userId ?? "";
+
+  const board = useMemo(
+    () => (
+      <AnimatePresence mode="wait">
+        <motion.div
+          key={projectId || "moodboard"}
+          initial={{ opacity: 0, y: 24 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: -24 }}
+          transition={{ duration: 0.25 }}
+        >
+          <MoodboardCanvas projectId={projectId} userId={currentUserId} />
+        </motion.div>
+      </AnimatePresence>
+    ),
+    [currentUserId, projectId]
+  );
+
+  return (
+    <ProjectPageLayout
+      projectId={projectId}
+      header={
+        <ProjectHeader
+          parseStatusToNumber={parseStatusToNumber}
+          userId={currentUserId}
+          onProjectDeleted={handleProjectDeleted}
+          activeProject={activeProject}
+          showWelcomeScreen={showWelcomeScreen}
+          onActiveProjectChange={handleActiveProjectChange}
+          onOpenFiles={() => {}}
+          onOpenQuickLinks={() => {}}
+        />
+      }
+    >
+      {board}
+    </ProjectPageLayout>
+  );
+};
+
+export default MoodboardPage;

--- a/frontend/src/features/moodboard/types.ts
+++ b/frontend/src/features/moodboard/types.ts
@@ -1,0 +1,36 @@
+export type StickerType = "note" | "photo" | "link";
+
+export type NoteStickerContent = {
+  text: string;
+  color: string;
+};
+
+export type PhotoStickerContent = {
+  url: string;
+  alt?: string;
+};
+
+export type LinkStickerContent = {
+  label: string;
+  url: string;
+};
+
+export type StickerDraft =
+  | { type: "note"; content: NoteStickerContent }
+  | { type: "photo"; content: PhotoStickerContent }
+  | { type: "link"; content: LinkStickerContent };
+
+interface StickerBase {
+  id: string;
+  x: number;
+  y: number;
+  rotation: number;
+  z: number;
+  createdBy: string;
+  createdAt: string;
+}
+
+export type Sticker =
+  | (StickerBase & { type: "note"; content: NoteStickerContent })
+  | (StickerBase & { type: "photo"; content: PhotoStickerContent })
+  | (StickerBase & { type: "link"; content: LinkStickerContent });

--- a/frontend/src/features/project/components/ProjectHeader.tsx
+++ b/frontend/src/features/project/components/ProjectHeader.tsx
@@ -27,6 +27,7 @@ import {
   LayoutDashboard,
   Coins,
   Calendar as CalendarIcon,
+  StickyNote,
 } from "lucide-react";
 import { uploadData } from "aws-amplify/storage";
 import { useData } from "@/app/contexts/useData";
@@ -1690,13 +1691,77 @@ const ProjectTabs: React.FC<{ projectSlug: string }> = ({ projectSlug }) => {
   const [transitionEnabled, setTransitionEnabled] = useState(false);
   const storageKey = `project-tabs-prev:${projectSlug}`;
 
+  const { user } = useData();
+  const isAdmin = user?.role === "admin";
+  const isDesigner = user?.role === "designer";
+  const showBudgetTab = isAdmin;
+  const showCalendarTab = isAdmin || isDesigner;
+  const showMoodboardTab = isAdmin || isDesigner;
+  const showEditorTab = isAdmin || isDesigner;
+
+  const basePath = `/dashboard/projects/${projectSlug}`;
+
+  const tabs = useMemo(
+    () =>
+      [
+        {
+          key: "overview",
+          label: "Overview",
+          icon: <LayoutDashboard size={16} />,
+          path: basePath,
+          visible: true,
+          matches: (pathname: string) => pathname === basePath,
+        },
+        {
+          key: "budget",
+          label: "Budget",
+          icon: <Coins size={16} />,
+          path: `${basePath}/budget`,
+          visible: showBudgetTab,
+          matches: (pathname: string) => pathname.startsWith(`${basePath}/budget`),
+        },
+        {
+          key: "calendar",
+          label: "Calendar",
+          icon: <CalendarIcon size={16} />,
+          path: `${basePath}/calendar`,
+          visible: showCalendarTab,
+          matches: (pathname: string) => pathname.startsWith(`${basePath}/calendar`),
+        },
+        {
+          key: "moodboard",
+          label: "Moodboard",
+          icon: <StickyNote size={16} />,
+          path: `${basePath}/moodboard`,
+          visible: showMoodboardTab,
+          matches: (pathname: string) => pathname.startsWith(`${basePath}/moodboard`),
+        },
+        {
+          key: "editor",
+          label: "Editor",
+          icon: <PenTool size={16} />,
+          path: `${basePath}/editor`,
+          visible: showEditorTab,
+          matches: (pathname: string) => pathname.startsWith(`${basePath}/editor`),
+        },
+      ].filter((tab) => tab.visible),
+    [
+      basePath,
+      showBudgetTab,
+      showCalendarTab,
+      showEditorTab,
+      showMoodboardTab,
+    ]
+  );
+
+  useEffect(() => {
+    tabRefs.current = tabRefs.current.slice(0, tabs.length);
+  }, [tabs.length]);
+
   const getActiveIndex = useCallback(() => {
-    const base = `/dashboard/projects/${projectSlug}`;
-    if (location.pathname.startsWith(`${base}/budget`)) return 1;
-    if (location.pathname.startsWith(`${base}/calendar`)) return 2;
-    if (location.pathname.startsWith(`${base}/editor`)) return 3;
-    return 0;
-  }, [location.pathname, projectSlug]);
+    const index = tabs.findIndex((tab) => tab.matches(location.pathname));
+    return index === -1 ? 0 : index;
+  }, [location.pathname, tabs]);
 
   const getFromIndex = useCallback(() => {
     if (location.state?.fromTab !== undefined) {
@@ -1752,13 +1817,6 @@ const ProjectTabs: React.FC<{ projectSlug: string }> = ({ projectSlug }) => {
     [navigate, getActiveIndex]
   );
 
-  const { user } = useData();
-  const isAdmin = user?.role === "admin";
-  const isDesigner = user?.role === "designer";
-  const showBudgetTab = isAdmin;
-  const showCalendarTab = isAdmin || isDesigner;
-  const showEditorTab = isAdmin || isDesigner;
-
   return (
     <div
       className="segmented-control with-slider"
@@ -1775,95 +1833,24 @@ const ProjectTabs: React.FC<{ projectSlug: string }> = ({ projectSlug }) => {
         aria-hidden="true"
       />
 
-      <button
-        type="button"
-        ref={(el) => {
-          if (el) tabRefs.current[0] = el;
-        }}
-        onClick={() => confirmNavigate(`/dashboard/projects/${projectSlug}`)}
-        className={
-          location.pathname === `/dashboard/projects/${projectSlug}` ? "active" : ""
-        }
-        aria-pressed={location.pathname === `/dashboard/projects/${projectSlug}`}
-      >
-        <LayoutDashboard size={16} />
-        <span>Overview</span>
-      </button>
-
-      {showBudgetTab && (
-        <button
-          type="button"
-          ref={(el) => {
-            if (el) tabRefs.current[1] = el;
-          }}
-          onClick={() =>
-            confirmNavigate(`/dashboard/projects/${projectSlug}/budget`)
-          }
-          className={
-            location.pathname.startsWith(
-              `/dashboard/projects/${projectSlug}/budget`
-            )
-              ? "active"
-              : ""
-          }
-          aria-pressed={location.pathname.startsWith(
-            `/dashboard/projects/${projectSlug}/budget`
-          )}
-        >
-          <Coins size={16} />
-          <span>Budget</span>
-        </button>
-      )}
-
-      {showCalendarTab && (
-        <button
-          type="button"
-          ref={(el) => {
-            if (el) tabRefs.current[2] = el;
-          }}
-          onClick={() =>
-            confirmNavigate(`/dashboard/projects/${projectSlug}/calendar`)
-          }
-          className={
-            location.pathname.startsWith(
-              `/dashboard/projects/${projectSlug}/calendar`
-            )
-              ? "active"
-              : ""
-          }
-          aria-pressed={location.pathname.startsWith(
-            `/dashboard/projects/${projectSlug}/calendar`
-          )}
-        >
-          <CalendarIcon size={16} />
-          <span>Calendar</span>
-        </button>
-      )}
-
-      {showEditorTab && (
-        <button
-          type="button"
-          ref={(el) => {
-            if (el) tabRefs.current[3] = el;
-          }}
-          onClick={() =>
-            confirmNavigate(`/dashboard/projects/${projectSlug}/editor`)
-          }
-          className={
-            location.pathname.startsWith(
-              `/dashboard/projects/${projectSlug}/editor`
-            )
-              ? "active"
-              : ""
-          }
-          aria-pressed={location.pathname.startsWith(
-            `/dashboard/projects/${projectSlug}/editor`
-          )}
-        >
-          <PenTool size={16} />
-          <span>Editor</span>
-        </button>
-      )}
+      {tabs.map((tab, index) => {
+        const isActive = tab.matches(location.pathname);
+        return (
+          <button
+            key={tab.key}
+            type="button"
+            ref={(el) => {
+              if (el) tabRefs.current[index] = el;
+            }}
+            onClick={() => confirmNavigate(tab.path)}
+            className={isActive ? "active" : ""}
+            aria-pressed={isActive}
+          >
+            {tab.icon}
+            <span>{tab.label}</span>
+          </button>
+        );
+      })}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add a moodboard canvas with draggable stickers, keyboard nudging, and quick insert actions
- persist sticker layout per project with a local storage backed moodboard store and styled sticker variants
- expose the moodboard page under project navigation and dashboard routing

## Testing
- npm run typecheck *(fails: existing issues in WelcomeHeader and Squircle)*

------
https://chatgpt.com/codex/tasks/task_e_68c8f9d88c648324a5307491e18e2a5e