### PR TITLE
Adjust moodboard quick insert styling

### DIFF
--- a/frontend/src/features/moodboard/components/MoodboardCanvas.tsx
+++ b/frontend/src/features/moodboard/components/MoodboardCanvas.tsx
@@ -123,6 +123,7 @@ const MoodboardCanvas: React.FC<MoodboardCanvasProps> = ({
 
   const themeStyle = useMemo<React.CSSProperties>(() => {
     const [r, g, b] = hexToRgbTuple(accent);
+    const accentRgb: [number, number, number] = [r, g, b];
     const weakRgb = hexToRgbTuple(accentWeak);
     const strongRgb = hexToRgbTuple(accentStrong);
 
@@ -138,8 +139,8 @@ const MoodboardCanvas: React.FC<MoodboardCanvasProps> = ({
     const canvasGrid = tupleToRgba(mixRgbTuples(weakRgb, WHITE_RGB, 0.32), 0.18);
     const canvasBorder = tupleToRgba(mixRgbTuples(strongRgb, weakRgb, 0.48), 0.58);
     const canvasShadow = tupleToRgba(mixRgbTuples(weakRgb, BRAND_BG_RGB, 0.28), 0.22);
-    const overlayTint = tupleToRgba(mixRgbTuples(weakRgb, BRAND_BG_RGB, 0.35), 0.72);
-    const raisedSurface = tupleToRgba(mixRgbTuples(weakRgb, BRAND_BG_RGB, 0.18), 0.96);
+    const overlayBase = mixRgbTuples(accentRgb, BRAND_BG_RGB, 0.72);
+    const overlayTint = tupleToRgba(overlayBase, 0.78);
     const raisedBorder = tupleToRgba(mixRgbTuples(strongRgb, weakRgb, 0.34), 0.42);
 
     return {
@@ -162,7 +163,7 @@ const MoodboardCanvas: React.FC<MoodboardCanvasProps> = ({
       "--moodboard-canvas-border": canvasBorder,
       "--moodboard-canvas-shadow": canvasShadow,
       "--moodboard-overlay": overlayTint,
-      "--moodboard-surface-raised": raisedSurface,
+      "--moodboard-surface-raised": PROJECT_BRAND_BG,
       "--moodboard-surface-raised-border": raisedBorder,
     } as React.CSSProperties;
   }, [accent, accentStrong, accentWeak]);

--- a/frontend/src/features/moodboard/moodboard.module.css
+++ b/frontend/src/features/moodboard/moodboard.module.css
@@ -32,7 +32,7 @@
   --moodboard-canvas-bg: rgba(15, 23, 42, 0.65);
   --moodboard-canvas-shadow: rgba(148, 163, 184, 0.1);
   --moodboard-overlay: rgba(15, 23, 42, 0.72);
-  --moodboard-surface-raised: rgba(15, 16, 20, 0.98);
+  --moodboard-surface-raised: #0c0c0c;
   --moodboard-surface-raised-border: rgba(148, 163, 184, 0.35);
 }
 
@@ -253,7 +253,7 @@
 
 .palette {
   width: min(520px, 100%);
-  background: var(--moodboard-surface-raised, rgba(15, 16, 20, 0.98));
+  background: var(--moodboard-surface-raised, #0c0c0c);
   border-radius: 24px;
   border: 1px solid var(--moodboard-surface-raised-border, rgba(148, 163, 184, 0.35));
   box-shadow: 0 30px 60px var(--moodboard-brand-shadow, rgba(15, 23, 42, 0.55));


### PR DESCRIPTION
## Summary
- ensure the moodboard quick insert panel always uses the MYLG dark surface
- tint the quick insert overlay with the active project accent so the backdrop reflects the project color

## Testing
- `npm run lint` *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c9540fff3c8324952c1da1232cc18e