### PR TITLE
Reorder welcome overview sections

### DIFF
--- a/frontend/src/features/dashboard/components/WelcomeHeader.tsx
+++ b/frontend/src/features/dashboard/components/WelcomeHeader.tsx
@@ -12,7 +12,6 @@ import './GlobalSearch.css';
 import { getFileUrl } from '../../../shared/utils/api';
 import { useAppShell } from '@/app/layout/AppShell';
 import WeekWidgetCard from "@/features/schedule/WeekWidgetCard";
-import TasksOverviewCard from "./TasksOverviewCard";
 
 const WelcomeHeader: React.FC<{ userName?: string; setActiveView?: (view: string) => void }> = ({ userName: propUserName, setActiveView }) => {
   const { userData } = useData();
@@ -232,9 +231,16 @@ const WelcomeHeader: React.FC<{ userName?: string; setActiveView?: (view: string
       </div>
 
       {showWelcomeCards && (
-        <div className="welcome-header-extras" role="region" aria-label="This week overview">
-          <WeekWidgetCard className="welcome-header-week-card" />
-          <TasksOverviewCard className="welcome-header-tasks-card" />
+        <div className="welcome-header-extras" role="region" aria-label="Dashboard welcome overview">
+          <nav className="welcome-header-toc" aria-label="Quick jumps">
+            <a href="#week">This Week</a>
+            <a href="#projects">Projects</a>
+            <a href="#tasks">Tasks</a>
+          </nav>
+
+          <div id="week" className="welcome-section-anchor">
+            <WeekWidgetCard className="welcome-header-week-card" />
+          </div>
         </div>
       )}
 

--- a/frontend/src/features/dashboard/pages/DashboardHome.tsx
+++ b/frontend/src/features/dashboard/pages/DashboardHome.tsx
@@ -15,6 +15,7 @@ import Collaborators from "@/features/dashboard/components/Collaborators";
 import SpinnerScreen from "@/shared/ui/SpinnerScreen";
 import PendingApprovalScreen from "@/shared/ui/PendingApprovalScreen";
 import AllProjectsWeekWidget from "@/features/dashboard/components/AllProjectsWeekWidget";
+import TasksOverviewCard from "@/features/dashboard/components/TasksOverviewCard";
 import NavigationDrawer from "@/shared/ui/NavigationDrawer";
 import DashboardNavPanel from "@/shared/ui/DashboardNavPanel";
 import AppShell from "@/app/layout/AppShell";
@@ -151,9 +152,15 @@ const WelcomeScreen: React.FC = () => {
     if (isDesktop) {
       return (
         <div className="dashboard-home-grid">
-          <ProjectsPanelDesktop
-            onOpenProject={(projectId) => handleNavigateToProject({ projectId })}
-          />
+          <section id="projects" className="welcome-section-anchor">
+            <ProjectsPanelDesktop
+              onOpenProject={(projectId) => handleNavigateToProject({ projectId })}
+            />
+          </section>
+
+          <section id="tasks" className="welcome-section-anchor">
+            <TasksOverviewCard className="welcome-header-tasks-card" />
+          </section>
         </div>
       );
     }

--- a/frontend/src/features/dashboard/styles/components/welcome-header.css
+++ b/frontend/src/features/dashboard/styles/components/welcome-header.css
@@ -37,11 +37,55 @@
 .welcome-header-extras {
   display: flex;
   flex-direction: column;
-  gap: var(--space-3, 24px);
+  gap: clamp(16px, 2vw, 20px);
   width: 100%;
   margin-top: clamp(12px, 1.5vw, 18px);
   padding: 0 clamp(16px, 4vw, 28px) clamp(18px, 3vw, 28px);
   box-sizing: border-box;
+}
+
+.welcome-header-toc {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  font-size: 12px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.welcome-header-toc a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: rgba(255, 255, 255, 0.04);
+  color: inherit;
+  text-decoration: none;
+  transition: border-color 0.16s ease, background-color 0.16s ease, color 0.16s ease,
+    box-shadow 0.16s ease;
+}
+
+.welcome-header-toc a:hover {
+  border-color: rgba(255, 255, 255, 0.3);
+  color: rgba(255, 255, 255, 0.9);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.welcome-header-toc a:focus-visible {
+  outline: none;
+  border-color: rgba(255, 255, 255, 0.45);
+  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.18);
+  color: rgba(255, 255, 255, 0.92);
+}
+
+.welcome-section-anchor {
+  width: 100%;
+  scroll-margin-top: clamp(84px, 14vw, 128px);
 }
 
 .welcome-header-week-card,
@@ -144,6 +188,16 @@
   .welcome-header-desktop {
     padding: 8px 12px;
     gap: 12px;
+  }
+
+  .welcome-header-toc {
+    gap: 10px;
+    font-size: 11px;
+    letter-spacing: 0.04em;
+  }
+
+  .welcome-header-toc a {
+    padding: 5px 10px;
   }
   .welcome-header__brand {
     width: 34px;

--- a/frontend/src/features/schedule/WeekWidgetCard.module.css
+++ b/frontend/src/features/schedule/WeekWidgetCard.module.css
@@ -96,6 +96,32 @@
   color: rgba(255, 255, 255, 0.6);
 }
 
+.badges {
+  display: flex;
+  flex-wrap: wrap;
+  column-gap: 0;
+  row-gap: 6px;
+  margin-top: 8px;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  line-height: 1.1;
+}
+
+.badge:not(:last-of-type)::after {
+  content: "·";
+  margin-left: 12px;
+  margin-right: 12px;
+  color: rgba(255, 255, 255, 0.5);
+}
+
 .morePill {
   display: inline-flex;
   align-items: center;

--- a/frontend/src/features/schedule/WeekWidgetCard.tsx
+++ b/frontend/src/features/schedule/WeekWidgetCard.tsx
@@ -109,6 +109,11 @@ const WeekWidgetCard: React.FC<WeekWidgetCardProps> = ({ className }) => {
         <div className={styles.titleWrap}>
           <h3 className={styles.title}>This Week</h3>
           <p className={styles.subtitle}>Timeline snapshots across your projects.</p>
+          <div className={styles.badges} aria-label="Week status badges">
+            <span className={styles.badge}>Overdue</span>
+            <span className={styles.badge}>Due Today</span>
+            <span className={styles.badge}>New</span>
+          </div>
         </div>
         {moreCount > 0 && (
           <span

--- a/frontend/src/shared/styles/layout.css
+++ b/frontend/src/shared/styles/layout.css
@@ -55,7 +55,7 @@
 
 .dashboard-home-grid {
   display: grid;
-  gap: var(--space-3, 24px);
+  gap: clamp(16px, 2vw, 20px);
 }
 
 .dashboard-home-grid > * {


### PR DESCRIPTION
## Summary
- add a quick navigation TOC to the welcome header and expose anchors for week, projects, and tasks
- move the tasks overview card below the desktop projects panel to match the desired reading order and tighten section gaps
- surface status badges in the week widget header for clearer context cues

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c928daeaf88324b77164b1967a7132