### PR TITLE
Fix desktop projects panel height and scrolling

### DIFF
--- a/frontend/src/features/dashboard/styles/components/welcome-screen.css
+++ b/frontend/src/features/dashboard/styles/components/welcome-screen.css
@@ -44,6 +44,13 @@
   flex: 1;
   min-height: 0;
   overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.welcome-desktop-projects-scroll > .week-widget {
+  flex: 1 1 auto;
+  min-height: 0;
 }
 
 .welcome-desktop-footer {

--- a/frontend/src/features/projects/ProjectsPanelDesktop.module.css
+++ b/frontend/src/features/projects/ProjectsPanelDesktop.module.css
@@ -11,6 +11,8 @@
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
   overflow: hidden;
   isolation: isolate;
+  flex: 1 1 auto;
+  min-height: 0;
 }
 
 /* remove gradient overlay completely */
@@ -59,6 +61,14 @@
   z-index: 1;
 }
 
+.content {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
 .headerTop {
   display: flex;
   gap: var(--space-2, 16px);
@@ -94,7 +104,9 @@
 }
 
 .tableWrap {
-  overflow-x: auto;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: auto;
 }
 
 .table {
@@ -196,6 +208,7 @@
 .footer {
   display: flex;
   justify-content: flex-end;
+  margin-top: auto;
 }
 .footerButton {
   border: 1px solid rgba(255, 255, 255, 0.12);
@@ -218,15 +231,23 @@
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.06);
   padding: var(--space-2, 16px);
   background: rgba(255, 255, 255, 0.04);
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
 }
 .gridWrap :global(.list) {
   max-height: none;
+  flex: 1 1 auto;
+  min-height: 0;
 }
 .gridWrap :global(.row) {
   border-radius: 12px;
 }
 .gridWrap :global(.listScrollable) {
-  max-height: 420px;
+  max-height: none;
+  overflow-y: auto;
 }
 
 @media (max-width: 1440px) {

--- a/frontend/src/features/projects/ProjectsPanelDesktop.tsx
+++ b/frontend/src/features/projects/ProjectsPanelDesktop.tsx
@@ -460,6 +460,43 @@ const ProjectsPanelDesktop: React.FC<ProjectsPanelDesktopProps> = ({ onOpenProje
 
   const errorText = projectsError ? "Failed to load projects." : undefined;
 
+  let bodyContent: React.ReactNode;
+
+  if (errorText) {
+    bodyContent = <div className={desktopStyles.errorState}>{errorText}</div>;
+  } else if (viewMode === "table") {
+    bodyContent = (
+      <div className={desktopStyles.tableWrap}>
+        {isLoading ? (
+          <div className={desktopStyles.emptyState}>Loading projects…</div>
+        ) : items.length === 0 ? (
+          <div className={desktopStyles.emptyState}>No projects match filters.</div>
+        ) : (
+          <table className={desktopStyles.table} aria-label="Projects table">
+            <thead>
+              <tr>
+                <th scope="col">Project</th>
+                <th scope="col">Status</th>
+                <th scope="col">Deadline</th>
+                <th scope="col">Owner</th>
+                <th scope="col">Unread</th>
+              </tr>
+            </thead>
+            <tbody>{tableRows}</tbody>
+          </table>
+        )}
+      </div>
+    );
+  } else {
+    bodyContent = isLoading ? (
+      <div className={desktopStyles.emptyState}>Loading projects…</div>
+    ) : items.length === 0 ? (
+      <div className={desktopStyles.emptyState}>No projects match filters.</div>
+    ) : (
+      renderGrid()
+    );
+  }
+
   return (
     <section
       aria-label="Projects overview"
@@ -604,38 +641,7 @@ const ProjectsPanelDesktop: React.FC<ProjectsPanelDesktopProps> = ({ onOpenProje
         </div>
       </header>
 
-      {errorText && <div className={desktopStyles.errorState}>{errorText}</div>}
-
-      {!errorText && viewMode === "table" && (
-        <div className={desktopStyles.tableWrap}>
-          {isLoading ? (
-            <div className={desktopStyles.emptyState}>Loading projects…</div>
-          ) : items.length === 0 ? (
-            <div className={desktopStyles.emptyState}>No projects match filters.</div>
-          ) : (
-            <table className={desktopStyles.table} aria-label="Projects table">
-              <thead>
-                <tr>
-                  <th scope="col">Project</th>
-                  <th scope="col">Status</th>
-                  <th scope="col">Deadline</th>
-                  <th scope="col">Owner</th>
-                  <th scope="col">Unread</th>
-                </tr>
-              </thead>
-              <tbody>{tableRows}</tbody>
-            </table>
-          )}
-        </div>
-      )}
-
-      {!errorText && viewMode === "grid" && (isLoading ? (
-        <div className={desktopStyles.emptyState}>Loading projects…</div>
-      ) : items.length === 0 ? (
-        <div className={desktopStyles.emptyState}>No projects match filters.</div>
-      ) : (
-        renderGrid()
-      ))}
+      <div className={desktopStyles.content}>{bodyContent}</div>
 
       <div className={desktopStyles.footer}>
         <button


### PR DESCRIPTION
## Summary
- make the desktop projects panel fill its container and keep footer pinned
- allow the table and grid views to flex and scroll inside the panel
- let the dashboard projects column stretch the projects card to avoid background gaps

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*
- npx eslint src/features/projects/ProjectsPanelDesktop.tsx


------
https://chatgpt.com/codex/tasks/task_e_68cb2cbe2d788324804c0dbca2d566af