### PR TITLE
Refine dashboard home layout to fill viewport

### DIFF
--- a/frontend/src/features/dashboard/components/MobileTasksOverviewCard.module.css
+++ b/frontend/src/features/dashboard/components/MobileTasksOverviewCard.module.css
@@ -159,6 +159,13 @@
   gap: 12px;
 }
 
+.itemMore {
+  align-items: center;
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.6);
+  font-weight: 600;
+}
+
 .itemDot {
   width: 10px;
   height: 10px;
@@ -182,6 +189,12 @@
 .itemMeta {
   font-size: 12px;
   color: rgba(255, 255, 255, 0.62);
+}
+
+.moreGroups {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.55);
+  text-align: right;
 }
 
 .empty {
@@ -235,4 +248,37 @@
   .footerActions {
     margin-top: 4px;
   }
+}
+
+:global(.home-dashboard-card--tasks) .card {
+  height: 100%;
+  min-height: 0;
+  gap: 14px;
+  padding: 16px;
+  overflow: hidden;
+}
+
+:global(.home-dashboard-card--tasks) .subtitle,
+:global(.home-dashboard-card--tasks) .viewAllButton {
+  display: none;
+}
+
+:global(.home-dashboard-card--tasks) .groups {
+  gap: 10px;
+  overflow: hidden;
+}
+
+:global(.home-dashboard-card--tasks) .items {
+  gap: 8px;
+}
+
+:global(.home-dashboard-card--tasks) .itemTitle {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+:global(.home-dashboard-card--tasks) .footerActions {
+  margin-top: auto;
 }

--- a/frontend/src/features/dashboard/components/MobileTasksOverviewCard.tsx
+++ b/frontend/src/features/dashboard/components/MobileTasksOverviewCard.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 
 import Squircle from "@/shared/ui/Squircle";
 
@@ -6,8 +6,15 @@ import { useTasksOverview } from "./useTasksOverview";
 import styles from "./MobileTasksOverviewCard.module.css";
 
 const CARD_RADIUS = 20;
+const MAX_COMPACT_GROUPS = 2;
+const MAX_COMPACT_ITEMS = 2;
 
-const MobileTasksOverviewCard: React.FC = () => {
+type Props = {
+  className?: string;
+  compact?: boolean;
+};
+
+const MobileTasksOverviewCard: React.FC<Props> = ({ className, compact = false }) => {
   const { loading, error, stats, groups, handleNavigateToPrimary, handleViewAll, canNavigateToProject } =
     useTasksOverview();
 
@@ -17,12 +24,24 @@ const MobileTasksOverviewCard: React.FC = () => {
     return value;
   };
 
+  const cardClassName = useMemo(
+    () => [styles.card, className || ""].filter(Boolean).join(" "),
+    [className]
+  );
+
+  const limitedGroups = useMemo(() => {
+    if (!compact) return groups;
+    return groups.slice(0, MAX_COMPACT_GROUPS);
+  }, [compact, groups]);
+
+  const hiddenGroupCount = compact ? Math.max(0, groups.length - limitedGroups.length) : 0;
+
   return (
     <Squircle
       as="section"
       radius={CARD_RADIUS}
       smoothing={0.6}
-      className={styles.card}
+      className={cardClassName}
       aria-label="Tasks overview"
     >
       <header className={styles.header}>
@@ -52,39 +71,56 @@ const MobileTasksOverviewCard: React.FC = () => {
 
       {error ? (
         <div className={styles.empty}>We couldn’t load tasks right now. Please try again later.</div>
-      ) : groups.length ? (
+      ) : limitedGroups.length ? (
         <div className={styles.groups}>
-          {groups.map((group) => (
-            <div key={group.id} className={styles.group}>
-              <div className={styles.groupHeader}>
-                <span className={styles.groupDay}>{group.dayLabel}</span>
-                <span className={styles.groupCount}>
-                  {group.items.length} {group.items.length === 1 ? "task" : "tasks"}
-                </span>
+          {limitedGroups.map((group) => {
+            const items = compact ? group.items.slice(0, MAX_COMPACT_ITEMS) : group.items;
+            const hiddenItems = compact
+              ? Math.max(0, group.items.length - items.length)
+              : 0;
+
+            return (
+              <div key={group.id} className={styles.group}>
+                <div className={styles.groupHeader}>
+                  <span className={styles.groupDay}>{group.dayLabel}</span>
+                  <span className={styles.groupCount}>
+                    {group.items.length} {group.items.length === 1 ? "task" : "tasks"}
+                  </span>
+                </div>
+                <ul className={styles.items}>
+                  {items.map((item) => (
+                    <li key={item.id} className={styles.item}>
+                      <span
+                        className={styles.itemDot}
+                        style={{ backgroundColor: item.color || "var(--brand, #fa3356)" }}
+                        aria-hidden="true"
+                      />
+                      <div className={styles.itemBody}>
+                        <span className={styles.itemTitle}>{item.title}</span>
+                        {(item.time || item.project) && (
+                          <span className={styles.itemMeta}>
+                            {item.time}
+                            {item.time && item.project ? " · " : ""}
+                            {item.project}
+                          </span>
+                        )}
+                      </div>
+                    </li>
+                  ))}
+                  {hiddenItems > 0 && (
+                    <li className={`${styles.item} ${styles.itemMore}`} aria-hidden>
+                      +{hiddenItems} more
+                    </li>
+                  )}
+                </ul>
               </div>
-              <ul className={styles.items}>
-                {group.items.map((item) => (
-                  <li key={item.id} className={styles.item}>
-                    <span
-                      className={styles.itemDot}
-                      style={{ backgroundColor: item.color || "var(--brand, #fa3356)" }}
-                      aria-hidden="true"
-                    />
-                    <div className={styles.itemBody}>
-                      <span className={styles.itemTitle}>{item.title}</span>
-                      {(item.time || item.project) && (
-                        <span className={styles.itemMeta}>
-                          {item.time}
-                          {item.time && item.project ? " · " : ""}
-                          {item.project}
-                        </span>
-                      )}
-                    </div>
-                  </li>
-                ))}
-              </ul>
+            );
+          })}
+          {hiddenGroupCount > 0 && (
+            <div className={styles.moreGroups} aria-hidden>
+              +{hiddenGroupCount} more days
             </div>
-          ))}
+          )}
         </div>
       ) : (
         <div className={styles.empty}>

--- a/frontend/src/features/dashboard/components/ProjectsPanel.tsx
+++ b/frontend/src/features/dashboard/components/ProjectsPanel.tsx
@@ -12,6 +12,7 @@ import { MICRO_WOBBLE_SCALE, SPRING_FAST } from "@/shared/ui/motionTokens";
 
 type Props = {
   onOpenProject: (projectId: string) => void;
+  className?: string;
 };
 
 const DEFAULT_PROJECT_ROWS = 3;
@@ -56,7 +57,7 @@ const getProjectActivityTs = (p: ProjectLike): number => {
   return timestamps.length ? Math.max(...timestamps) : 0;
 };
 
-const ProjectsPanel: React.FC<Props> = ({ onOpenProject }) => {
+const ProjectsPanel: React.FC<Props> = ({ onOpenProject, className }) => {
   const reduceMotion = useReducedMotion();
   const { projects, isLoading, projectsError, fetchProjects } = useData();
   const navigate = useNavigate();
@@ -232,11 +233,12 @@ const ProjectsPanel: React.FC<Props> = ({ onOpenProject }) => {
 
   const scopeLabel = scope === "recents" ? "Recents" : "All projects";
 
+  const panelClassName = [styles.panel, styles.panelFullBleed, className || ""]
+    .filter(Boolean)
+    .join(" ");
+
   return (
-    <section
-      aria-label="Projects"
-      className={`${styles.panel} ${styles.panelFullBleed}`}
-    >
+    <section aria-label="Projects" className={panelClassName}>
       <header className={styles.header}>
         <div className={styles.titleWrap}>
           <h3 className={styles.title}>Projects</h3>

--- a/frontend/src/features/dashboard/components/WelcomeHeader.tsx
+++ b/frontend/src/features/dashboard/components/WelcomeHeader.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { User, Bell, Menu, Plus } from "lucide-react";
 import { useData } from '@/app/contexts/useData';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { useOnlineStatus } from '@/app/contexts/OnlineStatusContext';
 import NotificationsDrawer from '../../../shared/ui/NotificationsDrawer';
 import { useNotifications } from "../../../app/contexts/useNotifications";
@@ -10,13 +10,11 @@ import GlobalSearch from './GlobalSearch';
 import './GlobalSearch.css';
 import { getFileUrl } from '../../../shared/utils/api';
 import { useAppShell } from '@/app/layout/AppShell';
-import WeekWidgetCard from "@/features/schedule/WeekWidgetCard";
 
 const WelcomeHeader: React.FC<{ userName?: string; setActiveView?: (view: string) => void }> = ({ userName: propUserName, setActiveView }) => {
   const { userData } = useData();
   const { isOnline } = useOnlineStatus(); // <-- only need this now
   const navigate = useNavigate();
-  const location = useLocation();
   const appShell = useAppShell();
 
   const userName = propUserName || userData?.firstName || userData?.email || 'User';
@@ -92,20 +90,6 @@ const WelcomeHeader: React.FC<{ userName?: string; setActiveView?: (view: string
   ]
     .filter(Boolean)
     .join(' ');
-
-  const activeView = React.useMemo(() => {
-    const segments = location.pathname.split('/').filter(Boolean);
-    const idx = segments.indexOf('dashboard');
-    if (idx === -1) return null;
-
-    let view = segments[idx + 1] ?? 'welcome';
-    if (view === 'welcome') {
-      view = segments[idx + 2] ?? 'welcome';
-    }
-    return view;
-  }, [location.pathname]);
-
-  const showWelcomeCards = Boolean(isDesktopShell && activeView === 'welcome');
 
   return (
     <>
@@ -228,16 +212,6 @@ const WelcomeHeader: React.FC<{ userName?: string; setActiveView?: (view: string
           </div>
         </div>
       </div>
-
-      {showWelcomeCards && (
-        <div className="welcome-header-extras" role="region" aria-label="Dashboard welcome overview">
-       
-
-          <div id="week" className="welcome-section-anchor">
-            <WeekWidgetCard className="welcome-header-week-card" />
-          </div>
-        </div>
-      )}
 
       <NotificationsDrawer
         open={notificationsOpen}

--- a/frontend/src/features/dashboard/components/projects-panel.module.css
+++ b/frontend/src/features/dashboard/components/projects-panel.module.css
@@ -584,7 +584,7 @@
   }
 
   /* Ensure text truncation works on iPhone Safari */
-  .name {
+.name {
     max-width: 100%;
     text-overflow: ellipsis;
     -webkit-text-overflow: ellipsis;
@@ -602,4 +602,36 @@
 }
 
 /* Removed mobile touch sizing to keep rows compact */
+
+:global(.home-dashboard-card--projects) .panel {
+  height: 100%;
+  min-height: 0;
+  max-height: none;
+  padding: 14px;
+  margin: 0;
+  flex-shrink: 1;
+  overflow: hidden;
+}
+
+:global(.home-dashboard-card--projects) .header {
+  margin-bottom: 4px;
+}
+
+:global(.home-dashboard-card--projects) .iconsStrip,
+:global(.home-dashboard-card--projects) .recentsWrap,
+:global(.home-dashboard-card--projects) .kpis {
+  display: none;
+}
+
+:global(.home-dashboard-card--projects) .list {
+  overflow: hidden;
+}
+
+:global(.home-dashboard-card--projects) .row {
+  padding: 0 4px;
+}
+
+:global(.home-dashboard-card--projects) .row + .row {
+  margin-top: 1px;
+}
 

--- a/frontend/src/features/dashboard/components/week-widget.css
+++ b/frontend/src/features/dashboard/components/week-widget.css
@@ -11,6 +11,17 @@
   flex-shrink: 0;
 }
 
+.home-dashboard-card--week .week-widget {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  flex-shrink: 1;
+  padding: 12px;
+  gap: 6px;
+  overflow: hidden;
+}
+
 .week-widget--mobile {
   width: 100%;
   max-width: 100vw;
@@ -46,6 +57,11 @@
   gap: 4px;
 }
 
+.home-dashboard-card--week .week-days {
+  flex: 0 0 auto;
+  margin-bottom: 4px;
+}
+
 .week-day {
   position: relative;
   flex: 1;
@@ -55,6 +71,10 @@
   border-radius: 10px;
   background: rgba(255,255,255,0.02);
   border: 1px solid rgba(255,255,255,0.08);
+}
+
+.home-dashboard-card--week .week-day {
+  padding: 4px 0 12px;
 }
 .week-day:hover { background: rgba(255,255,255,0.05); }
 .week-day.today { outline: 1px solid rgba(255,255,255,0.18); }
@@ -85,8 +105,12 @@
 .week-tracks {
   position: relative;
   height: 12px;
-  
-  
+
+
+}
+
+.home-dashboard-card--week .week-tracks {
+  margin-top: auto;
 }
 
 .track {

--- a/frontend/src/features/dashboard/pages/DashboardHome.tsx
+++ b/frontend/src/features/dashboard/pages/DashboardHome.tsx
@@ -14,13 +14,11 @@ import Settings from "@/features/dashboard/components/Settings";
 import Collaborators from "@/features/dashboard/components/Collaborators";
 import SpinnerScreen from "@/shared/ui/SpinnerScreen";
 import PendingApprovalScreen from "@/shared/ui/PendingApprovalScreen";
-import AllProjectsWeekWidget from "@/features/dashboard/components/AllProjectsWeekWidget";
-import TasksOverviewCard from "@/features/dashboard/components/TasksOverviewCard";
 import MobileTasksOverviewCard from "@/features/dashboard/components/MobileTasksOverviewCard";
 import NavigationDrawer from "@/shared/ui/NavigationDrawer";
 import DashboardNavPanel from "@/shared/ui/DashboardNavPanel";
 import AppShell from "@/app/layout/AppShell";
-import ProjectsPanelDesktop from "@/features/projects/ProjectsPanelDesktop";
+import WeekWidgetCard from "@/features/schedule/WeekWidgetCard";
 
 import "./dashboard-styles.css";
 
@@ -147,38 +145,63 @@ const WelcomeScreen: React.FC = () => {
   const isFullWidthView = ["projects", "notifications", "messages", "settings", "collaborators"].includes(
     activeView
   );
-  const showTopBar = !isFullWidthView && !isDesktop; // TODO: Remove legacy desktop bento tiles after mobile parity update.
+  const isWelcomeView = activeView === "welcome";
+  const showTopBar = !isFullWidthView && !isDesktop && !isWelcomeView; // Compact home layout hides legacy top bar.
+
+  const wrapperClassName = [
+    "dashboard-wrapper",
+    "welcome-screen",
+    "no-vertical-center",
+    isWelcomeView ? "home-dashboard" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const rowLayoutClassName = ["row-layout", isWelcomeView ? "row-layout--home" : ""]
+    .filter(Boolean)
+    .join(" ");
+
+  const dashboardContentClassName = [
+    "dashboard-content",
+    isFullWidthView ? "full-width" : "",
+    isWelcomeView ? "dashboard-content--home" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const mainContentClassName = [
+    "main-content",
+    isWelcomeView ? "main-content--welcome" : "",
+    isWelcomeView ? "main-content--home" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
 
   const renderWelcomeView = () => {
-    if (isDesktop) {
-      return (
-        <div className="dashboard-home-grid">
-          <section id="projects" className="welcome-section-anchor">
-            <ProjectsPanelDesktop
-              onOpenProject={(projectId) => handleNavigateToProject({ projectId })}
-            />
-          </section>
-
-          <section id="tasks" className="welcome-section-anchor">
-            <TasksOverviewCard className="welcome-header-tasks-card" />
-          </section>
-        </div>
-      );
-    }
+    const handleOpenProject = (projectId?: string) => {
+      if (!projectId) return;
+      handleNavigateToProject({ projectId });
+    };
 
     return (
-      <div className="mobile-welcome-layout">
-        <div className="mobile-projects-section">
+      <div className="home-dashboard-stack" role="presentation">
+        <section className="home-dashboard-section home-dashboard-section--week">
+          <WeekWidgetCard className="home-dashboard-card home-dashboard-card--week" />
+        </section>
+
+        <section className="home-dashboard-section home-dashboard-section--projects">
           <ProjectsPanel
-            onOpenProject={(projectId) => handleNavigateToProject({ projectId })}
+            className="home-dashboard-card home-dashboard-card--projects"
+            onOpenProject={(projectId) => handleOpenProject(projectId)}
           />
-        </div>
-        <div className="mobile-tasks-section">
-          <MobileTasksOverviewCard />
-        </div>
-        <div className="mobile-calendar-section">
-          <AllProjectsWeekWidget />
-        </div>
+        </section>
+
+        <section className="home-dashboard-section home-dashboard-section--tasks">
+          <MobileTasksOverviewCard
+            className="home-dashboard-card home-dashboard-card--tasks"
+            compact
+          />
+        </section>
       </div>
     );
   };
@@ -220,25 +243,15 @@ const WelcomeScreen: React.FC = () => {
         />
       )}
     >
-      <div className="dashboard-wrapper welcome-screen no-vertical-center">
+      <div className={wrapperClassName}>
         <WelcomeHeader userName={userName} setActiveView={setActiveView} />
 
-        <div className="row-layout">
+        <div className={rowLayoutClassName}>
           <div className="welcome-screen-details">
             {showTopBar && !isMobile && <TopBar setActiveView={setActiveView} />}
 
-            <div
-              className={`dashboard-content ${
-                isFullWidthView ? "full-width" : ""
-              }`}
-            >
-              <div
-                className={`main-content${
-                  activeView === "welcome" && isDesktop
-                    ? " main-content--welcome"
-                    : ""
-                }`}
-              >
+            <div className={dashboardContentClassName}>
+              <div className={mainContentClassName}>
                 {renderActiveView()}
               </div>
             </div>

--- a/frontend/src/features/dashboard/styles/components/welcome-screen.css
+++ b/frontend/src/features/dashboard/styles/components/welcome-screen.css
@@ -72,11 +72,75 @@
   max-width: 100vw;
 }
 
+.dashboard-wrapper.home-dashboard {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  height: 100dvh;
+  min-height: 100vh;
+  min-height: 100dvh;
+  padding-bottom: env(safe-area-inset-bottom);
+  overflow: hidden;
+}
+
+.row-layout--home {
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.dashboard-content--home {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+}
+
+.main-content--home {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  overflow: hidden;
+}
+
+.main-content--home > * {
+  flex: 1;
+  min-height: 0;
+}
+
+.home-dashboard-stack {
+  display: grid;
+  grid-template-rows: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
+  align-content: stretch;
+}
+
+.home-dashboard-section {
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
+.home-dashboard-card {
+  flex: 1;
+  min-height: 0;
+  width: 100%;
+  display: flex;
+}
+
 /* Ensure projects header is more compact on mobile */
 @media (max-width: 768px) {
   .dashboard-wrapper.welcome-screen .main-content {
     align-items: stretch;
     justify-content: flex-start;
+  }
+
+  .home-dashboard-stack {
+    gap: 10px;
   }
 
   .mobile-projects-section .projects-header {
@@ -95,6 +159,12 @@
   
   .mobile-calendar-section .all-projects-calendar-wrapper {
     padding: 0;
+  }
+}
+
+@media (max-width: 480px) {
+  .home-dashboard-stack {
+    gap: 8px;
   }
 }
 

--- a/frontend/src/features/schedule/WeekWidgetCard.module.css
+++ b/frontend/src/features/schedule/WeekWidgetCard.module.css
@@ -138,3 +138,21 @@
 .widget {
   margin-top: 8px;
 }
+
+:global(.home-dashboard-card--week) .card {
+  height: 100%;
+  min-height: 0;
+  gap: 14px;
+  padding: 16px;
+  overflow: hidden;
+}
+
+:global(.home-dashboard-card--week) .badge,
+:global(.home-dashboard-card--week) .morePill {
+  display: none;
+}
+
+:global(.home-dashboard-card--week) .widget {
+  flex: 1;
+  min-height: 0;
+}


### PR DESCRIPTION
## Summary
- stack the "This Week", Projects, and Tasks sections in the welcome view and size the dashboard wrapper to fill the viewport without scrolling
- add a compact tasks overview variant and styling overrides so cards truncate overflowing data inside the new layout
- trim project and week widgets plus header extras so optional UI is hidden when space is limited

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*
- npx eslint src/features/dashboard/components/MobileTasksOverviewCard.tsx src/features/dashboard/components/ProjectsPanel.tsx src/features/dashboard/components/WelcomeHeader.tsx src/features/dashboard/pages/DashboardHome.tsx


------
https://chatgpt.com/codex/tasks/task_e_68c952857ad88324a689a7344483eeec