### PR TITLE
Restore separate project KPIs and enforce full-width cards

### DIFF
--- a/frontend/src/features/dashboard/components/ProjectsPanel.tsx
+++ b/frontend/src/features/dashboard/components/ProjectsPanel.tsx
@@ -206,6 +206,7 @@ const ProjectsPanel: React.FC<Props> = ({ onOpenProject }) => {
 
   const nextProjectTitle =
     nextProjectLabel !== "No upcoming projects" ? nextProjectLabel : undefined;
+  const pendingLabel = `${kpis.pendingProjects} Pending`;
 
   const errorText = projectsError ? "Failed to load projects." : undefined;
 
@@ -371,26 +372,6 @@ const ProjectsPanel: React.FC<Props> = ({ onOpenProject }) => {
         </div>
 
         <div className={styles.kpis}>
-          <div className={styles.kpiGroup}>
-            <motion.span
-              className={`${styles.chip} ${styles.chipNoWrap}`}
-              whileHover={reduceMotion ? undefined : { scale: MICRO_WOBBLE_SCALE }}
-              whileFocus={reduceMotion ? undefined : { scale: MICRO_WOBBLE_SCALE }}
-              transition={reduceMotion ? undefined : SPRING_FAST}
-            >
-              {kpis.totalProjects} Projects
-            </motion.span>
-            <span className={styles.dot} />
-            <motion.span
-              className={`${styles.chip} ${styles.chipNoWrap}`}
-              whileHover={reduceMotion ? undefined : { scale: MICRO_WOBBLE_SCALE }}
-              whileFocus={reduceMotion ? undefined : { scale: MICRO_WOBBLE_SCALE }}
-              transition={reduceMotion ? undefined : SPRING_FAST}
-            >
-              {kpis.pendingProjects} Pending
-            </motion.span>
-          </div>
-          <span className={styles.dot} />
           <motion.span
             className={`${styles.chip} ${styles.chipNext}`}
             title={nextProjectTitle}
@@ -399,6 +380,15 @@ const ProjectsPanel: React.FC<Props> = ({ onOpenProject }) => {
             transition={reduceMotion ? undefined : SPRING_FAST}
           >
             {nextProjectLabel}
+          </motion.span>
+          <motion.span
+            className={`${styles.chip} ${styles.chipNoWrap}`}
+            title={pendingLabel}
+            whileHover={reduceMotion ? undefined : { scale: MICRO_WOBBLE_SCALE }}
+            whileFocus={reduceMotion ? undefined : { scale: MICRO_WOBBLE_SCALE }}
+            transition={reduceMotion ? undefined : SPRING_FAST}
+          >
+            {pendingLabel}
           </motion.span>
         </div>
       </header>

--- a/frontend/src/features/dashboard/components/projects-panel.module.css
+++ b/frontend/src/features/dashboard/components/projects-panel.module.css
@@ -12,6 +12,10 @@
   max-height: 275px;
   display: flex;
   flex-direction: column;
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+  flex-shrink: 0;
 }
 
 .header {

--- a/frontend/src/features/dashboard/components/week-widget.css
+++ b/frontend/src/features/dashboard/components/week-widget.css
@@ -1,11 +1,14 @@
 .week-widget {
   width: 100%;
+  max-width: 100%;
   margin:  0;
   background: var(--bg2, #111111);
   border: 2px solid rgba(255, 255, 255, 0.10);
   border-radius: var(--radius-squircle, var(--radius-lg, 24px));
   overflow: visible;
   padding: 10px;
+  box-sizing: border-box;
+  flex-shrink: 0;
 }
 
 .week-widget-header {

--- a/frontend/src/features/dashboard/styles/components/welcome-screen.css
+++ b/frontend/src/features/dashboard/styles/components/welcome-screen.css
@@ -37,15 +37,19 @@
   overflow: visible;
   padding: 0; /* remove outer grey wrapper */
   background: transparent;
+  width: 100%;
+  min-width: 0;
 }
 
 .mobile-calendar-section {
-  flex: 1;
+  flex: 1 0 auto;
   min-height: 0;
   overflow: auto;
-  
+
   border-radius: 8px;
   padding: 0px;
+  width: 100%;
+  min-width: 0;
 }
 
 /* Ensure projects header is more compact on mobile */


### PR DESCRIPTION
## Summary
- keep the upcoming project and pending counts in their own chips while leaving the total projects pill removed
- ensure the mobile projects panel and week widget stretch to the full available width without shrinking
- adjust the welcome layout containers to keep the project and calendar sections at 100% width

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c91ddfd7f083248a3f100fef6a4636