### PR TITLE
Adjust mobile dashboard layout and tasks overview

### DIFF
--- a/frontend/src/features/dashboard/components/MobileTasksOverviewCard.module.css
+++ b/frontend/src/features/dashboard/components/MobileTasksOverviewCard.module.css
@@ -1,64 +1,44 @@
 .card {
   display: flex;
   flex-direction: column;
-  gap: 18px;
-  padding: 20px;
-  color: rgba(255, 255, 255, 0.95);
+  justify-content: space-between;
+  height: 100%;
+  min-height: 0;
+  padding: 14px 16px;
+  gap: 12px;
+  color: rgba(255, 255, 255, 0.92);
   background:
-    radial-gradient(140% 140% at 100% 0%, color-mix(in srgb, var(--brand, #fa3356) 18%, transparent) 0%, transparent 58%),
-    linear-gradient(180deg, rgba(255, 255, 255, 0.08) 0%, rgba(255, 255, 255, 0) 68%),
+    radial-gradient(120% 120% at 100% 0%, color-mix(in srgb, var(--brand, #fa3356) 12%, transparent) 0%, transparent 60%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.06) 0%, rgba(255, 255, 255, 0) 70%),
     var(--bg2, #111213);
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.12);
   border-radius: var(--radius-squircle, 20px);
-  box-shadow:
-    inset 0 0 0 1px rgba(255, 255, 255, 0.05),
-    0 12px 32px rgba(0, 0, 0, 0.35);
-  overflow: hidden;
-}
-
-@supports (color: color-mix(in srgb, white 50%, black 50%)) {
-  .card {
-    border-color: color-mix(in srgb, rgba(255, 255, 255, 0.08) 78%, transparent 22%);
-    box-shadow:
-      inset 0 0 0 1px color-mix(in srgb, rgba(255, 255, 255, 0.08) 55%, transparent 45%),
-      0 12px 32px rgba(0, 0, 0, 0.35);
-  }
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
 }
 
 .header {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   justify-content: space-between;
-  gap: 12px;
-}
-
-.titleWrap {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
+  gap: 8px;
 }
 
 .title {
   margin: 0;
-  font-size: 18px;
+  font-size: 16px;
   font-weight: 600;
-}
-
-.subtitle {
-  margin: 0;
-  font-size: 13px;
-  color: rgba(255, 255, 255, 0.65);
+  letter-spacing: -0.01em;
 }
 
 .viewAllButton {
   border: none;
   background: none;
-  color: rgba(255, 255, 255, 0.82);
-  font-size: 13px;
+  color: rgba(255, 255, 255, 0.75);
+  font-size: 12px;
   font-weight: 600;
-  text-decoration: underline;
-  padding: 6px 4px;
-  align-self: flex-start;
+  text-decoration: none;
+  padding: 4px 0;
+  cursor: pointer;
 }
 
 .viewAllButton:focus-visible {
@@ -72,167 +52,68 @@
 
 .statRow {
   display: flex;
-  gap: 10px;
+  gap: 8px;
 }
 
 .stat {
-  flex: 1;
+  flex: 1 1 0;
   display: flex;
   flex-direction: column;
+  justify-content: center;
   gap: 4px;
-  padding: 12px 14px;
-  border-radius: 16px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  background: rgba(255, 255, 255, 0.04);
-  min-height: 70px;
+  padding: 10px 12px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  min-height: 64px;
 }
 
 .statValue {
-  font-size: 20px;
+  font-size: 18px;
   font-weight: 600;
 }
 
 .statLabel {
   font-size: 11px;
   text-transform: uppercase;
-  letter-spacing: 0.04em;
-  color: rgba(255, 255, 255, 0.65);
+  letter-spacing: 0.06em;
+  color: rgba(255, 255, 255, 0.6);
 }
 
 .statOk {
-  border-color: color-mix(in srgb, var(--color-success, #4caf50) 48%, transparent);
-  background: color-mix(in srgb, var(--color-success, #4caf50) 14%, transparent);
-}
-
-.statWarn {
-  border-color: color-mix(in srgb, var(--color-warning, #ff9800) 48%, transparent);
-  background: color-mix(in srgb, var(--color-warning, #ff9800) 14%, transparent);
+  background: color-mix(in srgb, var(--color-success, #4caf50) 12%, transparent);
+  border-color: color-mix(in srgb, var(--color-success, #4caf50) 36%, transparent);
 }
 
 .statDanger {
-  border-color: color-mix(in srgb, var(--color-error, #ef5350) 52%, transparent);
-  background: color-mix(in srgb, var(--color-error, #ef5350) 18%, transparent);
+  background: color-mix(in srgb, var(--color-error, #ef5350) 14%, transparent);
+  border-color: color-mix(in srgb, var(--color-error, #ef5350) 38%, transparent);
 }
 
-.groups {
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
+.statWarn {
+  background: color-mix(in srgb, var(--color-warning, #ff9800) 14%, transparent);
+  border-color: color-mix(in srgb, var(--color-warning, #ff9800) 36%, transparent);
 }
 
-.group {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.groupHeader {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 8px;
-}
-
-.groupDay {
-  font-size: 13px;
-  font-weight: 600;
-  color: rgba(255, 255, 255, 0.85);
-}
-
-.groupCount {
-  font-size: 12px;
-  color: rgba(255, 255, 255, 0.6);
-}
-
-.items {
-  list-style: none;
+.status {
   margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-
-.item {
-  display: flex;
-  align-items: flex-start;
-  gap: 12px;
-}
-
-.itemDot {
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  margin-top: 6px;
-  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.35);
-}
-
-.itemBody {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-
-.itemTitle {
-  font-size: 14px;
-  font-weight: 600;
-  color: rgba(255, 255, 255, 0.95);
-}
-
-.itemMeta {
-  font-size: 12px;
-  color: rgba(255, 255, 255, 0.62);
-}
-
-.empty {
   font-size: 13px;
-  color: rgba(255, 255, 255, 0.6);
-  padding: 4px 0 2px;
-}
-
-.footerActions {
-  display: flex;
-  justify-content: stretch;
-}
-
-.primaryButton {
-  flex: 1;
-  padding: 12px 16px;
-  border-radius: 16px;
-  border: 1px solid color-mix(in srgb, var(--brand, #fa3356) 45%, transparent);
-  background: color-mix(in srgb, var(--brand, #fa3356) 18%, transparent);
-  color: color-mix(in srgb, var(--brand, #fa3356) 85%, white 15%);
-  font-size: 14px;
-  font-weight: 600;
-}
-
-.primaryButton:hover:not(:disabled) {
-  background: color-mix(in srgb, var(--brand, #fa3356) 26%, transparent);
-}
-
-.primaryButton:disabled {
-  opacity: 0.5;
-}
-
-.primaryButton:focus-visible {
-  outline: 2px solid var(--color-focus, var(--brand, #fa3356));
-  outline-offset: 2px;
+  color: rgba(255, 255, 255, 0.65);
+  line-height: 1.3;
 }
 
 @media (max-width: 480px) {
   .card {
-    padding: 18px;
+    padding: 12px 14px;
+    gap: 10px;
   }
 
   .statRow {
-    flex-wrap: wrap;
+    gap: 6px;
   }
 
   .stat {
-    flex: 1 1 45%;
-  }
-
-  .footerActions {
-    margin-top: 4px;
+    padding: 10px;
+    border-radius: 16px;
   }
 }

--- a/frontend/src/features/dashboard/components/MobileTasksOverviewCard.tsx
+++ b/frontend/src/features/dashboard/components/MobileTasksOverviewCard.tsx
@@ -8,14 +8,26 @@ import styles from "./MobileTasksOverviewCard.module.css";
 const CARD_RADIUS = 20;
 
 const MobileTasksOverviewCard: React.FC = () => {
-  const { loading, error, stats, groups, handleNavigateToPrimary, handleViewAll, canNavigateToProject } =
-    useTasksOverview();
+  const { loading, error, stats, groups, handleViewAll } = useTasksOverview();
 
   const formatStatValue = (value: number): string | number => {
     if (error) return "—";
     if (loading) return "…";
     return value;
   };
+
+  const statusMessage = React.useMemo(() => {
+    if (error) return "We couldn’t load tasks right now.";
+    if (loading) return "Loading tasks…";
+    if (!groups.length) return "No open tasks this week.";
+
+    const nextGroup = groups[0];
+    if (!nextGroup) return "You're up to date.";
+
+    const count = nextGroup.items.length;
+    const noun = count === 1 ? "task" : "tasks";
+    return `${count} ${noun} due ${nextGroup.dayLabel}.`;
+  }, [error, loading, groups]);
 
   return (
     <Squircle
@@ -26,10 +38,7 @@ const MobileTasksOverviewCard: React.FC = () => {
       aria-label="Tasks overview"
     >
       <header className={styles.header}>
-        <div className={styles.titleWrap}>
-          <h3 className={styles.title}>Tasks</h3>
-          <p className={styles.subtitle}>Stay on top of what’s due this week.</p>
-        </div>
+        <h3 className={styles.title}>Tasks</h3>
         <button type="button" className={styles.viewAllButton} onClick={handleViewAll}>
           View all
         </button>
@@ -50,58 +59,7 @@ const MobileTasksOverviewCard: React.FC = () => {
         </div>
       </div>
 
-      {error ? (
-        <div className={styles.empty}>We couldn’t load tasks right now. Please try again later.</div>
-      ) : groups.length ? (
-        <div className={styles.groups}>
-          {groups.map((group) => (
-            <div key={group.id} className={styles.group}>
-              <div className={styles.groupHeader}>
-                <span className={styles.groupDay}>{group.dayLabel}</span>
-                <span className={styles.groupCount}>
-                  {group.items.length} {group.items.length === 1 ? "task" : "tasks"}
-                </span>
-              </div>
-              <ul className={styles.items}>
-                {group.items.map((item) => (
-                  <li key={item.id} className={styles.item}>
-                    <span
-                      className={styles.itemDot}
-                      style={{ backgroundColor: item.color || "var(--brand, #fa3356)" }}
-                      aria-hidden="true"
-                    />
-                    <div className={styles.itemBody}>
-                      <span className={styles.itemTitle}>{item.title}</span>
-                      {(item.time || item.project) && (
-                        <span className={styles.itemMeta}>
-                          {item.time}
-                          {item.time && item.project ? " · " : ""}
-                          {item.project}
-                        </span>
-                      )}
-                    </div>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          ))}
-        </div>
-      ) : (
-        <div className={styles.empty}>
-          {loading ? "Loading tasks…" : "No open tasks are due this week. You’re all caught up!"}
-        </div>
-      )}
-
-      <div className={styles.footerActions}>
-        <button
-          type="button"
-          className={styles.primaryButton}
-          onClick={handleNavigateToPrimary}
-          disabled={!canNavigateToProject}
-        >
-          Review next project
-        </button>
-      </div>
+      <p className={styles.status}>{statusMessage}</p>
     </Squircle>
   );
 };

--- a/frontend/src/features/dashboard/styles/components/welcome-screen.css
+++ b/frontend/src/features/dashboard/styles/components/welcome-screen.css
@@ -74,43 +74,52 @@
 .mobile-welcome-layout {
   display: flex;
   flex-direction: column;
-  height: 100%;
+  height: 100dvh;
+  min-height: 100dvh;
   width: 100%;
   max-width: 100vw;
-  overflow: visible; /* allow children (CTA) to be fully visible */
+  overflow: hidden;
   align-items: stretch;
-  
-}
-
-.mobile-projects-section {
-  flex: 0 0 auto;
-  max-height: none;
-  overflow: visible;
-  padding: 0; /* remove outer grey wrapper */
-  background: transparent;
-  width: 100%;
-  max-width: 100vw;
-}
-
-.mobile-tasks-section {
-  flex: 0 0 auto;
-  width: 100%;
-  max-width: 100vw;
-  overflow: visible;
 }
 
 .mobile-calendar-section {
-  flex: 1 0 auto;
-  min-height: 0;
-  overflow: auto;
-
-  border-radius: 8px;
-  padding: 0px;
-  width: 100%;
-  max-width: 100vw;
+  flex: 0 0 120px;
+  max-height: 130px;
+  min-height: 110px;
   display: flex;
   flex-direction: column;
   align-items: stretch;
+  overflow: hidden;
+  border-radius: 8px;
+  padding: 0;
+  width: 100%;
+  max-width: 100vw;
+}
+
+.mobile-projects-section {
+  flex: 1 1 240px;
+  min-height: 200px;
+  max-height: 400px;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  max-width: 100vw;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding: 0;
+  background: transparent;
+  scrollbar-gutter: stable both-edges;
+}
+
+.mobile-tasks-section {
+  flex: 0 0 160px;
+  max-height: 160px;
+  width: 100%;
+  max-width: 100vw;
+  display: flex;
+  align-items: stretch;
+  overflow: hidden;
+  padding: 0;
 }
 
 .mobile-projects-section > *,
@@ -118,6 +127,7 @@
 .mobile-calendar-section > * {
   width: 100%;
   max-width: 100vw;
+  height: 100%;
 }
 
 /* Ensure projects header is more compact on mobile */


### PR DESCRIPTION
## Summary
- constrain the mobile welcome layout to a three-row, full-height structure with fixed calendar/tasks areas and a scrollable projects panel
- refactor the mobile tasks overview card into a compact stats row with streamlined header and status message

## Testing
- npm run lint *(fails: existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cb395ce1648324a94698a957a52909