### PR TITLE
Improve global search input width and copy

### DIFF
--- a/frontend/src/features/dashboard/components/GlobalSearch.css
+++ b/frontend/src/features/dashboard/components/GlobalSearch.css
@@ -3,14 +3,35 @@
   position: relative;
   flex: 1 1 auto;
   width: 100%;
-  max-width: 100%;
-  min-width: 0;
-  margin-left: 0;
+  max-width: clamp(320px, 45vw, 560px);
+  min-width: 280px;
+  margin-left: auto;
 }
 
 .global-search--active {
-  width: 100%;
-  max-width: 100%;
+  max-width: clamp(360px, 50vw, 600px);
+}
+
+@media (max-width: 900px) {
+  .global-search {
+    max-width: min(100%, 520px);
+    min-width: 0;
+  }
+
+  .global-search--active {
+    max-width: min(100%, 560px);
+  }
+}
+
+@media (max-width: 768px) {
+  .global-search {
+    max-width: 100%;
+    margin-left: 0;
+  }
+
+  .global-search--active {
+    max-width: 100%;
+  }
 }
 
 .global-search-input-container {

--- a/frontend/src/features/dashboard/components/GlobalSearch.test.tsx
+++ b/frontend/src/features/dashboard/components/GlobalSearch.test.tsx
@@ -135,12 +135,12 @@ describe('GlobalSearch', () => {
 
   it('renders search input', () => {
     renderGlobalSearch();
-    expect(screen.getByPlaceholderText('Search projects and messages...')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Search for projects, people, or conversations')).toBeInTheDocument();
   });
 
   it('shows search results when typing', async () => {
     renderGlobalSearch();
-    const input = screen.getByPlaceholderText('Search projects and messages...');
+    const input = screen.getByPlaceholderText('Search for projects, people, or conversations');
     
     fireEvent.focus(input);
     fireEvent.change(input, { target: { value: 'test' } });
@@ -158,7 +158,7 @@ describe('GlobalSearch', () => {
 
   it('searches projects by title', async () => {
     renderGlobalSearch();
-    const input = screen.getByPlaceholderText('Search projects and messages...');
+    const input = screen.getByPlaceholderText('Search for projects, people, or conversations');
     
     fireEvent.focus(input);
     fireEvent.change(input, { target: { value: 'demo' } });
@@ -176,7 +176,7 @@ describe('GlobalSearch', () => {
 
   it('searches projects by description', async () => {
     renderGlobalSearch();
-    const input = screen.getByPlaceholderText('Search projects and messages...');
+    const input = screen.getByPlaceholderText('Search for projects, people, or conversations');
     
     fireEvent.focus(input);
     fireEvent.change(input, { target: { value: 'functionality' } });
@@ -188,7 +188,7 @@ describe('GlobalSearch', () => {
 
   it('searches messages content', async () => {
     renderGlobalSearch();
-    const input = screen.getByPlaceholderText('Search projects and messages...');
+    const input = screen.getByPlaceholderText('Search for projects, people, or conversations');
 
     fireEvent.focus(input);
     fireEvent.change(input, { target: { value: 'features' } });
@@ -206,7 +206,7 @@ describe('GlobalSearch', () => {
 
   it('lists collaborators when query starts with @', async () => {
     renderGlobalSearch();
-    const input = screen.getByPlaceholderText('Search projects and messages...');
+    const input = screen.getByPlaceholderText('Search for projects, people, or conversations');
 
     fireEvent.focus(input);
     fireEvent.change(input, { target: { value: '@' } });
@@ -223,7 +223,7 @@ describe('GlobalSearch', () => {
 
   it('navigates to direct messages when collaborator result is selected', async () => {
     renderGlobalSearch();
-    const input = screen.getByPlaceholderText('Search projects and messages...');
+    const input = screen.getByPlaceholderText('Search for projects, people, or conversations');
 
     fireEvent.focus(input);
     fireEvent.change(input, { target: { value: '@Jane' } });
@@ -252,7 +252,7 @@ describe('GlobalSearch', () => {
 
   it('shows no results when search returns empty', async () => {
     renderGlobalSearch();
-    const input = screen.getByPlaceholderText('Search projects and messages...');
+    const input = screen.getByPlaceholderText('Search for projects, people, or conversations');
 
     fireEvent.focus(input);
     fireEvent.change(input, { target: { value: 'nonexistent' } });
@@ -264,7 +264,7 @@ describe('GlobalSearch', () => {
 
   it('clears search when clear button is clicked', async () => {
     renderGlobalSearch();
-    const input = screen.getByPlaceholderText('Search projects and messages...') as HTMLInputElement;
+    const input = screen.getByPlaceholderText('Search for projects, people, or conversations') as HTMLInputElement;
     
     fireEvent.change(input, { target: { value: 'test' } });
     
@@ -276,7 +276,7 @@ describe('GlobalSearch', () => {
 
   it('navigates to project when project result is clicked', async () => {
     renderGlobalSearch();
-    const input = screen.getByPlaceholderText('Search projects and messages...');
+    const input = screen.getByPlaceholderText('Search for projects, people, or conversations');
     
     fireEvent.focus(input);
     fireEvent.change(input, { target: { value: 'test' } });
@@ -311,7 +311,7 @@ describe('GlobalSearch', () => {
 
   it('supports keyboard navigation', async () => {
     renderGlobalSearch();
-    const input = screen.getByPlaceholderText('Search projects and messages...');
+    const input = screen.getByPlaceholderText('Search for projects, people, or conversations');
     
     fireEvent.focus(input);
     fireEvent.change(input, { target: { value: 'test' } });
@@ -338,7 +338,7 @@ describe('GlobalSearch', () => {
 
   it('renders project metadata with status and due date', async () => {
     renderGlobalSearch();
-    const input = screen.getByPlaceholderText('Search projects and messages...');
+    const input = screen.getByPlaceholderText('Search for projects, people, or conversations');
 
     fireEvent.focus(input);
     fireEvent.change(input, { target: { value: 'test' } });
@@ -380,7 +380,7 @@ describe('GlobalSearch', () => {
     ];
 
     renderGlobalSearch();
-    const input = screen.getByPlaceholderText('Search projects and messages...');
+    const input = screen.getByPlaceholderText('Search for projects, people, or conversations');
 
     fireEvent.focus(input);
     fireEvent.change(input, { target: { value: 'lexical' } });
@@ -394,7 +394,7 @@ describe('GlobalSearch', () => {
 
   it('closes search results on Escape key', async () => {
     renderGlobalSearch();
-    const input = screen.getByPlaceholderText('Search projects and messages...');
+    const input = screen.getByPlaceholderText('Search for projects, people, or conversations');
     
     fireEvent.focus(input);
     fireEvent.change(input, { target: { value: 'test' } });

--- a/frontend/src/features/dashboard/components/GlobalSearch.tsx
+++ b/frontend/src/features/dashboard/components/GlobalSearch.tsx
@@ -601,7 +601,8 @@ const GlobalSearch: React.FC<GlobalSearchProps> = ({ className = '' }) => {
           onChange={(e) => setQuery(e.target.value)}
           onFocus={handleInputFocus}
           onKeyDown={handleKeyDown}
-          placeholder="Search projects and messages..."
+          placeholder="Search for projects, people, or conversations"
+          aria-label="Search for projects, people, or conversations"
           className="global-search-input"
         />
         {query && (

--- a/frontend/src/features/dashboard/styles/components/welcome-header.css
+++ b/frontend/src/features/dashboard/styles/components/welcome-header.css
@@ -22,7 +22,8 @@
 .welcome-header-center {
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-end;
+  flex: 1 1 100%;
   width: auto;
   max-width: none;
   min-width: 0;


### PR DESCRIPTION
## Summary
- clamp the global search width so it stays right-aligned without stretching across the header
- let the header center section flex so the wider search field hugs the right edge on larger screens
- refresh the search placeholder microcopy and update the matching tests

## Testing
- node verify-global-search.cjs
- npm test -- GlobalSearch.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68c9e043dd40832487e81110bf3e5bd1