### PR TITLE
Refine dashboard create actions and styling

### DIFF
--- a/frontend/src/features/dashboard/components/AllProjects.tsx
+++ b/frontend/src/features/dashboard/components/AllProjects.tsx
@@ -17,6 +17,7 @@ import {
   Search,
   MoreVertical,
   Pin,
+  Plus,
 } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { getFileUrl } from '../../../shared/utils/api';
@@ -551,6 +552,15 @@ const AllProjects: React.FC = () => {
       <div className="projects-header">
         <div className="projects-title">Projects</div>
         <div className="project-pills">
+          <button
+            type="button"
+            className="projects-create-button"
+            onClick={() => navigate('/dashboard/new')}
+            title="New project"
+          >
+            <Plus size={18} strokeWidth={2} aria-hidden />
+            <span>New project</span>
+          </button>
           {[{ key: 'all', label: `All Projects (${projects.length})` },
             ...statusOptions.map((s) => ({
               key: s,

--- a/frontend/src/features/dashboard/components/ProjectsPanel.tsx
+++ b/frontend/src/features/dashboard/components/ProjectsPanel.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { motion, useReducedMotion } from "framer-motion";
 import { useNavigate } from "react-router-dom";
-import { ChevronDown } from "lucide-react";
+import { ChevronDown, Plus } from "lucide-react";
 import { Kebab } from "@/shared/icons/Kebab";
 import { useData } from "@/app/contexts/useData";
 import SVGThumbnail from "./SvgThumbnail";
@@ -292,6 +292,15 @@ const ProjectsPanel: React.FC<Props> = ({ onOpenProject }) => {
             );
           })()}
         </div>
+        <button
+          type="button"
+          className={styles.createButton}
+          onClick={() => navigate('/dashboard/new')}
+          title="New project"
+        >
+          <Plus size={16} strokeWidth={2.25} aria-hidden />
+          <span>New project</span>
+        </button>
         <div className={styles.recentsWrap} ref={filtersRef}>
           <button
             type="button"

--- a/frontend/src/features/dashboard/components/TasksOverviewCard.module.css
+++ b/frontend/src/features/dashboard/components/TasksOverviewCard.module.css
@@ -89,22 +89,22 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 38px;
-  height: 38px;
-  border-radius: 14px;
+  width: 32px;
+  height: 32px;
+  border-radius: 12px;
   border: 1px solid rgba(255, 255, 255, 0.14);
-  background: rgba(255, 255, 255, 0.05);
+  background: rgba(255, 255, 255, 0.06);
   color: rgba(255, 255, 255, 0.92);
   transition: background-color 0.18s ease, border-color 0.18s ease, transform 0.18s ease;
 }
 
 .iconButton:hover:not(:disabled) {
   transform: translateY(-1px);
-  background: rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.1);
 }
 
 .iconButton:focus-visible {
-  outline: 2px solid var(--color-focus, var(--brand, #fa3356));
+  outline: 2px solid rgba(255, 255, 255, 0.6);
   outline-offset: 2px;
 }
 
@@ -113,14 +113,36 @@
   cursor: not-allowed;
 }
 
-.iconButtonPrimary {
-  border-color: color-mix(in srgb, var(--brand, #fa3356) 52%, transparent);
-  background: color-mix(in srgb, var(--brand, #fa3356) 18%, transparent);
-  color: color-mix(in srgb, var(--brand, #fa3356) 82%, white 18%);
+.createButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 16px;
+  height: 38px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.95);
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1;
+  transition: background-color 0.18s ease, border-color 0.18s ease, transform 0.18s ease;
 }
 
-.iconButtonPrimary:hover:not(:disabled) {
-  background: color-mix(in srgb, var(--brand, #fa3356) 26%, transparent);
+.createButton:hover:not(:disabled) {
+  transform: translateY(-1px);
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.createButton:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.6);
+  outline-offset: 2px;
+}
+
+.createButton:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  transform: none;
 }
 
 .statGrid {

--- a/frontend/src/features/dashboard/components/TasksOverviewCard.tsx
+++ b/frontend/src/features/dashboard/components/TasksOverviewCard.tsx
@@ -382,18 +382,20 @@ const TasksOverviewCard: React.FC<TasksOverviewCardProps> = ({ className }) => {
         <div className={styles.actions}>
           <button
             type="button"
-            className={`${styles.iconButton} ${styles.iconButtonPrimary}`}
+            className={styles.createButton}
             onClick={handleNavigateToPrimary}
-            aria-label="Add or review tasks for the next project"
+            title="Add task"
             disabled={!canNavigateToProject}
           >
-            <Plus size={18} strokeWidth={2} />
+            <Plus size={18} strokeWidth={2} aria-hidden />
+            <span>Add task</span>
           </button>
           <button
             type="button"
             className={styles.iconButton}
             onClick={handleViewAll}
             aria-label="View all projects"
+            title="View all projects"
           >
             <MoreHorizontal size={18} strokeWidth={2} />
           </button>

--- a/frontend/src/features/dashboard/components/WelcomeHeader.tsx
+++ b/frontend/src/features/dashboard/components/WelcomeHeader.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import { User, Bell, Menu, Plus } from "lucide-react";
 import { useData } from '@/app/contexts/useData';
 import { useLocation, useNavigate } from 'react-router-dom';
@@ -48,6 +48,37 @@ const WelcomeHeader: React.FC<{ userName?: string; setActiveView?: (view: string
     window.addEventListener('resize', handleResize);
     return () => window.removeEventListener('resize', handleResize);
   }, []);
+
+  const handleStartSomething = useCallback(() => {
+    navigate('/dashboard/new');
+  }, [navigate]);
+
+  useEffect(() => {
+    const handleShortcut = (event: KeyboardEvent) => {
+      if (event.defaultPrevented) return;
+      const key = event.key.toLowerCase();
+      if ((event.metaKey || event.ctrlKey) && key === 'n') {
+        const target = event.target as HTMLElement | null;
+        if (target) {
+          const tag = target.tagName.toLowerCase();
+          const isFormField =
+            tag === 'input' ||
+            tag === 'textarea' ||
+            target.isContentEditable ||
+            target.getAttribute('role') === 'textbox';
+          if (isFormField) {
+            return;
+          }
+        }
+
+        event.preventDefault();
+        handleStartSomething();
+      }
+    };
+
+    window.addEventListener('keydown', handleShortcut);
+    return () => window.removeEventListener('keydown', handleShortcut);
+  }, [handleStartSomething]);
 
   const handleHomeClick = () => navigate('/');
   const handleNotificationsToggle = () => setNotificationsOpen(!notificationsOpen);
@@ -108,6 +139,8 @@ const WelcomeHeader: React.FC<{ userName?: string; setActiveView?: (view: string
 
   const showWelcomeCards = Boolean(isDesktopShell && activeView === 'welcome');
 
+  const showMobileCreate = !isDesktopShell;
+
   return (
     <>
       <div className="welcome-header-desktop">
@@ -155,13 +188,19 @@ const WelcomeHeader: React.FC<{ userName?: string; setActiveView?: (view: string
 
         {/* Right: Create, Notifications, Avatar (+ online dot) */}
         <div className="welcome-header-right">
-          <div
-            className="nav-item-style"
-            onClick={() => navigate("/dashboard/new")}
-            title="Start something"
-          >
-            <Plus size={isMobile ? 20 : 26} color="white" />
-          </div>
+          {showMobileCreate && (
+            <button
+              type="button"
+              className="welcome-header__create-button"
+              onClick={handleStartSomething}
+              title="Start something"
+              aria-label="Start something"
+              aria-haspopup="menu"
+              aria-expanded={false}
+            >
+              <Plus size={isMobile ? 18 : 20} strokeWidth={2.25} />
+            </button>
+          )}
 
           <div
             className="nav-icon-wrapper nav-icon-style"
@@ -169,6 +208,7 @@ const WelcomeHeader: React.FC<{ userName?: string; setActiveView?: (view: string
             role="button"
             tabIndex={0}
             aria-label="Open notifications"
+            title="Notifications"
             onKeyDown={handleNotificationKeyDown}
           >
             <Bell size={isMobile ? 24 : 26} color="white" />

--- a/frontend/src/features/dashboard/components/projects-panel.module.css
+++ b/frontend/src/features/dashboard/components/projects-panel.module.css
@@ -16,7 +16,7 @@
 
 .header {
   display: grid;
-  grid-template-columns: 1fr auto;
+  grid-template-columns: minmax(0, 1fr) auto auto;
   align-items: center;
   gap: 8px;
   margin-bottom: 6px; /* compact */
@@ -27,6 +27,7 @@
   align-items: center;
   gap: 6px; /* fit icons tightly next to title */
   min-width: 0;
+  flex: 1 1 auto;
 }
 
 .title {
@@ -81,6 +82,37 @@
 }
 
 .recentsWrap { position: relative; }
+
+.createButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 14px;
+  height: 34px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, .16);
+  background: rgba(255, 255, 255, .08);
+  color: var(--text-color, #fff);
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1;
+  cursor: pointer;
+  transition: background-color 0.18s ease, border-color 0.18s ease, transform 0.18s ease;
+}
+
+.createButton:hover {
+  transform: translateY(-1px);
+  background: rgba(255, 255, 255, .12);
+}
+
+.createButton:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, .6);
+  outline-offset: 2px;
+}
+
+.createButton:active {
+  transform: translateY(0);
+}
 
 .recents {
   display: inline-flex;
@@ -545,6 +577,18 @@
   height: 12px;
   border-radius: 6px;
   background: rgba(255, 255, 255, .08);
+}
+
+@media (max-width: 480px) {
+  .header {
+    grid-template-columns: minmax(0, 1fr);
+    row-gap: 10px;
+  }
+
+  .createButton,
+  .recentsWrap {
+    justify-self: flex-start;
+  }
 }
 
 /* iPhone compact widths */

--- a/frontend/src/features/dashboard/styles/components/projects-header.css
+++ b/frontend/src/features/dashboard/styles/components/projects-header.css
@@ -91,6 +91,37 @@
   flex-wrap: wrap;
 }
 
+.projects-create-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 16px;
+  height: 38px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: rgba(255, 255, 255, 0.08);
+  color: inherit;
+  font-size: 0.9rem;
+  font-weight: 500;
+  line-height: 1;
+  cursor: pointer;
+  transition: background-color 0.18s ease, border-color 0.18s ease, transform 0.18s ease;
+}
+
+.projects-create-button:hover {
+  transform: translateY(-1px);
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.projects-create-button:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.6);
+  outline-offset: 2px;
+}
+
+.projects-create-button:active {
+  transform: translateY(0);
+}
+
 .pill {
   position: relative;
   border: none;

--- a/frontend/src/features/dashboard/styles/components/welcome-header.css
+++ b/frontend/src/features/dashboard/styles/components/welcome-header.css
@@ -36,6 +36,34 @@
   gap: 8px;
 }
 
+.welcome-header__create-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: rgba(255, 255, 255, 0.06);
+  color: inherit;
+  cursor: pointer;
+  transition: background-color 0.18s ease, border-color 0.18s ease, transform 0.18s ease;
+}
+
+.welcome-header__create-button:hover {
+  transform: translateY(-1px);
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.welcome-header__create-button:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.6);
+  outline-offset: 2px;
+}
+
+.welcome-header__create-button:active {
+  transform: translateY(0);
+}
+
 .welcome-header-extras {
   display: flex;
   flex-direction: column;
@@ -108,6 +136,32 @@
 
 /* Notification/nav badges used in header */
 .nav-icon-wrapper { position: relative; display: inline-block; }
+.nav-icon-style {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: rgba(255, 255, 255, 0.06);
+  cursor: pointer;
+  transition: background-color 0.18s ease, border-color 0.18s ease, transform 0.18s ease;
+}
+
+.nav-icon-style:hover {
+  transform: translateY(-1px);
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.nav-icon-style:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.6);
+  outline-offset: 2px;
+}
+
+.nav-icon-style:active {
+  transform: translateY(0);
+}
 .nav-bar-badge {
   position: absolute;
   top: -4px;
@@ -151,6 +205,12 @@
     width: 34px;
     height: 34px;
     font-size: 16px;
+  }
+}
+
+@media (min-width: 1024px) {
+  .welcome-header__create-button {
+    display: none;
   }
 }
 


### PR DESCRIPTION
## Summary
- hide the desktop header plus button, restyle the header icons, and expose the mobile create button with a Cmd/Ctrl+N shortcut to open Start something
- update the Tasks overview header to use a labelled “Add task” pill and refreshed icon-only styling to match the spec
- surface “New project” buttons with capsule styling in both the all-projects view and the mobile projects panel

## Testing
- `npm run lint` *(fails: existing repository lint errors outside the touched files)*

------
https://chatgpt.com/codex/tasks/task_e_68c92b86448083248235426b435ab239