### PR TITLE
Add tasks overview card to welcome header

### DIFF
--- a/frontend/src/features/dashboard/components/TasksOverviewCard.module.css
+++ b/frontend/src/features/dashboard/components/TasksOverviewCard.module.css
@@ -1,0 +1,241 @@
+.card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2, 16px);
+  padding: clamp(20px, 2.2vw, 28px);
+  color: rgba(255, 255, 255, 0.95);
+  background:
+    radial-gradient(140% 140% at 100% 0%, color-mix(in srgb, var(--brand, #fa3356) 18%, transparent) 0%, transparent 58%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.08) 0%, rgba(255, 255, 255, 0) 68%),
+    var(--bg2, #111213);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--radius-squircle, var(--radius-lg, 24px));
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 255, 255, 0.02),
+    0 18px 48px rgba(0, 0, 0, 0.45);
+  overflow: hidden;
+  isolation: isolate;
+}
+
+@supports (color: color-mix(in srgb, white 50%, black 50%)) {
+  .card {
+    border-color: color-mix(in srgb, rgba(255, 255, 255, 0.08) 78%, transparent 22%);
+    box-shadow:
+      inset 0 0 0 1px color-mix(in srgb, rgba(255, 255, 255, 0.08) 55%, transparent 45%),
+      0 18px 48px rgba(0, 0, 0, 0.45);
+  }
+}
+
+.card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='96' height='96'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='.9' numOctaves='3' stitchTiles='stitch'/></filter><rect width='96' height='96' filter='url(%23n)' opacity='.08'/></svg>");
+  background-size: 180px 180px;
+  mix-blend-mode: soft-light;
+  opacity: 0.45;
+}
+
+@media (prefers-reduced-transparency: reduce) {
+  .card {
+    background: var(--bg2, #111213);
+    box-shadow: 0 18px 48px rgba(0, 0, 0, 0.45);
+  }
+
+  .card::after {
+    display: none;
+  }
+}
+
+.card > * {
+  position: relative;
+  z-index: 1;
+}
+
+.header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-2, 16px);
+}
+
+.titleWrap {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.title {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.subtitle {
+  margin: 0;
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.iconButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 38px;
+  height: 38px;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: rgba(255, 255, 255, 0.05);
+  color: rgba(255, 255, 255, 0.92);
+  transition: background-color 0.18s ease, border-color 0.18s ease, transform 0.18s ease;
+}
+
+.iconButton:hover:not(:disabled) {
+  transform: translateY(-1px);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.iconButton:focus-visible {
+  outline: 2px solid var(--color-focus, var(--brand, #fa3356));
+  outline-offset: 2px;
+}
+
+.iconButton:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.iconButtonPrimary {
+  border-color: color-mix(in srgb, var(--brand, #fa3356) 52%, transparent);
+  background: color-mix(in srgb, var(--brand, #fa3356) 18%, transparent);
+  color: color-mix(in srgb, var(--brand, #fa3356) 82%, white 18%);
+}
+
+.iconButtonPrimary:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--brand, #fa3356) 26%, transparent);
+}
+
+.statGrid {
+  display: grid;
+  gap: var(--space-2, 16px);
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}
+
+.stat {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 14px 16px;
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.04);
+  min-height: 82px;
+}
+
+.statOk {
+  border-color: color-mix(in srgb, var(--color-success, #4caf50) 48%, transparent);
+  background: color-mix(in srgb, var(--color-success, #4caf50) 15%, transparent);
+}
+
+.statWarn {
+  border-color: color-mix(in srgb, var(--color-warning, #ff9800) 48%, transparent);
+  background: color-mix(in srgb, var(--color-warning, #ff9800) 15%, transparent);
+}
+
+.statDanger {
+  border-color: color-mix(in srgb, var(--color-error, #ef5350) 52%, transparent);
+  background: color-mix(in srgb, var(--color-error, #ef5350) 18%, transparent);
+}
+
+.statLabel {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.7);
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.statValue {
+  font-size: 24px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.groups {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2, 16px);
+}
+
+.group {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.groupLabel {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.58);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.02em;
+}
+
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 14px;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.05);
+  color: rgba(255, 255, 255, 0.9);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  font-size: 13px;
+  line-height: 1.2;
+}
+
+.chipDot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.35);
+}
+
+.chipTitle {
+  font-weight: 600;
+}
+
+.chipMeta {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.62);
+}
+
+.empty {
+  padding: 18px 0 6px;
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+@media (max-width: 900px) {
+  .card {
+    padding: 20px;
+  }
+
+  .statGrid {
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  }
+}

--- a/frontend/src/features/dashboard/components/TasksOverviewCard.tsx
+++ b/frontend/src/features/dashboard/components/TasksOverviewCard.tsx
@@ -1,0 +1,456 @@
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Plus, MoreHorizontal } from "lucide-react";
+
+import { useData } from "@/app/contexts/useData";
+import type { Project } from "@/app/contexts/DataProvider";
+import { fetchTasks } from "@/shared/utils/api";
+import { getColor } from "@/shared/utils/colorUtils";
+import { slugify } from "@/shared/utils/slug";
+import pLimit from "@/shared/utils/pLimit";
+import Squircle from "@/shared/ui/Squircle";
+import { endOfWeek, startOfWeek } from "@/features/dashboard/utils/dateUtils";
+
+import styles from "./TasksOverviewCard.module.css";
+
+const CARD_RADIUS = 24;
+
+const dayFormatter = new Intl.DateTimeFormat(undefined, {
+  weekday: "short",
+  month: "short",
+  day: "numeric",
+});
+
+const timeFormatter = new Intl.DateTimeFormat(undefined, {
+  hour: "numeric",
+  minute: "2-digit",
+});
+
+type RawTask = {
+  taskId?: string;
+  id?: string;
+  projectId?: string;
+  title?: string;
+  name?: string;
+  status?: string;
+  dueAt?: string | number | Date;
+  due_at?: string | number | Date;
+  dueDate?: string | number | Date;
+  due_date?: string | number | Date;
+  due?: string | number | Date;
+  [key: string]: unknown;
+};
+
+type TaskStatus = "todo" | "in_progress" | "done" | string;
+
+type NormalizedTask = {
+  id: string;
+  title: string;
+  status: TaskStatus;
+  dueDate: Date | null;
+  projectId: string;
+  projectName: string;
+  projectColor: string;
+  dueKey?: string;
+  timeLabel?: string;
+};
+
+type EventChip = {
+  id: string;
+  title: string;
+  time?: string;
+  project?: string;
+  color?: string;
+};
+
+type EventGroup = {
+  id: string;
+  dayLabel: string;
+  items: EventChip[];
+};
+
+type TasksOverviewCardProps = {
+  className?: string;
+};
+
+function parseDueDate(value?: unknown): Date | null {
+  if (value == null || value === "") return null;
+
+  if (value instanceof Date) {
+    const copy = new Date(value.getTime());
+    return Number.isNaN(copy.getTime()) ? null : copy;
+  }
+
+  if (typeof value === "number") {
+    const byNumber = new Date(value);
+    return Number.isNaN(byNumber.getTime()) ? null : byNumber;
+  }
+
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+
+    const direct = new Date(trimmed);
+    if (!Number.isNaN(direct.getTime())) {
+      return direct;
+    }
+
+    if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
+      const iso = new Date(`${trimmed}T00:00:00`);
+      return Number.isNaN(iso.getTime()) ? null : iso;
+    }
+  }
+
+  return null;
+}
+
+function normalizeTitle(value?: unknown): string {
+  if (typeof value !== "string") return "Untitled task";
+  const trimmed = value.trim();
+  if (!trimmed) return "Untitled task";
+
+  if (trimmed === trimmed.toUpperCase()) {
+    return trimmed
+      .toLowerCase()
+      .split(/\s+/)
+      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+      .join(" ");
+  }
+
+  return trimmed;
+}
+
+function pickDue(raw: RawTask): { value: Date | null; key?: string; timeLabel?: string } {
+  const candidate =
+    raw.dueAt ?? raw.due_at ?? raw.dueDate ?? raw.due_date ?? raw.due ?? null;
+
+  const dueDate = parseDueDate(candidate);
+  if (!dueDate) {
+    return { value: null, key: undefined, timeLabel: undefined };
+  }
+
+  const key = `${dueDate.getFullYear()}-${String(dueDate.getMonth() + 1).padStart(2, "0")}-${String(
+    dueDate.getDate(),
+  ).padStart(2, "0")}`;
+
+  const rawString = typeof candidate === "string" ? candidate : undefined;
+  const timeLabel = rawString && rawString.includes("T") ? timeFormatter.format(dueDate) : undefined;
+
+  return { value: dueDate, key, timeLabel };
+}
+
+const TasksOverviewCard: React.FC<TasksOverviewCardProps> = ({ className }) => {
+  const { projects = [] } = useData() as { projects: Project[] };
+  const navigate = useNavigate();
+
+  const [tasks, setTasks] = useState<NormalizedTask[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(false);
+
+  const projectMap = useMemo(() => {
+    const map = new Map<string, Project>();
+    projects.forEach((project) => {
+      if (project?.projectId) {
+        map.set(project.projectId, project);
+      }
+    });
+    return map;
+  }, [projects]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const limit = pLimit(3);
+
+    const load = async () => {
+      if (!projects.length) {
+        setTasks([]);
+        setLoading(false);
+        setError(false);
+        return;
+      }
+
+      setLoading(true);
+      setError(false);
+
+      try {
+        const results = await Promise.all(
+          projects
+            .filter((project) => project?.projectId)
+            .map((project) =>
+              limit(async () => {
+                try {
+                  const raw = await fetchTasks(project.projectId);
+                  return (raw || []).map((task: RawTask, idx) => {
+                    const { value: dueDate, key: dueKey, timeLabel } = pickDue(task);
+                    const projectName = project.title || project.projectId;
+                    const projectColor = project.color || getColor(project.projectId);
+                    const id =
+                      (task.taskId as string | undefined) ||
+                      (task.id as string | undefined) ||
+                      `${project.projectId}-${idx}`;
+
+                    const status = typeof task.status === "string" ? task.status.toLowerCase() : "todo";
+                    const title = normalizeTitle(task.title ?? task.name);
+
+                    return {
+                      id,
+                      title,
+                      status,
+                      dueDate,
+                      dueKey,
+                      timeLabel,
+                      projectId: project.projectId,
+                      projectName,
+                      projectColor,
+                    } satisfies NormalizedTask;
+                  });
+                } catch (err) {
+                  console.error("Failed to fetch tasks for project", project.projectId, err);
+                  return [] as NormalizedTask[];
+                }
+              }),
+            ),
+        );
+
+        if (cancelled) return;
+
+        setTasks(results.flat());
+      } catch (err) {
+        if (!cancelled) {
+          console.error("Failed to load tasks overview", err);
+          setTasks([]);
+          setError(true);
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+
+    load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [projects]);
+
+  const projectSlugMap = useMemo(() => {
+    const map = new Map<string, string>();
+    projects.forEach((project) => {
+      if (project?.projectId) {
+        const slug = slugify(project.title || project.projectId);
+        map.set(project.projectId, slug);
+      }
+    });
+    return map;
+  }, [projects]);
+
+  const { completed, dueSoon, overdue, groups, primaryProjectId } = useMemo(() => {
+    const now = new Date();
+    const weekStart = startOfWeek(now);
+    const weekEnd = endOfWeek(now);
+    const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+
+    let completedCount = 0;
+    let dueSoonCount = 0;
+    let overdueCount = 0;
+
+    const groupMap = new Map<
+      string,
+      {
+        id: string;
+        label: string;
+        date: Date;
+        items: Array<EventChip & { due: Date }>;
+      }
+    >();
+
+    tasks.forEach((task) => {
+      if (!task.dueDate) {
+        return;
+      }
+
+      const due = task.dueDate;
+      const isDone = task.status === "done";
+
+      if (isDone && due >= weekStart && due <= weekEnd) {
+        completedCount += 1;
+      }
+
+      if (!isDone) {
+        if (due < todayStart) {
+          overdueCount += 1;
+        } else if (due <= weekEnd) {
+          dueSoonCount += 1;
+        }
+      }
+
+      if (!isDone && due >= weekStart && due <= weekEnd) {
+        const key = task.dueKey || `${due.getFullYear()}-${due.getMonth()}-${due.getDate()}`;
+        let group = groupMap.get(key);
+        if (!group) {
+          group = {
+            id: key,
+            label: dayFormatter.format(due),
+            date: due,
+            items: [],
+          };
+          groupMap.set(key, group);
+        }
+
+        group.items.push({
+          id: task.id,
+          title: task.title,
+          time: task.timeLabel,
+          project: task.projectName,
+          color: task.projectColor,
+          due,
+        });
+      }
+    });
+
+    const groups: EventGroup[] = Array.from(groupMap.values())
+      .sort((a, b) => a.date.getTime() - b.date.getTime())
+      .map((group) => ({
+        id: group.id,
+        dayLabel: group.label,
+        items: group.items
+          .sort((a, b) => a.due.getTime() - b.due.getTime() || a.title.localeCompare(b.title))
+          .map((item) => ({
+            id: item.id,
+            title: item.title,
+            time: item.time,
+            project: item.project,
+            color: item.color,
+          })),
+      }));
+
+    const sortedByUrgency = tasks
+      .filter((task) => task.dueDate && task.status !== "done")
+      .sort((a, b) => {
+        if (!a.dueDate || !b.dueDate) return 0;
+        return a.dueDate.getTime() - b.dueDate.getTime();
+      });
+
+    const primaryProjectId = sortedByUrgency[0]?.projectId ?? tasks[0]?.projectId ?? null;
+
+    return {
+      completed: completedCount,
+      dueSoon: dueSoonCount,
+      overdue: overdueCount,
+      groups,
+      primaryProjectId,
+    };
+  }, [tasks]);
+
+  const handleNavigateToPrimary = useCallback(() => {
+    if (!primaryProjectId) {
+      navigate("/dashboard/projects");
+      return;
+    }
+
+    const slug = projectSlugMap.get(primaryProjectId) ?? primaryProjectId;
+    navigate(`/dashboard/projects/${slug}`);
+  }, [navigate, primaryProjectId, projectSlugMap]);
+
+  const handleViewAll = useCallback(() => {
+    navigate("/dashboard/projects");
+  }, [navigate]);
+
+  const canNavigateToProject = Boolean(primaryProjectId && projectMap.has(primaryProjectId));
+
+  const formatStatValue = (value: number): string | number => {
+    if (error) return "—";
+    if (loading) return "…";
+    return value;
+  };
+
+  return (
+    <Squircle
+      as="section"
+      radius={CARD_RADIUS}
+      smoothing={0.6}
+      className={`${styles.card} ${className ?? ""}`.trim()}
+      aria-label="Tasks overview"
+    >
+      <header className={styles.header}>
+        <div className={styles.titleWrap}>
+          <h3 className={styles.title}>Tasks</h3>
+          <p className={styles.subtitle}>Track progress and deadlines across your projects.</p>
+        </div>
+        <div className={styles.actions}>
+          <button
+            type="button"
+            className={`${styles.iconButton} ${styles.iconButtonPrimary}`}
+            onClick={handleNavigateToPrimary}
+            aria-label="Add or review tasks for the next project"
+            disabled={!canNavigateToProject}
+          >
+            <Plus size={18} strokeWidth={2} />
+          </button>
+          <button
+            type="button"
+            className={styles.iconButton}
+            onClick={handleViewAll}
+            aria-label="View all projects"
+          >
+            <MoreHorizontal size={18} strokeWidth={2} />
+          </button>
+        </div>
+      </header>
+
+      <div className={styles.statGrid}>
+        <div className={`${styles.stat} ${styles.statOk}`}>
+          <span className={styles.statLabel}>Completed</span>
+          <span className={styles.statValue}>{formatStatValue(completed)}</span>
+        </div>
+        <div className={`${styles.stat} ${styles.statDanger}`}>
+          <span className={styles.statLabel}>Overdue</span>
+          <span className={styles.statValue}>{formatStatValue(overdue)}</span>
+        </div>
+        <div className={`${styles.stat} ${styles.statWarn}`}>
+          <span className={styles.statLabel}>Due</span>
+          <span className={styles.statValue}>{formatStatValue(dueSoon)}</span>
+        </div>
+      </div>
+
+      {error ? (
+        <div className={styles.empty}>We couldn’t load tasks right now. Please try again later.</div>
+      ) : groups.length ? (
+        <div className={styles.groups}>
+          {groups.map((group) => (
+            <div key={group.id} className={styles.group}>
+              <div className={styles.groupLabel}>{group.dayLabel}</div>
+              <div className={styles.chips}>
+                {group.items.map((item) => (
+                  <div key={item.id} className={styles.chip}>
+                    <span
+                      className={styles.chipDot}
+                      style={{ backgroundColor: item.color || "var(--brand, #fa3356)" }}
+                      aria-hidden="true"
+                    />
+                    <span className={styles.chipTitle}>{item.title}</span>
+                    {(item.time || item.project) && (
+                      <span className={styles.chipMeta}>
+                        {item.time}
+                        {item.time && item.project ? " · " : ""}
+                        {item.project}
+                      </span>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className={styles.empty}>
+          {loading ? "Loading tasks…" : "No open tasks are due this week. You’re all caught up!"}
+        </div>
+      )}
+    </Squircle>
+  );
+};
+
+export default TasksOverviewCard;

--- a/frontend/src/features/dashboard/components/WelcomeHeader.tsx
+++ b/frontend/src/features/dashboard/components/WelcomeHeader.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { User, Bell, Menu } from "lucide-react";
 import { useData } from '@/app/contexts/useData';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { useOnlineStatus } from '@/app/contexts/OnlineStatusContext';
 import NotificationsDrawer from '../../../shared/ui/NotificationsDrawer';
 import { useNotifications } from "../../../app/contexts/useNotifications";
@@ -11,11 +11,14 @@ import GlobalSearch from './GlobalSearch';
 import './GlobalSearch.css';
 import { getFileUrl } from '../../../shared/utils/api';
 import { useAppShell } from '@/app/layout/AppShell';
+import WeekWidgetCard from "@/features/schedule/WeekWidgetCard";
+import TasksOverviewCard from "./TasksOverviewCard";
 
 const WelcomeHeader: React.FC<{ userName?: string; setActiveView?: (view: string) => void }> = ({ userName: propUserName, setActiveView }) => {
   const { userData } = useData();
   const { isOnline } = useOnlineStatus(); // <-- only need this now
   const navigate = useNavigate();
+  const location = useLocation();
   const appShell = useAppShell();
 
   const userName = propUserName || userData?.firstName || userData?.email || 'User';
@@ -91,6 +94,20 @@ const WelcomeHeader: React.FC<{ userName?: string; setActiveView?: (view: string
   ]
     .filter(Boolean)
     .join(' ');
+
+  const activeView = React.useMemo(() => {
+    const segments = location.pathname.split('/').filter(Boolean);
+    const idx = segments.indexOf('dashboard');
+    if (idx === -1) return null;
+
+    let view = segments[idx + 1] ?? 'welcome';
+    if (view === 'welcome') {
+      view = segments[idx + 2] ?? 'welcome';
+    }
+    return view;
+  }, [location.pathname]);
+
+  const showWelcomeCards = Boolean(isDesktopShell && activeView === 'welcome');
 
   return (
     <>
@@ -213,6 +230,13 @@ const WelcomeHeader: React.FC<{ userName?: string; setActiveView?: (view: string
           </div>
         </div>
       </div>
+
+      {showWelcomeCards && (
+        <div className="welcome-header-extras" role="region" aria-label="This week overview">
+          <WeekWidgetCard className="welcome-header-week-card" />
+          <TasksOverviewCard className="welcome-header-tasks-card" />
+        </div>
+      )}
 
       <NotificationsDrawer
         open={notificationsOpen}

--- a/frontend/src/features/dashboard/pages/DashboardHome.tsx
+++ b/frontend/src/features/dashboard/pages/DashboardHome.tsx
@@ -19,7 +19,6 @@ import NavigationDrawer from "@/shared/ui/NavigationDrawer";
 import DashboardNavPanel from "@/shared/ui/DashboardNavPanel";
 import AppShell from "@/app/layout/AppShell";
 import ProjectsPanelDesktop from "@/features/projects/ProjectsPanelDesktop";
-import WeekWidgetCard from "@/features/schedule/WeekWidgetCard";
 
 import "./dashboard-styles.css";
 
@@ -155,7 +154,6 @@ const WelcomeScreen: React.FC = () => {
           <ProjectsPanelDesktop
             onOpenProject={(projectId) => handleNavigateToProject({ projectId })}
           />
-          <WeekWidgetCard />
         </div>
       );
     }

--- a/frontend/src/features/dashboard/styles/components/welcome-header.css
+++ b/frontend/src/features/dashboard/styles/components/welcome-header.css
@@ -34,6 +34,21 @@
   gap: 8px;
 }
 
+.welcome-header-extras {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3, 24px);
+  width: 100%;
+  margin-top: clamp(12px, 1.5vw, 18px);
+  padding: 0 clamp(16px, 4vw, 28px) clamp(18px, 3vw, 28px);
+  box-sizing: border-box;
+}
+
+.welcome-header-week-card,
+.welcome-header-tasks-card {
+  width: 100%;
+}
+
 /* Small, consistent icon button hit area */
 .header-icon-btn {
   display: inline-flex;


### PR DESCRIPTION
## Summary
- add a TasksOverviewCard component that aggregates project tasks, computes weekly stats, and renders grouped chips using the Squircle surface
- surface the week widget and new tasks overview within the welcome header on desktop while removing the duplicate week card from the desktop content layout
- style the new card and header section with design-token-friendly squircle visuals and responsive spacing

## Testing
- `npm run lint` *(fails: existing lint errors in unrelated test files)*

------
https://chatgpt.com/codex/tasks/task_e_68c91edc86a48324b2556faf09f8840b