### PR TITLE
Ensure mobile dashboard panels span full width

### DIFF
--- a/frontend/src/features/dashboard/components/ProjectsPanel.tsx
+++ b/frontend/src/features/dashboard/components/ProjectsPanel.tsx
@@ -195,7 +195,10 @@ const ProjectsPanel: React.FC<Props> = ({ onOpenProject }) => {
   const scopeLabel = scope === "recents" ? "Recents" : "All projects";
 
   return (
-    <section aria-label="Projects" className={styles.panel}>
+    <section
+      aria-label="Projects"
+      className={`${styles.panel} ${styles.panelFullBleed}`}
+    >
       <header className={styles.header}>
         <div className={styles.titleWrap}>
           <h3 className={styles.title}>Projects</h3>

--- a/frontend/src/features/dashboard/components/WeekWidget.tsx
+++ b/frontend/src/features/dashboard/components/WeekWidget.tsx
@@ -198,8 +198,16 @@ export default function WeekWidget({
     );
   }, [mobile, tooltipDate, items, anchor, showAll]);
 
+  const containerClass = [
+    "week-widget",
+    className,
+    mobile ? "week-widget--mobile" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
   return (
-    <div className={`week-widget ${className}`} style={{ position: "relative" }}>
+    <div className={containerClass} style={{ position: "relative" }}>
       <div className="week-widget-header">
         <button className="week-nav-btn" onClick={() => onPrevWeek?.(addDays(weekStart, -7))} aria-label="Previous week">
           ‹

--- a/frontend/src/features/dashboard/components/projects-panel.module.css
+++ b/frontend/src/features/dashboard/components/projects-panel.module.css
@@ -14,6 +14,12 @@
   flex-direction: column;
 }
 
+.panelFullBleed {
+  width: 100%;
+  max-width: 100vw;
+  align-self: stretch;
+}
+
 .header {
   display: grid;
   grid-template-columns: 1fr auto;

--- a/frontend/src/features/dashboard/components/week-widget.css
+++ b/frontend/src/features/dashboard/components/week-widget.css
@@ -8,6 +8,14 @@
   padding: 10px;
 }
 
+.week-widget--mobile {
+  width: 100%;
+  max-width: 100vw;
+  align-self: stretch;
+  margin-left: auto;
+  margin-right: auto;
+}
+
 .week-widget-header {
   display: flex;
   justify-content: space-between;

--- a/frontend/src/features/dashboard/styles/components/welcome-screen.css
+++ b/frontend/src/features/dashboard/styles/components/welcome-screen.css
@@ -27,8 +27,10 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-  
+  width: 100%;
+  max-width: 100vw;
   overflow: visible; /* allow children (CTA) to be fully visible */
+  align-items: stretch;
 }
 
 .mobile-projects-section {
@@ -37,19 +39,37 @@
   overflow: visible;
   padding: 0; /* remove outer grey wrapper */
   background: transparent;
+  width: 100%;
+  max-width: 100vw;
 }
 
 .mobile-calendar-section {
   flex: 1;
   min-height: 0;
   overflow: auto;
-  
+
   border-radius: 8px;
   padding: 0px;
+  width: 100%;
+  max-width: 100vw;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+}
+
+.mobile-projects-section > *,
+.mobile-calendar-section > * {
+  width: 100%;
+  max-width: 100vw;
 }
 
 /* Ensure projects header is more compact on mobile */
 @media (max-width: 768px) {
+  .dashboard-wrapper.welcome-screen .main-content {
+    align-items: stretch;
+    justify-content: flex-start;
+  }
+
   .mobile-projects-section .projects-header {
     padding: 8px 0;
     margin-bottom: 12px;


### PR DESCRIPTION
## Summary
- add a full-bleed class to the projects panel so the mobile list stretches to the viewport width
- mark WeekWidget mobile usage with a modifier class and tweak its styling to fill the viewport
- update the welcome screen mobile layout so both sections inherit the full-width behavior

## Testing
- npm run lint *(fails: existing `@typescript-eslint/no-explicit-any` errors in `BudgetProvider.test.tsx` and `TasksComponent.test.tsx`)*

------
https://chatgpt.com/codex/tasks/task_e_68c93364aa3083248e9890c1d6b1067d