### PR TITLE
refactor: share project filter state hook

### DIFF
--- a/frontend/src/features/dashboard/components/ProjectsPanel.tsx
+++ b/frontend/src/features/dashboard/components/ProjectsPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { motion, useReducedMotion } from "framer-motion";
 import { useNavigate } from "react-router-dom";
 import { ChevronDown } from "lucide-react";
@@ -7,14 +7,13 @@ import { useData } from "@/app/contexts/useData";
 import SVGThumbnail from "./SvgThumbnail";
 import styles from "./projects-panel.module.css";
 import { useProjectKpis, type ProjectLike } from "../hooks/useProjectKpis";
+import useProjectsFilterState from "@/features/dashboard/hooks/useProjectsFilterState";
 import { getFileUrl } from "../../../shared/utils/api";
 import { MICRO_WOBBLE_SCALE, SPRING_FAST } from "@/shared/ui/motionTokens";
 
 type Props = {
   onOpenProject: (projectId: string) => void;
 };
-
-type ProjectWithMeta = ProjectLike & { _activity: number; _created: number };
 
 const getMaxQuickProjectIcons = (width?: number): number => {
   if (!width) return 5;
@@ -33,27 +32,6 @@ const formatShortDate = (iso?: string): string | undefined => {
   return d.toLocaleString(undefined, { month: "short", day: "numeric" });
 };
 
-const getProjectActivityTs = (p: ProjectLike): number => {
-  const candidates: (string | undefined)[] = [
-    p.updatedAt,
-    p.dateUpdated,
-    p.lastModified,
-    p.date,
-    p.dateCreated,
-  ];
-  if (Array.isArray(p.timelineEvents)) {
-    for (const ev of p.timelineEvents) {
-      if (ev?.timestamp) candidates.push(ev.timestamp);
-      if (ev?.date) candidates.push(ev.date);
-    }
-  }
-  const timestamps = candidates
-    .filter(Boolean)
-    .map((s) => new Date(s as string).getTime())
-    .filter((n) => Number.isFinite(n));
-  return timestamps.length ? Math.max(...timestamps) : 0;
-};
-
 const ProjectsPanel: React.FC<Props> = ({ onOpenProject }) => {
   const reduceMotion = useReducedMotion();
   const { projects, isLoading, projectsError, fetchProjects } = useData();
@@ -69,12 +47,20 @@ const ProjectsPanel: React.FC<Props> = ({ onOpenProject }) => {
     )
   );
 
-  // Compact filter/sort options (mirrors AllProjects)
-  type SortOption = "titleAsc" | "titleDesc" | "dateNewest" | "dateOldest";
-  const [sortOption, setSortOption] = useState<SortOption>("dateNewest");
-  const [statusFilter, setStatusFilter] = useState<string>("");
-  const [query, setQuery] = useState<string>("");
-  const [scope, setScope] = useState<"recents" | "all">("recents");
+  const {
+    scope,
+    setScope,
+    query,
+    setQuery,
+    statusFilter,
+    setStatusFilter,
+    sortOption,
+    setSortOption,
+    statuses,
+    statusOptions,
+    sortOptions,
+    filteredProjects,
+  } = useProjectsFilterState(projects as ProjectLike[]);
   // Icons-only strip lives next to the title; main list remains compact list rows
 
   useEffect(() => {
@@ -119,75 +105,6 @@ const ProjectsPanel: React.FC<Props> = ({ onOpenProject }) => {
     document.addEventListener("click", onDocClick);
     return () => document.removeEventListener("click", onDocClick);
   }, [filtersOpen]);
-
-  const statuses = useMemo(() => {
-    try {
-      return Array.from(
-        new Set(
-          (projects as ProjectLike[])
-            .map((p) => String(p.status || "").toLowerCase())
-            .filter(Boolean)
-        )
-      );
-    } catch {
-      return [] as string[];
-    }
-  }, [projects]);
-
-  const items = useMemo(() => {
-    const list: ProjectWithMeta[] = (projects as ProjectLike[]).map((p) => ({
-      ...p,
-      _activity: getProjectActivityTs(p),
-      _created: new Date(p.dateCreated || p.date || 0).getTime() || 0,
-    }));
-
-    // Base ordering by scope
-    let ordered = list.slice();
-    if (scope === "recents") {
-      ordered.sort((a, b) => b._activity - a._activity);
-    }
-
-    // Filters
-    const q = query.trim().toLowerCase();
-    if (q) {
-      ordered = ordered.filter((p) =>
-        (p.title || "").toLowerCase().includes(q)
-      );
-    }
-    if (statusFilter) {
-      ordered = ordered.filter(
-        (p) => String(p.status || "").toLowerCase() === statusFilter
-      );
-    }
-
-    // Sort
-    const byTitle = (a: ProjectLike, b: ProjectLike) =>
-      (a.title || "").localeCompare(b.title || "", undefined, {
-        sensitivity: "base",
-      });
-    const byCreated = (a: ProjectWithMeta, b: ProjectWithMeta) =>
-      b._created - a._created; // newest first
-    const byCreatedAsc = (a: ProjectWithMeta, b: ProjectWithMeta) =>
-      a._created - b._created; // oldest first
-
-    switch (sortOption) {
-      case "titleAsc":
-        ordered.sort(byTitle);
-        break;
-      case "titleDesc":
-        ordered.sort((a, b) => -byTitle(a, b));
-        break;
-      case "dateOldest":
-        ordered.sort(byCreatedAsc);
-        break;
-      case "dateNewest":
-      default:
-        ordered.sort(byCreated);
-        break;
-    }
-
-    return ordered;
-  }, [projects, sortOption, statusFilter, query, scope]);
 
   const kpis = useProjectKpis(projects as ProjectLike[]);
 
@@ -343,10 +260,12 @@ const ProjectsPanel: React.FC<Props> = ({ onOpenProject }) => {
                     onChange={(e) => setStatusFilter(e.target.value)}
                     aria-label="Filter by status"
                   >
-                    <option value="">All statuses</option>
-                    {statuses.map((s) => (
-                      <option key={s} value={s}>
-                        {s}
+                    {statusOptions.map((option) => (
+                      <option
+                        key={`status-${option.value || "all"}`}
+                        value={option.value}
+                      >
+                        {option.label}
                       </option>
                     ))}
                   </select>
@@ -355,13 +274,21 @@ const ProjectsPanel: React.FC<Props> = ({ onOpenProject }) => {
                 <select
                   className={styles.select}
                   value={sortOption}
-                  onChange={(e) => setSortOption(e.target.value as SortOption)}
+                  onChange={(event) => {
+                    const next = sortOptions.find(
+                      (option) => option.value === event.target.value
+                    );
+                    if (next) {
+                      setSortOption(next.value);
+                    }
+                  }}
                   aria-label="Sort projects"
                 >
-                  <option value="titleAsc">Title (A-Z)</option>
-                  <option value="titleDesc">Title (Z-A)</option>
-                  <option value="dateNewest">Date (Newest)</option>
-                  <option value="dateOldest">Date (Oldest)</option>
+                  {sortOptions.map((option) => (
+                    <option key={`sort-${option.value}`} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
                 </select>
               </div>
             </div>
@@ -400,12 +327,12 @@ const ProjectsPanel: React.FC<Props> = ({ onOpenProject }) => {
               <div className={styles.skelBar} />
             </div>
           </div>
-        ) : items.length === 0 ? (
+        ) : filteredProjects.length === 0 ? (
           <div className={styles.empty} role="note">
             No projects match filters
           </div>
         ) : (
-          items.map((p) => {
+          filteredProjects.map((p) => {
             const dateIso =
               p.updatedAt ||
               p.dateUpdated ||

--- a/frontend/src/features/dashboard/hooks/useProjectsFilterState.ts
+++ b/frontend/src/features/dashboard/hooks/useProjectsFilterState.ts
@@ -1,0 +1,187 @@
+import { useMemo, useState, type Dispatch, type SetStateAction } from "react";
+
+import type { ProjectLike } from "./useProjectKpis";
+
+export type ScopeOption = "recents" | "all";
+
+export type SortOption = "titleAsc" | "titleDesc" | "dateNewest" | "dateOldest";
+
+export type ProjectWithMeta = ProjectLike & {
+  _activity: number;
+  _created: number;
+};
+
+export type StatusOption = {
+  value: string;
+  label: string;
+};
+
+export type SortOptionDescriptor = {
+  value: SortOption;
+  label: string;
+};
+
+export const PROJECT_SORT_OPTIONS: SortOptionDescriptor[] = [
+  { value: "titleAsc", label: "Title (A-Z)" },
+  { value: "titleDesc", label: "Title (Z-A)" },
+  { value: "dateNewest", label: "Date (Newest)" },
+  { value: "dateOldest", label: "Date (Oldest)" },
+];
+
+export type UseProjectsFilterConfig = {
+  defaultScope?: ScopeOption;
+  defaultSort?: SortOption;
+  recentsLimit?: number;
+};
+
+export type UseProjectsFilterState = {
+  scope: ScopeOption;
+  setScope: Dispatch<SetStateAction<ScopeOption>>;
+  query: string;
+  setQuery: Dispatch<SetStateAction<string>>;
+  statusFilter: string;
+  setStatusFilter: Dispatch<SetStateAction<string>>;
+  sortOption: SortOption;
+  setSortOption: Dispatch<SetStateAction<SortOption>>;
+  statuses: string[];
+  statusOptions: StatusOption[];
+  sortOptions: SortOptionDescriptor[];
+  filteredProjects: ProjectWithMeta[];
+  visibleProjects: ProjectWithMeta[];
+};
+
+const getProjectActivityTs = (project: ProjectLike): number => {
+  const candidates: (string | undefined)[] = [
+    project.updatedAt,
+    project.dateUpdated,
+    project.lastModified,
+    project.date,
+    project.dateCreated,
+  ];
+
+  if (Array.isArray(project.timelineEvents)) {
+    for (const event of project.timelineEvents) {
+      if (event?.timestamp) candidates.push(event.timestamp);
+      if (event?.date) candidates.push(event.date);
+    }
+  }
+
+  const timestamps = candidates
+    .filter(Boolean)
+    .map((value) => new Date(value as string).getTime())
+    .filter((value) => Number.isFinite(value));
+
+  return timestamps.length ? Math.max(...timestamps) : 0;
+};
+
+const mapProjectsWithMeta = (projects: ProjectLike[] = []): ProjectWithMeta[] =>
+  projects.map((project) => ({
+    ...(project as ProjectWithMeta),
+    _activity: getProjectActivityTs(project),
+    _created: new Date(project.dateCreated || project.date || 0).getTime() || 0,
+  }));
+
+export const useProjectsFilterState = (
+  projects: ProjectLike[] | undefined,
+  config: UseProjectsFilterConfig = {}
+): UseProjectsFilterState => {
+  const { defaultScope = "recents", defaultSort = "dateNewest", recentsLimit } = config;
+
+  const [scope, setScope] = useState<ScopeOption>(defaultScope);
+  const [query, setQuery] = useState<string>("");
+  const [statusFilter, setStatusFilter] = useState<string>("");
+  const [sortOption, setSortOption] = useState<SortOption>(defaultSort);
+
+  const statuses = useMemo(() => {
+    const source = Array.isArray(projects) ? projects : [];
+
+    try {
+      return Array.from(
+        new Set(
+          source
+            .map((project) => String(project.status || "").toLowerCase())
+            .filter(Boolean)
+        )
+      );
+    } catch {
+      return [] as string[];
+    }
+  }, [projects]);
+
+  const statusOptions = useMemo<StatusOption[]>(
+    () => [{ value: "", label: "All statuses" }, ...statuses.map((status) => ({ value: status, label: status }))],
+    [statuses]
+  );
+
+  const list = useMemo(
+    () => mapProjectsWithMeta(Array.isArray(projects) ? projects : []),
+    [projects]
+  );
+
+  const filteredProjects = useMemo(() => {
+    let ordered = list.slice();
+
+    if (scope === "recents") {
+      ordered.sort((a, b) => b._activity - a._activity);
+    }
+
+    const q = query.trim().toLowerCase();
+    if (q) {
+      ordered = ordered.filter((project) => (project.title || "").toLowerCase().includes(q));
+    }
+
+    if (statusFilter) {
+      ordered = ordered.filter(
+        (project) => String(project.status || "").toLowerCase() === statusFilter
+      );
+    }
+
+    const byTitle = (a: ProjectLike, b: ProjectLike) =>
+      (a.title || "").localeCompare(b.title || "", undefined, { sensitivity: "base" });
+    const byCreated = (a: ProjectWithMeta, b: ProjectWithMeta) => b._created - a._created;
+    const byCreatedAsc = (a: ProjectWithMeta, b: ProjectWithMeta) => a._created - b._created;
+
+    switch (sortOption) {
+      case "titleAsc":
+        ordered.sort(byTitle);
+        break;
+      case "titleDesc":
+        ordered.sort((a, b) => -byTitle(a, b));
+        break;
+      case "dateOldest":
+        ordered.sort(byCreatedAsc);
+        break;
+      case "dateNewest":
+      default:
+        ordered.sort(byCreated);
+        break;
+    }
+
+    return ordered;
+  }, [list, scope, query, statusFilter, sortOption]);
+
+  const visibleProjects = useMemo(() => {
+    if (scope === "recents" && typeof recentsLimit === "number") {
+      return filteredProjects.slice(0, recentsLimit);
+    }
+    return filteredProjects;
+  }, [filteredProjects, scope, recentsLimit]);
+
+  return {
+    scope,
+    setScope,
+    query,
+    setQuery,
+    statusFilter,
+    setStatusFilter,
+    sortOption,
+    setSortOption,
+    statuses,
+    statusOptions,
+    sortOptions: PROJECT_SORT_OPTIONS,
+    filteredProjects,
+    visibleProjects,
+  };
+};
+
+export default useProjectsFilterState;

--- a/frontend/src/features/projects/ProjectsPanelDesktop.tsx
+++ b/frontend/src/features/projects/ProjectsPanelDesktop.tsx
@@ -11,6 +11,10 @@ import { CalendarDays, ChevronDown, Search } from "lucide-react";
 import { useData } from "@/app/contexts/useData";
 import type { UserLite } from "@/app/contexts/DataProvider";
 import { useProjectKpis, type ProjectLike } from "@/features/dashboard/hooks/useProjectKpis";
+import useProjectsFilterState, {
+  type ProjectWithMeta,
+  type SortOption,
+} from "@/features/dashboard/hooks/useProjectsFilterState";
 import SVGThumbnail from "@/features/dashboard/components/SvgThumbnail";
 import { getFileUrl } from "@/shared/utils/api";
 import desktopStyles from "./ProjectsPanelDesktop.module.css";
@@ -25,11 +29,7 @@ export type ProjectsPanelDesktopProps = {
   onOpenProject?: (projectId: string) => void;
 };
 
-type SortOption = "titleAsc" | "titleDesc" | "dateNewest" | "dateOldest";
-
-type ProjectWithMeta = ProjectLike & {
-  _activity: number;
-  _created: number;
+type DesktopProject = ProjectWithMeta & {
   team?: Array<{ userId?: string; firstName?: string; lastName?: string; email?: string }>;
   unreadCount?: number;
 };
@@ -39,27 +39,6 @@ const formatShortDate = (iso?: string): string | undefined => {
   const d = new Date(iso);
   if (Number.isNaN(d.getTime())) return undefined;
   return d.toLocaleString(undefined, { month: "short", day: "numeric" });
-};
-
-const getProjectActivityTs = (p: ProjectLike): number => {
-  const candidates: (string | undefined)[] = [
-    p.updatedAt,
-    p.dateUpdated,
-    p.lastModified,
-    p.date,
-    p.dateCreated,
-  ];
-  if (Array.isArray(p.timelineEvents)) {
-    for (const ev of p.timelineEvents) {
-      if (ev?.timestamp) candidates.push(ev.timestamp);
-      if (ev?.date) candidates.push(ev.date);
-    }
-  }
-  const timestamps = candidates
-    .filter(Boolean)
-    .map((s) => new Date(s as string).getTime())
-    .filter((n) => Number.isFinite(n));
-  return timestamps.length ? Math.max(...timestamps) : 0;
 };
 
 function sanitizeId(raw: string) {
@@ -96,10 +75,22 @@ const ProjectsPanelDesktop: React.FC<ProjectsPanelDesktopProps> = ({ onOpenProje
     `projects-sort-${sanitizeId(Math.random().toString(36).slice(2))}`
   );
 
-  const [sortOption, setSortOption] = useState<SortOption>("dateNewest");
-  const [statusFilter, setStatusFilter] = useState<string>("");
-  const [query, setQuery] = useState<string>("");
-  const [scope, setScope] = useState<"recents" | "all">("recents");
+  const {
+    scope,
+    setScope,
+    query,
+    setQuery,
+    statusFilter,
+    setStatusFilter,
+    sortOption,
+    setSortOption,
+    statuses,
+    statusOptions,
+    sortOptions,
+    visibleProjects,
+  } = useProjectsFilterState(projects as ProjectLike[], {
+    recentsLimit: DEFAULT_DESKTOP_ROWS,
+  });
   const [statusDropdownOpen, setStatusDropdownOpen] = useState(false);
   const [statusHighlightIndex, setStatusHighlightIndex] = useState<number>(-1);
   const [sortDropdownOpen, setSortDropdownOpen] = useState(false);
@@ -189,25 +180,6 @@ const ProjectsPanelDesktop: React.FC<ProjectsPanelDesktopProps> = ({ onOpenProje
     }
   }, [filtersOpen]);
 
-  const statuses = useMemo(() => {
-    try {
-      return Array.from(
-        new Set(
-          projects
-            .map((p) => String(p.status || "").toLowerCase())
-            .filter(Boolean)
-        )
-      );
-    } catch {
-      return [] as string[];
-    }
-  }, [projects]);
-
-  const statusOptions = useMemo(
-    () => [{ value: "", label: "All statuses" }, ...statuses.map((s) => ({ value: s, label: s }))],
-    [statuses]
-  );
-
   useEffect(() => {
     if (!statusDropdownOpen) {
       setStatusHighlightIndex(-1);
@@ -218,16 +190,6 @@ const ProjectsPanelDesktop: React.FC<ProjectsPanelDesktopProps> = ({ onOpenProje
     setStatusHighlightIndex(selectedIndex >= 0 ? selectedIndex : 0);
   }, [statusDropdownOpen, statusFilter, statusOptions]);
 
-  const sortOptions = useMemo(
-    () => [
-      { value: "titleAsc" as SortOption, label: "Title (A-Z)" },
-      { value: "titleDesc" as SortOption, label: "Title (Z-A)" },
-      { value: "dateNewest" as SortOption, label: "Date (Newest)" },
-      { value: "dateOldest" as SortOption, label: "Date (Oldest)" },
-    ],
-    []
-  );
-
   useEffect(() => {
     if (!sortDropdownOpen) {
       setSortHighlightIndex(-1);
@@ -237,57 +199,6 @@ const ProjectsPanelDesktop: React.FC<ProjectsPanelDesktopProps> = ({ onOpenProje
     const selectedIndex = sortOptions.findIndex((opt) => opt.value === sortOption);
     setSortHighlightIndex(selectedIndex >= 0 ? selectedIndex : 0);
   }, [sortDropdownOpen, sortOption, sortOptions]);
-
-  const items = useMemo(() => {
-    const list: ProjectWithMeta[] = (projects as ProjectLike[]).map((p) => ({
-      ...(p as ProjectWithMeta),
-      _activity: getProjectActivityTs(p),
-      _created: new Date(p.dateCreated || p.date || 0).getTime() || 0,
-    }));
-
-    let ordered = list.slice();
-    if (scope === "recents") {
-      ordered.sort((a, b) => b._activity - a._activity);
-    }
-
-    const q = query.trim().toLowerCase();
-    if (q) {
-      ordered = ordered.filter((p) => (p.title || "").toLowerCase().includes(q));
-    }
-    if (statusFilter) {
-      ordered = ordered.filter(
-        (p) => String(p.status || "").toLowerCase() === statusFilter
-      );
-    }
-
-    const byTitle = (a: ProjectLike, b: ProjectLike) =>
-      (a.title || "").localeCompare(b.title || "", undefined, {
-        sensitivity: "base",
-      });
-    const byCreated = (a: ProjectWithMeta, b: ProjectWithMeta) => b._created - a._created;
-    const byCreatedAsc = (a: ProjectWithMeta, b: ProjectWithMeta) => a._created - b._created;
-
-    switch (sortOption) {
-      case "titleAsc":
-        ordered.sort(byTitle);
-        break;
-      case "titleDesc":
-        ordered.sort((a, b) => -byTitle(a, b));
-        break;
-      case "dateOldest":
-        ordered.sort(byCreatedAsc);
-        break;
-      case "dateNewest":
-      default:
-        ordered.sort(byCreated);
-        break;
-    }
-
-    if (scope === "recents") {
-      return ordered.slice(0, DEFAULT_DESKTOP_ROWS);
-    }
-    return ordered;
-  }, [projects, scope, query, statusFilter, sortOption]);
 
   const kpis = useProjectKpis(projects as ProjectLike[]);
 
@@ -500,7 +411,7 @@ const ProjectsPanelDesktop: React.FC<ProjectsPanelDesktopProps> = ({ onOpenProje
     }
   };
 
-  const getOwnerName = (project: ProjectWithMeta): string => {
+  const getOwnerName = (project: DesktopProject): string => {
     const team = Array.isArray(project.team) ? project.team : [];
     if (team.length === 0) return "—";
     const primary = team[0];
@@ -558,13 +469,16 @@ const ProjectsPanelDesktop: React.FC<ProjectsPanelDesktopProps> = ({ onOpenProje
     );
   };
 
-  const tableRows = items.map((p) => {
+  const tableRows = visibleProjects.map((project) => {
+    const p = project as DesktopProject;
     const id = p.projectId;
     const title = (p.title || "Untitled project").trim();
     const thumb = Array.isArray(p.thumbnails) && p.thumbnails[0] ? p.thumbnails[0] : undefined;
     const deadline = formatShortDate(p.finishline);
     const status = p.status ? String(p.status) : "—";
-    const unread = Number.isFinite(p.unreadCount as number) ? Number(p.unreadCount) : Number((p as { unreadCount?: number }).unreadCount ?? 0);
+    const unread = Number.isFinite(p.unreadCount as number)
+      ? Number(p.unreadCount)
+      : Number((p as { unreadCount?: number }).unreadCount ?? 0);
     const owner = getOwnerName(p);
 
     return (
@@ -622,7 +536,7 @@ const ProjectsPanelDesktop: React.FC<ProjectsPanelDesktopProps> = ({ onOpenProje
       <div className={desktopStyles.tableWrap}>
         {isLoading ? (
           <div className={desktopStyles.emptyState}>Loading projects…</div>
-        ) : items.length === 0 ? (
+        ) : visibleProjects.length === 0 ? (
           <div className={desktopStyles.emptyState}>No projects match filters.</div>
         ) : (
           <table className={desktopStyles.table} aria-label="Projects table">


### PR DESCRIPTION
## Summary
- add a reusable `useProjectsFilterState` hook that centralizes project scope/query/status/sort state and derived lists
- refactor desktop and dashboard project panels to consume the shared hook while keeping presentation-specific details

## Testing
- `npm run test` *(fails: snapshot mismatch in getSquirclePath asymmetric radii test)*

------
https://chatgpt.com/codex/tasks/task_e_68cb862ccf4483248310306c696c87f5