### PR TITLE
Update mobile dashboard layout and tasks panel

### DIFF
--- a/frontend/src/features/dashboard/components/MobileTasksOverviewCard.module.css
+++ b/frontend/src/features/dashboard/components/MobileTasksOverviewCard.module.css
@@ -1,64 +1,56 @@
 .card {
   display: flex;
   flex-direction: column;
-  gap: 18px;
-  padding: 20px;
+  justify-content: space-between;
+  gap: 12px;
+  height: 100%;
+  min-height: 0;
+  max-height: 100%;
+  padding: 16px 18px;
   color: rgba(255, 255, 255, 0.95);
   background:
-    radial-gradient(140% 140% at 100% 0%, color-mix(in srgb, var(--brand, #fa3356) 18%, transparent) 0%, transparent 58%),
-    linear-gradient(180deg, rgba(255, 255, 255, 0.08) 0%, rgba(255, 255, 255, 0) 68%),
-    var(--bg2, #111213);
-  border: 1px solid rgba(255, 255, 255, 0.1);
+    linear-gradient(180deg, rgba(255, 255, 255, 0.04) 0%, rgba(255, 255, 255, 0) 70%),
+    color-mix(in srgb, var(--bg2, #111213) 88%, rgba(250, 51, 86, 0.2) 12%);
   border-radius: var(--radius-squircle, 20px);
+  border: 1px solid rgba(255, 255, 255, 0.12);
   box-shadow:
-    inset 0 0 0 1px rgba(255, 255, 255, 0.05),
-    0 12px 32px rgba(0, 0, 0, 0.35);
+    inset 0 0 0 1px rgba(255, 255, 255, 0.04),
+    0 10px 24px rgba(0, 0, 0, 0.35);
   overflow: hidden;
 }
 
-@supports (color: color-mix(in srgb, white 50%, black 50%)) {
+@supports not (color: color-mix(in srgb, white 50%, black 50%)) {
   .card {
-    border-color: color-mix(in srgb, rgba(255, 255, 255, 0.08) 78%, transparent 22%);
-    box-shadow:
-      inset 0 0 0 1px color-mix(in srgb, rgba(255, 255, 255, 0.08) 55%, transparent 45%),
-      0 12px 32px rgba(0, 0, 0, 0.35);
+    background: var(--bg2, #111213);
   }
 }
 
 .header {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   justify-content: space-between;
   gap: 12px;
 }
 
-.titleWrap {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-
 .title {
   margin: 0;
-  font-size: 18px;
+  font-size: 16px;
   font-weight: 600;
-}
-
-.subtitle {
-  margin: 0;
-  font-size: 13px;
-  color: rgba(255, 255, 255, 0.65);
 }
 
 .viewAllButton {
   border: none;
   background: none;
   color: rgba(255, 255, 255, 0.82);
-  font-size: 13px;
+  font-size: 12px;
   font-weight: 600;
   text-decoration: underline;
-  padding: 6px 4px;
-  align-self: flex-start;
+  text-decoration-thickness: 1px;
+  padding: 4px 0;
+}
+
+.viewAllButton:hover {
+  color: rgba(255, 255, 255, 0.95);
 }
 
 .viewAllButton:focus-visible {
@@ -66,30 +58,27 @@
   outline-offset: 2px;
 }
 
-.viewAllButton:hover {
-  color: rgba(255, 255, 255, 0.95);
-}
-
 .statRow {
-  display: flex;
-  gap: 10px;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
 }
 
 .stat {
-  flex: 1;
   display: flex;
   flex-direction: column;
   gap: 4px;
-  padding: 12px 14px;
-  border-radius: 16px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
+  padding: 10px 12px;
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
   background: rgba(255, 255, 255, 0.04);
-  min-height: 70px;
+  min-height: 64px;
 }
 
 .statValue {
-  font-size: 20px;
+  font-size: 18px;
   font-weight: 600;
+  line-height: 1.1;
 }
 
 .statLabel {
@@ -100,139 +89,41 @@
 }
 
 .statOk {
-  border-color: color-mix(in srgb, var(--color-success, #4caf50) 48%, transparent);
-  background: color-mix(in srgb, var(--color-success, #4caf50) 14%, transparent);
+  border-color: rgba(76, 175, 80, 0.32);
+  background: rgba(76, 175, 80, 0.18);
+  border-color: color-mix(in srgb, var(--color-success, #4caf50) 38%, transparent);
+  background: color-mix(in srgb, var(--color-success, #4caf50) 16%, transparent);
 }
 
 .statWarn {
-  border-color: color-mix(in srgb, var(--color-warning, #ff9800) 48%, transparent);
-  background: color-mix(in srgb, var(--color-warning, #ff9800) 14%, transparent);
+  border-color: rgba(255, 183, 77, 0.34);
+  background: rgba(255, 183, 77, 0.2);
+  border-color: color-mix(in srgb, var(--color-warning, #ffb74d) 42%, transparent);
+  background: color-mix(in srgb, var(--color-warning, #ffb74d) 18%, transparent);
 }
 
 .statDanger {
-  border-color: color-mix(in srgb, var(--color-error, #ef5350) 52%, transparent);
+  border-color: rgba(239, 83, 80, 0.36);
+  background: rgba(239, 83, 80, 0.2);
+  border-color: color-mix(in srgb, var(--color-error, #ef5350) 44%, transparent);
   background: color-mix(in srgb, var(--color-error, #ef5350) 18%, transparent);
 }
 
-.groups {
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
-}
-
-.group {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.groupHeader {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 8px;
-}
-
-.groupDay {
-  font-size: 13px;
-  font-weight: 600;
-  color: rgba(255, 255, 255, 0.85);
-}
-
-.groupCount {
+.status {
   font-size: 12px;
-  color: rgba(255, 255, 255, 0.6);
-}
-
-.items {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-
-.item {
-  display: flex;
-  align-items: flex-start;
-  gap: 12px;
-}
-
-.itemDot {
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  margin-top: 6px;
-  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.35);
-}
-
-.itemBody {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-
-.itemTitle {
-  font-size: 14px;
-  font-weight: 600;
-  color: rgba(255, 255, 255, 0.95);
-}
-
-.itemMeta {
-  font-size: 12px;
-  color: rgba(255, 255, 255, 0.62);
-}
-
-.empty {
-  font-size: 13px;
-  color: rgba(255, 255, 255, 0.6);
-  padding: 4px 0 2px;
-}
-
-.footerActions {
-  display: flex;
-  justify-content: stretch;
-}
-
-.primaryButton {
-  flex: 1;
-  padding: 12px 16px;
-  border-radius: 16px;
-  border: 1px solid color-mix(in srgb, var(--brand, #fa3356) 45%, transparent);
-  background: color-mix(in srgb, var(--brand, #fa3356) 18%, transparent);
-  color: color-mix(in srgb, var(--brand, #fa3356) 85%, white 15%);
-  font-size: 14px;
-  font-weight: 600;
-}
-
-.primaryButton:hover:not(:disabled) {
-  background: color-mix(in srgb, var(--brand, #fa3356) 26%, transparent);
-}
-
-.primaryButton:disabled {
-  opacity: 0.5;
-}
-
-.primaryButton:focus-visible {
-  outline: 2px solid var(--color-focus, var(--brand, #fa3356));
-  outline-offset: 2px;
+  color: rgba(255, 255, 255, 0.72);
+  margin-top: auto;
+  padding-top: 4px;
 }
 
 @media (max-width: 480px) {
   .card {
-    padding: 18px;
-  }
-
-  .statRow {
-    flex-wrap: wrap;
+    padding: 14px 16px;
+    gap: 10px;
   }
 
   .stat {
-    flex: 1 1 45%;
-  }
-
-  .footerActions {
-    margin-top: 4px;
+    padding: 10px;
+    border-radius: 16px;
   }
 }

--- a/frontend/src/features/dashboard/components/MobileTasksOverviewCard.tsx
+++ b/frontend/src/features/dashboard/components/MobileTasksOverviewCard.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 
 import Squircle from "@/shared/ui/Squircle";
 
@@ -8,14 +8,33 @@ import styles from "./MobileTasksOverviewCard.module.css";
 const CARD_RADIUS = 20;
 
 const MobileTasksOverviewCard: React.FC = () => {
-  const { loading, error, stats, groups, handleNavigateToPrimary, handleViewAll, canNavigateToProject } =
-    useTasksOverview();
+  const { loading, error, stats, groups, handleViewAll } = useTasksOverview();
 
   const formatStatValue = (value: number): string | number => {
     if (error) return "—";
     if (loading) return "…";
     return value;
   };
+
+  const statusMessage = useMemo(() => {
+    if (error) return "Tasks unavailable. Try again soon.";
+    if (loading) return "Checking tasks…";
+
+    const hasOpenTasks = groups.some((group) => group.items.length > 0);
+    if (!hasOpenTasks) {
+      return "No open tasks this week.";
+    }
+
+    if (stats.overdue > 0) {
+      return `${stats.overdue} overdue ${stats.overdue === 1 ? "task" : "tasks"}.`;
+    }
+
+    if (stats.dueSoon > 0) {
+      return `${stats.dueSoon} due soon.`;
+    }
+
+    return "You're on track.";
+  }, [error, loading, groups, stats.overdue, stats.dueSoon]);
 
   return (
     <Squircle
@@ -26,10 +45,7 @@ const MobileTasksOverviewCard: React.FC = () => {
       aria-label="Tasks overview"
     >
       <header className={styles.header}>
-        <div className={styles.titleWrap}>
-          <h3 className={styles.title}>Tasks</h3>
-          <p className={styles.subtitle}>Stay on top of what’s due this week.</p>
-        </div>
+        <h3 className={styles.title}>Tasks</h3>
         <button type="button" className={styles.viewAllButton} onClick={handleViewAll}>
           View all
         </button>
@@ -50,58 +66,7 @@ const MobileTasksOverviewCard: React.FC = () => {
         </div>
       </div>
 
-      {error ? (
-        <div className={styles.empty}>We couldn’t load tasks right now. Please try again later.</div>
-      ) : groups.length ? (
-        <div className={styles.groups}>
-          {groups.map((group) => (
-            <div key={group.id} className={styles.group}>
-              <div className={styles.groupHeader}>
-                <span className={styles.groupDay}>{group.dayLabel}</span>
-                <span className={styles.groupCount}>
-                  {group.items.length} {group.items.length === 1 ? "task" : "tasks"}
-                </span>
-              </div>
-              <ul className={styles.items}>
-                {group.items.map((item) => (
-                  <li key={item.id} className={styles.item}>
-                    <span
-                      className={styles.itemDot}
-                      style={{ backgroundColor: item.color || "var(--brand, #fa3356)" }}
-                      aria-hidden="true"
-                    />
-                    <div className={styles.itemBody}>
-                      <span className={styles.itemTitle}>{item.title}</span>
-                      {(item.time || item.project) && (
-                        <span className={styles.itemMeta}>
-                          {item.time}
-                          {item.time && item.project ? " · " : ""}
-                          {item.project}
-                        </span>
-                      )}
-                    </div>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          ))}
-        </div>
-      ) : (
-        <div className={styles.empty}>
-          {loading ? "Loading tasks…" : "No open tasks are due this week. You’re all caught up!"}
-        </div>
-      )}
-
-      <div className={styles.footerActions}>
-        <button
-          type="button"
-          className={styles.primaryButton}
-          onClick={handleNavigateToPrimary}
-          disabled={!canNavigateToProject}
-        >
-          Review next project
-        </button>
-      </div>
+      {statusMessage ? <div className={styles.status}>{statusMessage}</div> : null}
     </Squircle>
   );
 };

--- a/frontend/src/features/dashboard/styles/components/welcome-screen.css
+++ b/frontend/src/features/dashboard/styles/components/welcome-screen.css
@@ -74,43 +74,56 @@
 .mobile-welcome-layout {
   display: flex;
   flex-direction: column;
-  height: 100%;
+  justify-content: flex-start;
+  height: 100dvh;
+  max-height: 100dvh;
+  min-height: 100dvh;
   width: 100%;
   max-width: 100vw;
-  overflow: visible; /* allow children (CTA) to be fully visible */
+  overflow: hidden;
   align-items: stretch;
-  
-}
-
-.mobile-projects-section {
-  flex: 0 0 auto;
-  max-height: none;
-  overflow: visible;
-  padding: 0; /* remove outer grey wrapper */
-  background: transparent;
-  width: 100%;
-  max-width: 100vw;
-}
-
-.mobile-tasks-section {
-  flex: 0 0 auto;
-  width: 100%;
-  max-width: 100vw;
-  overflow: visible;
+  gap: 12px;
 }
 
 .mobile-calendar-section {
-  flex: 1 0 auto;
-  min-height: 0;
-  overflow: auto;
-
+  flex: 0 0 120px;
+  height: 120px;
+  max-height: 128px;
+  min-height: 112px;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: stretch;
   border-radius: 8px;
-  padding: 0px;
+  padding: 0;
+  overflow: hidden;
+  width: 100%;
+  max-width: 100vw;
+}
+
+.mobile-projects-section {
+  flex: 1 1 auto;
+  min-height: 200px;
+  max-height: 400px;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  max-width: 100vw;
+  overflow: hidden;
+  padding: 0;
+  background: transparent;
+}
+
+.mobile-tasks-section {
+  flex: 0 0 160px;
+  height: 160px;
+  max-height: 168px;
   width: 100%;
   max-width: 100vw;
   display: flex;
   flex-direction: column;
-  align-items: stretch;
+  justify-content: flex-end;
+  overflow: hidden;
 }
 
 .mobile-projects-section > *,
@@ -118,6 +131,34 @@
 .mobile-calendar-section > * {
   width: 100%;
   max-width: 100vw;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+.mobile-projects-section > *,
+.mobile-tasks-section > * {
+  display: flex;
+  flex-direction: column;
+}
+
+.mobile-projects-section .panel {
+  height: 100%;
+  min-height: 100%;
+  max-height: 100%;
+  margin: 0;
+  overflow: hidden;
+}
+
+.mobile-projects-section .listScrollable,
+.mobile-projects-section .gridScrollable {
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+@media (max-height: 540px) {
+  .mobile-welcome-layout {
+    overflow-y: auto;
+  }
 }
 
 /* Ensure projects header is more compact on mobile */


### PR DESCRIPTION
## Summary
- resize the mobile welcome layout to fill 100dvh with fixed calendar and task rows while constraining the projects section
- refresh the mobile tasks overview card into a compact stat row with contextual status messaging and tighter styling

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cb3294f9f883249d2f557a2421693b