### PR TITLE
Implement compact no-scroll dashboard home layout

### DIFF
--- a/frontend/src/features/dashboard/components/TasksOverviewCard.module.css
+++ b/frontend/src/features/dashboard/components/TasksOverviewCard.module.css
@@ -54,6 +54,12 @@
   z-index: 1;
 }
 
+.cardCompact {
+  padding: clamp(16px, 1.8vw, 24px);
+  gap: clamp(12px, 1.4vw, 18px);
+  height: 100%;
+}
+
 .header {
   display: flex;
   align-items: flex-start;
@@ -77,6 +83,16 @@
   margin: 0;
   font-size: 13px;
   color: rgba(255, 255, 255, 0.65);
+}
+
+.headerCompact {
+  align-items: flex-start;
+  gap: clamp(12px, 1.2vw, 18px);
+}
+
+.subtitleCompact {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.58);
 }
 
 .actions {
@@ -129,6 +145,10 @@
   grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
 }
 
+.statGridCompact {
+  gap: clamp(10px, 1vw, 14px);
+}
+
 .stat {
   display: flex;
   flex-direction: column;
@@ -138,6 +158,12 @@
   border: 1px solid rgba(255, 255, 255, 0.1);
   background: rgba(255, 255, 255, 0.04);
   min-height: 82px;
+}
+
+.statCompact {
+  padding: clamp(12px, 1.2vw, 14px);
+  gap: 4px;
+  min-height: 0;
 }
 
 .statOk {
@@ -168,16 +194,28 @@
   letter-spacing: -0.01em;
 }
 
+.statValueCompact {
+  font-size: 20px;
+}
+
 .groups {
   display: flex;
   flex-direction: column;
   gap: var(--space-2, 16px);
 }
 
+.groupsCompact {
+  gap: clamp(10px, 1vw, 14px);
+}
+
 .group {
   display: flex;
   flex-direction: column;
   gap: 10px;
+}
+
+.groupCompact {
+  gap: 8px;
 }
 
 .groupLabel {
@@ -187,10 +225,19 @@
   letter-spacing: 0.02em;
 }
 
