### PR TITLE
Refine projects status filter dropdown styling

### DIFF
--- a/frontend/src/features/projects/ProjectsPanelDesktop.module.css
+++ b/frontend/src/features/projects/ProjectsPanelDesktop.module.css
@@ -197,6 +197,124 @@
   gap: 12px;
 }
 
+.statusDropdown {
+  position: relative;
+  width: 100%;
+}
+
+.statusTrigger {
+  width: 100%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 10px 14px;
+  border-radius: 12px;
+  border: 1px solid var(--border-color, #2a2a2a);
+  background-color: var(--bg2, #111213);
+  background-image: linear-gradient(140deg, rgba(28, 29, 30, 0.88), rgba(17, 18, 19, 0.94));
+  color: var(--text-color-muted, #9aa0a6);
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  transition: border-color 0.2s ease, background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+}
+
+.statusTrigger span {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.statusTrigger svg {
+  flex: 0 0 auto;
+  opacity: 0.7;
+  transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+.statusTrigger[aria-expanded="true"] svg {
+  transform: rotate(-180deg);
+  opacity: 0.9;
+}
+
+.statusTrigger:hover {
+  border-color: var(--border-color-light, #3a3a3a);
+  background-image: linear-gradient(140deg, rgba(34, 35, 37, 0.9), rgba(20, 21, 22, 0.96));
+  color: var(--text-color, #eaecee);
+}
+
+.statusTrigger:focus-visible {
+  outline: 2px solid var(--border-color-light, #3a3a3a);
+  outline-offset: 2px;
+  color: var(--text-color, #eaecee);
+}
+
+.statusOptions {
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 0;
+  right: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px;
+  border-radius: 14px;
+  background-color: var(--bg2, #111213);
+  background-image: linear-gradient(145deg, rgba(28, 29, 30, 0.92), rgba(17, 18, 19, 0.97));
+  border: 1px solid var(--border-color, #2a2a2a);
+  box-shadow: 0 18px 32px rgba(0, 0, 0, 0.35);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  z-index: 40;
+}
+
+.statusOptions li {
+  list-style: none;
+}
+
+.statusOptionButton {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 8px;
+  padding: 10px 12px;
+  border: none;
+  border-radius: 10px;
+  background: transparent;
+  color: var(--text-color-muted, #9aa0a6);
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+  text-align: left;
+}
+
+.statusOptionButton:hover,
+.statusOptionButton:focus-visible {
+  background: rgba(48, 49, 50, 0.55);
+  color: var(--text-color, #eaecee);
+  outline: none;
+  box-shadow: inset 0 0 0 1px rgba(72, 74, 75, 0.55);
+}
+
+.statusOptionSelected {
+  background: rgba(44, 45, 47, 0.65);
+  color: var(--text-color, #eaecee);
+  box-shadow: inset 0 0 0 1px rgba(80, 82, 84, 0.55);
+}
+
+.statusOptionActive:not(.statusOptionSelected) {
+  background: rgba(40, 41, 42, 0.6);
+  color: var(--text-color, #eaecee);
+}
+
 .thumb {
   width: 38px;
   height: 38px;

--- a/frontend/src/features/projects/ProjectsPanelDesktop.tsx
+++ b/frontend/src/features/projects/ProjectsPanelDesktop.tsx
@@ -87,11 +87,15 @@ const ProjectsPanelDesktop: React.FC<ProjectsPanelDesktopProps> = ({ onOpenProje
   const [filtersOpen, setFiltersOpen] = useState(false);
   const filtersRef = useRef<HTMLDivElement | null>(null);
   const filtersIdRef = useRef(`projects-filters-${sanitizeId(Math.random().toString(36).slice(2))}`);
+  const statusDropdownRef = useRef<HTMLDivElement | null>(null);
+  const statusListIdRef = useRef(`projects-status-${sanitizeId(Math.random().toString(36).slice(2))}`);
 
   const [sortOption, setSortOption] = useState<SortOption>("dateNewest");
   const [statusFilter, setStatusFilter] = useState<string>("");
   const [query, setQuery] = useState<string>("");
   const [scope, setScope] = useState<"recents" | "all">("recents");
+  const [statusDropdownOpen, setStatusDropdownOpen] = useState(false);
+  const [statusHighlightIndex, setStatusHighlightIndex] = useState<number>(-1);
 
   useEffect(() => {
     if (!isLoading && projects.length === 0 && !projectsError) {
@@ -114,6 +118,40 @@ const ProjectsPanelDesktop: React.FC<ProjectsPanelDesktopProps> = ({ onOpenProje
     return () => document.removeEventListener("click", onDocClick);
   }, [filtersOpen]);
 
+  useEffect(() => {
+    if (!statusDropdownOpen) return;
+
+    const handlePointer = (event: MouseEvent) => {
+      if (
+        statusDropdownRef.current &&
+        event.target instanceof Node &&
+        !statusDropdownRef.current.contains(event.target)
+      ) {
+        setStatusDropdownOpen(false);
+      }
+    };
+
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setStatusDropdownOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handlePointer);
+    document.addEventListener("keydown", handleKey);
+
+    return () => {
+      document.removeEventListener("mousedown", handlePointer);
+      document.removeEventListener("keydown", handleKey);
+    };
+  }, [statusDropdownOpen]);
+
+  useEffect(() => {
+    if (!filtersOpen) {
+      setStatusDropdownOpen(false);
+    }
+  }, [filtersOpen]);
+
   const statuses = useMemo(() => {
     try {
       return Array.from(
@@ -127,6 +165,21 @@ const ProjectsPanelDesktop: React.FC<ProjectsPanelDesktopProps> = ({ onOpenProje
       return [] as string[];
     }
   }, [projects]);
+
+  const statusOptions = useMemo(
+    () => [{ value: "", label: "All statuses" }, ...statuses.map((s) => ({ value: s, label: s }))],
+    [statuses]
+  );
+
+  useEffect(() => {
+    if (!statusDropdownOpen) {
+      setStatusHighlightIndex(-1);
+      return;
+    }
+
+    const selectedIndex = statusOptions.findIndex((opt) => opt.value === statusFilter);
+    setStatusHighlightIndex(selectedIndex >= 0 ? selectedIndex : 0);
+  }, [statusDropdownOpen, statusFilter, statusOptions]);
 
   const items = useMemo(() => {
     const list: ProjectWithMeta[] = (projects as ProjectLike[]).map((p) => ({
@@ -198,6 +251,99 @@ const ProjectsPanelDesktop: React.FC<ProjectsPanelDesktopProps> = ({ onOpenProje
       }
     },
     [onOpenProject, navigate]
+  );
+
+  const statusTriggerLabel = useMemo(() => {
+    const found = statusOptions.find((opt) => opt.value === statusFilter);
+    return found ? found.label : "All statuses";
+  }, [statusFilter, statusOptions]);
+
+  const statusActiveOptionId =
+    statusDropdownOpen && statusHighlightIndex >= 0
+      ? `${statusListIdRef.current}-option-${statusHighlightIndex}`
+      : undefined;
+
+  const updateHighlight = useCallback(
+    (direction: 1 | -1) => {
+      setStatusHighlightIndex((current) => {
+        if (!statusOptions.length) return -1;
+        const next = current < 0 ? 0 : current + direction;
+        if (next < 0) return statusOptions.length - 1;
+        if (next >= statusOptions.length) return 0;
+        return next;
+      });
+    },
+    [statusOptions.length]
+  );
+
+  const handleStatusSelect = useCallback(
+    (value: string) => {
+      setStatusFilter(value);
+      setStatusDropdownOpen(false);
+    },
+    []
+  );
+
+  const handleStatusTriggerKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLButtonElement>) => {
+      if (!statusOptions.length) return;
+
+      switch (event.key) {
+        case "ArrowDown": {
+          event.preventDefault();
+          if (!statusDropdownOpen) {
+            setStatusDropdownOpen(true);
+            return;
+          }
+          updateHighlight(1);
+          break;
+        }
+        case "ArrowUp": {
+          event.preventDefault();
+          if (!statusDropdownOpen) {
+            setStatusDropdownOpen(true);
+            return;
+          }
+          updateHighlight(-1);
+          break;
+        }
+        case "Home": {
+          if (!statusDropdownOpen) return;
+          event.preventDefault();
+          setStatusHighlightIndex(statusOptions.length ? 0 : -1);
+          break;
+        }
+        case "End": {
+          if (!statusDropdownOpen) return;
+          event.preventDefault();
+          setStatusHighlightIndex(statusOptions.length ? statusOptions.length - 1 : -1);
+          break;
+        }
+        case "Enter":
+        case " ": {
+          event.preventDefault();
+          if (statusDropdownOpen && statusHighlightIndex >= 0) {
+            const option = statusOptions[statusHighlightIndex];
+            if (option) {
+              handleStatusSelect(option.value);
+            }
+          } else {
+            setStatusDropdownOpen((open) => !open);
+          }
+          break;
+        }
+        case "Escape": {
+          if (statusDropdownOpen) {
+            event.preventDefault();
+            setStatusDropdownOpen(false);
+          }
+          break;
+        }
+        default:
+          break;
+      }
+    },
+    [handleStatusSelect, statusDropdownOpen, statusHighlightIndex, statusOptions, updateHighlight]
   );
 
   const handleRowKeyDown = (e: React.KeyboardEvent<HTMLTableRowElement>, id: string) => {
@@ -410,19 +556,57 @@ const ProjectsPanelDesktop: React.FC<ProjectsPanelDesktopProps> = ({ onOpenProje
                 />
 
                 {statuses.length > 0 && (
-                  <select
-                    className={mobileStyles.select}
-                    value={statusFilter}
-                    onChange={(e) => setStatusFilter(e.target.value)}
-                    aria-label="Filter by status"
+                  <div
+                    className={desktopStyles.statusDropdown}
+                    ref={statusDropdownRef}
                   >
-                    <option value="">All statuses</option>
-                    {statuses.map((s) => (
-                      <option key={s} value={s}>
-                        {s}
-                      </option>
-                    ))}
-                  </select>
+                    <button
+                      type="button"
+                      className={desktopStyles.statusTrigger}
+                      aria-haspopup="listbox"
+                      aria-expanded={statusDropdownOpen}
+                      aria-controls={statusListIdRef.current}
+                      aria-activedescendant={statusActiveOptionId}
+                      onClick={() => setStatusDropdownOpen((open) => !open)}
+                      onKeyDown={handleStatusTriggerKeyDown}
+                    >
+                      <span>{statusTriggerLabel}</span>
+                      <ChevronDown size={14} aria-hidden />
+                    </button>
+                    {statusDropdownOpen && (
+                      <ul
+                        className={desktopStyles.statusOptions}
+                        role="listbox"
+                        id={statusListIdRef.current}
+                      >
+                        {statusOptions.map((option, index) => {
+                          const optionId = `${statusListIdRef.current}-option-${index}`;
+                          const isSelected = statusFilter === option.value;
+                          const isActive = statusHighlightIndex === index;
+                          return (
+                            <li
+                              key={`${option.value || "all"}-${index}`}
+                              role="option"
+                              id={optionId}
+                              aria-selected={isSelected}
+                            >
+                              <button
+                                type="button"
+                                className={`${desktopStyles.statusOptionButton} ${
+                                  isSelected ? desktopStyles.statusOptionSelected : ""
+                                } ${isActive ? desktopStyles.statusOptionActive : ""}`}
+                                onClick={() => handleStatusSelect(option.value)}
+                                onMouseEnter={() => setStatusHighlightIndex(index)}
+                                onFocus={() => setStatusHighlightIndex(index)}
+                              >
+                                {option.label}
+                              </button>
+                            </li>
+                          );
+                        })}
+                      </ul>
+                    )}
+                  </div>
                 )}
 
                 <select


### PR DESCRIPTION
## Summary
- replace the projects panel status <select> with a custom dropdown that matches the MYLG frosted grey styling and removes native browser chrome
- add keyboard navigation, hover, and focus handling so status filtering remains accessible without blue highlights or brand accents
- introduce dedicated module styles for the dropdown trigger and list with rounded, blurred grey surfaces and subtle borders/shadows

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cb6701b99c83248708072602d6e3b7