### PR TITLE
Refactor dashboard shell layout

### DIFF
--- a/frontend/src/features/dashboard/components/WelcomeHeader.tsx
+++ b/frontend/src/features/dashboard/components/WelcomeHeader.tsx
@@ -12,7 +12,23 @@ import { getFileUrl } from '../../../shared/utils/api';
 import { useAppShell } from '@/app/layout/AppShell';
 import WeekWidgetCard from "@/features/schedule/WeekWidgetCard";
 
-const WelcomeHeader: React.FC<{ userName?: string; setActiveView?: (view: string) => void }> = ({ userName: propUserName, setActiveView }) => {
+interface WelcomeHeaderProps {
+  userName?: string;
+  setActiveView?: (view: string) => void;
+  onToggleNavigation?: () => void;
+  isNavigationOpen?: boolean;
+  navigationDrawerId?: string;
+  isDesktopLayout?: boolean;
+}
+
+const WelcomeHeader: React.FC<WelcomeHeaderProps> = ({
+  userName: propUserName,
+  setActiveView,
+  onToggleNavigation,
+  isNavigationOpen,
+  navigationDrawerId,
+  isDesktopLayout,
+}) => {
   const { userData } = useData();
   const { isOnline } = useOnlineStatus(); // <-- only need this now
   const navigate = useNavigate();
@@ -34,10 +50,11 @@ const WelcomeHeader: React.FC<{ userName?: string; setActiveView?: (view: string
   // online status (derived from presenceChanged events via OnlineStatusContext)
   const isUserOnline = !!userId && isOnline(String(userId));
 
-  const baseDrawerId = appShell?.drawerId;
-  const isDrawerOpen = appShell?.isDrawerOpen ?? false;
-  const isDesktopShell = appShell?.isDesktop ?? false;
-  const showHamburger = Boolean(setActiveView && appShell && !appShell.isDesktop);
+  const baseDrawerId = appShell?.drawerId ?? navigationDrawerId;
+  const isDrawerOpen = appShell?.isDrawerOpen ?? isNavigationOpen ?? false;
+  const isDesktopShell = appShell?.isDesktop ?? isDesktopLayout ?? false;
+  const hasNavigationToggle = Boolean(appShell || onToggleNavigation);
+  const showHamburger = Boolean(setActiveView && hasNavigationToggle && !isDesktopShell);
   const showBrandInHeader = !isDesktopShell;
 
   const [isMobile, setIsMobile] = useState(false);
@@ -54,6 +71,8 @@ const WelcomeHeader: React.FC<{ userName?: string; setActiveView?: (view: string
   const handleNavigationToggle = () => {
     if (appShell && !appShell.isDesktop) {
       appShell.openDrawer();
+    } else if (onToggleNavigation) {
+      onToggleNavigation();
     }
   };
 
@@ -133,9 +152,11 @@ const WelcomeHeader: React.FC<{ userName?: string; setActiveView?: (view: string
               aria-label="Toggle navigation"
               aria-controls={
                 baseDrawerId
-                  ? appShell?.isDesktop
-                    ? baseDrawerId
-                    : `${baseDrawerId}-overlay`
+                  ? appShell
+                    ? appShell.isDesktop
+                      ? baseDrawerId
+                      : `${baseDrawerId}-overlay`
+                    : baseDrawerId
                   : undefined
               }
               aria-expanded={isDrawerOpen}

--- a/frontend/src/features/dashboard/pages/DashboardHome.tsx
+++ b/frontend/src/features/dashboard/pages/DashboardHome.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useId, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useData } from "@/app/contexts/useData";
 import { UserLite } from "@/app/contexts/DataProvider";
@@ -19,7 +19,6 @@ import TasksOverviewCard from "@/features/dashboard/components/TasksOverviewCard
 import MobileTasksOverviewCard from "@/features/dashboard/components/MobileTasksOverviewCard";
 import NavigationDrawer from "@/shared/ui/NavigationDrawer";
 import DashboardNavPanel from "@/shared/ui/DashboardNavPanel";
-import AppShell from "@/app/layout/AppShell";
 import ProjectsPanelDesktop from "@/features/projects/ProjectsPanelDesktop";
 
 import "./dashboard-styles.css";
@@ -65,6 +64,12 @@ const WelcomeScreen: React.FC = () => {
   const [dmUserSlug, setDmUserSlug] = useState<string | null>(initialDMUserSlug);
   const [isMobile, setIsMobile] = useState(false);
   const [isDesktop, setIsDesktop] = useState(false);
+  const [isNavigationOpen, setIsNavigationOpen] = useState(false);
+  const rawDrawerId = useId();
+  const drawerId = React.useMemo(
+    () => `dashboard-nav-${rawDrawerId.replace(/[^a-zA-Z0-9_-]/g, "")}`,
+    [rawDrawerId]
+  );
 
   useEffect(() => {
     const handleResize = () => {
@@ -78,6 +83,12 @@ const WelcomeScreen: React.FC = () => {
       return () => window.removeEventListener("resize", handleResize);
     }
   }, []);
+
+  useEffect(() => {
+    if (isDesktop) {
+      setIsNavigationOpen(false);
+    }
+  }, [isDesktop]);
 
   const handleNavigateToProject = async ({ projectId }: { projectId?: string }) => {
     if (!projectId) return;
@@ -208,20 +219,20 @@ const WelcomeScreen: React.FC = () => {
     }
   };
 
-  return (
-    <AppShell
-      drawer={<DashboardNavPanel variant="persistent" setActiveView={setActiveView} />}
-      renderOverlayDrawer={({ open, onClose, drawerId }) => (
-        <NavigationDrawer
-          open={open}
-          onClose={onClose}
-          setActiveView={setActiveView}
-          drawerId={drawerId}
-        />
-      )}
-    >
+  const handleOpenNavigation = () => setIsNavigationOpen(true);
+  const handleCloseNavigation = () => setIsNavigationOpen(false);
+
+  const mainContent = (
+    <main className="dashboard-main">
       <div className="dashboard-wrapper welcome-screen no-vertical-center">
-        <WelcomeHeader userName={userName} setActiveView={setActiveView} />
+        <WelcomeHeader
+          userName={userName}
+          setActiveView={setActiveView}
+          onToggleNavigation={!isDesktop ? handleOpenNavigation : undefined}
+          isNavigationOpen={!isDesktop ? isNavigationOpen : undefined}
+          navigationDrawerId={!isDesktop ? drawerId : undefined}
+          isDesktopLayout={isDesktop}
+        />
 
         <div className="row-layout">
           <div className="welcome-screen-details">
@@ -245,7 +256,30 @@ const WelcomeScreen: React.FC = () => {
           </div>
         </div>
       </div>
-    </AppShell>
+    </main>
+  );
+
+  if (isDesktop) {
+    return (
+      <div className="dashboard-root">
+        <aside>
+          <DashboardNavPanel variant="persistent" setActiveView={setActiveView} />
+        </aside>
+        {mainContent}
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <NavigationDrawer
+        open={isNavigationOpen}
+        onClose={handleCloseNavigation}
+        setActiveView={setActiveView}
+        drawerId={drawerId}
+      />
+      {mainContent}
+    </>
   );
 };
 

--- a/frontend/src/features/dashboard/pages/dashboard-styles.css
+++ b/frontend/src/features/dashboard/pages/dashboard-styles.css
@@ -2,3 +2,26 @@
 @import '../styles/index.css';
 @import './overrides.css';
 
+.dashboard-root {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  height: 100dvh;
+}
+
+.dashboard-main {
+  min-width: 0;
+  overflow: auto;
+}
+
+.dashboard-wrapper {
+  padding: clamp(12px, 2vw, 24px);
+}
+
+.dashboard-wrapper.welcome-screen {
+  padding: clamp(12px, 2vw, 24px);
+}
+
+.dashboard-wrapper.welcome-screen.no-vertical-center {
+  padding-bottom: calc(16px + env(safe-area-inset-bottom) + 56px);
+}
+


### PR DESCRIPTION
## Summary
- replace the DashboardHome AppShell wrapper with a simple two-pane layout that manages mobile navigation state locally
- update WelcomeHeader to support toggling the mobile drawer when no AppShell context is provided
- add dashboard-root and dashboard-main styles to size the persistent sidebar grid and keep padding confined to the dashboard wrapper

## Testing
- npm run lint *(fails: pre-existing lint errors in unrelated files)*
- npx eslint src/features/dashboard/pages/DashboardHome.tsx src/features/dashboard/components/WelcomeHeader.tsx

------
https://chatgpt.com/codex/tasks/task_e_68c9d2bde8bc8324a5331b4aac435922