### PR TITLE
Add draggable moodboard stickers

### DIFF
--- a/frontend/src/app/contexts/DataProvider.tsx
+++ b/frontend/src/app/contexts/DataProvider.tsx
@@ -46,6 +46,22 @@ export interface QuickLink {
   [k: string]: unknown;
 }
 
+export interface MoodboardSticker {
+  id: string;
+  type: "note" | "photo" | "link";
+  title?: string;
+  subtitle?: string;
+  body?: string;
+  url?: string;
+  imageUrl?: string;
+  imageAlt?: string;
+  accentColor?: string;
+  textColor?: string;
+  x: number;
+  y: number;
+  rotation?: number;
+}
+
 export interface Project {
   projectId: string;
   title?: string;
@@ -67,6 +83,7 @@ export interface Project {
   clientEmail?: string;
   previewUrl?: string;
   quickLinks?: QuickLink[];
+  moodboardStickers?: MoodboardSticker[];
   [k: string]: unknown;
 }
 

--- a/frontend/src/features/project/components/Sticker.tsx
+++ b/frontend/src/features/project/components/Sticker.tsx
@@ -1,0 +1,154 @@
+import React, { useMemo } from "react";
+import { Link2 } from "lucide-react";
+import type {
+  DraggableAttributes,
+  DraggableSyntheticListeners,
+  Transform,
+} from "@dnd-kit/core";
+import { CSS } from "@dnd-kit/utilities";
+import type { MoodboardSticker } from "@/app/contexts/DataProvider";
+import { getFileUrl } from "@/shared/utils/api";
+import styles from "./sticker.module.css";
+
+interface StickerProps {
+  sticker: MoodboardSticker;
+  transform: Transform | null;
+  isDragging?: boolean;
+  attributes: DraggableAttributes;
+  listeners: DraggableSyntheticListeners;
+  setNodeRef: (node: HTMLElement | null) => void;
+  zIndex: number;
+  onKeyDown?: (event: React.KeyboardEvent<HTMLDivElement>) => void;
+}
+
+const Sticker: React.FC<StickerProps> = ({
+  sticker,
+  transform,
+  isDragging = false,
+  attributes,
+  listeners,
+  setNodeRef,
+  zIndex,
+  onKeyDown,
+}) => {
+  const translate = CSS.Translate.toString(transform);
+  const rotation = Number.isFinite(sticker.rotation) ? sticker.rotation ?? 0 : 0;
+  const transformString = useMemo(() => {
+    const parts = [] as string[];
+    if (translate) parts.push(translate);
+    parts.push(`rotate(${rotation}deg)`);
+    return parts.join(" ");
+  }, [translate, rotation]);
+
+  const imageSrc = useMemo(() => {
+    if (!sticker.imageUrl) return undefined;
+    try {
+      return getFileUrl(sticker.imageUrl);
+    } catch {
+      return sticker.imageUrl;
+    }
+  }, [sticker.imageUrl]);
+
+  const computedStyle: React.CSSProperties & Record<string, string | number> = {
+    left: sticker.x,
+    top: sticker.y,
+    zIndex,
+    transform: transformString,
+    transformOrigin: "center center",
+  };
+
+  if (sticker.type === "note") {
+    if (sticker.accentColor) {
+      computedStyle["--sticker-note-bg"] = sticker.accentColor;
+    }
+    if (sticker.textColor) {
+      computedStyle["--sticker-note-fg"] = sticker.textColor;
+    }
+  }
+
+  if (sticker.type === "link" && sticker.accentColor) {
+    computedStyle.borderColor = sticker.accentColor;
+  }
+
+  const className = [
+    styles.sticker,
+    styles[sticker.type] ?? "",
+    isDragging ? styles.dragging : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const label = useMemo(() => {
+    if (sticker.title) return sticker.title;
+    if (sticker.subtitle) return sticker.subtitle;
+    if (sticker.body) return sticker.body.slice(0, 80);
+    if (sticker.url) return sticker.url;
+    return "Moodboard sticker";
+  }, [sticker.body, sticker.subtitle, sticker.title, sticker.url]);
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    onKeyDown?.(event);
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      className={className}
+      style={computedStyle}
+      aria-label={label}
+      data-type={sticker.type}
+      {...attributes}
+      onPointerDown={listeners.onPointerDown}
+      onKeyDown={handleKeyDown}
+    >
+      {sticker.type === "note" && (
+        <>
+          {sticker.subtitle && <span className={styles.meta}>{sticker.subtitle}</span>}
+          {sticker.title && <span className={styles.title}>{sticker.title}</span>}
+          {sticker.body && <p className={styles.body}>{sticker.body}</p>}
+        </>
+      )}
+
+      {sticker.type === "photo" && (
+        <>
+          {sticker.subtitle && <span className={styles.badge}>{sticker.subtitle}</span>}
+          {imageSrc && (
+            <img
+              src={imageSrc}
+              alt={sticker.imageAlt || sticker.title || "Moodboard reference"}
+              className={styles.photoImage}
+              draggable={false}
+            />
+          )}
+          {sticker.title && <span className={styles.title}>{sticker.title}</span>}
+          {sticker.body && <p className={styles.photoCaption}>{sticker.body}</p>}
+        </>
+      )}
+
+      {sticker.type === "link" && (
+        <>
+          <div className={styles.linkHeader}>
+            <span className={styles.badge}>{sticker.subtitle || "Link"}</span>
+          </div>
+          <a
+            href={sticker.url || "#"}
+            className={styles.linkAnchor}
+            target={sticker.url ? "_blank" : undefined}
+            rel={sticker.url ? "noopener noreferrer" : undefined}
+            onClick={(event) => {
+              if (!sticker.url) {
+                event.preventDefault();
+              }
+            }}
+          >
+            <Link2 size={16} />
+            <span>{sticker.title || sticker.url || "Open resource"}</span>
+          </a>
+          {sticker.body && <p className={styles.linkMeta}>{sticker.body}</p>}
+        </>
+      )}
+    </div>
+  );
+};
+
+export default Sticker;

--- a/frontend/src/features/project/components/StickerBoard.tsx
+++ b/frontend/src/features/project/components/StickerBoard.tsx
@@ -1,0 +1,338 @@
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import {
+  DndContext,
+  type DragEndEvent,
+  type DragStartEvent,
+  type DragCancelEvent,
+  useDraggable,
+  type Coordinates,
+} from "@dnd-kit/core";
+import type { MoodboardSticker } from "@/app/contexts/DataProvider";
+import { useData } from "@/app/contexts/useData";
+import { enqueueProjectUpdate } from "@/shared/utils/requestQueue";
+import Sticker from "./Sticker";
+import styles from "./sticker-board.module.css";
+
+const GRID_SIZE = 8;
+const MIN_ROTATION = 1;
+const MAX_ROTATION = 2;
+
+const snapToGrid = (value: number): number =>
+  Math.round(value / GRID_SIZE) * GRID_SIZE;
+
+const randomRotation = (): number => {
+  const magnitude = MIN_ROTATION + Math.random() * (MAX_ROTATION - MIN_ROTATION);
+  const sign = Math.random() > 0.5 ? 1 : -1;
+  return Number((magnitude * sign).toFixed(2));
+};
+
+const sanitizeSticker = (sticker: MoodboardSticker): MoodboardSticker => ({
+  ...sticker,
+  x: Math.round(sticker.x),
+  y: Math.round(sticker.y),
+  rotation:
+    sticker.rotation === undefined || Number.isNaN(sticker.rotation)
+      ? randomRotation()
+      : Number(sticker.rotation.toFixed(2)),
+});
+
+const sanitizeStickers = (items: MoodboardSticker[]): MoodboardSticker[] =>
+  items.map(sanitizeSticker);
+
+const buildDefaultStickers = (project: Project | null): MoodboardSticker[] => {
+  const quickLink = Array.isArray(project?.quickLinks)
+    ? project?.quickLinks?.find((link) => Boolean(link?.url))
+    : undefined;
+  const thumbnail = Array.isArray(project?.thumbnails)
+    ? project?.thumbnails.find((item) => typeof item === "string" && item.length > 0)
+    : undefined;
+
+  const description = (project?.description || "")
+    .replace(/\s+/g, " ")
+    .trim();
+  const truncatedDescription = description
+    ? `${description.slice(0, 170)}${description.length > 170 ? "…" : ""}`
+    : "Collect palette notes, adjectives and inspo cues so every collaborator stays on the same wavelength.";
+
+  const defaults: MoodboardSticker[] = [
+    {
+      id: "mood-note",
+      type: "note",
+      subtitle: "Creative North Star",
+      title: project?.title ? `${project.title} direction` : "Creative direction",
+      body: truncatedDescription,
+      accentColor: "#fef3c7",
+      textColor: "#2b1708",
+      x: 40,
+      y: 48,
+    },
+    {
+      id: "mood-photo",
+      type: "photo",
+      subtitle: "Visual Ref",
+      title: project?.title ? `${project.title} hero` : "Hero reference",
+      body: project?.clientName
+        ? `Client: ${project.clientName}`
+        : "Drop renders, swatches or lighting tests here.",
+      imageUrl: thumbnail ?? "/images/Og.png",
+      imageAlt: project?.title ? `${project.title} mood reference` : "Moodboard reference",
+      x: 224,
+      y: 200,
+    },
+    {
+      id: "mood-link",
+      type: "link",
+      subtitle: "Reference",
+      title: quickLink?.title || "Deck & shared inspiration",
+      url: quickLink?.url || "https://mylg.studio",
+      body: quickLink?.url || "Add the working deck, Notion hub or Pinterest link.",
+      accentColor: "#89c7ff",
+      x: 360,
+      y: 64,
+    },
+  ];
+
+  return defaults;
+};
+
+const normalizeStickers = (
+  items: MoodboardSticker[]
+): { stickers: MoodboardSticker[]; changed: boolean } => {
+  const seen = new Set<string>();
+  let changed = false;
+  const normalized: MoodboardSticker[] = [];
+
+  items.forEach((item, index) => {
+    if (!item || typeof item.id !== "string" || seen.has(item.id)) {
+      return;
+    }
+    seen.add(item.id);
+
+    const baseX = Number.isFinite(item.x) ? Number(item.x) : 56 + index * 96;
+    const baseY = Number.isFinite(item.y) ? Number(item.y) : 72 + index * 112;
+    const x = snapToGrid(baseX);
+    const y = snapToGrid(baseY);
+    const rotation =
+      typeof item.rotation === "number" && !Number.isNaN(item.rotation)
+        ? Number(item.rotation.toFixed(2))
+        : randomRotation();
+
+    if (x !== item.x || y !== item.y || rotation !== item.rotation) {
+      changed = true;
+    }
+
+    normalized.push({ ...item, x, y, rotation });
+  });
+
+  return { stickers: normalized, changed };
+};
+
+type DraggableStickerProps = {
+  sticker: MoodboardSticker;
+  isActive: boolean;
+  index: number;
+  onKeyboardNudge: (id: string, delta: Coordinates) => void;
+};
+
+const DraggableSticker: React.FC<DraggableStickerProps> = ({
+  sticker,
+  isActive,
+  index,
+  onKeyboardNudge,
+}) => {
+  const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
+    id: sticker.id,
+  });
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (event.defaultPrevented) return;
+      let delta: Coordinates | null = null;
+      switch (event.key) {
+        case "ArrowUp":
+          delta = { x: 0, y: -GRID_SIZE };
+          break;
+        case "ArrowDown":
+          delta = { x: 0, y: GRID_SIZE };
+          break;
+        case "ArrowLeft":
+          delta = { x: -GRID_SIZE, y: 0 };
+          break;
+        case "ArrowRight":
+          delta = { x: GRID_SIZE, y: 0 };
+          break;
+        default:
+          break;
+      }
+      if (!delta) return;
+      event.preventDefault();
+      onKeyboardNudge(sticker.id, delta);
+    },
+    [onKeyboardNudge, sticker.id]
+  );
+
+  const zIndex = isDragging ? 120 + index : isActive ? 90 + index : 50 + index;
+
+  return (
+    <Sticker
+      sticker={sticker}
+      transform={transform}
+      isDragging={isDragging || isActive}
+      attributes={attributes}
+      listeners={listeners}
+      setNodeRef={setNodeRef}
+      zIndex={zIndex}
+      onKeyDown={handleKeyDown}
+    />
+  );
+};
+
+const StickerBoard: React.FC = () => {
+  const { activeProject, updateProjectFields } = useData();
+  const projectId = activeProject?.projectId ?? null;
+  const [stickers, setStickers] = useState<MoodboardSticker[]>([]);
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const lastPersistedRef = useRef<string>("");
+
+  const persistStickers = useCallback(
+    (next: MoodboardSticker[]) => {
+      if (!projectId || !updateProjectFields) return;
+      const sanitized = sanitizeStickers(next);
+      const serialized = JSON.stringify(sanitized);
+      if (lastPersistedRef.current === serialized) return;
+      lastPersistedRef.current = serialized;
+      void enqueueProjectUpdate(updateProjectFields, projectId, {
+        moodboardStickers: sanitized,
+      });
+    },
+    [projectId, updateProjectFields]
+  );
+
+  useEffect(() => {
+    if (!activeProject || !projectId) {
+      setStickers([]);
+      lastPersistedRef.current = "";
+      return;
+    }
+
+    const stored = Array.isArray(activeProject.moodboardStickers)
+      ? (activeProject.moodboardStickers as MoodboardSticker[])
+      : [];
+    const seed = stored.length ? stored : buildDefaultStickers(activeProject);
+    const { stickers: normalized, changed } = normalizeStickers(seed);
+    setStickers(normalized);
+
+    const serialized = JSON.stringify(sanitizeStickers(normalized));
+    lastPersistedRef.current = serialized;
+
+    if ((changed || stored.length === 0) && projectId && updateProjectFields) {
+      void enqueueProjectUpdate(updateProjectFields, projectId, {
+        moodboardStickers: sanitizeStickers(normalized),
+      });
+    }
+  }, [activeProject, projectId, updateProjectFields]);
+
+  const handleDragStart = useCallback((event: DragStartEvent) => {
+    setActiveId(String(event.active.id));
+  }, []);
+
+  const handleDragCancel = useCallback((event: DragCancelEvent) => {
+    if (event?.active?.id) {
+      setActiveId(null);
+    }
+  }, []);
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const id = String(event.active.id);
+      setActiveId(null);
+      const delta = event.delta;
+      if (!delta || (!delta.x && !delta.y)) return;
+
+      let updated: MoodboardSticker[] | null = null;
+      setStickers((prev) => {
+        const index = prev.findIndex((item) => item.id === id);
+        if (index === -1) return prev;
+        const current = prev[index];
+        const nextX = snapToGrid(current.x + delta.x);
+        const nextY = snapToGrid(current.y + delta.y);
+        if (nextX === current.x && nextY === current.y) return prev;
+        const next = [...prev];
+        next[index] = { ...current, x: nextX, y: nextY };
+        updated = next;
+        return next;
+      });
+
+      if (updated) {
+        persistStickers(updated);
+      }
+    },
+    [persistStickers]
+  );
+
+  const handleKeyboardNudge = useCallback(
+    (id: string, delta: Coordinates) => {
+      let updated: MoodboardSticker[] | null = null;
+      setActiveId(id);
+      setStickers((prev) => {
+        const index = prev.findIndex((item) => item.id === id);
+        if (index === -1) return prev;
+        const current = prev[index];
+        const nextX = snapToGrid(current.x + delta.x);
+        const nextY = snapToGrid(current.y + delta.y);
+        if (nextX === current.x && nextY === current.y) return prev;
+        const next = [...prev];
+        next[index] = { ...current, x: nextX, y: nextY };
+        updated = next;
+        return next;
+      });
+      if (updated) {
+        persistStickers(updated);
+      }
+    },
+    [persistStickers]
+  );
+
+  const hasStickers = stickers.length > 0;
+
+  return (
+    <div className={styles.wrapper}>
+      <div className={styles.card}>
+        <div className={styles.header}>
+          <span className={styles.legend}>Moodboard Stickers</span>
+          <h3 className={styles.title}>Project Atmosphere</h3>
+          <p className={styles.subtitle}>
+            Drop visual cues, notes, and quick links. Everything snaps to the grid so the
+            board stays effortlessly tidy.
+          </p>
+        </div>
+        <div className={styles.board}>
+          <DndContext
+            onDragStart={handleDragStart}
+            onDragEnd={handleDragEnd}
+            onDragCancel={handleDragCancel}
+          >
+            <div className={styles.canvas}>
+              {hasStickers ? null : (
+                <div className={styles.emptyState}>
+                  Start by adding a note, photo, or link to set the tone for your team.
+                </div>
+              )}
+              {stickers.map((sticker, index) => (
+                <DraggableSticker
+                  key={sticker.id}
+                  sticker={sticker}
+                  index={index}
+                  isActive={activeId === sticker.id}
+                  onKeyboardNudge={handleKeyboardNudge}
+                />
+              ))}
+            </div>
+          </DndContext>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default StickerBoard;

--- a/frontend/src/features/project/components/sticker-board.module.css
+++ b/frontend/src/features/project/components/sticker-board.module.css
@@ -1,0 +1,125 @@
+.wrapper {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding: 22px 24px 28px;
+  border-radius: 26px;
+  border: 2px solid rgba(255, 255, 255, 0.14);
+  background: linear-gradient(135deg, rgba(18, 19, 25, 0.92), rgba(8, 9, 12, 0.94));
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.35);
+  overflow: hidden;
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  z-index: 1;
+}
+
+.title {
+  font-size: clamp(1.15rem, 2vw, 1.6rem);
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+.subtitle {
+  font-size: 0.95rem;
+  line-height: 1.45;
+  max-width: 520px;
+  color: rgba(238, 242, 255, 0.7);
+}
+
+.board {
+  position: relative;
+  border-radius: 22px;
+  padding: clamp(22px, 4vw, 36px);
+  min-height: clamp(320px, 46vh, 520px);
+  background: radial-gradient(circle at 12% 16%, rgba(38, 44, 60, 0.35), transparent 55%),
+    radial-gradient(circle at 88% 82%, rgba(50, 24, 44, 0.3), transparent 58%),
+    linear-gradient(145deg, rgba(10, 11, 16, 0.94), rgba(8, 9, 12, 0.88));
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+  overflow: hidden;
+}
+
+.board::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image: linear-gradient(
+      rgba(255, 255, 255, 0.06) 1px,
+      transparent 1px
+    ),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.05) 1px, transparent 1px);
+  background-size: 32px 32px;
+  opacity: 0.24;
+  pointer-events: none;
+}
+
+.board::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='128' height='128'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='.9' numOctaves='3' stitchTiles='stitch'/></filter><rect width='128' height='128' filter='url(%23n)' opacity='.18'/></svg>");
+  mix-blend-mode: screen;
+  opacity: 0.22;
+  pointer-events: none;
+}
+
+.canvas {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  min-height: clamp(280px, 40vh, 460px);
+}
+
+.emptyState {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 24px;
+  font-size: 0.95rem;
+  color: rgba(236, 240, 255, 0.62);
+  pointer-events: none;
+}
+
+.legend {
+  display: flex;
+  gap: 14px;
+  align-items: center;
+  font-size: 0.72rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(225, 230, 255, 0.45);
+}
+
+.legend::before {
+  content: "•";
+  color: #fa3356;
+  font-size: 1.1rem;
+}
+
+@media (max-width: 768px) {
+  .card {
+    padding: 20px 18px 24px;
+  }
+  .board {
+    padding: 22px;
+    min-height: clamp(260px, 52vh, 420px);
+  }
+  .canvas {
+    min-height: clamp(240px, 48vh, 400px);
+  }
+}

