### PR TITLE
Add global noise texture utility

### DIFF
--- a/frontend/src/shared/styles/design-tokens/textures.css
+++ b/frontend/src/shared/styles/design-tokens/textures.css
@@ -1,0 +1,5 @@
+/* Texture tokens */
+:root {
+  --noise-data-uri: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHdpZHRoPScyMDAnIGhlaWdodD0nMjAwJz4KICA8ZmlsdGVyIGlkPSduJz4KICAgIDxmZVR1cmJ1bGVuY2UgdHlwZT0nZnJhY3RhbE5vaXNlJyBiYXNlRnJlcXVlbmN5PScwLjgnIG51bU9jdGF2ZXM9JzQnIHNlZWQ9JzInLz4KICA8L2ZpbHRlcj4KICA8cmVjdCB3aWR0aD0nMjAwJyBoZWlnaHQ9JzIwMCcgZmlsdGVyPSd1cmwoI24pJyBvcGFjaXR5PScwLjM1Jy8+Cjwvc3ZnPg==");
+}
+

--- a/frontend/src/shared/styles/index.css
+++ b/frontend/src/shared/styles/index.css
@@ -6,6 +6,7 @@
 @import './design-tokens/typography.css';
 @import './design-tokens/spacing.css';
 @import './design-tokens/breakpoints.css';
+@import './design-tokens/textures.css';
 @import './design-tokens/design-guide-utilities.css'; /* New design guide compliant utilities */
 
 /* Base Styles - Global resets and base elements */
@@ -39,3 +40,4 @@
 @import './utilities/display.css';
 @import './utilities/spacing.css';
 @import './utilities/typography.css';
+@import './utilities/effects.css';

--- a/frontend/src/shared/styles/utilities/effects.css
+++ b/frontend/src/shared/styles/utilities/effects.css
@@ -1,0 +1,32 @@
+/* Ultra-light texture helpers */
+.noise-surface {
+  position: relative;
+  z-index: 0;
+  isolation: isolate;
+}
+
+.noise-surface::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0.025;
+  background-image: var(--noise-data-uri);
+  background-size: 200px 200px;
+  background-repeat: repeat;
+  mix-blend-mode: soft-light;
+}
+
+[data-noise='off'] .noise-surface::after,
+.noise-surface[data-noise='off']::after {
+  content: none;
+}
+
+@media print,
+  (prefers-contrast: more),
+  (prefers-reduced-motion: reduce),
+  (forced-colors: active) {
+  .noise-surface::after {
+    content: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable texture token for the global noise data URI
- create a `.noise-surface` helper that overlays a subtle noise blend
- disable the noise layer for print, high-contrast, reduced-motion, and manual opt outs

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68c8f9e6c0c08324bf0b5110d097aa49