### PR TITLE
Update microcopy across project creation and messaging flows

### DIFF
--- a/frontend/src/features/dashboard/components/Settings.tsx
+++ b/frontend/src/features/dashboard/components/Settings.tsx
@@ -211,7 +211,7 @@ const Settings: React.FC = () => {
       setUserData(updatedUserData);
       toggleSettingsUpdated();
       setShowSavedWindow(true);
-      toast.success("Profile updated");
+      toast.success("Saved. Nice.");
       setIsFormDirty(false);
       setUploadedKey(null);
 
@@ -345,7 +345,7 @@ const Settings: React.FC = () => {
                 className="modal-submit-button settings primary"
                 disabled={isSaving || !isFormDirty}
               >
-                {isSaving ? "Saving..." : showSavedWindow ? "Saved" : "Save"}
+                {isSaving ? "Saving..." : showSavedWindow ? "Saved. Nice." : "Save"}
               </button>
             </div>
           </form>

--- a/frontend/src/features/dashboard/components/WelcomeHeader.tsx
+++ b/frontend/src/features/dashboard/components/WelcomeHeader.tsx
@@ -142,7 +142,7 @@ const WelcomeHeader: React.FC<{ userName?: string; setActiveView?: (view: string
           <div
             className="nav-item-style"
             onClick={() => navigate("/dashboard/new")}
-            title="Create New Project"
+            title="Start something"
           >
             <GridPlus size={isMobile ? 20 : 26} color="white" />
           </div>

--- a/frontend/src/features/dashboard/pages/DashboardLayout.tsx
+++ b/frontend/src/features/dashboard/pages/DashboardLayout.tsx
@@ -20,7 +20,7 @@ const Dashboard: React.FC = () => {
       case "/dashboard":
         return `Dashboard - Welcome, ${userName ?? "Guest"}`;
       case "/dashboard/new":
-        return "Dashboard - New Project";
+        return "Dashboard - Start something";
       case "/dashboard/projects":
         return "Dashboard - All Projects";
       case "/dashboard/settings":

--- a/frontend/src/features/editor/components/canvas/designercomponent.tsx
+++ b/frontend/src/features/editor/components/canvas/designercomponent.tsx
@@ -148,11 +148,12 @@ const DesignerComponent = forwardRef<DesignerRef, DesignerComponentProps>(
           // console.debug('Save successful:', responseData);
           setActiveProject((prev: Project | null) => (prev ? { ...prev, canvasJson } : prev));
           setIsDirty(false);
-          if (showToast) notify("success", "Canvas saved successfully");
+          if (showToast) notify("success", "Saved. Nice.");
         } catch (err: unknown) {
           const error = err as { message?: string };
           console.error("Failed to save canvas:", error);
-          if (showToast) notify("error", `Failed to save canvas: ${error.message || 'Unknown error'}`);
+          if (showToast)
+            notify("error", "Can’t reach the server—your edits are safe; we’ll retry.");
         }
       },
       [activeProject, setActiveProject]

--- a/frontend/src/features/editor/pages/editorpage.tsx
+++ b/frontend/src/features/editor/pages/editorpage.tsx
@@ -62,12 +62,12 @@ const EditorPage: React.FC = () => {
           description: briefContent,
         });
         setIsBriefDirty(false);
-        if (showToast) notify("success", "Brief saved successfully");
+        if (showToast) notify("success", "Saved. Nice.");
       } catch (err) {
         const error = err as { message?: string };
         console.error("Failed to save brief:", error);
         if (showToast)
-          notify("error", `Failed to save brief: ${error.message || "Unknown error"}`);
+          notify("error", "Can’t reach the server—your edits are safe; we’ll retry.");
       }
     },
     [activeProject?.projectId, briefContent, isBriefDirty, updateProjectFields]

--- a/frontend/src/features/gallery/GalleryPage.tsx
+++ b/frontend/src/features/gallery/GalleryPage.tsx
@@ -479,7 +479,7 @@ const GalleryPage: FC<GalleryPageProps> = ({ projectId: propProjectId }) => {
             className={styles.passwordInput}
           />
           <button type="submit" className={styles.button}>
-            Submit
+            Send it
           </button>
         </form>
       </div>

--- a/frontend/src/features/messages/Messages.refactor.test.tsx
+++ b/frontend/src/features/messages/Messages.refactor.test.tsx
@@ -59,6 +59,6 @@ describe("Refactored Messages Components", () => {
 
     render(<MessageInput {...mockProps} />);
     expect(screen.getByPlaceholderText("Type a message...")).toBeInTheDocument();
-    expect(screen.getByText("Send")).toBeInTheDocument();
+    expect(screen.getByText("Send it")).toBeInTheDocument();
   });
 });

--- a/frontend/src/features/messages/ProjectMessagesThread.tsx
+++ b/frontend/src/features/messages/ProjectMessagesThread.tsx
@@ -580,7 +580,7 @@ const ProjectMessagesThread: React.FC<ProjectMessagesThreadProps> = ({
         setNewMessage("");
       } catch (error) {
         console.error("Error sending WS message:", error);
-        setSendError("Failed to send message.");
+        setSendError("Can’t reach the server—your edits are safe; we’ll retry.");
       }
     };
     trySend();
