### PR TITLE
Refine projects status filter dropdown styling

### DIFF
--- a/frontend/src/features/projects/ProjectsPanelDesktop.module.css
+++ b/frontend/src/features/projects/ProjectsPanelDesktop.module.css
@@ -250,6 +250,129 @@
   overflow-y: auto;
 }
 
+.statusFilter {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.statusFilterTrigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  width: 100%;
+  padding: 9px 14px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-color, #eaecee);
+  background: linear-gradient(135deg, rgba(32, 34, 37, 0.92), rgba(18, 19, 21, 0.94));
+  border: 1px solid rgba(72, 76, 81, 0.45);
+  border-radius: 12px;
+  cursor: pointer;
+  transition: background 0.24s ease, border-color 0.24s ease, box-shadow 0.24s ease,
+    color 0.24s ease;
+  -webkit-backdrop-filter: blur(12px);
+  backdrop-filter: blur(12px);
+}
+
+.statusFilterTrigger:hover,
+.statusFilterTrigger:focus-visible {
+  background: linear-gradient(135deg, rgba(40, 42, 46, 0.94), rgba(24, 26, 29, 0.96));
+  border-color: rgba(104, 108, 114, 0.55);
+  color: var(--text-color, #eaecee);
+}
+
+.statusFilterTrigger:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 1px rgba(122, 126, 132, 0.55);
+}
+
+.statusFilterPlaceholder {
+  color: var(--text-color-muted, #9aa0a6);
+}
+
+.statusFilterValue {
+  flex: 1;
+  text-align: left;
+  color: inherit;
+  font-weight: 600;
+}
+
+.statusFilterChevron {
+  color: var(--text-color-muted, #9aa0a6);
+  transition: transform 0.2s ease, color 0.2s ease;
+}
+
+.statusFilterTrigger:hover .statusFilterChevron,
+.statusFilterTrigger:focus-visible .statusFilterChevron {
+  color: var(--text-color, #eaecee);
+}
+
+.statusFilterOpen .statusFilterChevron {
+  transform: rotate(-180deg);
+  color: var(--text-color, #eaecee);
+}
+
+.statusFilterList {
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 0;
+  right: 0;
+  margin: 0;
+  padding: 8px;
+  list-style: none;
+  border-radius: 14px;
+  border: 1px solid rgba(72, 76, 81, 0.45);
+  background: linear-gradient(135deg, rgba(24, 25, 28, 0.96), rgba(12, 13, 15, 0.95));
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.55);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-height: 240px;
+  overflow-y: auto;
+  z-index: 20;
+  -webkit-backdrop-filter: blur(16px);
+  backdrop-filter: blur(16px);
+}
+
+.statusFilterOption {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 8px;
+  width: 100%;
+  border: none;
+  background: transparent;
+  color: var(--text-color, #eaecee);
+  font-size: 13px;
+  font-weight: 600;
+  padding: 8px 10px;
+  border-radius: 10px;
+  cursor: pointer;
+  transition: background-color 0.22s ease, color 0.22s ease, box-shadow 0.22s ease;
+}
+
+.statusFilterOption:hover,
+.statusFilterOption:focus-visible {
+  background: rgba(68, 72, 76, 0.45);
+  color: var(--text-color, #eaecee);
+  outline: none;
+  box-shadow: 0 0 0 1px rgba(110, 114, 118, 0.55);
+}
+
+.statusFilterOptionActive {
+  background: rgba(58, 62, 66, 0.55);
+  color: var(--text-color, #eaecee);
+  box-shadow: inset 0 0 0 1px rgba(110, 114, 118, 0.38);
+}
+
+.statusFilterOptionActive:hover,
+.statusFilterOptionActive:focus-visible {
+  background: rgba(66, 70, 74, 0.6);
+}
+
 @media (max-width: 1440px) {
   .table {
     min-width: 560px;

--- a/frontend/src/features/projects/ProjectsPanelDesktop.tsx
+++ b/frontend/src/features/projects/ProjectsPanelDesktop.tsx
@@ -67,6 +67,16 @@ function sanitizeId(raw: string) {
   return raw.replace(/[^a-zA-Z0-9_-]/g, "");
 }
 
+const formatStatusLabel = (status: string): string => {
+  const clean = status.trim();
+  if (!clean) return "";
+  return clean
+    .split(/[_\s-]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+};
+
 const ProjectsPanelDesktop: React.FC<ProjectsPanelDesktopProps> = ({ onOpenProject }) => {
   const reduceMotion = useReducedMotion();
   const {
@@ -96,6 +106,14 @@ const ProjectsPanelDesktop: React.FC<ProjectsPanelDesktopProps> = ({ onOpenProje
   const [query, setQuery] = useState<string>("");
   const [scope, setScope] = useState<"recents" | "all">("recents");
   const [viewMode, setViewMode] = useState<"table" | "grid">("table");
+  const [statusDropdownOpen, setStatusDropdownOpen] = useState(false);
+
+  const statusDropdownRef = useRef<HTMLDivElement | null>(null);
+  const statusDropdownListRef = useRef<HTMLUListElement | null>(null);
+  const statusTriggerRef = useRef<HTMLButtonElement | null>(null);
+  const statusListIdRef = useRef(
+    `projects-status-filter-${sanitizeId(Math.random().toString(36).slice(2))}`
+  );
 
   useEffect(() => {
     if (!isLoading && projects.length === 0 && !projectsError) {
@@ -129,6 +147,51 @@ const ProjectsPanelDesktop: React.FC<ProjectsPanelDesktopProps> = ({ onOpenProje
     document.addEventListener("click", onDocClick);
     return () => document.removeEventListener("click", onDocClick);
   }, [filtersOpen]);
+
+  useEffect(() => {
+    if (!statusDropdownOpen) return;
+    const handleClick = (event: MouseEvent) => {
+      if (
+        statusDropdownRef.current &&
+        event.target instanceof Node &&
+        !statusDropdownRef.current.contains(event.target)
+      ) {
+        setStatusDropdownOpen(false);
+      }
+    };
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        setStatusDropdownOpen(false);
+        statusTriggerRef.current?.focus();
+      }
+    };
+    document.addEventListener("mousedown", handleClick);
+    document.addEventListener("keydown", handleKey);
+    return () => {
+      document.removeEventListener("mousedown", handleClick);
+      document.removeEventListener("keydown", handleKey);
+    };
+  }, [statusDropdownOpen]);
+
+  useEffect(() => {
+    if (!statusDropdownOpen) return;
+    const listEl = statusDropdownListRef.current;
+    if (!listEl) return;
+    const focusOption = () => {
+      const selected = listEl.querySelector<HTMLButtonElement>("[data-selected='true']");
+      const first = listEl.querySelector<HTMLButtonElement>("button");
+      (selected ?? first)?.focus();
+    };
+    const raf = requestAnimationFrame(focusOption);
+    return () => cancelAnimationFrame(raf);
+  }, [statusDropdownOpen]);
+
+  useEffect(() => {
+    if (!filtersOpen && statusDropdownOpen) {
+      setStatusDropdownOpen(false);
+    }
+  }, [filtersOpen, statusDropdownOpen]);
 
   const statuses = useMemo(() => {
     try {
@@ -578,19 +641,143 @@ const ProjectsPanelDesktop: React.FC<ProjectsPanelDesktopProps> = ({ onOpenProje
                 />
 
                 {statuses.length > 0 && (
-                  <select
-                    className={mobileStyles.select}
-                    value={statusFilter}
-                    onChange={(e) => setStatusFilter(e.target.value)}
-                    aria-label="Filter by status"
+                  <div
+                    className={`${desktopStyles.statusFilter} ${
+                      statusDropdownOpen ? desktopStyles.statusFilterOpen : ""
+                    }`}
+                    ref={statusDropdownRef}
                   >
-                    <option value="">All statuses</option>
-                    {statuses.map((s) => (
-                      <option key={s} value={s}>
-                        {s}
-                      </option>
-                    ))}
-                  </select>
+                    <button
+                      type="button"
+                      ref={statusTriggerRef}
+                      className={`${desktopStyles.statusFilterTrigger} ${
+                        statusFilter ? "" : desktopStyles.statusFilterPlaceholder
+                      }`}
+                      aria-haspopup="listbox"
+                      aria-expanded={statusDropdownOpen}
+                      aria-controls={statusListIdRef.current}
+                      onClick={() =>
+                        setStatusDropdownOpen((open) => !open)
+                      }
+                      onKeyDown={(event) => {
+                        if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+                          event.preventDefault();
+                          setStatusDropdownOpen(true);
+                        }
+                        if (event.key === "Escape" && statusDropdownOpen) {
+                          event.preventDefault();
+                          setStatusDropdownOpen(false);
+                        }
+                      }}
+                    >
+                      <span className={desktopStyles.statusFilterValue}>
+                        {statusFilter
+                          ? formatStatusLabel(statusFilter)
+                          : "All statuses"}
+                      </span>
+                      <ChevronDown
+                        aria-hidden
+                        size={14}
+                        className={desktopStyles.statusFilterChevron}
+                      />
+                    </button>
+                    {statusDropdownOpen && (
+                      <ul
+                        className={desktopStyles.statusFilterList}
+                        role="listbox"
+                        id={statusListIdRef.current}
+                        aria-label="Filter by status"
+                        ref={statusDropdownListRef}
+                        onKeyDown={(event) => {
+                          const buttons = Array.from(
+                            statusDropdownListRef.current?.querySelectorAll<HTMLButtonElement>(
+                              "button"
+                            ) ?? []
+                          );
+                          if (event.key === "Escape") {
+                            event.preventDefault();
+                            setStatusDropdownOpen(false);
+                            statusTriggerRef.current?.focus();
+                            return;
+                          }
+                          if (event.key === "Tab") {
+                            setStatusDropdownOpen(false);
+                            return;
+                          }
+                          if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+                            event.preventDefault();
+                            if (buttons.length === 0) return;
+                            const activeElement = document.activeElement as HTMLButtonElement | null;
+                            const currentIndex = activeElement
+                              ? buttons.indexOf(activeElement)
+                              : -1;
+                            const offset = event.key === "ArrowDown" ? 1 : -1;
+                            const nextIndex =
+                              currentIndex === -1
+                                ? offset > 0
+                                  ? 0
+                                  : buttons.length - 1
+                                : (currentIndex + offset + buttons.length) % buttons.length;
+                            buttons[nextIndex]?.focus();
+                          }
+                          if (event.key === "Home") {
+                            event.preventDefault();
+                            buttons[0]?.focus();
+                          }
+                          if (event.key === "End") {
+                            event.preventDefault();
+                            if (buttons.length === 0) return;
+                            buttons[buttons.length - 1]?.focus();
+                          }
+                        }}
+                      >
+                        <li>
+                          <button
+                            type="button"
+                            role="option"
+                            className={`${desktopStyles.statusFilterOption} ${
+                              statusFilter ? "" : desktopStyles.statusFilterOptionActive
+                            }`}
+                            aria-selected={!statusFilter}
+                            data-selected={!statusFilter ? "true" : undefined}
+                            onClick={() => {
+                              setStatusFilter("");
+                              setStatusDropdownOpen(false);
+                              statusTriggerRef.current?.focus();
+                            }}
+                          >
+                            All statuses
+                          </button>
+                        </li>
+                        {statuses.map((s) => {
+                          const isActive = statusFilter === s;
+                          return (
+                            <li key={s}>
+                              <button
+                                type="button"
+                                role="option"
+                                className={`${desktopStyles.statusFilterOption} ${
+                                  isActive
+                                    ? desktopStyles.statusFilterOptionActive
+                                    : ""
+                                }`}
+                                id={`status-filter-option-${sanitizeId(s)}`}
+                                aria-selected={isActive}
+                                data-selected={isActive ? "true" : undefined}
+                                onClick={() => {
+                                  setStatusFilter(s);
+                                  setStatusDropdownOpen(false);
+                                  statusTriggerRef.current?.focus();
+                                }}
+                              >
+                                {formatStatusLabel(s)}
+                              </button>
+                            </li>
+                          );
+                        })}
+                      </ul>
+                    )}
+                  </div>
                 )}
 
                 <select


### PR DESCRIPTION
## Summary
- replace the native status filter select with a custom dropdown that matches the MYLG greyscale frosted styling
- add keyboard and focus handling plus grey-only hover states for the status options list
- extend the desktop projects panel styles with rounded, blurred dropdown and option treatments

## Testing
- npm run lint *(fails: pre-existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cb64c4ace48324bc628f16e67d3397