### PR TITLE
Implement flexible desktop welcome layout for dashboard

### DIFF
--- a/frontend/src/features/dashboard/pages/DashboardHome.tsx
+++ b/frontend/src/features/dashboard/pages/DashboardHome.tsx
@@ -262,25 +262,38 @@ const WelcomeScreen: React.FC = () => {
   const renderWelcomeView = () => {
     if (isDesktop) {
       return (
-        <div className="dashboard-home-grid">
-          <WeekWidgetDesktop
-            weekOf={weekOf}
-            tracks={tracks}
-            dots={dots}
-            onPrevWeek={(d) => setWeekOf(d)}
-            onNextWeek={(d) => setWeekOf(d)}
-            onSelectDate={(d) => setWeekOf(d)}
-            getTooltipItems={getTooltipItems}
-          />
-          <section id="projects" className="welcome-section-anchor">
-            <ProjectsPanelDesktop
-              onOpenProject={(projectId) =>
-                handleNavigateToProject({ projectId })
-              }
+        <div className="welcome-desktop-layout">
+          <section
+            id="calendar"
+            className="welcome-section-anchor welcome-desktop-header"
+          >
+            <WeekWidgetDesktop
+              weekOf={weekOf}
+              tracks={tracks}
+              dots={dots}
+              onPrevWeek={(d) => setWeekOf(d)}
+              onNextWeek={(d) => setWeekOf(d)}
+              onSelectDate={(d) => setWeekOf(d)}
+              getTooltipItems={getTooltipItems}
             />
           </section>
+          <section
+            id="projects"
+            className="welcome-section-anchor welcome-desktop-projects"
+          >
+            <div className="welcome-desktop-projects-scroll">
+              <ProjectsPanelDesktop
+                onOpenProject={(projectId) =>
+                  handleNavigateToProject({ projectId })
+                }
+              />
+            </div>
+          </section>
 
-          <section id="tasks" className="welcome-section-anchor">
+          <section
+            id="tasks"
+            className="welcome-section-anchor welcome-desktop-footer"
+          >
             <TasksOverviewCard className="welcome-header-tasks-card" />
           </section>
         </div>

--- a/frontend/src/features/dashboard/pages/dashboard-styles.css
+++ b/frontend/src/features/dashboard/pages/dashboard-styles.css
@@ -5,21 +5,59 @@
 .dashboard-root {
   display: grid;
   grid-template-columns: 280px 1fr;
-  height: 100dvh;
+  height: 100vh;
   max-width: 1920px;
   margin: 0 auto;
+  overflow: hidden;
+}
+
+.dashboard-root > aside {
+  position: sticky;
+  top: 0;
+  align-self: start;
+  height: 100vh;
+  display: flex;
+}
+
+.dashboard-root > aside > * {
+  flex: 1;
 }
 
 .dashboard-main {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
   min-width: 0;
-  overflow: auto;
+  overflow: hidden;
 }
 
 .dashboard-wrapper {
-  padding: clamp(12px, 2vw, 24px);
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  padding: 24px;
+  overflow: hidden;
 }
 
 .dashboard-wrapper.welcome-screen {
-  padding: clamp(12px, 2vw, 24px);
+  padding: 24px;
+}
+
+@media (max-width: 1023px) {
+  .dashboard-root {
+    display: block;
+    height: auto;
+  }
+
+  .dashboard-main {
+    height: auto;
+    overflow: auto;
+  }
+
+  .dashboard-wrapper,
+  .dashboard-wrapper.welcome-screen {
+    padding: 16px;
+  }
 }
 

--- a/frontend/src/features/dashboard/styles/components/welcome-screen.css
+++ b/frontend/src/features/dashboard/styles/components/welcome-screen.css
@@ -18,6 +18,40 @@
   gap: 8px;
 }
 
+.welcome-desktop-layout {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  gap: 16px;
+}
+
+.welcome-desktop-header {
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.welcome-desktop-projects {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+}
+
+.welcome-desktop-projects-scroll {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.welcome-desktop-footer {
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
 .welcome-screen-header {
   color: white;
   display: flex;

--- a/frontend/src/shared/styles/layouts/dashboard.css
+++ b/frontend/src/shared/styles/layouts/dashboard.css
@@ -2,10 +2,13 @@
 
 .dashboard-content {
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
   gap: var(--space-5);
-  align-items: flex-start;
+  align-items: stretch;
   width: 100%;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
 }
 
 /* Row layout wrapper used in DashboardHome */
@@ -13,7 +16,8 @@
   display: flex;
   width: 100%;
   flex: 1;
-  overflow: auto; /* allow scrolling on iOS */
+  min-height: 0;
+  overflow: hidden;
   overscroll-behavior-y: contain;
 }
 
@@ -22,36 +26,33 @@
   display: flex;
   flex-direction: column;
   flex: 1;
-  overflow: auto; /* allow content to scroll; avoid clipping CTA */
-  min-height: 0;    /* Allow children to shrink when viewport is short */
-  justify-content: center; /* Center calendar vertically */
-  align-items: center;      /* Center calendar horizontally */
+  min-height: 0;
+  overflow: hidden;
+  justify-content: flex-start;
+  align-items: stretch;
 }
 
 .main-content--welcome {
-  align-items: stretch;
-  justify-content: flex-start;
+  gap: var(--space-5);
 }
 
 .main-content--welcome > * {
   width: 100%;
 }
 
-
 /* Full-width view adjustments (e.g., Notifications) */
 .dashboard-content.full-width .main-content {
-  justify-content: flex-start;
-  align-items: stretch;
+  gap: 0;
 }
 
 .dashboard-wrapper {
   position: relative;
+  display: flex;
   flex-direction: column;
-  
-  justify-content: center;
-  align-items: center;
-  min-height: 100svh;
-  min-height: -webkit-fill-available;
+  justify-content: flex-start;
+  align-items: stretch;
+  flex: 1;
+  min-height: 0;
   width: 100%;
   max-width: var(--container-max-width);
   margin: 0 auto;
@@ -61,8 +62,8 @@
 .dashboard-wrapper.welcome-screen {
   display: flex;
   flex-direction: column;
-  min-height: 100svh;
-  min-height: -webkit-fill-available;
+  flex: 1;
+  min-height: 0;
   background-color: var(--bg-color);
   margin: 0 auto;
   padding: 0;
@@ -70,16 +71,10 @@
 
 .dashboard-wrapper.welcome-screen.no-vertical-center {
   justify-content: flex-start;
-  align-items: flex-start;
- 
-  
-
-  display: flex;
-  flex-direction: column;
-  min-height: 100svh;
-  min-height: -webkit-fill-available;
-  height: 100svh;
-  height: -webkit-fill-available;
+  align-items: stretch;
+  flex: 1;
+  min-height: 0;
+  height: 100%;
   margin: 0 auto;
 }
 


### PR DESCRIPTION
## Summary
- restructure the desktop welcome view into explicit header, project list, and task footer sections
- revise dashboard shell styling to fill the viewport and keep the navigation panel fixed
- add flex-based helpers so the project list scrolls independently while the surrounding sections stay pinned

## Testing
- npm run lint *(fails: existing lint violations in untouched test files and utilities)*

------
https://chatgpt.com/codex/tasks/task_e_68ca1c3a6b44832491eec459303861da