@@ -932,7 +932,7 @@ const ProjectMessagesThread: React.FC<ProjectMessagesThreadProps> = ({
               <div
                 style={{ color: "#aaa", fontSize: "16px", textAlign: "center" }}
               >
-                No messages yet.
+                Looks quiet. Drop your first idea here.
               </div>
             ) : (
               displayMessages.map((msg, index) => (
@@ -972,7 +972,7 @@ const ProjectMessagesThread: React.FC<ProjectMessagesThreadProps> = ({
               className="message-input"
             />
             <button onClick={sendMessage} className="send-button">
-              Send
+              Send it
             </button>
           </div>
         )}

--- a/frontend/src/features/messages/components/ChatWindow.tsx
+++ b/frontend/src/features/messages/components/ChatWindow.tsx
@@ -122,7 +122,7 @@ const ChatWindow: React.FC<ChatWindowProps & {
       >
         {displayMessages.length === 0 && !isLoading ? (
           <div style={{ color: "#aaa", fontSize: 16, textAlign: "center" }}>
-            No messages yet.
+            Looks quiet. Drop your first idea here.
           </div>
         ) : (
           displayMessages.map((msg, index) => (

--- a/frontend/src/features/messages/components/MessageInput.tsx
+++ b/frontend/src/features/messages/components/MessageInput.tsx
@@ -91,7 +91,7 @@ const MessageInput: React.FC<MessageInputProps> = ({
           cursor: "pointer",
         }}
       >
-        Send
+        Send it
       </button>
     </div>
   );

--- a/frontend/src/features/project/components/NewProjectHeader.tsx
+++ b/frontend/src/features/project/components/NewProjectHeader.tsx
@@ -28,7 +28,7 @@ const ProjectHeader: React.FC<ProjectHeaderProps> = () => {
               role="button"
               tabIndex={0}
             />
-            <h2>Create New Project</h2>
+            <h2>Start something</h2>
           </div>
           <div className="right-side">
             <svg

--- a/frontend/src/features/project/components/QuickLinksComponent.tsx
+++ b/frontend/src/features/project/components/QuickLinksComponent.tsx
@@ -127,7 +127,7 @@ const QuickLinksComponent = forwardRef<QuickLinksRef, QuickLinksProps>(
           activeProject.projectId,
           { quickLinks: updatedLinks }
         );
-        toast.success("Quick Links saved");
+        toast.success("Saved. Nice.");
       } catch (err) {
         console.error("Error updating Quick Links:", err);
         setError("Failed to update Quick Links.");

--- a/frontend/src/features/project/pages/NewProject.tsx
+++ b/frontend/src/features/project/pages/NewProject.tsx
@@ -291,7 +291,7 @@ const NewProject: React.FC = () => {
   return (
     <HelmetProvider>
       <Helmet>
-        <title>Create New Project | *MYLG!*</title>
+        <title>Start something | *MYLG!*</title>
         <meta
           name="description"
           content="Create a new project with *MYLG!* - Set budget, timeline, and upload files to get started."
@@ -310,7 +310,7 @@ const NewProject: React.FC = () => {
             >
               <FaArrowLeft />
             </button>
-            <h1 className={styles.newProjectTitle}>Create New Project</h1>
+            <h1 className={styles.newProjectTitle}>Start something</h1>
             <p className={styles.newProjectSubtitle}>
               Set up your project details, budget, and timeline to get started
             </p>
@@ -394,10 +394,10 @@ const NewProject: React.FC = () => {
                               fill="none"
                             />
                           </svg>
-                          Creating Project...
+                          Starting...
                         </div>
                       ) : (
-                        "Create Project"
+                        "Start something"
                       )}
                     </button>
 

--- a/frontend/src/shared/ui/InfoSection.tsx
+++ b/frontend/src/shared/ui/InfoSection.tsx
@@ -20,7 +20,7 @@ export const InfoSection: React.FC<InfoSectionProps> = ({ style }) => {
     const email = emailInput?.value ?? '';
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
     if (!email || !emailRegex.test(email)) {
-      alert('Please enter a valid email address.');
+      alert('Hmm, that doesn’t look right—try email@site.com');
       return;
     }
 

--- a/frontend/src/shared/ui/useDashboardNavigation.tsx
+++ b/frontend/src/shared/ui/useDashboardNavigation.tsx
@@ -78,7 +78,7 @@ export function useDashboardNavigation({ setActiveView, onClose }: UseDashboardN
       {
         key: "create",
         icon: <GridPlus size={24} color="white" />, // icon colors handled in CSS
-        label: "Create New Project",
+        label: "Start something",
         onClick: handleCreateProject,
         isAction: true,
       },


### PR DESCRIPTION
## Summary
- refresh the project creation experience copy by renaming the CTA to "Start something" across navigation, header, and submit states
- update messaging UI microcopy: empty states, send button label, and optimistic error feedback now use the new tone
- align other touchpoints (newsletter validation, quick links, settings, editor saves, gallery password gate) with the updated success/error wording

## Testing
- npm run test -- src/features/messages/Messages.refactor.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68c8f9dd0730832486dba49582d54208