+.groupLabelCompact {
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.55);
+}
+
 .chips {
   display: flex;
   flex-wrap: wrap;
   gap: 10px;
+}
+
+.chipsCompact {
+  gap: 8px;
 }
 
 .chip {
@@ -205,6 +252,13 @@
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
   font-size: 13px;
   line-height: 1.2;
+}
+
+.chipCompact {
+  gap: 8px;
+  padding: 8px 12px;
+  border-radius: 14px;
+  font-size: 12px;
 }
 
 .chipDot {
@@ -222,6 +276,35 @@
 .chipMeta {
   font-size: 12px;
   color: rgba(255, 255, 255, 0.62);
+}
+
+.chipMetaCompact {
+  font-size: 11px;
+}
+
+.chipOverflow {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 10px;
+  border-radius: 999px;
+  border: 1px dashed rgba(255, 255, 255, 0.24);
+  color: rgba(255, 255, 255, 0.75);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.compactOverflow {
+  margin-top: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.compactOverflowDot {
+  opacity: 0.6;
 }
 
 .empty {

--- a/frontend/src/features/dashboard/components/TasksOverviewCard.tsx
+++ b/frontend/src/features/dashboard/components/TasksOverviewCard.tsx
@@ -69,8 +69,13 @@ type EventGroup = {
   items: EventChip[];
 };
 
+type TrimmedGroup = EventGroup & { hiddenItems: number };
+
 type TasksOverviewCardProps = {
   className?: string;
+  variant?: "default" | "compact";
+  maxGroups?: number;
+  maxItemsPerGroup?: number;
 };
 
 function parseDueDate(value?: unknown): Date | null {
@@ -139,7 +144,13 @@ function pickDue(raw: RawTask): { value: Date | null; key?: string; timeLabel?: 
   return { value: dueDate, key, timeLabel };
 }
 
-const TasksOverviewCard: React.FC<TasksOverviewCardProps> = ({ className }) => {
+const TasksOverviewCard: React.FC<TasksOverviewCardProps> = ({
+  className,
+  variant = "default",
+  maxGroups,
+  maxItemsPerGroup,
+}) => {
+  const isCompact = variant === "compact";
   const { projects = [] } = useData() as { projects: Project[] };
   const navigate = useNavigate();
 
@@ -344,6 +355,44 @@ const TasksOverviewCard: React.FC<TasksOverviewCardProps> = ({ className }) => {
     };
   }, [tasks]);
 
+  const groupLimit = isCompact ? maxGroups ?? 2 : undefined;
+  const itemsLimit = isCompact ? maxItemsPerGroup ?? 2 : undefined;
+
+  const {
+    visibleGroups,
+    hiddenGroupsCount,
+    hiddenTasksCount,
+  }: {
+    visibleGroups: TrimmedGroup[];
+    hiddenGroupsCount: number;
+    hiddenTasksCount: number;
+  } = useMemo(() => {
+    const limitGroups =
+      typeof groupLimit === "number" ? Math.max(groupLimit, 0) : groups.length;
+    const visibleSource = groups.slice(0, limitGroups);
+
+    let hiddenTasks = 0;
+
+    const mapped: TrimmedGroup[] = visibleSource.map((group) => {
+      if (typeof itemsLimit !== "number") {
+        return { ...group, hiddenItems: 0 };
+      }
+      const trimmedItems = group.items.slice(0, Math.max(itemsLimit, 0));
+      const hidden = Math.max(0, group.items.length - trimmedItems.length);
+      hiddenTasks += hidden;
+      return { ...group, items: trimmedItems, hiddenItems: hidden };
+    });
+
+    const remainingGroups = groups.slice(visibleSource.length);
+    hiddenTasks += remainingGroups.reduce((sum, group) => sum + group.items.length, 0);
+
+    return {
+      visibleGroups: mapped,
+      hiddenGroupsCount: Math.max(0, groups.length - visibleSource.length),
+      hiddenTasksCount: hiddenTasks,
+    };
+  }, [groups, groupLimit, itemsLimit]);
+
   const handleNavigateToPrimary = useCallback(() => {
     if (!primaryProjectId) {
       navigate("/dashboard/projects");
@@ -366,65 +415,124 @@ const TasksOverviewCard: React.FC<TasksOverviewCardProps> = ({ className }) => {
     return value;
   };
 
+  const cardClassName = [
+    styles.card,
+    isCompact ? styles.cardCompact : "",
+    className ?? "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const headerClassName = [
+    styles.header,
+    isCompact ? styles.headerCompact : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const subtitleClassName = [
+    styles.subtitle,
+    isCompact ? styles.subtitleCompact : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const statGridClassName = [
+    styles.statGrid,
+    isCompact ? styles.statGridCompact : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const groupsClassName = [
+    styles.groups,
+    isCompact ? styles.groupsCompact : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const chipsClassName = [
+    styles.chips,
+    isCompact ? styles.chipsCompact : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
   return (
     <Squircle
       as="section"
       radius={CARD_RADIUS}
       smoothing={0.6}
-      className={`${styles.card} ${className ?? ""}`.trim()}
+      className={cardClassName}
       aria-label="Tasks overview"
     >
-      <header className={styles.header}>
+      <header className={headerClassName}>
         <div className={styles.titleWrap}>
           <h3 className={styles.title}>Tasks</h3>
-          <p className={styles.subtitle}>Track progress and deadlines across your projects.</p>
+          <p className={subtitleClassName}>Track progress and deadlines across your projects.</p>
         </div>
-        <div className={styles.actions}>
-          <button
-            type="button"
-            className={`${styles.iconButton} ${styles.iconButtonPrimary}`}
-            onClick={handleNavigateToPrimary}
-            aria-label="Add or review tasks for the next project"
-            disabled={!canNavigateToProject}
-          >
-            <Plus size={18} strokeWidth={2} />
-          </button>
-          <button
-            type="button"
-            className={styles.iconButton}
-            onClick={handleViewAll}
-            aria-label="View all projects"
-          >
-            <MoreHorizontal size={18} strokeWidth={2} />
-          </button>
-        </div>
+        {!isCompact && (
+          <div className={styles.actions}>
+            <button
+              type="button"
+              className={`${styles.iconButton} ${styles.iconButtonPrimary}`}
+              onClick={handleNavigateToPrimary}
+              aria-label="Add or review tasks for the next project"
+              disabled={!canNavigateToProject}
+            >
+              <Plus size={18} strokeWidth={2} />
+            </button>
+            <button
+              type="button"
+              className={styles.iconButton}
+              onClick={handleViewAll}
+              aria-label="View all projects"
+            >
+              <MoreHorizontal size={18} strokeWidth={2} />
+            </button>
+          </div>
+        )}
       </header>
 
-      <div className={styles.statGrid}>
-        <div className={`${styles.stat} ${styles.statOk}`}>
+      <div className={statGridClassName}>
+        <div
+          className={`${styles.stat} ${isCompact ? styles.statCompact : ""} ${styles.statOk}`}
+        >
           <span className={styles.statLabel}>Completed</span>
-          <span className={styles.statValue}>{formatStatValue(completed)}</span>
+          <span className={`${styles.statValue} ${isCompact ? styles.statValueCompact : ""}`}>
+            {formatStatValue(completed)}
+          </span>
         </div>
-        <div className={`${styles.stat} ${styles.statDanger}`}>
+        <div
+          className={`${styles.stat} ${isCompact ? styles.statCompact : ""} ${styles.statDanger}`}
+        >
           <span className={styles.statLabel}>Overdue</span>
-          <span className={styles.statValue}>{formatStatValue(overdue)}</span>
+          <span className={`${styles.statValue} ${isCompact ? styles.statValueCompact : ""}`}>
+            {formatStatValue(overdue)}
+          </span>
         </div>
-        <div className={`${styles.stat} ${styles.statWarn}`}>
+        <div
+          className={`${styles.stat} ${isCompact ? styles.statCompact : ""} ${styles.statWarn}`}
+        >
           <span className={styles.statLabel}>Due</span>
-          <span className={styles.statValue}>{formatStatValue(dueSoon)}</span>
+          <span className={`${styles.statValue} ${isCompact ? styles.statValueCompact : ""}`}>
+            {formatStatValue(dueSoon)}
+          </span>
         </div>
       </div>
 
       {error ? (
         <div className={styles.empty}>We couldn’t load tasks right now. Please try again later.</div>
-      ) : groups.length ? (
-        <div className={styles.groups}>
-          {groups.map((group) => (
-            <div key={group.id} className={styles.group}>
-              <div className={styles.groupLabel}>{group.dayLabel}</div>
-              <div className={styles.chips}>
+      ) : visibleGroups.length ? (
+        <div className={groupsClassName}>
+          {visibleGroups.map((group) => (
+            <div key={group.id} className={`${styles.group} ${isCompact ? styles.groupCompact : ""}`}>
+              <div className={`${styles.groupLabel} ${isCompact ? styles.groupLabelCompact : ""}`}>
+                {group.dayLabel}
+              </div>
+              <div className={chipsClassName}>
                 {group.items.map((item) => (
-                  <div key={item.id} className={styles.chip}>
+                  <div key={item.id} className={`${styles.chip} ${isCompact ? styles.chipCompact : ""}`}>
                     <span
                       className={styles.chipDot}
                       style={{ backgroundColor: item.color || "var(--brand, #fa3356)" }}
@@ -432,7 +540,9 @@ const TasksOverviewCard: React.FC<TasksOverviewCardProps> = ({ className }) => {
                     />
                     <span className={styles.chipTitle}>{item.title}</span>
                     {(item.time || item.project) && (
-                      <span className={styles.chipMeta}>
+                      <span
+                        className={`${styles.chipMeta} ${isCompact ? styles.chipMetaCompact : ""}`}
+                      >
                         {item.time}
                         {item.time && item.project ? " · " : ""}
                         {item.project}
@@ -440,6 +550,9 @@ const TasksOverviewCard: React.FC<TasksOverviewCardProps> = ({ className }) => {
                     )}
                   </div>
                 ))}
+                {group.hiddenItems > 0 && (
+                  <span className={styles.chipOverflow}>+{group.hiddenItems}</span>
+                )}
               </div>
             </div>
           ))}
@@ -449,6 +562,27 @@ const TasksOverviewCard: React.FC<TasksOverviewCardProps> = ({ className }) => {
           {loading ? "Loading tasks…" : "No open tasks are due this week. You’re all caught up!"}
         </div>
       )}
+
+      {isCompact &&
+        !error &&
+        !loading &&
+        (hiddenGroupsCount > 0 || hiddenTasksCount > 0) && (
+          <div className={styles.compactOverflow}>
+            {hiddenGroupsCount > 0 && (
+              <span>
+                +{hiddenGroupsCount} more day{hiddenGroupsCount === 1 ? "" : "s"}
+              </span>
+            )}
+            {hiddenGroupsCount > 0 && hiddenTasksCount > 0 && (
+              <span className={styles.compactOverflowDot}>·</span>
+            )}
+            {hiddenTasksCount > 0 && (
+              <span>
+                +{hiddenTasksCount} task{hiddenTasksCount === 1 ? "" : "s"}
+              </span>
+            )}
+          </div>
+        )}
     </Squircle>
   );
 };

--- a/frontend/src/features/dashboard/components/WelcomeHeader.tsx
+++ b/frontend/src/features/dashboard/components/WelcomeHeader.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { User, Bell, Menu, Plus } from "lucide-react";
 import { useData } from '@/app/contexts/useData';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { useOnlineStatus } from '@/app/contexts/OnlineStatusContext';
 import NotificationsDrawer from '../../../shared/ui/NotificationsDrawer';
 import { useNotifications } from "../../../app/contexts/useNotifications";
@@ -10,13 +10,11 @@ import GlobalSearch from './GlobalSearch';
 import './GlobalSearch.css';
 import { getFileUrl } from '../../../shared/utils/api';
 import { useAppShell } from '@/app/layout/AppShell';
-import WeekWidgetCard from "@/features/schedule/WeekWidgetCard";
 
 const WelcomeHeader: React.FC<{ userName?: string; setActiveView?: (view: string) => void }> = ({ userName: propUserName, setActiveView }) => {
   const { userData } = useData();
   const { isOnline } = useOnlineStatus(); // <-- only need this now
   const navigate = useNavigate();
-  const location = useLocation();
   const appShell = useAppShell();
 
   const userName = propUserName || userData?.firstName || userData?.email || 'User';
@@ -92,20 +90,6 @@ const WelcomeHeader: React.FC<{ userName?: string; setActiveView?: (view: string
   ]
     .filter(Boolean)
     .join(' ');
-
-  const activeView = React.useMemo(() => {
-    const segments = location.pathname.split('/').filter(Boolean);
-    const idx = segments.indexOf('dashboard');
-    if (idx === -1) return null;
-
-    let view = segments[idx + 1] ?? 'welcome';
-    if (view === 'welcome') {
-      view = segments[idx + 2] ?? 'welcome';
-    }
-    return view;
-  }, [location.pathname]);
-
-  const showWelcomeCards = Boolean(isDesktopShell && activeView === 'welcome');
 
   return (
     <>
@@ -228,16 +212,6 @@ const WelcomeHeader: React.FC<{ userName?: string; setActiveView?: (view: string
           </div>
         </div>
       </div>
-
-      {showWelcomeCards && (
-        <div className="welcome-header-extras" role="region" aria-label="Dashboard welcome overview">
-       
-
-          <div id="week" className="welcome-section-anchor">
-            <WeekWidgetCard className="welcome-header-week-card" />
-          </div>
-        </div>
-      )}
 
       <NotificationsDrawer
         open={notificationsOpen}

--- a/frontend/src/features/dashboard/pages/DashboardHome.tsx
+++ b/frontend/src/features/dashboard/pages/DashboardHome.tsx
@@ -20,6 +20,7 @@ import NavigationDrawer from "@/shared/ui/NavigationDrawer";
 import DashboardNavPanel from "@/shared/ui/DashboardNavPanel";
 import AppShell from "@/app/layout/AppShell";
 import ProjectsPanelDesktop from "@/features/projects/ProjectsPanelDesktop";
+import WeekWidgetCard from "@/features/schedule/WeekWidgetCard";
 
 import "./dashboard-styles.css";
 
@@ -151,16 +152,24 @@ const WelcomeScreen: React.FC = () => {
   const renderWelcomeView = () => {
     if (isDesktop) {
       return (
-        <div className="dashboard-home-grid">
-          <section id="projects" className="welcome-section-anchor">
-            <ProjectsPanelDesktop
-              onOpenProject={(projectId) => handleNavigateToProject({ projectId })}
-            />
-          </section>
+        <div className="dashboard-home-viewport">
+          <div className="dashboard-home-desktop" role="region" aria-label="Home overview">
+            <section id="projects" className="welcome-section-anchor dashboard-home-desktop__projects">
+              <ProjectsPanelDesktop
+                variant="compact"
+                onOpenProject={(projectId) => handleNavigateToProject({ projectId })}
+              />
+            </section>
 
-          <section id="tasks" className="welcome-section-anchor">
-            <TasksOverviewCard className="welcome-header-tasks-card" />
-          </section>
+            <div className="dashboard-home-desktop__side">
+              <section id="week" className="welcome-section-anchor">
+                <WeekWidgetCard variant="compact" />
+              </section>
+              <section id="tasks" className="welcome-section-anchor">
+                <TasksOverviewCard variant="compact" />
+              </section>
+            </div>
+          </div>
         </div>
       );
     }
@@ -219,7 +228,11 @@ const WelcomeScreen: React.FC = () => {
       <div className="dashboard-wrapper welcome-screen no-vertical-center">
         <WelcomeHeader userName={userName} setActiveView={setActiveView} />
 
-        <div className="row-layout">
+        <div
+          className={`row-layout${
+            activeView === "welcome" && isDesktop ? " row-layout--fixed" : ""
+          }`}
+        >
           <div className="welcome-screen-details">
             {showTopBar && !isMobile && <TopBar setActiveView={setActiveView} />}
 
@@ -231,7 +244,11 @@ const WelcomeScreen: React.FC = () => {
               <div
                 className={`main-content${
                   activeView === "welcome" && isDesktop
-                    ? " main-content--welcome"
+                    ? " main-content--welcome main-content--fixed"
+                    : ""
+                }${
+                  activeView === "welcome" && isDesktop
+                    ? " main-content--home"
                     : ""
                 }`}
               >

--- a/frontend/src/features/projects/ProjectsPanelDesktop.module.css
+++ b/frontend/src/features/projects/ProjectsPanelDesktop.module.css
@@ -48,6 +48,12 @@
   z-index: 1;
 }
 
+.cardCompact {
+  padding: clamp(16px, 1.8vw, 24px);
+  gap: clamp(12px, 1.4vw, 18px);
+  height: 100%;
+}
+
 /* Header (transparent, faint divider only) */
 .header {
   display: flex;
@@ -58,6 +64,172 @@
   padding-bottom: var(--space-1, 12px);
   position: relative;
   z-index: 1;
+}
+
+.headerCompact {
+  border-bottom: none;
+  padding-bottom: 6px;
+  gap: clamp(8px, 1vw, 12px);
+}
+
+.compactTitleWrap {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.compactSubtitle {
+  margin: 0;
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.65);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.compactMetaLine {
+  margin: 0;
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.5);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.compactOverflowPill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  font-size: 12px;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.85);
+  white-space: nowrap;
+}
+
+.compactList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(8px, 1vw, 12px);
+  flex: 1;
+  min-height: 0;
+}
+
+.compactRow {
+  min-width: 0;
+}
+
+.compactRowButton {
+  width: 100%;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: clamp(10px, 1vw, 16px);
+  align-items: center;
+  padding: clamp(10px, 1.4vw, 14px);
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.04);
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: background-color 0.16s ease, border-color 0.16s ease, transform 0.16s ease;
+}
+
+.compactRowButton:hover {
+  background: rgba(255, 255, 255, 0.07);
+  border-color: rgba(255, 255, 255, 0.14);
+  transform: translateY(-1px);
+}
+
+.compactRowButton:focus-visible {
+  outline: 2px solid var(--color-focus, var(--brand, #fa3356));
+  outline-offset: 2px;
+}
+
+.compactRowMain {
+  display: flex;
+  align-items: center;
+  gap: clamp(10px, 1vw, 14px);
+  min-width: 0;
+}
+
+.thumbCompact {
+  width: 36px;
+  height: 36px;
+  border-radius: 12px;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.08);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.thumbCompactImg {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: inherit;
+}
+
+.compactText {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.compactTitle {
+  font-size: 15px;
+  font-weight: 600;
+  margin: 0;
+  color: rgba(255, 255, 255, 0.92);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.compactMeta {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.58);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.compactMetaWrap {
+  display: inline-flex;
+  align-items: center;
+  gap: clamp(8px, 0.8vw, 12px);
+}
+
+.compactDeadline {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.7);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.compactUnread {
+  min-width: 28px;
+  padding: 3px 8px;
+  border-radius: 999px;
+  background: rgba(250, 51, 86, 0.2);
+  color: #fff;
+  font-size: 12px;
+  font-weight: 600;
+  text-align: center;
+}
+
+.footerCompact {
+  justify-content: flex-start;
+  margin-top: auto;
 }
 
 .headerTop {

--- a/frontend/src/features/projects/ProjectsPanelDesktop.tsx
+++ b/frontend/src/features/projects/ProjectsPanelDesktop.tsx
@@ -23,9 +23,20 @@ const PANEL_RADIUS = 24;
 const PANEL_CORNER_RADII = Object.freeze({ top: PANEL_RADIUS + 2, bottom: PANEL_RADIUS - 2 });
 
 const DEFAULT_DESKTOP_ROWS = 6;
+const DEFAULT_COMPACT_ROWS = 4;
+const MIN_COMPACT_ROWS = 2;
+
+const getCompactRowTarget = (height: number): number => {
+  if (!Number.isFinite(height)) return DEFAULT_COMPACT_ROWS;
+  if (height < 680) return MIN_COMPACT_ROWS;
+  if (height < 820) return 3;
+  return DEFAULT_COMPACT_ROWS;
+};
 
 export type ProjectsPanelDesktopProps = {
   onOpenProject?: (projectId: string) => void;
+  variant?: "default" | "compact";
+  maxRows?: number;
 };
 
 type SortOption = "titleAsc" | "titleDesc" | "dateNewest" | "dateOldest";
@@ -69,7 +80,12 @@ function sanitizeId(raw: string) {
   return raw.replace(/[^a-zA-Z0-9_-]/g, "");
 }
 
-const ProjectsPanelDesktop: React.FC<ProjectsPanelDesktopProps> = ({ onOpenProject }) => {
+const ProjectsPanelDesktop: React.FC<ProjectsPanelDesktopProps> = ({
+  onOpenProject,
+  variant = "default",
+  maxRows,
+}) => {
+  const isCompact = variant === "compact";
   const reduceMotion = useReducedMotion();
   const {
     projects = [],
@@ -92,6 +108,33 @@ const ProjectsPanelDesktop: React.FC<ProjectsPanelDesktopProps> = ({ onOpenProje
   const [filtersOpen, setFiltersOpen] = useState(false);
   const filtersRef = useRef<HTMLDivElement | null>(null);
   const filtersIdRef = useRef(`projects-filters-${sanitizeId(Math.random().toString(36).slice(2))}`);
+
+  const [compactRowEstimate, setCompactRowEstimate] = useState(() => {
+    if (!isCompact) return DEFAULT_COMPACT_ROWS;
+    if (typeof window === "undefined") return DEFAULT_COMPACT_ROWS;
+    return getCompactRowTarget(window.innerHeight);
+  });
+
+  useEffect(() => {
+    if (!isCompact) return;
+    if (typeof window === "undefined") return;
+
+    const handleResize = () => {
+      const next = getCompactRowTarget(window.innerHeight);
+      setCompactRowEstimate((prev) => (prev === next ? prev : next));
+    };
+
+    handleResize();
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, [isCompact]);
+
+  const compactRowLimit = isCompact
+    ? Math.max(
+        MIN_COMPACT_ROWS,
+        Math.min(maxRows ?? DEFAULT_COMPACT_ROWS, compactRowEstimate)
+      )
+    : undefined;
 
   const [sortOption, setSortOption] = useState<SortOption>("dateNewest");
   const [statusFilter, setStatusFilter] = useState<string>("");
@@ -146,7 +189,7 @@ const ProjectsPanelDesktop: React.FC<ProjectsPanelDesktopProps> = ({ onOpenProje
     }
   }, [projects]);
 
-  const items = useMemo(() => {
+  const { items, hiddenCount }: { items: ProjectWithMeta[]; hiddenCount: number } = useMemo(() => {
     const list: ProjectWithMeta[] = (projects as ProjectLike[]).map((p) => ({
       ...(p as ProjectWithMeta),
       _activity: getProjectActivityTs(p),
@@ -191,11 +234,27 @@ const ProjectsPanelDesktop: React.FC<ProjectsPanelDesktopProps> = ({ onOpenProje
         break;
     }
 
-    if (scope === "recents") {
-      return ordered.slice(0, DEFAULT_DESKTOP_ROWS);
-    }
-    return ordered;
-  }, [projects, scope, query, statusFilter, sortOption]);
+    const limit = isCompact
+      ? compactRowLimit ?? DEFAULT_COMPACT_ROWS
+      : scope === "recents"
+        ? DEFAULT_DESKTOP_ROWS
+        : undefined;
+
+    const limited =
+      typeof limit === "number" ? ordered.slice(0, Math.max(limit, 0)) : ordered;
+    const hidden =
+      typeof limit === "number" ? Math.max(0, ordered.length - limited.length) : 0;
+
+    return { items: limited, hiddenCount: hidden };
+  }, [
+    projects,
+    scope,
+    query,
+    statusFilter,
+    sortOption,
+    isCompact,
+    compactRowLimit,
+  ]);
 
   const kpis = useProjectKpis(projects as ProjectLike[]);
 
@@ -252,6 +311,7 @@ const ProjectsPanelDesktop: React.FC<ProjectsPanelDesktopProps> = ({ onOpenProje
   };
 
   const renderIconsStrip = () => {
+    if (isCompact) return null;
     const allProjects = projects as ProjectLike[];
     const maxIcons = 7;
     const shown = allProjects.slice(0, maxIcons);
@@ -461,6 +521,120 @@ const ProjectsPanelDesktop: React.FC<ProjectsPanelDesktopProps> = ({ onOpenProje
   );
 
   const errorText = projectsError ? "Failed to load projects." : undefined;
+  const totalFiltered = items.length + hiddenCount;
+  const summaryLabel = `Showing ${items.length}${
+    hiddenCount > 0 ? ` of ${totalFiltered}` : ""
+  }`;
+  const pendingLabel = `${kpis.pendingProjects} pending`;
+  const nextProjectSummary = kpis.nextProject
+    ? `Next: ${kpis.nextProject.title ?? ""}${
+        kpis.nextProject.date ? ` · ${kpis.nextProject.date}` : ""
+      }`
+    : undefined;
+
+  if (isCompact) {
+    return (
+      <Squircle
+        as="section"
+        aria-label="Projects overview"
+        className={`${desktopStyles.card} ${desktopStyles.cardCompact}`}
+        radius={PANEL_RADIUS}
+        smoothing={0.6}
+        cornerRadii={PANEL_CORNER_RADII}
+      >
+        <header className={`${desktopStyles.header} ${desktopStyles.headerCompact}`}>
+          <div className={desktopStyles.compactTitleWrap}>
+            <div className={mobileStyles.titleWrap}>
+              <h3 className={mobileStyles.title}>Projects</h3>
+            </div>
+            <p className={desktopStyles.compactSubtitle}>{`${summaryLabel} • ${pendingLabel}`}</p>
+            {nextProjectSummary && (
+              <p className={desktopStyles.compactMetaLine}>{nextProjectSummary}</p>
+            )}
+          </div>
+          {hiddenCount > 0 && (
+            <span className={desktopStyles.compactOverflowPill}>+{hiddenCount}</span>
+          )}
+        </header>
+
+        {errorText ? (
+          <div className={desktopStyles.errorState}>{errorText}</div>
+        ) : isLoading ? (
+          <div className={desktopStyles.emptyState}>Loading projects…</div>
+        ) : items.length === 0 ? (
+          <div className={desktopStyles.emptyState}>No projects match filters.</div>
+        ) : (
+          <ul className={desktopStyles.compactList} role="list">
+            {items.map((p) => {
+              const id = p.projectId;
+              const title = (p.title || "Untitled project").trim();
+              const thumb =
+                Array.isArray(p.thumbnails) && p.thumbnails[0] ? p.thumbnails[0] : undefined;
+              const deadline = formatShortDate(p.finishline);
+              const status = p.status ? String(p.status) : "—";
+              const unread = Number.isFinite(p.unreadCount as number)
+                ? Number(p.unreadCount)
+                : Number((p as { unreadCount?: number }).unreadCount ?? 0);
+              const owner = getOwnerName(p);
+
+              return (
+                <li key={id} className={desktopStyles.compactRow} role="listitem">
+                  <button
+                    type="button"
+                    className={desktopStyles.compactRowButton}
+                    onClick={() => handleOpen(id)}
+                    aria-label={`Open project ${title}`}
+                  >
+                    <span className={desktopStyles.compactRowMain}>
+                      <span className={desktopStyles.thumbCompact} aria-hidden>
+                        {thumb && !imgError[id] ? (
+                          <img
+                            className={desktopStyles.thumbCompactImg}
+                            src={getFileUrl(thumb)}
+                            alt=""
+                            onError={() => setImgError((m) => ({ ...m, [id]: true }))}
+                          />
+                        ) : (
+                          <SVGThumbnail
+                            initial={title.charAt(0).toUpperCase() || "#"}
+                            className={desktopStyles.thumbCompactImg}
+                          />
+                        )}
+                      </span>
+                      <span className={desktopStyles.compactText}>
+                        <span className={desktopStyles.compactTitle}>{title}</span>
+                        <span className={desktopStyles.compactMeta}>
+                          {owner}
+                          {owner && status ? " · " : ""}
+                          {status}
+                        </span>
+                      </span>
+                    </span>
+                    <span className={desktopStyles.compactMetaWrap}>
+                      <span className={desktopStyles.compactDeadline}>{deadline ?? "—"}</span>
+                      {unread > 0 && (
+                        <span className={desktopStyles.compactUnread}>{unread}</span>
+                      )}
+                    </span>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+
+        <div className={`${desktopStyles.footer} ${desktopStyles.footerCompact}`}>
+          <button
+            type="button"
+            className={desktopStyles.footerButton}
+            onClick={() => navigate("/dashboard/projects")}
+          >
+            See all projects
+          </button>
+        </div>
+      </Squircle>
+    );
+  }
 
   return (
     <Squircle

--- a/frontend/src/features/schedule/WeekWidgetCard.module.css
+++ b/frontend/src/features/schedule/WeekWidgetCard.module.css
@@ -71,11 +71,21 @@
   z-index: 1;
 }
 
+.cardCompact {
+  padding: clamp(16px, 1.8vw, 24px);
+  gap: clamp(12px, 1.4vw, 18px);
+  height: 100%;
+}
+
 .header {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
   gap: var(--space-2, 16px);
+}
+
+.headerCompact {
+  gap: clamp(10px, 1.1vw, 16px);
 }
 
 .titleWrap {
@@ -94,6 +104,11 @@
   margin: 0;
   font-size: 13px;
   color: rgba(255, 255, 255, 0.6);
+}
+
+.subtitleCompact {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.55);
 }
 
 .badges {
@@ -135,6 +150,15 @@
   white-space: nowrap;
 }
 
+.morePillCompact {
+  padding: 5px 10px;
+  background: rgba(250, 51, 86, 0.15);
+}
+
 .widget {
   margin-top: 8px;
+}
+
+.widgetCompact {
+  margin-top: 4px;
 }

--- a/frontend/src/features/schedule/WeekWidgetCard.tsx
+++ b/frontend/src/features/schedule/WeekWidgetCard.tsx
@@ -22,6 +22,7 @@ const MAX_VISIBLE_TRACKS = 3;
 
 type WeekWidgetCardProps = {
   className?: string;
+  variant?: "default" | "compact";
 };
 
 function toDay(d?: string | Date | number) {
@@ -29,15 +30,12 @@ function toDay(d?: string | Date | number) {
   const v = d instanceof Date ? d : new Date(d);
   return Number.isNaN(v.getTime()) ? null : new Date(v.getFullYear(), v.getMonth(), v.getDate());
 }
-
 function sameDay(a: Date | null, b: Date | null) {
-  return !!(a && b) &&
-    a.getFullYear() === b.getFullYear() &&
-    a.getMonth() === b.getMonth() &&
-    a.getDate() === b.getDate();
+  return !!(a && b) && a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth() && a.getDate() === b.getDate();
 }
 
-const WeekWidgetCard: React.FC<WeekWidgetCardProps> = ({ className }) => {
+const WeekWidgetCard: React.FC<WeekWidgetCardProps> = ({ className, variant = "default" }) => {
+  const isCompact = variant === "compact";
   const { projects = [] } = useData() as { projects: Project[] };
   const [weekOf, setWeekOf] = useState<Date>(new Date());
 
@@ -96,28 +94,35 @@ const WeekWidgetCard: React.FC<WeekWidgetCardProps> = ({ className }) => {
     return items;
   };
 
+  const cardClassName = [styles.card, isCompact ? styles.cardCompact : "", className ?? ""].filter(Boolean).join(" ");
+  const headerClassName = [styles.header, isCompact ? styles.headerCompact : ""].filter(Boolean).join(" ");
+  const subtitleClassName = [styles.subtitle, isCompact ? styles.subtitleCompact : ""].filter(Boolean).join(" ");
+  const widgetClassName = [styles.widget, isCompact ? styles.widgetCompact : ""].filter(Boolean).join(" ");
+
   return (
     <Squircle
       as="section"
       radius={CARD_RADIUS}
       smoothing={0.6}
       cornerRadii={CARD_CORNER_RADII}
-      className={`${styles.card} ${className ?? ""}`.trim()}
+      className={cardClassName}
       aria-label="Week overview"
     >
-      <header className={styles.header}>
+      <header className={headerClassName}>
         <div className={styles.titleWrap}>
           <h3 className={styles.title}>This Week</h3>
-          <p className={styles.subtitle}>Timeline snapshots across your projects.</p>
-          <div className={styles.badges} aria-label="Week status badges">
-            <span className={styles.badge}>Overdue</span>
-            <span className={styles.badge}>Due Today</span>
-            <span className={styles.badge}>New</span>
-          </div>
+          <p className={subtitleClassName}>Timeline snapshots across your projects.</p>
+          {!isCompact && (
+            <div className={styles.badges} aria-label="Week status badges">
+              <span className={styles.badge}>Overdue</span>
+              <span className={styles.badge}>Due Today</span>
+              <span className={styles.badge}>New</span>
+            </div>
+          )}
         </div>
         {moreCount > 0 && (
           <span
-            className={styles.morePill}
+            className={`${styles.morePill} ${isCompact ? styles.morePillCompact : ""}`}
             aria-label={`${moreCount} more active projects this week`}
           >
             +{moreCount} more
@@ -129,7 +134,7 @@ const WeekWidgetCard: React.FC<WeekWidgetCardProps> = ({ className }) => {
         weekOf={weekOf}
         tracks={tracks}
         dots={dots}
-        className={styles.widget}
+        className={widgetClassName}
         onPrevWeek={(d) => setWeekOf(d)}
         onNextWeek={(d) => setWeekOf(d)}
         onSelectDate={(d) => setWeekOf(d)}

--- a/frontend/src/shared/styles/layouts/dashboard.css
+++ b/frontend/src/shared/styles/layouts/dashboard.css
@@ -17,6 +17,16 @@
   overscroll-behavior-y: contain;
 }
 
+.row-layout--fixed {
+  overflow: hidden;
+  min-height: 0;
+}
+
+.row-layout--fixed .dashboard-content {
+  height: 100%;
+  min-height: 0;
+}
+
 /* Main content area wrapper */
 .main-content {
   display: flex;
@@ -35,6 +45,66 @@
 
 .main-content--welcome > * {
   width: 100%;
+}
+
+.main-content--fixed {
+  overflow: hidden;
+}
+
+.main-content--home {
+  justify-content: flex-start;
+  align-items: stretch;
+}
+
+.main-content--home > * {
+  flex: 1;
+  min-height: 0;
+}
+
+.dashboard-home-viewport {
+  flex: 1;
+  display: flex;
+  min-height: 0;
+}
+
+.dashboard-home-desktop {
+  display: grid;
+  grid-template-columns: minmax(0, 1.25fr) minmax(0, 0.75fr);
+  gap: clamp(12px, 1.8vw, 20px);
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+}
+
+.dashboard-home-desktop__projects {
+  min-height: 0;
+}
+
+.dashboard-home-desktop__side {
+  display: grid;
+  grid-template-rows: minmax(0, 0.55fr) minmax(0, 0.45fr);
+  gap: clamp(12px, 1.8vw, 20px);
+  min-height: 0;
+}
+
+.dashboard-home-desktop__side > * {
+  min-height: 0;
+}
+
+@media (max-width: 1440px) {
+  .dashboard-home-desktop {
+    grid-template-columns: minmax(0, 1.15fr) minmax(0, 0.85fr);
+  }
+
+  .dashboard-home-desktop__side {
+    grid-template-rows: minmax(0, 0.5fr) minmax(0, 0.5fr);
+  }
+}
+
+@media (max-width: 1180px) {
+  .dashboard-home-desktop {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }
 
 


### PR DESCRIPTION
## Summary
- reorganize the desktop dashboard home into a fixed-height grid that shows projects, week insights, and tasks without scrollable regions
- add compact variants for the projects, tasks, and week widgets with truncated lists and condensed styling to prevent overflow
- remove the redundant week card from the header and adjust shared layout styles to support the new viewport-fitting experience

## Testing
- npm run lint *(fails: existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c932345bc48324877c6ac73ed99507