### PR TITLE
Improve Projects panel mobile layout

### DIFF
--- a/frontend/src/features/dashboard/components/ProjectsPanel.tsx
+++ b/frontend/src/features/dashboard/components/ProjectsPanel.tsx
@@ -18,6 +18,16 @@ const DEFAULT_PROJECT_ROWS = 3;
 
 type ProjectWithMeta = ProjectLike & { _activity: number; _created: number };
 
+const getMaxQuickProjectIcons = (width?: number): number => {
+  if (!width) return 5;
+  if (width <= 360) return 2;
+  if (width <= 400) return 3;
+  if (width <= 520) return 4;
+  if (width <= 680) return 5;
+  if (width <= 840) return 6;
+  return 7;
+};
+
 const formatShortDate = (iso?: string): string | undefined => {
   if (!iso) return undefined;
   const d = new Date(iso);
@@ -55,6 +65,11 @@ const ProjectsPanel: React.FC<Props> = ({ onOpenProject }) => {
   const menuRefs = useRef<Record<string, HTMLDivElement | null>>({});
   const [filtersOpen, setFiltersOpen] = useState(false);
   const filtersRef = useRef<HTMLDivElement | null>(null);
+  const [maxQuickIcons, setMaxQuickIcons] = useState(() =>
+    getMaxQuickProjectIcons(
+      typeof window === "undefined" ? undefined : window.innerWidth
+    )
+  );
 
   // Compact filter/sort options (mirrors AllProjects)
   type SortOption = "titleAsc" | "titleDesc" | "dateNewest" | "dateOldest";
@@ -69,6 +84,15 @@ const ProjectsPanel: React.FC<Props> = ({ onOpenProject }) => {
       fetchProjects();
     }
   }, [isLoading, projects.length, projectsError, fetchProjects]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const handleResize = () =>
+      setMaxQuickIcons(getMaxQuickProjectIcons(window.innerWidth));
+    handleResize();
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
 
   useEffect(() => {
     const onDocClick = (e: MouseEvent) => {
@@ -205,9 +229,7 @@ const ProjectsPanel: React.FC<Props> = ({ onOpenProject }) => {
           {/* Icons strip: ultra-compact, icons only */}
           {(() => {
             const allProjects = projects as ProjectLike[];
-            const maxIcons = 7;
-
-            const shown = allProjects.slice(0, maxIcons);
+            const shown = allProjects.slice(0, maxQuickIcons);
             const more = Math.max(0, allProjects.length - shown.length);
 
             return (
@@ -339,23 +361,25 @@ const ProjectsPanel: React.FC<Props> = ({ onOpenProject }) => {
         </div>
 
         <div className={styles.kpis}>
-          <motion.span
-            className={styles.chip}
-            whileHover={reduceMotion ? undefined : { scale: MICRO_WOBBLE_SCALE }}
-            whileFocus={reduceMotion ? undefined : { scale: MICRO_WOBBLE_SCALE }}
-            transition={reduceMotion ? undefined : SPRING_FAST}
-          >
-            {kpis.totalProjects} Projects
-          </motion.span>
-          <span className={styles.dot} />
-          <motion.span
-            className={styles.chip}
-            whileHover={reduceMotion ? undefined : { scale: MICRO_WOBBLE_SCALE }}
-            whileFocus={reduceMotion ? undefined : { scale: MICRO_WOBBLE_SCALE }}
-            transition={reduceMotion ? undefined : SPRING_FAST}
-          >
-            {kpis.pendingProjects} Pending
-          </motion.span>
+          <div className={styles.kpiGroup}>
+            <motion.span
+              className={`${styles.chip} ${styles.chipNoWrap}`}
+              whileHover={reduceMotion ? undefined : { scale: MICRO_WOBBLE_SCALE }}
+              whileFocus={reduceMotion ? undefined : { scale: MICRO_WOBBLE_SCALE }}
+              transition={reduceMotion ? undefined : SPRING_FAST}
+            >
+              {kpis.totalProjects} Projects
+            </motion.span>
+            <span className={styles.dot} />
+            <motion.span
+              className={`${styles.chip} ${styles.chipNoWrap}`}
+              whileHover={reduceMotion ? undefined : { scale: MICRO_WOBBLE_SCALE }}
+              whileFocus={reduceMotion ? undefined : { scale: MICRO_WOBBLE_SCALE }}
+              transition={reduceMotion ? undefined : SPRING_FAST}
+            >
+              {kpis.pendingProjects} Pending
+            </motion.span>
+          </div>
           <span className={styles.dot} />
           <motion.span
             className={styles.chip}

--- a/frontend/src/features/dashboard/components/projects-panel.module.css
+++ b/frontend/src/features/dashboard/components/projects-panel.module.css
@@ -110,6 +110,13 @@
   margin: 4px 2px; /* compact */
 }
 
+.kpiGroup {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: nowrap;
+}
+
 .chip {
   border: 1px solid var(--chip-border, rgba(255, 255, 255, .16));
   border-radius: 999px;
@@ -125,6 +132,10 @@
   justify-content: center;
   will-change: transform;
   transform-origin: center;
+}
+
+.chipNoWrap {
+  white-space: nowrap;
 }
 
 .dot {


### PR DESCRIPTION
## Summary
- adjust the quick projects strip to show fewer icons on smaller screens so the overflow pill stays visible
- group the KPI chips and prevent the project counts from wrapping to separate lines on mobile

## Testing
- npm run lint *(fails: existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c9105077f08324b6c2426d78e1b983