### PR TITLE
Align moodboard accents with project palette

### DIFF
--- a/frontend/src/features/moodboard/components/MoodboardCanvas.tsx
+++ b/frontend/src/features/moodboard/components/MoodboardCanvas.tsx
@@ -11,12 +11,51 @@ import QuickInsertPalette from "./QuickInsertPalette";
 import { useMoodboardStore } from "../hooks/useMoodboardStore";
 import type { Sticker, StickerDraft } from "../types";
 import styles from "../moodboard.module.css";
+import type { ProjectAccentPalette } from "@/features/project/hooks/useProjectPalette";
+
+const DEFAULT_ACCENT = "#FA3356";
+const DEFAULT_RGB: [number, number, number] = [250, 51, 86];
+
+const clamp = (value: number, min: number, max: number): number =>
+  Math.min(Math.max(value, min), max);
+
+const hexToRgbTuple = (hex?: string): [number, number, number] => {
+  if (!hex) return DEFAULT_RGB;
+  let cleaned = hex.trim();
+  if (!cleaned) return DEFAULT_RGB;
+  if (cleaned.startsWith("#")) cleaned = cleaned.slice(1);
+  if (cleaned.length === 3) {
+    cleaned = cleaned
+      .split("")
+      .map((char) => char + char)
+      .join("");
+  }
+  if (cleaned.length !== 6) return DEFAULT_RGB;
+  const r = Number.parseInt(cleaned.slice(0, 2), 16);
+  const g = Number.parseInt(cleaned.slice(2, 4), 16);
+  const b = Number.parseInt(cleaned.slice(4, 6), 16);
+  if ([r, g, b].some((channel) => Number.isNaN(channel))) {
+    return DEFAULT_RGB;
+  }
+  return [r, g, b];
+};
+
+const mixWithWhite = (hex: string, amount = 0.82, alpha = 0.95): string => {
+  const [r, g, b] = hexToRgbTuple(hex);
+  const mix = clamp(amount, 0, 1);
+  const blend = (channel: number) =>
+    Math.round(channel + (255 - channel) * mix);
+  const blended = [blend(r), blend(g), blend(b)];
+  const clampedAlpha = clamp(alpha, 0, 1);
+  return `rgba(${blended[0]}, ${blended[1]}, ${blended[2]}, ${clampedAlpha})`;
+};
 
 const GRID_STEP = 8;
 
 export interface MoodboardCanvasProps {
   projectId?: string;
   userId?: string;
+  palette?: ProjectAccentPalette;
 }
 
 type DragState = {
@@ -25,7 +64,11 @@ type DragState = {
   stickerStart: { x: number; y: number };
 };
 
-const MoodboardCanvas: React.FC<MoodboardCanvasProps> = ({ projectId, userId }) => {
+const MoodboardCanvas: React.FC<MoodboardCanvasProps> = ({
+  projectId,
+  userId,
+  palette,
+}) => {
   const { stickers, addSticker, updateSticker, removeSticker, bringToFront, clear } =
     useMoodboardStore({ projectId, userId });
   const boardRef = useRef<HTMLDivElement | null>(null);
@@ -33,6 +76,19 @@ const MoodboardCanvas: React.FC<MoodboardCanvasProps> = ({ projectId, userId }) 
   const [dragState, setDragState] = useState<DragState | null>(null);
   const [dragOffset, setDragOffset] = useState<{ x: number; y: number } | null>(null);
   const [paletteOpen, setPaletteOpen] = useState(false);
+
+  const accent = palette?.accent ?? DEFAULT_ACCENT;
+  const accentStrong = palette?.accentStrong ?? accent;
+
+  const themeStyle = useMemo<React.CSSProperties>(() => {
+    const [r, g, b] = hexToRgbTuple(accent);
+    return {
+      "--moodboard-brand": accent,
+      "--moodboard-brand-rgb": `${r}, ${g}, ${b}`,
+      "--moodboard-brand-gradient-end": accentStrong,
+      "--moodboard-brand-text-soft": mixWithWhite(accent),
+    } as React.CSSProperties;
+  }, [accent, accentStrong]);
 
   const selectedSticker = useMemo<Sticker | null>(() => {
     if (!selectedId) return null;
@@ -180,7 +236,7 @@ const MoodboardCanvas: React.FC<MoodboardCanvasProps> = ({ projectId, userId }) 
   const showEmptyState = stickers.length === 0;
 
   return (
-    <div className={styles.moodboardPage}>
+    <div className={styles.moodboardPage} style={themeStyle}>
       <div className={styles.toolbar}>
         <div className={styles.toolbarButtons}>
           <button

--- a/frontend/src/features/moodboard/components/MoodboardCanvas.tsx
+++ b/frontend/src/features/moodboard/components/MoodboardCanvas.tsx
@@ -11,9 +11,13 @@ import QuickInsertPalette from "./QuickInsertPalette";
 import { useMoodboardStore } from "../hooks/useMoodboardStore";
 import type { Sticker, StickerDraft } from "../types";
 import styles from "../moodboard.module.css";
-import type { ProjectAccentPalette } from "@/features/project/hooks/useProjectPalette";
+import {
+  PROJECT_BRAND_ACCENT,
+  PROJECT_BRAND_BG,
+  type ProjectAccentPalette,
+} from "@/features/project/hooks/useProjectPalette";
 
-const DEFAULT_ACCENT = "#FA3356";
+const DEFAULT_ACCENT = PROJECT_BRAND_ACCENT;
 const DEFAULT_RGB: [number, number, number] = [250, 51, 86];
 
 const clamp = (value: number, min: number, max: number): number =>
@@ -39,6 +43,42 @@ const hexToRgbTuple = (hex?: string): [number, number, number] => {
   }
   return [r, g, b];
 };
+
+const tupleToHex = ([r, g, b]: [number, number, number]): string => {
+  const toHex = (channel: number) =>
+    Math.round(clamp(channel, 0, 255))
+      .toString(16)
+      .padStart(2, "0")
+      .toUpperCase();
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+};
+
+const mixRgbTuples = (
+  source: [number, number, number],
+  target: [number, number, number],
+  amount: number
+): [number, number, number] => {
+  const mix = clamp(amount, 0, 1);
+  const inv = 1 - mix;
+  return [
+    Math.round(source[0] * inv + target[0] * mix),
+    Math.round(source[1] * inv + target[1] * mix),
+    Math.round(source[2] * inv + target[2] * mix),
+  ];
+};
+
+const tupleToRgba = (
+  [r, g, b]: [number, number, number],
+  alpha = 1
+): string => `rgba(${Math.round(r)}, ${Math.round(g)}, ${Math.round(b)}, ${clamp(alpha, 0, 1)})`;
+
+const mixHexColors = (source: string, target: string, amount: number): string =>
+  tupleToHex(mixRgbTuples(hexToRgbTuple(source), hexToRgbTuple(target), amount));
+
+const DEFAULT_ACCENT_WEAK = mixHexColors(DEFAULT_ACCENT, PROJECT_BRAND_BG, 0.65);
+const BRAND_BG_RGB = hexToRgbTuple(PROJECT_BRAND_BG);
+
+const WHITE_RGB: [number, number, number] = [255, 255, 255];
 
 const mixWithWhite = (hex: string, amount = 0.82, alpha = 0.95): string => {
   const [r, g, b] = hexToRgbTuple(hex);
@@ -79,16 +119,53 @@ const MoodboardCanvas: React.FC<MoodboardCanvasProps> = ({
 
   const accent = palette?.accent ?? DEFAULT_ACCENT;
   const accentStrong = palette?.accentStrong ?? accent;
+  const accentWeak = palette?.accentWeak ?? DEFAULT_ACCENT_WEAK;
 
   const themeStyle = useMemo<React.CSSProperties>(() => {
     const [r, g, b] = hexToRgbTuple(accent);
+    const weakRgb = hexToRgbTuple(accentWeak);
+    const strongRgb = hexToRgbTuple(accentStrong);
+
+    const pageBackground = tupleToHex(mixRgbTuples(BRAND_BG_RGB, weakRgb, 0.22));
+    const toolbarSurface = tupleToRgba(mixRgbTuples(weakRgb, BRAND_BG_RGB, 0.38), 0.86);
+    const toolbarSurfaceHover = tupleToRgba(mixRgbTuples(weakRgb, strongRgb, 0.28), 0.92);
+    const toolbarBorder = tupleToRgba(mixRgbTuples(weakRgb, strongRgb, 0.35), 0.48);
+    const toolbarBorderStrong = tupleToRgba(mixRgbTuples(strongRgb, weakRgb, 0.2), 0.72);
+    const mutedText = tupleToRgba(mixRgbTuples(weakRgb, WHITE_RGB, 0.68), 0.82);
+    const keyboardBg = tupleToRgba(mixRgbTuples(weakRgb, strongRgb, 0.18), 0.28);
+    const keyboardBorder = tupleToRgba(mixRgbTuples(strongRgb, BRAND_BG_RGB, 0.35), 0.5);
+    const canvasBackground = tupleToRgba(mixRgbTuples(weakRgb, BRAND_BG_RGB, 0.52), 0.88);
+    const canvasGrid = tupleToRgba(mixRgbTuples(weakRgb, WHITE_RGB, 0.32), 0.18);
+    const canvasBorder = tupleToRgba(mixRgbTuples(strongRgb, weakRgb, 0.48), 0.58);
+    const canvasShadow = tupleToRgba(mixRgbTuples(weakRgb, BRAND_BG_RGB, 0.28), 0.22);
+    const overlayTint = tupleToRgba(mixRgbTuples(weakRgb, BRAND_BG_RGB, 0.35), 0.72);
+    const raisedSurface = tupleToRgba(mixRgbTuples(weakRgb, BRAND_BG_RGB, 0.18), 0.96);
+    const raisedBorder = tupleToRgba(mixRgbTuples(strongRgb, weakRgb, 0.34), 0.42);
+
     return {
       "--moodboard-brand": accent,
       "--moodboard-brand-rgb": `${r}, ${g}, ${b}`,
       "--moodboard-brand-gradient-end": accentStrong,
       "--moodboard-brand-text-soft": mixWithWhite(accent),
+      "--moodboard-brand-weak": accentWeak,
+      "--moodboard-brand-weak-rgb": `${weakRgb[0]}, ${weakRgb[1]}, ${weakRgb[2]}`,
+      "--moodboard-page-bg": pageBackground,
+      "--moodboard-toolbar-surface": toolbarSurface,
+      "--moodboard-toolbar-surface-hover": toolbarSurfaceHover,
+      "--moodboard-toolbar-border": toolbarBorder,
+      "--moodboard-toolbar-border-strong": toolbarBorderStrong,
+      "--moodboard-text-muted": mutedText,
+      "--moodboard-keyboard-kbd-bg": keyboardBg,
+      "--moodboard-keyboard-kbd-border": keyboardBorder,
+      "--moodboard-canvas-bg": canvasBackground,
+      "--moodboard-canvas-grid": canvasGrid,
+      "--moodboard-canvas-border": canvasBorder,
+      "--moodboard-canvas-shadow": canvasShadow,
+      "--moodboard-overlay": overlayTint,
+      "--moodboard-surface-raised": raisedSurface,
+      "--moodboard-surface-raised-border": raisedBorder,
     } as React.CSSProperties;
-  }, [accent, accentStrong]);
+  }, [accent, accentStrong, accentWeak]);
 
   const selectedSticker = useMemo<Sticker | null>(() => {
     if (!selectedId) return null;

--- a/frontend/src/features/moodboard/moodboard.module.css
+++ b/frontend/src/features/moodboard/moodboard.module.css
@@ -5,7 +5,7 @@
   padding: 1.5rem;
   min-height: 100%;
   background: radial-gradient(circle at top, rgba(255, 255, 255, 0.02), transparent 55%),
-    #0f1014;
+    var(--moodboard-page-bg, #0f1014);
   color: #f8fafc;
   --moodboard-brand: var(--brand, #fa3356);
   --moodboard-brand-rgb: 250, 51, 86;
@@ -18,6 +18,22 @@
   --moodboard-brand-shadow-strong: rgba(var(--moodboard-brand-rgb), 0.55);
   --moodboard-brand-gradient-end: #ff6b8a;
   --moodboard-brand-text-soft: rgba(255, 228, 233, 0.95);
+  --moodboard-brand-weak: var(--moodboard-brand);
+  --moodboard-brand-weak-rgb: var(--moodboard-brand-rgb);
+  --moodboard-toolbar-surface: rgba(15, 16, 20, 0.9);
+  --moodboard-toolbar-surface-hover: rgba(30, 41, 59, 0.85);
+  --moodboard-toolbar-border: rgba(148, 163, 184, 0.4);
+  --moodboard-toolbar-border-strong: rgba(148, 163, 184, 0.8);
+  --moodboard-text-muted: rgba(226, 232, 240, 0.72);
+  --moodboard-keyboard-kbd-bg: rgba(148, 163, 184, 0.15);
+  --moodboard-keyboard-kbd-border: rgba(148, 163, 184, 0.25);
+  --moodboard-canvas-border: rgba(51, 65, 85, 0.4);
+  --moodboard-canvas-grid: rgba(226, 232, 240, 0.04);
+  --moodboard-canvas-bg: rgba(15, 23, 42, 0.65);
+  --moodboard-canvas-shadow: rgba(148, 163, 184, 0.1);
+  --moodboard-overlay: rgba(15, 23, 42, 0.72);
+  --moodboard-surface-raised: rgba(15, 16, 20, 0.98);
+  --moodboard-surface-raised-border: rgba(148, 163, 184, 0.35);
 }
 
 .toolbar {
@@ -40,8 +56,8 @@
   justify-content: center;
   padding: 0.5rem 0.75rem;
   border-radius: 999px;
-  border: 1px solid rgba(148, 163, 184, 0.4);
-  background: rgba(15, 16, 20, 0.9);
+  border: 1px solid var(--moodboard-toolbar-border, rgba(148, 163, 184, 0.4));
+  background: var(--moodboard-toolbar-surface, rgba(15, 16, 20, 0.9));
   color: inherit;
   gap: 0.5rem;
   font-weight: 600;
@@ -51,8 +67,8 @@
 
 .iconButton:hover,
 .iconButton:focus-visible {
-  background: rgba(30, 41, 59, 0.85);
-  border-color: rgba(148, 163, 184, 0.8);
+  background: var(--moodboard-toolbar-surface-hover, rgba(30, 41, 59, 0.85));
+  border-color: var(--moodboard-toolbar-border-strong, rgba(148, 163, 184, 0.8));
 }
 
 .iconButton:active {
@@ -69,14 +85,14 @@
   display: flex;
   gap: 0.75rem;
   font-size: 0.85rem;
-  color: rgba(226, 232, 240, 0.72);
+  color: var(--moodboard-text-muted, rgba(226, 232, 240, 0.72));
 }
 
 .keyboardHint kbd {
   padding: 0.25rem 0.5rem;
   border-radius: 6px;
-  background: rgba(148, 163, 184, 0.15);
-  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: var(--moodboard-keyboard-kbd-bg, rgba(148, 163, 184, 0.15));
+  border: 1px solid var(--moodboard-keyboard-kbd-border, rgba(148, 163, 184, 0.25));
   font-family: "JetBrains Mono", "Fira Mono", monospace;
   font-size: 0.75rem;
   color: inherit;
@@ -88,12 +104,19 @@
   min-height: 520px;
   border-radius: 24px;
   overflow: hidden;
-  border: 1px solid rgba(51, 65, 85, 0.4);
-  background-image: linear-gradient(rgba(226, 232, 240, 0.04) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(226, 232, 240, 0.04) 1px, transparent 1px);
+  border: 1px solid var(--moodboard-canvas-border, rgba(51, 65, 85, 0.4));
+  background-image: linear-gradient(
+      var(--moodboard-canvas-grid, rgba(226, 232, 240, 0.04)) 1px,
+      transparent 1px
+    ),
+    linear-gradient(
+      90deg,
+      var(--moodboard-canvas-grid, rgba(226, 232, 240, 0.04)) 1px,
+      transparent 1px
+    );
   background-size: 8px 8px;
-  background-color: rgba(15, 23, 42, 0.65);
-  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.1);
+  background-color: var(--moodboard-canvas-bg, rgba(15, 23, 42, 0.65));
+  box-shadow: inset 0 0 0 1px var(--moodboard-canvas-shadow, rgba(148, 163, 184, 0.1));
 }
 
 .canvas {
@@ -193,8 +216,8 @@
 }
 
 .linkSticker {
-  background: var(--moodboard-brand-soft);
-  border: 1px solid var(--moodboard-brand-border);
+  background: rgba(var(--moodboard-brand-weak-rgb, 250, 51, 86), 0.24);
+  border: 1px solid rgba(var(--moodboard-brand-weak-rgb, 250, 51, 86), 0.45);
   color: var(--moodboard-brand-text-soft);
 }
 
@@ -220,7 +243,7 @@
 .paletteOverlay {
   position: fixed;
   inset: 0;
-  background: rgba(15, 23, 42, 0.72);
+  background: var(--moodboard-overlay, rgba(15, 23, 42, 0.72));
   display: flex;
   align-items: center;
   justify-content: center;
@@ -230,10 +253,10 @@
 
 .palette {
   width: min(520px, 100%);
-  background: rgba(15, 16, 20, 0.98);
+  background: var(--moodboard-surface-raised, rgba(15, 16, 20, 0.98));
   border-radius: 24px;
-  border: 1px solid rgba(148, 163, 184, 0.35);
-  box-shadow: 0 30px 60px rgba(15, 23, 42, 0.55);
+  border: 1px solid var(--moodboard-surface-raised-border, rgba(148, 163, 184, 0.35));
+  box-shadow: 0 30px 60px var(--moodboard-brand-shadow, rgba(15, 23, 42, 0.55));
   display: flex;
   flex-direction: column;
   gap: 1.25rem;
@@ -268,8 +291,8 @@
   flex: 1;
   border-radius: 14px;
   padding: 0.75rem 1rem;
-  border: 1px solid rgba(148, 163, 184, 0.35);
-  background: rgba(30, 41, 59, 0.55);
+  border: 1px solid var(--moodboard-toolbar-border, rgba(148, 163, 184, 0.35));
+  background: var(--moodboard-toolbar-surface, rgba(30, 41, 59, 0.55));
   color: inherit;
   cursor: pointer;
   font-weight: 600;
@@ -284,8 +307,8 @@
 
 .typeButton:hover,
 .typeButton:focus-visible {
-  background: rgba(148, 163, 184, 0.25);
-  border-color: rgba(148, 163, 184, 0.55);
+  background: var(--moodboard-toolbar-surface-hover, rgba(148, 163, 184, 0.25));
+  border-color: var(--moodboard-toolbar-border-strong, rgba(148, 163, 184, 0.55));
 }
 
 .fieldGroup {
@@ -335,14 +358,14 @@
 }
 
 .secondaryButton {
-  background: rgba(15, 23, 42, 0.75);
-  border-color: rgba(148, 163, 184, 0.35);
+  background: var(--moodboard-toolbar-surface, rgba(15, 23, 42, 0.75));
+  border-color: var(--moodboard-toolbar-border, rgba(148, 163, 184, 0.35));
 }
 
 .secondaryButton:hover,
 .secondaryButton:focus-visible {
-  background: rgba(30, 41, 59, 0.85);
-  border-color: rgba(148, 163, 184, 0.55);
+  background: var(--moodboard-toolbar-surface-hover, rgba(30, 41, 59, 0.85));
+  border-color: var(--moodboard-toolbar-border-strong, rgba(148, 163, 184, 0.55));
 }
 
 .primaryButton {

--- a/frontend/src/features/moodboard/moodboard.module.css
+++ b/frontend/src/features/moodboard/moodboard.module.css
@@ -7,6 +7,17 @@
   background: radial-gradient(circle at top, rgba(255, 255, 255, 0.02), transparent 55%),
     #0f1014;
   color: #f8fafc;
+  --moodboard-brand: var(--brand, #fa3356);
+  --moodboard-brand-rgb: 250, 51, 86;
+  --moodboard-brand-soft: rgba(var(--moodboard-brand-rgb), 0.12);
+  --moodboard-brand-soft-strong: rgba(var(--moodboard-brand-rgb), 0.25);
+  --moodboard-brand-border: rgba(var(--moodboard-brand-rgb), 0.4);
+  --moodboard-brand-border-strong: rgba(var(--moodboard-brand-rgb), 0.65);
+  --moodboard-brand-focus: rgba(var(--moodboard-brand-rgb), 0.35);
+  --moodboard-brand-shadow: rgba(var(--moodboard-brand-rgb), 0.45);
+  --moodboard-brand-shadow-strong: rgba(var(--moodboard-brand-rgb), 0.55);
+  --moodboard-brand-gradient-end: #ff6b8a;
+  --moodboard-brand-text-soft: rgba(255, 228, 233, 0.95);
 }
 
 .toolbar {
@@ -93,7 +104,7 @@
 }
 
 .canvas:focus-visible {
-  box-shadow: inset 0 0 0 2px rgba(96, 165, 250, 0.35);
+  box-shadow: inset 0 0 0 2px var(--moodboard-brand-focus);
 }
 
 .emptyState {
@@ -143,12 +154,12 @@
 }
 
 .stickerSelected {
-  box-shadow: 0 16px 34px rgba(59, 130, 246, 0.45), 0 0 0 2px rgba(96, 165, 250, 0.35);
+  box-shadow: 0 16px 34px var(--moodboard-brand-shadow), 0 0 0 2px var(--moodboard-brand-focus);
 }
 
 .stickerDragging {
   opacity: 0.92;
-  box-shadow: 0 18px 40px rgba(59, 130, 246, 0.55);
+  box-shadow: 0 18px 40px var(--moodboard-brand-shadow-strong);
 }
 
 .noteSticker {
@@ -182,9 +193,9 @@
 }
 
 .linkSticker {
-  background: rgba(96, 165, 250, 0.15);
-  border: 1px solid rgba(96, 165, 250, 0.4);
-  color: rgba(191, 219, 254, 0.95);
+  background: var(--moodboard-brand-soft);
+  border: 1px solid var(--moodboard-brand-border);
+  color: var(--moodboard-brand-text-soft);
 }
 
 .linkSticker a {
@@ -266,9 +277,9 @@
 }
 
 .typeButton[aria-pressed="true"] {
-  background: rgba(96, 165, 250, 0.25);
-  border-color: rgba(96, 165, 250, 0.65);
-  box-shadow: 0 0 0 1px rgba(59, 130, 246, 0.4);
+  background: var(--moodboard-brand-soft-strong);
+  border-color: var(--moodboard-brand-border-strong);
+  box-shadow: 0 0 0 1px var(--moodboard-brand-border);
 }
 
 .typeButton:hover,
@@ -335,14 +346,14 @@
 }
 
 .primaryButton {
-  background: linear-gradient(135deg, rgba(96, 165, 250, 0.8), rgba(129, 140, 248, 0.85));
+  background: linear-gradient(135deg, rgba(var(--moodboard-brand-rgb), 0.85), var(--moodboard-brand-gradient-end));
   color: #0b1120;
-  box-shadow: 0 12px 32px rgba(59, 130, 246, 0.35);
+  box-shadow: 0 12px 32px var(--moodboard-brand-shadow);
 }
 
 .primaryButton:hover,
 .primaryButton:focus-visible {
-  box-shadow: 0 14px 36px rgba(59, 130, 246, 0.45);
+  box-shadow: 0 14px 36px var(--moodboard-brand-shadow-strong);
   transform: translateY(-1px);
 }
 

--- a/frontend/src/features/moodboard/pages/MoodboardPage.tsx
+++ b/frontend/src/features/moodboard/pages/MoodboardPage.tsx
@@ -7,6 +7,8 @@ import MoodboardCanvas from "../components/MoodboardCanvas";
 import { useData } from "@/app/contexts/useData";
 import { findProjectBySlug, slugify } from "@/shared/utils/slug";
 import type { Project } from "@/app/contexts/DataProvider";
+import { useProjectPalette } from "@/features/project/hooks/useProjectPalette";
+import { resolveProjectCoverUrl } from "@/features/project/utils/theme";
 
 const MoodboardPage: React.FC = () => {
   const { projectSlug = "" } = useParams<{ projectSlug: string }>();
@@ -21,6 +23,9 @@ const MoodboardPage: React.FC = () => {
   } = useData();
 
   const [activeProject, setActiveProject] = useState<Project | null>(initialProject ?? null);
+
+  const coverImage = useMemo(() => resolveProjectCoverUrl(activeProject), [activeProject]);
+  const projectPalette = useProjectPalette(coverImage);
 
   useEffect(() => {
     setActiveProject(initialProject ?? null);
@@ -92,16 +97,21 @@ const MoodboardPage: React.FC = () => {
           exit={{ opacity: 0, y: -24 }}
           transition={{ duration: 0.25 }}
         >
-          <MoodboardCanvas projectId={projectId} userId={currentUserId} />
+          <MoodboardCanvas
+            projectId={projectId}
+            userId={currentUserId}
+            palette={projectPalette}
+          />
         </motion.div>
       </AnimatePresence>
     ),
-    [currentUserId, projectId]
+    [currentUserId, projectId, projectPalette]
   );
 
   return (
     <ProjectPageLayout
       projectId={projectId}
+      theme={projectPalette}
       header={
         <ProjectHeader
           parseStatusToNumber={parseStatusToNumber}


### PR DESCRIPTION
## Summary
- derive moodboard brand variables from the active project's accent palette via `useProjectPalette`
- pass the palette through the moodboard canvas and page layout so the UI aligns with the project's theme

## Testing
- npm run lint *(fails: existing lint errors in unrelated files — see output for details)*

------
https://chatgpt.com/codex/tasks/task_e_68c923d9a2a483248b327ef565d5633d