--- a/frontend/src/features/project/components/sticker.module.css
+++ b/frontend/src/features/project/components/sticker.module.css
@@ -1,0 +1,159 @@
+.sticker {
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 16px 18px 18px;
+  border-radius: 18px;
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.35);
+  cursor: grab;
+  user-select: none;
+  touch-action: none;
+  max-width: clamp(200px, 24vw, 260px);
+  transition: transform 0.2s ease, box-shadow 0.25s ease;
+  will-change: transform;
+  backdrop-filter: blur(0px);
+  isolation: isolate;
+}
+
+.sticker:focus-visible {
+  outline: 2px solid #fa3356;
+  outline-offset: 4px;
+}
+
+.sticker:hover {
+  animation: stickerShadowJitter 0.6s ease-in-out infinite alternate;
+}
+
+.dragging {
+  cursor: grabbing;
+  animation: none;
+  box-shadow: 0 26px 46px rgba(0, 0, 0, 0.48);
+}
+
+@keyframes stickerShadowJitter {
+  0% {
+    box-shadow: 4px 12px 26px rgba(0, 0, 0, 0.35);
+  }
+  50% {
+    box-shadow: -6px 18px 32px rgba(0, 0, 0, 0.42);
+  }
+  100% {
+    box-shadow: 6px 22px 38px rgba(0, 0, 0, 0.48);
+  }
+}
+
+.meta {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  opacity: 0.55;
+}
+
+.title {
+  font-size: 1rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+}
+
+.body {
+  font-size: 0.94rem;
+  line-height: 1.4;
+  white-space: pre-wrap;
+}
+
+.note {
+  background: var(--sticker-note-bg, #fef3c7);
+  color: var(--sticker-note-fg, #2f1b09);
+  border: 1px solid rgba(0, 0, 0, 0.12);
+}
+
+.note .body {
+  opacity: 0.92;
+}
+
+.photo {
+  padding: 14px 14px 16px;
+  background: linear-gradient(135deg, rgba(24, 26, 31, 0.95), rgba(18, 19, 24, 0.88));
+  color: #f7f9ff;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  gap: 10px;
+}
+
+.photoImage {
+  width: 100%;
+  height: clamp(120px, 18vw, 180px);
+  object-fit: cover;
+  border-radius: 14px;
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.38);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.photoCaption {
+  font-size: 0.86rem;
+  line-height: 1.35;
+  opacity: 0.82;
+}
+
+.link {
+  background: linear-gradient(140deg, rgba(21, 34, 52, 0.95), rgba(15, 26, 40, 0.9));
+  color: #e4edff;
+  border: 1px solid rgba(141, 184, 255, 0.25);
+  gap: 10px;
+}
+
+.linkHeader {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.linkAnchor {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: inherit;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.linkAnchor:hover,
+.linkAnchor:focus-visible {
+  text-decoration: underline;
+}
+
+.linkMeta {
+  font-size: 0.84rem;
+  line-height: 1.35;
+  opacity: 0.75;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  background: rgba(0, 0, 0, 0.12);
+  color: inherit;
+  opacity: 0.8;
+}
+
+.note .badge {
+  background: rgba(0, 0, 0, 0.08);
+  color: inherit;
+}
+
+.link .badge {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.subtle {
+  font-size: 0.78rem;
+  opacity: 0.65;
+  line-height: 1.35;
+}

--- a/frontend/src/features/project/pages/project.tsx
+++ b/frontend/src/features/project/pages/project.tsx
@@ -12,6 +12,7 @@ import QuickLinksComponent from "@/features/project/components/QuickLinksCompone
 import LocationComponent from "@/features/project/components/LocationComponent";
 import FileManagerComponent from "@/features/project/components/FileManager";
 import TasksComponent from "@/features/project/components/TasksComponent";
+import StickerBoard from "@/features/project/components/StickerBoard";
 import { BudgetProvider } from "@/features/budget/context/BudgetProvider";
 import { useData } from "@/app/contexts/useData";
 import { useSocket } from "@/app/contexts/useSocket";
@@ -205,6 +206,8 @@ const SingleProject: React.FC = () => {
                   <BudgetOverviewCard projectId={activeProject?.projectId} />
 
                   <GalleryComponent />
+
+                  <StickerBoard />
                 </div>
                 <div className="calendar-column">
                   <ProjectCalendar

--- a/frontend/src/lib/dnd-kit/core.tsx
+++ b/frontend/src/lib/dnd-kit/core.tsx
@@ -1,0 +1,298 @@
+/* eslint-disable react-refresh/only-export-components */
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+export type UniqueIdentifier = string | number;
+
+export interface Coordinates {
+  x: number;
+  y: number;
+}
+
+export interface Transform {
+  x: number;
+  y: number;
+  scaleX: number;
+  scaleY: number;
+}
+
+export interface Active {
+  id: UniqueIdentifier;
+}
+
+export interface DragStartEvent {
+  active: Active;
+}
+
+export interface DragMoveEvent {
+  active: Active;
+  delta: Coordinates;
+}
+
+export interface DragEndEvent {
+  active: Active;
+  delta: Coordinates;
+}
+
+export interface DragCancelEvent {
+  active: Active;
+}
+
+interface DragContextValue {
+  activeId: UniqueIdentifier | null;
+  beginDrag: (id: UniqueIdentifier) => void;
+  moveDrag: (id: UniqueIdentifier, delta: Coordinates) => void;
+  endDrag: (id: UniqueIdentifier, delta: Coordinates) => void;
+  cancelDrag: (id: UniqueIdentifier) => void;
+}
+
+const DragContext = createContext<DragContextValue | null>(null);
+
+export interface DndContextProps {
+  children: React.ReactNode;
+  onDragStart?: (event: DragStartEvent) => void;
+  onDragMove?: (event: DragMoveEvent) => void;
+  onDragEnd?: (event: DragEndEvent) => void;
+  onDragCancel?: (event: DragCancelEvent) => void;
+}
+
+export const DndContext: React.FC<DndContextProps> = ({
+  children,
+  onDragStart,
+  onDragMove,
+  onDragEnd,
+  onDragCancel,
+}) => {
+  const [activeId, setActiveId] = useState<UniqueIdentifier | null>(null);
+  const activeRef = useRef<UniqueIdentifier | null>(null);
+
+  const beginDrag = useCallback(
+    (id: UniqueIdentifier) => {
+      activeRef.current = id;
+      setActiveId(id);
+      onDragStart?.({ active: { id } });
+    },
+    [onDragStart]
+  );
+
+  const moveDrag = useCallback(
+    (id: UniqueIdentifier, delta: Coordinates) => {
+      if (activeRef.current !== id) return;
+      onDragMove?.({ active: { id }, delta });
+    },
+    [onDragMove]
+  );
+
+  const endDrag = useCallback(
+    (id: UniqueIdentifier, delta: Coordinates) => {
+      if (activeRef.current !== id) return;
+      activeRef.current = null;
+      setActiveId(null);
+      onDragEnd?.({ active: { id }, delta });
+    },
+    [onDragEnd]
+  );
+
+  const cancelDrag = useCallback(
+    (id: UniqueIdentifier) => {
+      if (activeRef.current !== id) return;
+      activeRef.current = null;
+      setActiveId(null);
+      onDragCancel?.({ active: { id } });
+    },
+    [onDragCancel]
+  );
+
+  const value = useMemo<DragContextValue>(
+    () => ({ activeId, beginDrag, moveDrag, endDrag, cancelDrag }),
+    [activeId, beginDrag, moveDrag, endDrag, cancelDrag]
+  );
+
+  return <DragContext.Provider value={value}>{children}</DragContext.Provider>;
+};
+
+export interface UseDraggableArguments {
+  id: UniqueIdentifier;
+  disabled?: boolean;
+}
+
+export interface DraggableAttributes {
+  role: string;
+  tabIndex: number;
+  "aria-roledescription": string;
+}
+
+export type DraggableSyntheticListeners = Pick<
+  React.DOMAttributes<HTMLElement>,
+  "onPointerDown"
+>;
+
+export interface UseDraggableReturn {
+  attributes: DraggableAttributes;
+  listeners: DraggableSyntheticListeners;
+  setNodeRef: (node: HTMLElement | null) => void;
+  transform: Transform | null;
+  isDragging: boolean;
+  active: Active | null;
+}
+
+type PointerState = {
+  pointerId: number;
+  cleanup: () => void;
+};
+
+export const useDraggable = ({
+  id,
+  disabled = false,
+}: UseDraggableArguments): UseDraggableReturn => {
+  const context = useContext(DragContext);
+  if (!context) {
+    throw new Error("useDraggable must be used within a DndContext");
+  }
+
+  const nodeRef = useRef<HTMLElement | null>(null);
+  const pointerStateRef = useRef<PointerState | null>(null);
+  const [transform, setTransform] = useState<Transform | null>(null);
+
+  const cleanupPointerListeners = useCallback(() => {
+    const current = pointerStateRef.current;
+    if (!current) return;
+    current.cleanup();
+    pointerStateRef.current = null;
+  }, []);
+
+  useEffect(() => () => {
+    if (pointerStateRef.current) {
+      const pointerId = pointerStateRef.current.pointerId;
+      cleanupPointerListeners();
+      context.cancelDrag(id);
+      if (nodeRef.current) {
+        nodeRef.current.releasePointerCapture?.(pointerId);
+      }
+    }
+  }, [cleanupPointerListeners, context, id]);
+
+  const handlePointerDown = useCallback(
+    (event: React.PointerEvent<HTMLElement>) => {
+      if (disabled) return;
+      if (event.button !== undefined && event.button !== 0) return;
+
+      const node = nodeRef.current;
+      if (!node) return;
+
+      event.preventDefault();
+      try {
+        node.focus({ preventScroll: true });
+      } catch {
+        /* ignore focus errors */
+      }
+
+      const pointerId = event.pointerId;
+      const originX = event.clientX;
+      const originY = event.clientY;
+      let deltaX = 0;
+      let deltaY = 0;
+
+      function cleanup(): void {
+        window.removeEventListener("pointermove", onMove as EventListener);
+        window.removeEventListener("pointerup", onUp as EventListener);
+        window.removeEventListener("pointercancel", onCancel as EventListener);
+        pointerStateRef.current = null;
+      }
+
+      function onMove(ev: PointerEvent): void {
+        if (ev.pointerId !== pointerId) return;
+        ev.preventDefault();
+        deltaX = ev.clientX - originX;
+        deltaY = ev.clientY - originY;
+        setTransform({ x: deltaX, y: deltaY, scaleX: 1, scaleY: 1 });
+        context.moveDrag(id, { x: deltaX, y: deltaY });
+      }
+
+      function onUp(ev: PointerEvent): void {
+        if (ev.pointerId !== pointerId) return;
+        cleanup();
+        node.releasePointerCapture?.(pointerId);
+        setTransform(null);
+        context.endDrag(id, { x: deltaX, y: deltaY });
+      }
+
+      function onCancel(ev: PointerEvent): void {
+        if (ev.pointerId !== pointerId) return;
+        cleanup();
+        setTransform(null);
+        context.cancelDrag(id);
+      }
+
+      pointerStateRef.current = { pointerId, cleanup };
+
+      window.addEventListener("pointermove", onMove as EventListener, {
+        passive: false,
+      });
+      window.addEventListener("pointerup", onUp as EventListener);
+      window.addEventListener("pointercancel", onCancel as EventListener);
+
+      try {
+        node.setPointerCapture?.(pointerId);
+      } catch {
+        /* ignore pointer capture errors */
+      }
+
+      context.beginDrag(id);
+      setTransform({ x: 0, y: 0, scaleX: 1, scaleY: 1 });
+    },
+    [context, disabled, id]
+  );
+
+  const setNodeRef = useCallback((node: HTMLElement | null) => {
+    nodeRef.current = node;
+  }, []);
+
+  const listeners = useMemo<DraggableSyntheticListeners>(
+    () => ({ onPointerDown: handlePointerDown }),
+    [handlePointerDown]
+  );
+
+  const attributes = useMemo<DraggableAttributes>(
+    () => ({
+      role: "button",
+      tabIndex: 0,
+      "aria-roledescription": "draggable",
+    }),
+    []
+  );
+
+  const isDragging = context.activeId === id;
+  const active = isDragging ? { id } : null;
+
+  return {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    isDragging,
+    active,
+  };
+};
+
+export const useDndContext = (): DragContextValue => {
+  const context = useContext(DragContext);
+  if (!context) {
+    throw new Error("useDndContext must be used within a DndContext");
+  }
+  return context;
+};
+
+export type KeyboardCoordinateGetter = (
+  event: KeyboardEvent,
+  context: { currentCoordinates: Coordinates | null }
+) => Coordinates | undefined;
+
+export const defaultKeyboardCoordinateGetter: KeyboardCoordinateGetter = () => undefined;

--- a/frontend/src/lib/dnd-kit/utilities.ts
+++ b/frontend/src/lib/dnd-kit/utilities.ts
@@ -1,0 +1,15 @@
+import type { Transform } from "./core";
+
+const toTranslateString = (transform: Transform | null | undefined): string | undefined => {
+  if (!transform) return undefined;
+  const { x, y } = transform;
+  return `translate3d(${x}px, ${y}px, 0)`;
+};
+
+export const CSS = {
+  Translate: {
+    toString: toTranslateString,
+  },
+};
+
+export default CSS;

--- a/frontend/src/shared/utils/api.ts
+++ b/frontend/src/shared/utils/api.ts
@@ -39,6 +39,22 @@ export interface QuickLink {
   [k: string]: unknown;
 }
 
+export interface MoodboardSticker {
+  id: string;
+  type: "note" | "photo" | "link";
+  title?: string;
+  subtitle?: string;
+  body?: string;
+  url?: string;
+  imageUrl?: string;
+  imageAlt?: string;
+  accentColor?: string;
+  textColor?: string;
+  x: number;
+  y: number;
+  rotation?: number;
+}
+
 export interface Project {
   projectId: string;
   title?: string;
@@ -60,6 +76,7 @@ export interface Project {
   clientEmail?: string;
   previewUrl?: string;
   quickLinks?: QuickLink[];
+  moodboardStickers?: MoodboardSticker[];
   [key: string]: unknown;
 }
 

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -7,7 +7,9 @@
     "jsx": "react-jsx",
     "baseUrl": "src",
     "paths": {
-      "@/*": ["*"]
+      "@/*": ["*"],
+      "@dnd-kit/core": ["lib/dnd-kit/core"],
+      "@dnd-kit/utilities": ["lib/dnd-kit/utilities"]
     },
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -52,6 +52,8 @@ export default defineConfig(({ mode }) => {
     resolve: {
       alias: {
         "@": path.resolve(__dirname, "src"),
+        "@dnd-kit/core": path.resolve(__dirname, "src/lib/dnd-kit/core.tsx"),
+        "@dnd-kit/utilities": path.resolve(__dirname, "src/lib/dnd-kit/utilities.ts"),
       },
     },
     define: { ...(isDev && { 'process.env': {} }) },


### PR DESCRIPTION
## Summary
- add a moodboard sticker board to the project overview with defaults, drag snapping, keyboard nudging, and persistence
- introduce a lightweight DnD context shim and sticker presentation layer with hover styling and noise texture
- extend project types to store sticker metadata and expose the board on the project page

## Testing
- npm run lint *(fails: pre-existing lint errors in unrelated test files)*

------
https://chatgpt.com/codex/tasks/task_e_68c8fa1069a883248d7895f5e0b9a957