### PR TITLE
Adjust mobile projects panel flex layout

### DIFF
--- a/frontend/src/features/dashboard/components/ProjectsPanel.tsx
+++ b/frontend/src/features/dashboard/components/ProjectsPanel.tsx
@@ -14,8 +14,6 @@ type Props = {
   onOpenProject: (projectId: string) => void;
 };
 
-const DEFAULT_PROJECT_ROWS = 3;
-
 type ProjectWithMeta = ProjectLike & { _activity: number; _created: number };
 
 const getMaxQuickProjectIcons = (width?: number): number => {
@@ -188,10 +186,6 @@ const ProjectsPanel: React.FC<Props> = ({ onOpenProject }) => {
         break;
     }
 
-    // Show fewer rows for Recents, all for All projects (scrolls in fixed panel)
-    if (scope === "recents") {
-      return ordered.slice(0, DEFAULT_PROJECT_ROWS);
-    }
     return ordered;
   }, [projects, sortOption, statusFilter, query, scope]);
 
@@ -398,12 +392,7 @@ const ProjectsPanel: React.FC<Props> = ({ onOpenProject }) => {
 
       {errorText && <div className={styles.inlineError}>{errorText}</div>}
 
-      <div
-        className={`${styles.list} ${
-          scope === "all" ? styles.listScrollable : ""
-        }`}
-        role="list"
-      >
+      <div className={styles.list} role="list">
         {isLoading ? (
           <div className={`${styles.row} ${styles.skeleton}`} aria-hidden>
             <div className={`${styles.icon} ${styles.skel}`} />

--- a/frontend/src/features/dashboard/components/projects-panel.module.css
+++ b/frontend/src/features/dashboard/components/projects-panel.module.css
@@ -6,16 +6,13 @@
   border: 2px solid rgba(255, 255, 255, 0.10);
   padding: 15px; /* compact */
   margin: 5px 0; /* compact */
-  /* Fixed panel height with internal scroll area */
-  height: 275px;
-  min-height: 275px;
-  max-height: 275px;
   display: flex;
   flex-direction: column;
   width: 100%;
   max-width: 100%;
   box-sizing: border-box;
-  flex-shrink: 0;
+  flex: 1 1 auto;
+  min-height: 0;
 }
 
 .panelFullBleed {
@@ -177,16 +174,12 @@
 .list {
   display: flex;
   flex-direction: column;
-  flex: 1;
+  flex: 1 1 auto;
   min-height: 0; /* allow flex child to shrink for scrolling */
-  overflow: visible; /* allow tooltips to overflow; no scroll unless explicitly enabled */
-  padding: 0;
-}
-
-/* Enable vertical scroll for long lists (e.g., All projects) */
-.listScrollable {
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
+  overscroll-behavior: contain;
+  padding: 0;
 }
 
 /* Compact tile (icon) grid */
@@ -519,10 +512,10 @@
 }
 
 .ctaWrap {
-  position: sticky;
-  bottom: calc(env(safe-area-inset-bottom) + 8px);
+  flex: 0 0 auto;
+  margin-top: 12px;
+  padding-top: 8px;
   background: var(--bg2, #111111);
-  
 }
 
 .cta {

--- a/frontend/src/features/dashboard/pages/DashboardHome.tsx
+++ b/frontend/src/features/dashboard/pages/DashboardHome.tsx
@@ -295,15 +295,19 @@ const WelcomeScreen: React.FC = () => {
         <div className="mobile-calendar-section">
           <AllProjectsWeekWidget />
         </div>
-        <div className="mobile-projects-section">
-          <ProjectsPanel
-            onOpenProject={(projectId) =>
-              handleNavigateToProject({ projectId })
-            }
-          />
-        </div>
-        <div className="mobile-tasks-section">
-          <MobileTasksOverviewCard />
+        <div className="mobile-projects-tasks">
+          <div className="mobile-projects-section">
+            <div className="mobile-projects-panel">
+              <ProjectsPanel
+                onOpenProject={(projectId) =>
+                  handleNavigateToProject({ projectId })
+                }
+              />
+            </div>
+          </div>
+          <div className="mobile-tasks-section dashboard-footer">
+            <MobileTasksOverviewCard />
+          </div>
         </div>
       </div>
     );

--- a/frontend/src/features/dashboard/pages/dashboard-styles.css
+++ b/frontend/src/features/dashboard/pages/dashboard-styles.css
@@ -47,16 +47,26 @@
 @media (max-width: 1023px) {
   .dashboard-root {
     display: block;
-    height: auto;
+    min-height: 100vh;
+    min-height: 100dvh;
   }
 
   .dashboard-main {
-    height: auto;
+    min-height: 100vh;
+    min-height: 100dvh;
+    height: 100vh;
+    height: 100dvh;
+    max-height: 100vh;
+    max-height: 100dvh;
+    display: flex;
+    flex-direction: column;
     overflow: auto;
   }
 
   .dashboard-wrapper,
   .dashboard-wrapper.welcome-screen {
+    flex: 1 1 auto;
+    min-height: 0;
     padding: 16px;
   }
 }

--- a/frontend/src/features/dashboard/styles/components/welcome-screen.css
+++ b/frontend/src/features/dashboard/styles/components/welcome-screen.css
@@ -90,13 +90,14 @@
   flex-direction: column;
   flex: 1 1 auto;
   min-height: 0;
+  overflow: hidden;
   gap: 16px;
 }
 
 .mobile-projects-section {
   flex: 1 1 auto;
   max-height: none;
-  overflow: visible;
+  overflow: hidden;
   padding: 0; /* remove outer grey wrapper */
   background: transparent;
   width: 100%;
@@ -111,6 +112,7 @@
   min-height: 0;
   display: flex;
   flex-direction: column;
+  overflow: hidden;
 }
 
 .mobile-projects-panel > * {
@@ -123,6 +125,7 @@
   width: 100%;
   max-width: 100vw;
   overflow: visible;
+  margin-top: auto;
 }
 
 .dashboard-footer {
@@ -130,7 +133,7 @@
 }
 
 .mobile-calendar-section {
-  flex: 1 0 auto;
+  flex: 0 0 auto;
   min-height: 0;
   overflow: auto;
 

--- a/frontend/src/features/dashboard/styles/components/welcome-screen.css
+++ b/frontend/src/features/dashboard/styles/components/welcome-screen.css
@@ -74,22 +74,48 @@
 .mobile-welcome-layout {
   display: flex;
   flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
   height: 100%;
   width: 100%;
   max-width: 100vw;
   overflow: visible; /* allow children (CTA) to be fully visible */
   align-items: stretch;
-  
+  gap: 16px;
+
+}
+
+.mobile-projects-tasks {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
+  gap: 16px;
 }
 
 .mobile-projects-section {
-  flex: 0 0 auto;
+  flex: 1 1 auto;
   max-height: none;
   overflow: visible;
   padding: 0; /* remove outer grey wrapper */
   background: transparent;
   width: 100%;
   max-width: 100vw;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.mobile-projects-panel {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.mobile-projects-panel > * {
+  flex: 1 1 auto;
+  min-height: 0;
 }
 
 .mobile-tasks-section {
@@ -97,6 +123,10 @@
   width: 100%;
   max-width: 100vw;
   overflow: visible;
+}
+
+.dashboard-footer {
+  flex: 0 0 auto;
 }
 
 .mobile-calendar-section {


### PR DESCRIPTION
## Summary
- allow the projects panel to render all recent projects while scrolling inside a flexible container
- let the mobile dashboard share flex space between the projects panel and the tasks overview so the footer stays visible
- update dashboard styles to keep the tasks card pinned to the bottom without hiding the "See all projects" CTA

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cb401b231083248044a70e7c83e8cc