### PR TITLE
Add micro spring animations for chips, badges, and toasts

### DIFF
--- a/frontend/src/features/dashboard/components/ProjectsPanel.tsx
+++ b/frontend/src/features/dashboard/components/ProjectsPanel.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
+import { motion, useReducedMotion } from "framer-motion";
 import { useNavigate } from "react-router-dom";
 import { ChevronDown } from "lucide-react";
 import { Kebab } from "@/shared/icons/Kebab";
@@ -7,6 +8,7 @@ import SVGThumbnail from "./SvgThumbnail";
 import styles from "./projects-panel.module.css";
 import { useProjectKpis, type ProjectLike } from "../hooks/useProjectKpis";
 import { getFileUrl } from "../../../shared/utils/api";
+import { MICRO_WOBBLE_SCALE, SPRING_FAST } from "@/shared/ui/motionTokens";
 
 type Props = {
   onOpenProject: (projectId: string) => void;
@@ -45,6 +47,7 @@ const getProjectActivityTs = (p: ProjectLike): number => {
 };
 
 const ProjectsPanel: React.FC<Props> = ({ onOpenProject }) => {
+  const reduceMotion = useReducedMotion();
   const { projects, isLoading, projectsError, fetchProjects } = useData();
   const navigate = useNavigate();
   const [menuOpenId, setMenuOpenId] = useState<string | null>(null);
@@ -336,15 +339,34 @@ const ProjectsPanel: React.FC<Props> = ({ onOpenProject }) => {
         </div>
 
         <div className={styles.kpis}>
-          <span className={styles.chip}>{kpis.totalProjects} Projects</span>
+          <motion.span
+            className={styles.chip}
+            whileHover={reduceMotion ? undefined : { scale: MICRO_WOBBLE_SCALE }}
+            whileFocus={reduceMotion ? undefined : { scale: MICRO_WOBBLE_SCALE }}
+            transition={reduceMotion ? undefined : SPRING_FAST}
+          >
+            {kpis.totalProjects} Projects
+          </motion.span>
           <span className={styles.dot} />
-          <span className={styles.chip}>{kpis.pendingProjects} Pending</span>
+          <motion.span
+            className={styles.chip}
+            whileHover={reduceMotion ? undefined : { scale: MICRO_WOBBLE_SCALE }}
+            whileFocus={reduceMotion ? undefined : { scale: MICRO_WOBBLE_SCALE }}
+            transition={reduceMotion ? undefined : SPRING_FAST}
+          >
+            {kpis.pendingProjects} Pending
+          </motion.span>
           <span className={styles.dot} />
-          <span className={styles.chip}>
+          <motion.span
+            className={styles.chip}
+            whileHover={reduceMotion ? undefined : { scale: MICRO_WOBBLE_SCALE }}
+            whileFocus={reduceMotion ? undefined : { scale: MICRO_WOBBLE_SCALE }}
+            transition={reduceMotion ? undefined : SPRING_FAST}
+          >
             {kpis.nextProject
               ? `Next: ${kpis.nextProject.title} ${kpis.nextProject.date}`
               : "No upcoming projects"}
-          </span>
+          </motion.span>
         </div>
       </header>
 

--- a/frontend/src/features/dashboard/components/projects-panel.module.css
+++ b/frontend/src/features/dashboard/components/projects-panel.module.css
@@ -117,6 +117,11 @@
   font-size: 11.5px;
   line-height: 1;
   opacity: .85;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  will-change: transform;
+  transform-origin: center;
 }
 
 .dot {

--- a/frontend/src/features/projects/ProjectsPanelDesktop.tsx
+++ b/frontend/src/features/projects/ProjectsPanelDesktop.tsx
@@ -5,6 +5,7 @@ import React, {
   useRef,
   useState,
 } from "react";
+import { motion, useReducedMotion } from "framer-motion";
 import { useNavigate } from "react-router-dom";
 import { ChevronDown } from "lucide-react";
 import { useData } from "@/app/contexts/useData";
@@ -16,6 +17,7 @@ import { getFileUrl } from "@/shared/utils/api";
 import Squircle from "@/shared/ui/Squircle";
 import desktopStyles from "./ProjectsPanelDesktop.module.css";
 import mobileStyles from "@/features/dashboard/components/projects-panel.module.css";
+import { MICRO_WOBBLE_SCALE, SPRING_FAST } from "@/shared/ui/motionTokens";
 
 const PANEL_RADIUS = 24;
 const PANEL_CORNER_RADII = Object.freeze({ top: PANEL_RADIUS + 2, bottom: PANEL_RADIUS - 2 });
@@ -68,6 +70,7 @@ function sanitizeId(raw: string) {
 }
 
 const ProjectsPanelDesktop: React.FC<ProjectsPanelDesktopProps> = ({ onOpenProject }) => {
+  const reduceMotion = useReducedMotion();
   const {
     projects = [],
     isLoading,
@@ -576,15 +579,34 @@ const ProjectsPanelDesktop: React.FC<ProjectsPanelDesktopProps> = ({ onOpenProje
         </div>
 
         <div className={mobileStyles.kpis}>
-          <span className={mobileStyles.chip}>{kpis.totalProjects} Projects</span>
+          <motion.span
+            className={mobileStyles.chip}
+            whileHover={reduceMotion ? undefined : { scale: MICRO_WOBBLE_SCALE }}
+            whileFocus={reduceMotion ? undefined : { scale: MICRO_WOBBLE_SCALE }}
+            transition={reduceMotion ? undefined : SPRING_FAST}
+          >
+            {kpis.totalProjects} Projects
+          </motion.span>
           <span className={mobileStyles.dot} />
-          <span className={mobileStyles.chip}>{kpis.pendingProjects} Pending</span>
+          <motion.span
+            className={mobileStyles.chip}
+            whileHover={reduceMotion ? undefined : { scale: MICRO_WOBBLE_SCALE }}
+            whileFocus={reduceMotion ? undefined : { scale: MICRO_WOBBLE_SCALE }}
+            transition={reduceMotion ? undefined : SPRING_FAST}
+          >
+            {kpis.pendingProjects} Pending
+          </motion.span>
           <span className={mobileStyles.dot} />
-          <span className={mobileStyles.chip}>
+          <motion.span
+            className={mobileStyles.chip}
+            whileHover={reduceMotion ? undefined : { scale: MICRO_WOBBLE_SCALE }}
+            whileFocus={reduceMotion ? undefined : { scale: MICRO_WOBBLE_SCALE }}
+            transition={reduceMotion ? undefined : SPRING_FAST}
+          >
             {kpis.nextProject
               ? `Next: ${kpis.nextProject.title} ${kpis.nextProject.date}`
               : "No upcoming projects"}
-          </span>
+          </motion.span>
         </div>
       </header>
 

--- a/frontend/src/shared/ui/NavBadge.tsx
+++ b/frontend/src/shared/ui/NavBadge.tsx
@@ -1,4 +1,7 @@
 import React from 'react';
+import { motion, useReducedMotion } from 'framer-motion';
+
+import { MICRO_WOBBLE_SCALE, SPRING_FAST } from './motionTokens';
 
 interface NavBadgeProps {
   count: number;
@@ -7,15 +10,25 @@ interface NavBadgeProps {
 }
 
 const NavBadge: React.FC<NavBadgeProps> = ({ count, label, className = 'nav-badge' }) => {
+  const reduceMotion = useReducedMotion();
   if (count === 0) return null;
 
   const display = count > 99 ? '99+' : count;
   const ariaLabel = `${count} unread ${label}${count === 1 ? '' : 's'}`;
 
   return (
-    <span className={className} aria-label={ariaLabel} data-count={display}>
+    <motion.span
+      className={className}
+      aria-label={ariaLabel}
+      data-count={display}
+      initial={reduceMotion ? false : { opacity: 0, scale: 0.9 }}
+      animate={reduceMotion ? undefined : { opacity: 1, scale: 1 }}
+      whileHover={reduceMotion ? undefined : { scale: MICRO_WOBBLE_SCALE }}
+      whileFocus={reduceMotion ? undefined : { scale: MICRO_WOBBLE_SCALE }}
+      transition={reduceMotion ? undefined : SPRING_FAST}
+    >
       {display}
-    </span>
+    </motion.span>
   );
 };
 

--- a/frontend/src/shared/ui/Notification.module.css
+++ b/frontend/src/shared/ui/Notification.module.css
@@ -10,4 +10,6 @@
   display: flex;
   align-items: center;
   gap: 8px;
+  will-change: transform;
+  transform-origin: center;
 }

--- a/frontend/src/shared/ui/NotificationsDrawer.tsx
+++ b/frontend/src/shared/ui/NotificationsDrawer.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { AnimatePresence, motion } from 'framer-motion';
+import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
 import NotificationList, { formatNotification } from './NotificationList';
 import ProjectAvatar from './ProjectAvatar';
 import { Pin, PinOff, Check } from 'lucide-react';
@@ -13,6 +13,7 @@ import { useSocket } from '../../app/contexts/useSocket';
 import { MESSAGES_THREADS_URL, apiFetch } from '../utils/api';
 import type { Thread } from '@/app/contexts/DataProvider';
 import './notifications-drawer.css';
+import { MICRO_WOBBLE_SCALE, SPRING_FAST } from '@/shared/ui/motionTokens';
 
 interface NotificationsDrawerProps {
   open: boolean;
@@ -47,6 +48,7 @@ const NotificationsDrawer: React.FC<NotificationsDrawerProps> = ({
   pinned,
   onTogglePin,
 }) => {
+  const reduceMotion = useReducedMotion();
   const [search, setSearch] = useState('');
   const [activeTab, setActiveTab] = useState<'notifications' | 'inbox'>('notifications');
 
@@ -301,7 +303,14 @@ const NotificationsDrawer: React.FC<NotificationsDrawerProps> = ({
                 >
                   Notifications
                   {unreadNotificationsCount > 0 && (
-                    <span className="drawer-tab-badge">{formatCount(unreadNotificationsCount)}</span>
+                    <motion.span
+                      className="drawer-tab-badge"
+                      whileHover={reduceMotion ? undefined : { scale: MICRO_WOBBLE_SCALE }}
+                      whileFocus={reduceMotion ? undefined : { scale: MICRO_WOBBLE_SCALE }}
+                      transition={reduceMotion ? undefined : SPRING_FAST}
+                    >
+                      {formatCount(unreadNotificationsCount)}
+                    </motion.span>
                   )}
                 </button>
                 <button
@@ -313,7 +322,14 @@ const NotificationsDrawer: React.FC<NotificationsDrawerProps> = ({
                 >
                   Inbox
                   {unreadThreadsCount > 0 && (
-                    <span className="drawer-tab-badge">{formatCount(unreadThreadsCount)}</span>
+                    <motion.span
+                      className="drawer-tab-badge"
+                      whileHover={reduceMotion ? undefined : { scale: MICRO_WOBBLE_SCALE }}
+                      whileFocus={reduceMotion ? undefined : { scale: MICRO_WOBBLE_SCALE }}
+                      transition={reduceMotion ? undefined : SPRING_FAST}
+                    >
+                      {formatCount(unreadThreadsCount)}
+                    </motion.span>
                   )}
                 </button>
               </div>

--- a/frontend/src/shared/ui/ToastNotifications.tsx
+++ b/frontend/src/shared/ui/ToastNotifications.tsx
@@ -1,9 +1,11 @@
 /* eslint-disable react-refresh/only-export-components */
 import React from 'react';
+import { motion, useReducedMotion } from 'framer-motion';
 import { ToastContainer, toast, Slide, Id } from 'react-toastify';
 import { FaCheckCircle, FaTimesCircle, FaInfoCircle, FaExclamationTriangle } from 'react-icons/fa';
 import styles from './Notification.module.css';
 import 'react-toastify/dist/ReactToastify.css';
+import { MICRO_WOBBLE_SCALE, SPRING_SOFT } from './motionTokens';
 
 type ToastType = 'success' | 'error' | 'info' | 'warning';
 
@@ -17,9 +19,28 @@ const icons: Record<ToastType, () => React.ReactNode> = {
 
 const TOAST_CONTAINER_ID = 'global';
 
+const ToastMessage: React.FC<{ message: string }> = ({ message }) => {
+  const reduceMotion = useReducedMotion();
+
+  return (
+    <motion.div
+      className={styles.body}
+      initial={reduceMotion ? false : { opacity: 0, y: -6, scale: 0.94 }}
+      animate={reduceMotion ? undefined : { opacity: 1, y: 0, scale: 1 }}
+      whileHover={reduceMotion ? undefined : { scale: MICRO_WOBBLE_SCALE }}
+      whileFocus={reduceMotion ? undefined : { scale: MICRO_WOBBLE_SCALE }}
+      transition={reduceMotion ? undefined : SPRING_SOFT}
+    >
+      {message}
+    </motion.div>
+  );
+};
+
+const renderToast = (message: string) => () => <ToastMessage message={message} />;
+
 export const notify = (type: ToastType, message: string) => {
   toast.dismiss();
-  return toast(message, {
+  return toast(renderToast(message), {
     type,
     icon: icons[type],
     className: styles.toast,
@@ -29,7 +50,7 @@ export const notify = (type: ToastType, message: string) => {
 
 export const notifyLoading = (message: string) => {
   toast.dismiss();
-  return toast.loading(message, {
+  return toast.loading(renderToast(message), {
     className: styles.toast,
     containerId: TOAST_CONTAINER_ID,
   });
@@ -37,7 +58,7 @@ export const notifyLoading = (message: string) => {
 
 export const updateNotification = (id: Id, type: ToastType, message: string) => {
   toast.update(id, {
-    render: message,
+    render: renderToast(message),
     type,
     icon: icons[type],
     className: styles.toast,

--- a/frontend/src/shared/ui/motionTokens.ts
+++ b/frontend/src/shared/ui/motionTokens.ts
@@ -1,0 +1,27 @@
+import type { Spring } from 'framer-motion';
+
+export const SPRING_FAST: Spring = Object.freeze({
+  type: 'spring',
+  stiffness: 340,
+  damping: 28,
+  mass: 0.9,
+});
+
+export const SPRING_SOFT: Spring = Object.freeze({
+  type: 'spring',
+  stiffness: 220,
+  damping: 24,
+  mass: 1.1,
+});
+
+export const MICRO_WOBBLE_SCALE = 1.03;
+
+export const getMicroHoverScale = (
+  prefersReducedMotion: boolean,
+  scale: number = MICRO_WOBBLE_SCALE,
+) => (prefersReducedMotion ? undefined : { scale });
+
+export const getMicroTransition = (
+  prefersReducedMotion: boolean,
+  spring: Spring = SPRING_FAST,
+) => (prefersReducedMotion ? undefined : spring);


### PR DESCRIPTION
## Summary
- introduce shared spring motion tokens for micro interactions
- apply micro-wobble hover springs to project KPI chips and notification badges
- wrap toast content with framer-motion to add subtle entry and hover overshoot while updating toast styling

## Testing
- npm run lint *(fails: pre-existing lint errors in unrelated tests)*
- npm run typecheck *(fails: pre-existing type errors in WelcomeHeader and Squircle)*

------
https://chatgpt.com/codex/tasks/task_e_68c8f9e1be948324b973057145fb04ec