### PR TITLE
refactor: modularize project file manager

### DIFF
--- a/frontend/src/features/project/components/FileManager.tsx
+++ b/frontend/src/features/project/components/FileManager.tsx
@@ -1,92 +1,47 @@
-import React, {
-  useState,
-  useEffect,
-  useRef,
-  forwardRef,
-  useImperativeHandle,
-  useCallback,
-  useMemo,
-  useLayoutEffect,
-} from "react";
+import { forwardRef, useCallback, useImperativeHandle } from "react";
 import Modal from "../../../shared/ui/ModalWithStack";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import {
-  faDownload,
-  faTrash,
-  faCheck,
-  faUpload,
-  faXmark,
-  faList,
-  faThLarge,
-} from "@fortawesome/free-solid-svg-icons";
-import { uploadData, list } from "aws-amplify/storage";
-import { FileText, Download, Layout, Upload, PenTool } from "lucide-react";
-import { FaFilePdf, FaFileExcel, FaFileAlt, FaDraftingCompass, FaCube } from "react-icons/fa";
-import { SiAdobe, SiSvg, SiHtml5 } from "react-icons/si";
-import { notify, notifyLoading, updateNotification } from "../../../shared/ui/ToastNotifications";
 import ConfirmModal from "@/shared/ui/ConfirmModal";
-import { Message } from "@/app/contexts/DataProvider";
+import { FileText, Download, Layout, Upload as UploadIcon, PenTool } from "lucide-react";
 import { useData } from "@/app/contexts/useData";
 import { useSocket } from "@/app/contexts/useSocket";
-import {
-  API_BASE_URL,
-  ZIP_FILES_URL,
-  DELETE_FILE_FROM_S3_URL,
-  apiFetch,
-  getFileUrl,
-  normalizeFileUrl,
-  fileUrlsToKeys,
-} from "../../../shared/utils/api";
-import { normalizeMessage } from "../../../shared/utils/websocketUtils";
-import Spinner from "../../../shared/ui/Spinner";
 import styles from "./file-manager.module.css";
-import Dropdown from "./Dropdown";
-import pLimit from "../../../shared/utils/pLimit";
-import PDFPreview from "./PDFPreview";
+import FileManagerToolbar from "./FileManagerToolbar";
+import FileManagerContent from "./FileManagerContent";
+import FileManagerFooter from "./FileManagerFooter";
+import FilePreviewModal from "./FilePreviewModal";
+import { useFileManagerState } from "./hooks/useFileManagerState";
+import { useFileMessenger } from "./hooks/useFileMessenger";
+import { useFileTransfers } from "./hooks/useFileTransfers";
+import type { Message } from "@/app/contexts/DataProvider";
+import type { FileManagerProps, FileManagerRef, FolderOption } from "./fileManagerTypes";
 
-export interface FileManagerProps {
-  folder?: string;
-  displayName?: string;
-  style?: React.CSSProperties;
-  showTrigger?: boolean;
-  isOpen?: boolean;
-  onRequestClose?: () => void;
-}
-
-export interface FileItem {
-  fileName: string;
-  url: string;
-  lastModified?: number;
-  size?: number;
-  kind?: string;
-  [key: string]: unknown;
-}
-
-interface FolderOption {
-  key: string;
-  name: string;
-}
-
-type ViewMode = "grid" | "list";
-type SortOption = "name-asc" | "name-desc" | "date-asc" | "date-desc" | "kind-asc" | "kind-desc";
-type FilterValue = "all" | string;
-
-type Project = Record<string, unknown>;
-
-export interface FileManagerRef {
-  open: () => Promise<void> | void;
-  close: () => void;
-}
+export type { FileManagerProps, FileManagerRef, FileItem } from "./fileManagerTypes";
 
 if (typeof document !== "undefined") {
   Modal.setAppElement("#root");
 }
 
-const encodeS3Key = (key: string = "") =>
-  key
-    .split("/")
-    .map((segment) => encodeURIComponent(segment).replace(/\+/g, '%20'))
-    .join("/");
+const SYSTEM_FOLDERS: FolderOption[] = [
+  { key: "uploads", name: "User Files" },
+  { key: "drawings", name: "Drawings" },
+  { key: "invoices", name: "Documents" },
+  { key: "downloads", name: "Downloads" },
+];
+
+const getFolderIcon = (key: string, size = 24) => {
+  switch (key) {
+    case "uploads":
+      return <UploadIcon size={size} />;
+    case "invoices":
+      return <FileText size={size} />;
+    case "downloads":
+      return <Download size={size} />;
+    case "floorplans":
+      return <Layout size={size} />;
+    default:
+      return <PenTool size={size} />;
+  }
+};
 
 const FileManagerComponent = forwardRef<FileManagerRef, FileManagerProps>(
   (
@@ -111,721 +66,112 @@ const FileManagerComponent = forwardRef<FileManagerRef, FileManagerProps>(
     } = useData();
     const { ws } = useSocket() || {};
 
-    const [folderKey, setFolderKey] = useState<string>(folder);
-    const renderedName =
-      displayName || (folderKey.charAt(0).toUpperCase() + folderKey.slice(1));
-
-    const getFolderIcon = (key: string, size = 24) => {
-      switch (key) {
-        case "uploads":
-          return <Upload size={size} />;
-        case "invoices":
-          return <FileText size={size} />;
-        case "downloads":
-          return <Download size={size} />;
-        case "floorplans":
-          return <Layout size={size} />;
-        default:
-          return <PenTool size={size} />;
-      }
-    };
-
-    const getFileKind = (fileName: string | undefined): string => {
-      if (!fileName) return "";
-      const ext = fileName.split(".").pop()?.toLowerCase() || "";
-      if (["jpg", "jpeg", "png", "gif", "bmp", "webp"].includes(ext)) return "image";
-      if (ext === "pdf") return "pdf";
-      if (ext === "svg") return "svg";
-      if (["html", "htm"].includes(ext)) return "html";
-      if (ext === "txt") return "text";
-      if (["xls", "xlsx", "csv"].includes(ext)) return "spreadsheet";
-      if (["dwg", "vwx"].includes(ext)) return "drawing";
-      if (["c4d", "obj"].includes(ext)) return "model";
-      if (["ai", "afdesign"].includes(ext)) return "adobe";
-      return ext;
-    };
-
     const canUpload = isAdmin || isBuilder || isDesigner || folder === "uploads";
     const canDelete = isAdmin || isBuilder || isDesigner;
 
-    const systemFolders: FolderOption[] = [
-      { key: "uploads", name: "User Files" },
-      { key: "drawings", name: "Drawings" },
-      { key: "invoices", name: "Documents" },
-      { key: "downloads", name: "Downloads" },
-    ];
+    const state = useFileManagerState({
+      folder,
+      displayName,
+      isOpen,
+      onRequestClose,
+      activeProject,
+    });
 
-    const fileInputRef = useRef<HTMLInputElement>(null);
-    const [isLoading, setIsLoading] = useState<boolean>(false);
-    const [localActiveProject, setLocalActiveProject] = useState<Project>(activeProject || {});
-    const [isFilesModalOpen, setFilesModalOpen] = useState<boolean>(false);
-    const [selectedFiles, setSelectedFiles] = useState<FileItem[]>([]);
-    const [isImageModalOpen, setImageModalOpen] = useState<boolean>(false);
-    const [selectedImage, setSelectedImage] = useState<string | null>(null);
-    const [selectedItems, setSelectedItems] = useState<Set<string>>(new Set());
-    const [isSelectMode, setIsSelectMode] = useState<boolean>(false);
-    const [currentIndex, setCurrentIndex] = useState<number | null>(null);
-    const [isConfirmingDelete, setIsConfirmingDelete] = useState<boolean>(false);
-    const [isDragging, setIsDragging] = useState<boolean>(false);
-    const [searchTerm, setSearchTerm] = useState<string>("");
-    const [viewMode, setViewMode] = useState<ViewMode>(() =>
-      typeof window !== "undefined"
-        ? ((localStorage.getItem("fileManagerViewMode") as ViewMode) || "grid")
-        : "grid"
-    );
-    const [sortOption, setSortOption] = useState<SortOption>("name-asc");
-    const [filterOption, setFilterOption] = useState<FilterValue>("all");
+    const {
+      fileInputRef,
+      scrollerRef,
+      folderKey,
+      setFolderKey,
+      renderedName,
+      setSelectedFiles,
+      isFilesModalOpen,
+      setFilesModalOpen,
+      closeFilesModal,
+      isImageModalOpen,
+      selectedImage,
+      currentIndex,
+      selectedItems,
+      setSelectedItems,
+      isSelectMode,
+      setIsSelectMode,
+      toggleSelectMode,
+      isConfirmingDelete,
+      setIsConfirmingDelete,
+      isDragging,
+      setIsDragging,
+      isLoading,
+      setIsLoading,
+      searchTerm,
+      setSearchTerm,
+      viewMode,
+      toggleViewMode,
+      layoutIconToUse,
+      sortOption,
+      setSortOption,
+      filterOption,
+      setFilterOption,
+      filterOptionsList,
+      displayedFiles,
+      handleSelectionChange,
+      handleSelectAll,
+      isSelected,
+      handleFileClick,
+      closeImageModal,
+      selectedFilesCount,
+      localActiveProject,
+      setLocalActiveProject,
+      handleTouchStart,
+      handleTouchMove,
+      handleTouchEnd,
+      sortOptionsList,
+    } = state;
 
-    const uploadQueue = useMemo(() => pLimit(3), []);
-    const editQueue = useMemo(() => pLimit(1), []);
+    const { removeReferences } = useFileMessenger({
+      activeProject: activeProject || {},
+      localActiveProject,
+      setLocalActiveProject,
+      projectMessages: projectMessages as Record<string, Message[]>,
+      setProjectMessages,
+      user,
+      ws,
+    });
 
-    const pendingUpdateRef = useRef<Array<{ fileName: string; url: string }> | null>(null);
-    const updateTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-    const scrollerRef = useRef<HTMLDivElement | null>(null);
+    const {
+      loadFiles,
+      handleFileSelect,
+      handleDragOver,
+      handleDragLeave,
+      handleDrop,
+      handleBulkDownload,
+      handleDelete,
+      performDelete,
+      handleDeleteSingle,
+      handleDownloadSingle,
+    } = useFileTransfers({
+      activeProject: activeProject || {},
+      folderKey,
+      selectedItems,
+      setSelectedFiles,
+      setSelectedItems,
+      setIsSelectMode,
+      setIsLoading,
+      setIsConfirmingDelete,
+      setIsDragging,
+      setLocalActiveProject,
+      removeReferences,
+      projectMessages: projectMessages as Record<string, Message[]>,
+      canDelete,
+    });
 
-    useEffect(() => {
-      return () => {
-        selectedFiles.forEach((f) => {
-          if (f.url && f.url.startsWith("blob:")) {
-            URL.revokeObjectURL(f.url);
-          }
-        });
-      };
-    }, [selectedFiles]);
-
-    useLayoutEffect(() => {
-      const y = sessionStorage.getItem("files.scrollY");
-      if (y && scrollerRef.current) scrollerRef.current.scrollTop = +y;
-    }, []);
-
-    useEffect(() => {
-      const el = scrollerRef.current;
-      const onScroll = () =>
-        sessionStorage.setItem("files.scrollY", String(el?.scrollTop ?? 0));
-      el?.addEventListener("scroll", onScroll);
-      return () => el?.removeEventListener("scroll", onScroll);
-    }, []);
-
-    const kindOptions = useMemo(() => {
-      const kinds = new Set(selectedFiles.map((f) => f.kind));
-      return Array.from(kinds).sort();
-    }, [selectedFiles]);
-
-    const filterOptionsList = useMemo(
-      () => [
-        { value: "all", label: "All types" },
-        ...kindOptions.map((kind) => ({
-          value: kind,
-          label: kind ? kind.charAt(0).toUpperCase() + kind.slice(1) : "Unknown",
-        })),
-      ],
-      [kindOptions]
-    );
-
-    const sortOptionsList: Array<{ value: SortOption; label: string }> = [
-      { value: "name-asc", label: "Name (A-Z)" },
-      { value: "name-desc", label: "Name (Z-A)" },
-      { value: "date-desc", label: "Newest" },
-      { value: "date-asc", label: "Oldest" },
-      { value: "kind-asc", label: "Type (A-Z)" },
-      { value: "kind-desc", label: "Type (Z-A)" },
-    ];
-
-    const sortFiles = useCallback(
-      (files: FileItem[]) => {
-        return [...files].sort((a, b) => {
-          switch (sortOption) {
-            case "name-desc":
-              return a.fileName.localeCompare(b.fileName) * -1;
-            case "date-asc":
-              return (a.lastModified || 0) - (b.lastModified || 0);
-            case "date-desc":
-              return (b.lastModified || 0) - (a.lastModified || 0);
-            case "kind-asc":
-              return (a.kind || "").localeCompare(b.kind || "");
-            case "kind-desc":
-              return (b.kind || "").localeCompare(a.kind || "");
-            case "name-asc":
-            default:
-              return a.fileName.localeCompare(b.fileName);
-          }
-        });
-      },
-      [sortOption]
-    );
-
-    const displayedFiles = useMemo(() => {
-      const filtered = selectedFiles.filter(
-        (f) =>
-          f.fileName.toLowerCase().includes(searchTerm.toLowerCase()) &&
-          (filterOption === "all" || f.kind === filterOption)
-      );
-      return sortFiles(filtered);
-    }, [selectedFiles, searchTerm, filterOption, sortFiles]);
-
-    const apiGatewayEndpoint = ZIP_FILES_URL;
-    const apiDeleteEndpoint = DELETE_FILE_FROM_S3_URL;
-
-    const getThumbnailUrl = (url: string, key: string) =>
-      url.replace(`/${key}/`, `/${key}_thumbnails/`);
-
-    const normalizeFiles = (files: FileItem[] = []) =>
-      files.map((f) => ({
-        ...f,
-        lastModified: f.lastModified ? new Date(f.lastModified).getTime() : 0,
-        kind: getFileKind(f.fileName),
-      }));
-
-    // Swipe navigation
-    const [touchStartX, setTouchStartX] = useState(0);
-    const [touchEndX, setTouchEndX] = useState(0);
-    const SWIPE_THRESHOLD = 50;
-
-    const handleTouchStart = (e: React.TouchEvent) => setTouchStartX(e.touches[0].clientX);
-    const handleTouchMove = (e: React.TouchEvent) => setTouchEndX(e.touches[0].clientX);
-    const handleTouchEnd = () => {
-      if (touchStartX - touchEndX > SWIPE_THRESHOLD) handleNextImage();
-      else if (touchEndX - touchStartX > SWIPE_THRESHOLD) handlePrevImage();
-    };
-
-    const openFilesModal = async () => {
-      setIsLoading(true);
+    const openFilesModal = useCallback(async () => {
       setFilesModalOpen(true);
-      const files = await fetchS3Files();
-      if (!files.length) {
-        setSelectedFiles(normalizeFiles((localActiveProject[folderKey] as FileItem[]) || []));
-      }
-      setIsLoading(false);
-    };
-
-    const closeFilesModal = useCallback(() => {
-      setFilesModalOpen(false);
-      onRequestClose?.();
-    }, [onRequestClose]);
-
-    useEffect(() => {
-      if (typeof isOpen === "boolean") {
-        if (isOpen) void openFilesModal();
-        else closeFilesModal();
-      }
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [isOpen]);
+      await loadFiles();
+    }, [loadFiles, setFilesModalOpen]);
 
     useImperativeHandle(ref, () => ({
       open: openFilesModal,
       close: closeFilesModal,
     }));
-
-    const closeImageModal = useCallback(() => setImageModalOpen(false), []);
-
-    const handleNextImage = useCallback(() => {
-      if (!displayedFiles.length || currentIndex === null) return;
-      const nextIndex = (currentIndex + 1) % displayedFiles.length;
-      setCurrentIndex(nextIndex);
-      setSelectedImage(displayedFiles[nextIndex].url);
-    }, [displayedFiles, currentIndex]);
-
-    const handlePrevImage = useCallback(() => {
-      if (!displayedFiles.length || currentIndex === null) return;
-      const prevIndex = (currentIndex - 1 + displayedFiles.length) % displayedFiles.length;
-      setCurrentIndex(prevIndex);
-      setSelectedImage(displayedFiles[prevIndex].url);
-    }, [displayedFiles, currentIndex]);
-
-    // Selection
-    const handleSelectionChange = (url: string) => {
-      const newSelected = new Set(selectedItems);
-      if (newSelected.has(url)) newSelected.delete(url);
-      else newSelected.add(url);
-      setSelectedItems(newSelected);
-    };
-
-    const handleSelectAll = () => {
-      if (selectedItems.size === selectedFiles.length) setSelectedItems(new Set());
-      else setSelectedItems(new Set(selectedFiles.map((u) => u.url)));
-    };
-
-    const isSelected = (url: string) => selectedItems.has(url);
-
-    const escapeRegExp = (str: string) => str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-
-    const removeReferences = async (urls: string[], messagesList: Message[]) => {
-      let description: string = (localActiveProject.description as string) || "";
-      let descChanged = false;
-
-      for (const url of urls) {
-        const regex = new RegExp(`<img[^>]*src=["']${escapeRegExp(url)}["'][^>]*>`, "g");
-        if (regex.test(description)) {
-          description = description.replace(regex, "");
-          descChanged = true;
-        }
-
-        const referencing = messagesList.filter(
-          (m) => (m.text && m.text.includes(url)) || ((m.file as { url?: string })?.url && (m.file as { url?: string }).url.includes(url))
-        );
-
-        for (const msg of referencing) {
-          if (msg.messageId) {
-            try {
-              // Update message via WebSocket
-              if (ws && ws.readyState === WebSocket.OPEN) {
-                const editPayload = {
-                  action: "editMessage",
-                  conversationType: "project",
-                  conversationId: `project#${activeProject.projectId}`,
-                  projectId: activeProject.projectId,
-                  messageId: msg.messageId,
-                  text: "File deleted.",
-                  timestamp: msg.timestamp,
-                  editedAt: new Date().toISOString(),
-                  editedBy: user.userId,
-                };
-                ws.send(JSON.stringify(normalizeMessage(editPayload, "editMessage")));
-              }
-
-              msg.text = "File deleted.";
-              delete msg.file;
-
-              setProjectMessages((prev: Record<string, Message[]>) => {
-                const msgs = Array.isArray(prev[activeProject.projectId])
-                  ? prev[activeProject.projectId]
-                  : [];
-                return {
-                  ...prev,
-                  [activeProject.projectId]: msgs.map((m) =>
-                    m.messageId === msg.messageId ? { ...m, text: "File deleted.", file: undefined } : m
-                  ),
-                };
-              });
-            } catch (err) {
-              console.error("Failed to strip file from message", err);
-            }
-          }
-        }
-      }
-
-      if (descChanged) {
-        try {
-          await apiFetch(`${API_BASE_URL}/editProject?projectId=${activeProject.projectId}`, {
-            method: "PUT",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ description }),
-          });
-          setLocalActiveProject((prev: Project) => ({ ...prev, description }));
-        } catch (err) {
-          console.error("Failed to update description", err);
-        }
-      }
-    };
-
-    const handleFileClick = (file: FileItem, index: number) => {
-      if (isSelectMode) {
-        handleSelectionChange(file.url);
-      } else {
-        const extension = file.fileName.split(".").pop()?.toLowerCase();
-        if (extension === "html") {
-          window.open(file.url, "_blank", "noopener,noreferrer");
-          return;
-        }
-        setCurrentIndex(index);
-        setSelectedImage(file.url);
-        setImageModalOpen(true);
-      }
-    };
-
-    const toggleSelectMode = () => {
-      setIsSelectMode((s) => !s);
-      if (isSelectMode) setSelectedItems(new Set());
-    };
-
-    const toggleViewMode = () => {
-      const newMode: ViewMode = viewMode === "grid" ? "list" : "grid";
-      setViewMode(newMode);
-      if (typeof window !== "undefined") {
-        localStorage.setItem("fileManagerViewMode", newMode);
-      }
-    };
-
-    const confirmDeletion = () => setIsConfirmingDelete(true);
-
-    const handleDelete = () => {
-      if (!(isAdmin || isBuilder || isDesigner)) {
-        notify("error", "Only authorized users can delete files.");
-        return;
-      }
-      confirmDeletion();
-    };
-
-    const performDelete = async () => {
-      const fileUrlsToDelete = Array.from(selectedItems);
-      const fileKeysToDelete = fileUrlsToKeys(fileUrlsToDelete);
-      setIsConfirmingDelete(false);
-
-      const messages = projectMessages[activeProject.projectId] || [];
-      await removeReferences(fileUrlsToDelete, messages);
-
-      const notificationId = notifyLoading("Deleting files...");
-      try {
-        await apiFetch(apiDeleteEndpoint, {
-          method: "POST",
-          body: JSON.stringify({
-            projectId: activeProject.projectId,
-            field: folderKey,
-            fileKeys: fileKeysToDelete,
-          }),
-          headers: { "Content-Type": "application/json" },
-        });
-
-        let remaining: FileItem[] = [];
-        setSelectedFiles((prev) => {
-          remaining = prev.filter((u) => !fileUrlsToDelete.includes(u.url));
-          return remaining;
-        });
-
-        if (folderKey !== "uploads") {
-          setLocalActiveProject((prev: Project) => ({ ...prev, [folderKey]: remaining }));
-        }
-        scheduleFolderUpdate(remaining.map((u) => ({ fileName: u.fileName, url: u.url })));
-
-        setSelectedItems(new Set());
-        setIsSelectMode(false);
-        updateNotification(notificationId, "success", "Files deleted successfully");
-      } catch (error) {
-        console.error("Error during deletion:", error);
-        updateNotification(notificationId, "error", "Failed to delete selected files. Please try again.");
-      }
-    };
-
-    const handleBulkDownload = async () => {
-      const fileUrls = Array.from(selectedItems);
-      if (fileUrls.length === 0) {
-        notify("warning", "No files selected for download.");
-        return;
-      }
-      const notificationId = notifyLoading("Preparing archive...");
-      try {
-        const zipFileUrl = await getZippedFiles(fileUrls);
-        updateNotification(notificationId, "success", "Archive ready! Downloading now...");
-        initiateDownload(zipFileUrl);
-        setSelectedItems(new Set());
-        setIsSelectMode(false);
-      } catch (error) {
-        console.error("Error during bulk download:", error);
-        updateNotification(notificationId, "error", "Failed to prepare archive. Try again.");
-      }
-    };
-
-    const initiateDownload = (url: string) => {
-      const link = document.createElement("a");
-      link.href = url;
-      link.download = "";
-      document.body.appendChild(link);
-      link.click();
-      link.remove();
-    };
-
-    const handleDeleteSingle = (url: string) => {
-      setSelectedItems(new Set([url]));
-      handleDelete();
-    };
-
-    const handleDownloadSingle = (url: string) => {
-      initiateDownload(url);
-    };
-
-    const getZippedFiles = async (fileUrls: string[]): Promise<string> => {
-      try {
-        const fileKeys = fileUrlsToKeys(fileUrls);
-
-        const response = await apiFetch<{ zipFileUrl: string }>(apiGatewayEndpoint, {
-          method: "POST",
-          body: JSON.stringify({ fileKeys }),
-          headers: { "Content-Type": "application/json" },
-        });
-        // Since apiFetch parses JSON and throws on error, response should be the data
-        return response.zipFileUrl;
-      } catch (error) {
-        console.error("Error getting zipped files:", error);
-        throw error;
-      }
-    };
-
-    const uploadFiles = async (files: File[]) => {
-      setIsLoading(true);
-      if (!files.length) {
-        setIsLoading(false);
-        return;
-      }
-      const notificationId = notifyLoading("Uploading files...");
-
-      const placeholders: (FileItem | null)[] = files.map((file) => ({
-        fileName: file.name,
-        url: URL.createObjectURL(file),
-        lastModified: file.lastModified || Date.now(),
-        kind: getFileKind(file.name),
-      }));
-
-      // optimistic placeholders
-      setSelectedFiles((prev) => [...prev, ...(placeholders as FileItem[])]);
-
-      await Promise.all(
-        files.map((file, idx) =>
-          handleFileUpload(activeProject.projectId, file)
-            .then((info) => {
-              const oldUrl = placeholders[idx]!.url;
-              placeholders[idx]!.url = info.url;
-              if (oldUrl.startsWith("blob:")) URL.revokeObjectURL(oldUrl);
-            })
-            .catch((error) => {
-              console.error("Upload failed:", error);
-              notify("error", `Upload failed for ${file.name}`);
-              const oldUrl = placeholders[idx]?.url;
-              if (oldUrl && oldUrl.startsWith("blob:")) URL.revokeObjectURL(oldUrl);
-              placeholders[idx] = null;
-            })
-        )
-      );
-
-      const completed = placeholders.filter(Boolean) as FileItem[];
-
-      let finalFiles: FileItem[] = [];
-      setSelectedFiles((prev) => {
-        const names = new Set(placeholders.map((p) => p?.fileName).filter(Boolean) as string[]);
-        finalFiles = [...prev.filter((f) => !names.has(f.fileName)), ...completed];
-        return finalFiles;
-      });
-
-      if (folderKey !== "uploads") {
-        setLocalActiveProject((prev: Project) => ({ ...prev, [folderKey]: finalFiles }));
-      }
-
-      updateNotification(notificationId, "success", "Files uploaded successfully");
-
-      if (folderKey !== "uploads") {
-        const payload = finalFiles.map((f) => ({ fileName: f.fileName, url: f.url }));
-        try {
-          await updateFolderFiles(activeProject.projectId, payload);
-        } catch (error) {
-          console.error("Error updating file metadata:", error);
-          notify("warning", "Files uploaded but metadata update failed");
-        }
-      }
-      setIsLoading(false);
-    };
-
-    const handleFileSelect: React.ChangeEventHandler<HTMLInputElement> = async (event) => {
-      const files = Array.from(event.target.files || []);
-      await uploadFiles(files);
-      event.target.value = "";
-    };
-
-    const handleDragOver = (event: React.DragEvent<HTMLDivElement>) => {
-      event.preventDefault();
-      setIsDragging(true);
-    };
-
-    const handleDragLeave = (event: React.DragEvent<HTMLDivElement>) => {
-      event.preventDefault();
-      setIsDragging(false);
-    };
-
-    const handleDrop = async (event: React.DragEvent<HTMLDivElement>) => {
-      event.preventDefault();
-      setIsDragging(false);
-      const files = Array.from(event.dataTransfer.files || []);
-      await uploadFiles(files);
-      if (folderKey === "uploads") {
-        await fetchS3Files();
-      }
-    };
-
-    const handleFileUpload = (projectId: string, file: File) =>
-      uploadQueue(async () => {
-        const filename = `projects/${projectId}/${folderKey}/${file.name}`;
-        try {
-          await uploadData({
-            key: filename,
-            data: file,
-            options: { accessLevel: "guest" },
-          });
-          // small delay for edge consistency
-          await new Promise((resolve) => setTimeout(resolve, 2000));
-          const fileUrl = getFileUrl(encodeS3Key(filename));
-          return { fileName: file.name, url: fileUrl };
-        } catch (error) {
-          console.error("Error uploading file:", error);
-          notify("error", `Error uploading ${file.name}`);
-          throw error;
-        }
-      });
-
-    const updateFolderFiles = useCallback(
-      (projectId: string, updatedFiles: Array<{ fileName: string; url: string }>) =>
-        editQueue(async () => {
-          const apiUrl = `${API_BASE_URL}/editProject?projectId=${projectId}`;
-          const payload: Record<string, unknown> = { [folderKey]: updatedFiles };
-          const response = await apiFetch<{ success?: boolean }>(apiUrl, {
-            method: "PUT",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify(payload),
-          });
-          // Since apiFetch throws on error, success means we got here
-          console.log("Update successful:", response);
-        }),
-      [folderKey, editQueue]
-    );
-
-    const scheduleFolderUpdate = useCallback(
-      (filesPayload: Array<{ fileName: string; url: string }>) => {
-        if (folderKey === "uploads") return;
-        pendingUpdateRef.current = filesPayload;
-
-        if (updateTimeoutRef.current) clearTimeout(updateTimeoutRef.current);
-        updateTimeoutRef.current = setTimeout(() => {
-          const pending = pendingUpdateRef.current;
-          pendingUpdateRef.current = null;
-          if (pending) {
-            updateFolderFiles(activeProject.projectId, pending).catch((err: unknown) =>
-              console.error("Error updating files:", err)
-            );
-          }
-        }, 500);
-      },
-      [folderKey, activeProject?.projectId, updateFolderFiles]
-    );
-
-    useEffect(
-      () => () => {
-        if (updateTimeoutRef.current) clearTimeout(updateTimeoutRef.current);
-      },
-      []
-    );
-
-    const renderFilePreview = (file: FileItem) => {
-      const extension = file.fileName.split(".").pop()?.toLowerCase();
-      if (!extension) return <FaFileAlt size={50} color="blue" />;
-
-      if (["jpg", "jpeg", "png"].includes(extension)) {
-        const thumbUrl = getThumbnailUrl(file.url, folderKey);
-        return (
-          <img
-            src={getFileUrl(fileUrlsToKeys([thumbUrl])[0])}
-            alt={file.fileName}
-            className={styles.previewImage}
-            onError={(e) => {
-              (e.target as HTMLImageElement).src = file.url;
-            }}
-            loading="lazy"
-          />
-        );
-      }
-      if (extension === "pdf") return <FaFilePdf size={50} color="red" />;
-      if (extension === "svg") return <SiSvg size={50} color="purple" />;
-      if (extension === "html") return <SiHtml5 size={50} color="orange" />;
-      if (extension === "txt") return <FaFileAlt size={50} color="gray" />;
-      if (["xls", "xlsx", "csv"].includes(extension)) return <FaFileExcel size={50} color="green" />;
-      if (["dwg", "vwx"].includes(extension)) return <FaDraftingCompass size={50} color="brown" />;
-      if (["c4d", "obj"].includes(extension)) return <FaCube size={50} color="purple" />;
-      if (["ai", "afdesign"].includes(extension)) return <SiAdobe size={50} color="orange" />;
-
-      return <FaFileAlt size={50} color="blue" />;
-    };
-
-    const truncateFileName = (fileName?: string, maxLength = 12) => {
-      if (!fileName) return "";
-      const parts = fileName.split(".");
-      if (parts.length < 2) return fileName;
-      const extension = parts.pop()!;
-      const baseName = parts.join(".");
-      if (baseName.length <= maxLength) return `${baseName}.${extension}`;
-      return `${baseName.substring(0, maxLength)}(..).${extension}`;
-    };
-
-    const fetchS3Files = async (): Promise<FileItem[]> => {
-      if (!activeProject?.projectId) return [];
-      const prefixes =
-        folderKey === "uploads"
-          ? ["uploads/", "lexical/", "chat_uploads/"].map(
-              (dir) => `projects/${activeProject.projectId}/${dir}`
-            )
-          : [`projects/${activeProject.projectId}/${folderKey}/`];
-
-      try {
-        setIsLoading(true);
-        const lists = await Promise.all(
-          prefixes.map((prefix) => list({ prefix, options: { accessLevel: "guest" } }))
-        );
-
-        const files: FileItem[] = lists
-          .flatMap((res: { items?: unknown[] }) => res?.items || [])
-          .filter((item: unknown) => (item as { key?: string }).key && !(item as { key?: string }).key!.endsWith("/"))
-          .map((item: unknown) => {
-            const key = (item as { key: string }).key;
-            const name: string = key.split("/").pop()!;
-            // Add public/ prefix since files are stored in public/ but Amplify keys don't include it
-            const fullKey = key.startsWith('public/') ? key : `public/${key}`;
-            const url = getFileUrl(encodeS3Key(fullKey));
-            return {
-              fileName: name,
-              url: normalizeFileUrl(url),
-              lastModified: (item as { lastModified?: string | Date }).lastModified ? new Date((item as { lastModified?: string | Date }).lastModified!).getTime() : 0,
-              kind: getFileKind(name),
-            };
-          });
-
-        // dedupe by url
-        const merged = Array.from(new Map(files.map((f) => [f.url, f])).values());
-        setSelectedFiles(merged);
-        return merged;
-      } catch (err) {
-        console.error("Error listing S3 files:", err);
-        notify("warning", "Could not load files from storage.");
-        return [];
-      } finally {
-        setIsLoading(false);
-      }
-    };
-
-    useEffect(() => {
-      setLocalActiveProject(activeProject || {});
-    }, [activeProject]);
-
-    useEffect(() => {
-      const load = async () => {
-        const files = await fetchS3Files();
-        if (!files.length) {
-          const rawFiles = activeProject?.[folderKey] as FileItem[] || [];
-          setSelectedFiles(normalizeFiles(rawFiles));
-        }
-      };
-      void load();
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [activeProject, folderKey]);
-
-    // Close with Escape
-    useEffect(() => {
-      const handleEscape = (e: KeyboardEvent) => {
-        if (e.key !== "Escape") return;
-        if (isImageModalOpen) closeImageModal();
-        else if (isFilesModalOpen) closeFilesModal();
-      };
-      window.addEventListener("keydown", handleEscape);
-      return () => window.removeEventListener("keydown", handleEscape);
-    }, [isFilesModalOpen, isImageModalOpen, closeFilesModal, closeImageModal]);
-
-    // Image modal keyboard nav
-    useEffect(() => {
-      const handleKeyDown = (e: KeyboardEvent) => {
-        if (!isImageModalOpen) return;
-        if (e.key === "ArrowRight") handleNextImage();
-        else if (e.key === "ArrowLeft") handlePrevImage();
-        else if (e.key === "Escape") closeImageModal();
-      };
-      window.addEventListener("keydown", handleKeyDown);
-      return () => window.removeEventListener("keydown", handleKeyDown);
-    }, [isImageModalOpen, currentIndex, selectedFiles, handleNextImage, handlePrevImage, closeImageModal]);
-
-    const layoutIconToUse = viewMode === "grid" ? faList : faThLarge;
 
     return (
       <>
@@ -861,228 +207,61 @@ const FileManagerComponent = forwardRef<FileManagerRef, FileManagerProps>(
           }}
           closeTimeoutMS={300}
         >
-          <div className={styles.modalHeader}>
-            <div className={styles.folderTabs}>
-              {systemFolders.map((f) => (
-                <button
-                  key={f.key}
-                  className={`${styles.tabButton} ${folderKey === f.key ? styles.activeTab : ""}`}
-                  onClick={() => setFolderKey(f.key)}
-                >
-                  {getFolderIcon(f.key, 16)} {f.name}
-                </button>
-              ))}
-            </div>
+          <FileManagerToolbar
+            folderKey={folderKey}
+            systemFolders={SYSTEM_FOLDERS}
+            onFolderChange={setFolderKey}
+            searchTerm={searchTerm}
+            onSearchChange={setSearchTerm}
+            filterOption={filterOption}
+            filterOptions={filterOptionsList}
+            onFilterChange={setFilterOption}
+            sortOption={sortOption}
+            sortOptions={sortOptionsList}
+            onSortChange={setSortOption}
+            onToggleView={toggleViewMode}
+            layoutIcon={layoutIconToUse}
+            onClose={closeFilesModal}
+            renderFolderIcon={getFolderIcon}
+          />
 
-            <div className={styles.actions}>
-              <input
-                type="text"
-                placeholder="Search"
-                value={searchTerm}
-                onChange={(e) => setSearchTerm(e.target.value)}
-                className={styles.searchInput}
-              />
-              <Dropdown
-                label="Filter files"
-                options={filterOptionsList}
-                value={filterOption}
-                onChange={(v: FilterValue) => setFilterOption(v)}
-              />
-              <Dropdown
-                label="Sort files"
-                options={sortOptionsList}
-                value={sortOption}
-                onChange={(v: SortOption) => setSortOption(v)}
-              />
-              <button className={styles.iconButton} onClick={toggleViewMode} aria-label="Toggle view">
-                <FontAwesomeIcon icon={layoutIconToUse} />
-              </button>
-              <button className={styles.iconButton} onClick={closeFilesModal} aria-label="Close">
-                <FontAwesomeIcon icon={faXmark} />
-              </button>
-            </div>
-          </div>
-
-          <div
-            ref={scrollerRef}
-            className={`${styles.modalContentInner} ${isDragging ? styles.dragging : ""}`}
+          <FileManagerContent
+            scrollerRef={scrollerRef}
+            isDragging={isDragging}
             onDragOver={handleDragOver}
             onDragLeave={handleDragLeave}
             onDrop={handleDrop}
-          >
-            {isDragging && <div className={styles.dragOverlay}>Drop files to upload</div>}
+            isLoading={isLoading}
+            displayedFiles={displayedFiles}
+            isSelectMode={isSelectMode}
+            onSelectAll={handleSelectAll}
+            selectedItems={selectedItems}
+            selectedFilesCount={selectedFilesCount}
+            viewMode={viewMode}
+            onFileClick={handleFileClick}
+            onSelectionChange={handleSelectionChange}
+            isSelected={isSelected}
+            onDownloadSingle={handleDownloadSingle}
+            onDeleteSingle={handleDeleteSingle}
+            canDelete={canDelete}
+            folderKey={folderKey}
+          />
 
-            {isLoading && (
-              <div className={styles.loadingOverlay}>
-                <Spinner style={{ position: "static" }} />
-                <div className={styles.loadingMessage}>Loading files…</div>
-              </div>
-            )}
-
-            {displayedFiles.length === 0 && !isLoading ? (
-              <div className={styles.emptyMessage}>
-                <Upload size={48} />
-                <span>No files yet.</span>
-              </div>
-            ) : (
-              <>
-                {isSelectMode && (
-                  <div>
-                    <input
-                      type="checkbox"
-                      checked={selectedItems.size === selectedFiles.length && selectedFiles.length > 0}
-                      onChange={handleSelectAll}
-                    />{" "}
-                    Select All
-                  </div>
-                )}
-
-                {viewMode === "grid" ? (
-                  <ul className={styles.fileGrid}>
-                    {displayedFiles.map((file, index) => (
-                      <li key={file.url} className={styles.fileItem}>
-                        <div
-                          onClick={() => {
-                            if (isSelectMode) handleSelectionChange(file.url);
-                            else handleFileClick(file, index);
-                          }}
-                          className={`${styles.filePreview} ${isSelectMode ? styles.clickable : ""}`}
-                        >
-                          {renderFilePreview(file)}
-
-                          {isSelectMode && (
-                            <div
-                              className={`${styles.selectionOverlay} ${
-                                isSelected(file.url) ? styles.selected : ""
-                              }`}
-                            >
-                              {isSelected(file.url) && (
-                                <FontAwesomeIcon icon={faCheck} className={styles.checkIcon} />
-                              )}
-                            </div>
-                          )}
-                        </div>
-                        <div className={styles.fileName} title={file.fileName}>
-                          {truncateFileName(file.fileName)}
-                        </div>
-                      </li>
-                    ))}
-                  </ul>
-                ) : (
-                  <table className={styles.fileTable}>
-                    <thead>
-                      <tr>
-                        <th>Name</th>
-                        <th>Actions</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {displayedFiles.map((file, index) => (
-                        <tr key={file.url}>
-                          <td onClick={() => handleFileClick(file, index)}>{file.fileName}</td>
-                          <td>
-                            <button
-                              className={styles.iconButton}
-                              onClick={() => handleDownloadSingle(file.url)}
-                              aria-label="Download file"
-                            >
-                              <FontAwesomeIcon icon={faDownload} />
-                            </button>
-                            {canDelete && (
-                              <button
-                                className={styles.iconButton}
-                                onClick={() => handleDeleteSingle(file.url)}
-                                aria-label="Delete file"
-                              >
-                                <FontAwesomeIcon icon={faTrash} />
-                              </button>
-                            )}
-                          </td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                )}
-              </>
-            )}
-          </div>
-
-          <div className={styles.modalFooter}>
-            {selectedFiles.length === 0 ? (
-              <>
-                {canUpload && (
-                  <>
-                    <input
-                      type="file"
-                      multiple
-                      onChange={handleFileSelect}
-                      ref={fileInputRef}
-                      className={styles.hiddenInput}
-                    />
-                    <button
-                      className={styles.iconButton}
-                      onClick={() => fileInputRef.current?.click()}
-                      aria-label="Upload files"
-                    >
-                      <FontAwesomeIcon icon={faUpload} /> Upload
-                    </button>
-                  </>
-                )}
-              </>
-            ) : isSelectMode ? (
-              <>
-                <button
-                  className={styles.iconButton}
-                  onClick={handleBulkDownload}
-                  aria-label="Download selected"
-                >
-                  <FontAwesomeIcon icon={faDownload} />
-                </button>
-                {canDelete && (
-                  <button className={styles.iconButton} onClick={handleDelete} aria-label="Delete selected">
-                    <FontAwesomeIcon icon={faTrash} />
-                  </button>
-                )}
-                <button
-                  className={styles.iconButton}
-                  onClick={() => setIsSelectMode(false)}
-                  aria-label="Cancel selection"
-                >
-                  <FontAwesomeIcon icon={faXmark} />
-                </button>
-              </>
-            ) : (
-              <>
-                {selectedFiles.length > 0 && (
-                  <button
-                    className={styles.iconButton}
-                    onClick={toggleSelectMode}
-                    aria-label="Select files"
-                  >
-                    <FontAwesomeIcon icon={faCheck} /> Select
-                  </button>
-                )}
-                {canUpload && (
-                  <>
-                    <input
-                      type="file"
-                      multiple
-                      onChange={handleFileSelect}
-                      ref={fileInputRef}
-                      className={styles.hiddenInput}
-                    />
-                    <button
-                      className={styles.iconButton}
-                      onClick={() => fileInputRef.current?.click()}
-                      aria-label="Upload files"
-                    >
-                      <FontAwesomeIcon icon={faUpload} /> Upload
-                    </button>
-                  </>
-                )}
-              </>
-            )}
-          </div>
+          <FileManagerFooter
+            selectedFilesCount={selectedFilesCount}
+            canUpload={canUpload}
+            canDelete={canDelete}
+            isSelectMode={isSelectMode}
+            fileInputRef={fileInputRef}
+            onFileSelect={handleFileSelect}
+            onToggleSelectMode={toggleSelectMode}
+            onBulkDownload={handleBulkDownload}
+            onDeleteSelected={handleDelete}
+            onCancelSelection={() => {
+              setIsSelectMode(false);
+              setSelectedItems(new Set());
+            }}
+          />
         </Modal>
 
         <ConfirmModal
@@ -1102,76 +281,21 @@ const FileManagerComponent = forwardRef<FileManagerRef, FileManagerProps>(
           }}
         />
 
-        <Modal
+        <FilePreviewModal
           isOpen={isImageModalOpen}
           onRequestClose={closeImageModal}
-          contentLabel="Image Preview Modal"
-          className={{
-            base: styles.imageModalContent,
-            afterOpen: styles.imageModalContentAfterOpen,
-            beforeClose: styles.imageModalContentBeforeClose,
-          }}
-          overlayClassName={{
-            base: styles.imageModalOverlay,
-            afterOpen: styles.imageModalOverlayAfterOpen,
-            beforeClose: styles.imageModalOverlayBeforeClose,
-          }}
-          closeTimeoutMS={300}
-        >
-          {selectedImage && currentIndex !== null && displayedFiles[currentIndex] && (
-            <div
-              className={styles.imageWrapper}
-              onTouchStart={handleTouchStart}
-              onTouchMove={handleTouchMove}
-              onTouchEnd={handleTouchEnd}
-            >
-              {(() => {
-                const ext = displayedFiles[currentIndex].fileName.split(".").pop()?.toLowerCase();
-                if (ext && ["jpg", "jpeg", "png"].includes(ext)) {
-                  return (
-                    <img
-                      src={selectedImage ? getFileUrl(fileUrlsToKeys([selectedImage])[0]) : ''}
-                      alt="Selected"
-                      onError={(e) => {
-                        (e.target as HTMLImageElement).src = selectedImage || '';
-                      }}
-                      className={styles.fullImage}
-                    />
-                  );
-                }
-                if (ext === "pdf") {
-                  return (
-                    <PDFPreview
-                      url={selectedImage}
-                      className={styles.pdfPreview}
-                      title={displayedFiles[currentIndex].fileName}
-                    />
-                  );
-                }
-                return (
-                  <div className={styles.filePlaceholder}>
-                    <div className={styles.placeholderIcon}>
-                      {renderFilePreview(displayedFiles[currentIndex])}
-                    </div>
-                    <div className={styles.imageInfo}>{displayedFiles[currentIndex].fileName}</div>
-                  </div>
-                );
-              })()}
-
-              <div className={styles.imageTopBar}>
-                <button onClick={closeImageModal} className={styles.iconButton} aria-label="Close image">
-                  <FontAwesomeIcon icon={faXmark} />
-                </button>
-                <a href={selectedImage ? getFileUrl(fileUrlsToKeys([selectedImage])[0]) : ''} download className={styles.iconButton} aria-label="Download image">
-                  <FontAwesomeIcon icon={faDownload} />
-                </a>
-              </div>
-            </div>
-          )}
-        </Modal>
+          displayedFiles={displayedFiles}
+          currentIndex={currentIndex}
+          selectedImage={selectedImage}
+          onTouchStart={handleTouchStart}
+          onTouchMove={handleTouchMove}
+          onTouchEnd={handleTouchEnd}
+        />
       </>
     );
   }
 );
+
+FileManagerComponent.displayName = "FileManagerComponent";
 
 export default FileManagerComponent;

--- a/frontend/src/features/project/components/FileManagerContent.tsx
+++ b/frontend/src/features/project/components/FileManagerContent.tsx
@@ -1,0 +1,183 @@
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faCheck, faDownload, faTrash } from "@fortawesome/free-solid-svg-icons";
+import { Upload } from "lucide-react";
+import Spinner from "../../../shared/ui/Spinner";
+import { fileUrlsToKeys, getFileUrl } from "../../../shared/utils/api";
+import type { FileItem, ViewMode } from "./fileManagerTypes";
+import {
+  getFilePreviewIcon,
+  getThumbnailUrl,
+  isPreviewableImage,
+  truncateFileName,
+} from "./fileManagerUtils";
+import styles from "./file-manager.module.css";
+
+interface FileManagerContentProps {
+  scrollerRef: React.RefObject<HTMLDivElement>;
+  isDragging: boolean;
+  onDragOver: (event: React.DragEvent<HTMLDivElement>) => void;
+  onDragLeave: (event: React.DragEvent<HTMLDivElement>) => void;
+  onDrop: (event: React.DragEvent<HTMLDivElement>) => void;
+  isLoading: boolean;
+  displayedFiles: FileItem[];
+  isSelectMode: boolean;
+  onSelectAll: () => void;
+  selectedItems: Set<string>;
+  selectedFilesCount: number;
+  viewMode: ViewMode;
+  onFileClick: (file: FileItem, index: number) => void;
+  onSelectionChange: (url: string) => void;
+  isSelected: (url: string) => boolean;
+  onDownloadSingle: (url: string) => void;
+  onDeleteSingle: (url: string) => void;
+  canDelete: boolean;
+  folderKey: string;
+}
+
+const renderPreview = (file: FileItem, folderKey: string) => {
+  const extension = file.fileName.split(".").pop()?.toLowerCase();
+  if (isPreviewableImage(file)) {
+    const thumbUrl = getThumbnailUrl(file.url, folderKey);
+    const key = fileUrlsToKeys([thumbUrl])[0];
+    return (
+      <img
+        src={getFileUrl(key)}
+        alt={file.fileName}
+        className={styles.previewImage}
+        onError={(e) => {
+          (e.target as HTMLImageElement).src = file.url;
+        }}
+        loading="lazy"
+      />
+    );
+  }
+
+  const icon = getFilePreviewIcon(extension);
+  return icon ?? null;
+};
+
+export const FileManagerContent = ({
+  scrollerRef,
+  isDragging,
+  onDragOver,
+  onDragLeave,
+  onDrop,
+  isLoading,
+  displayedFiles,
+  isSelectMode,
+  onSelectAll,
+  selectedItems,
+  selectedFilesCount,
+  viewMode,
+  onFileClick,
+  onSelectionChange,
+  isSelected,
+  onDownloadSingle,
+  onDeleteSingle,
+  canDelete,
+  folderKey,
+}: FileManagerContentProps) => {
+  return (
+    <div
+      ref={scrollerRef}
+      className={`${styles.modalContentInner} ${isDragging ? styles.dragging : ""}`}
+      onDragOver={onDragOver}
+      onDragLeave={onDragLeave}
+      onDrop={onDrop}
+    >
+      {isDragging && <div className={styles.dragOverlay}>Drop files to upload</div>}
+
+      {isLoading && (
+        <div className={styles.loadingOverlay}>
+          <Spinner style={{ position: "static" }} />
+          <div className={styles.loadingMessage}>Loading files…</div>
+        </div>
+      )}
+
+      {displayedFiles.length === 0 && !isLoading ? (
+        <div className={styles.emptyMessage}>
+          <Upload size={48} />
+          <span>No files yet.</span>
+        </div>
+      ) : (
+        <>
+          {isSelectMode && (
+            <div>
+              <input
+                type="checkbox"
+                checked={selectedItems.size === selectedFilesCount && selectedFilesCount > 0}
+                onChange={onSelectAll}
+              />{" "}
+              Select All
+            </div>
+          )}
+
+          {viewMode === "grid" ? (
+            <ul className={styles.fileGrid}>
+              {displayedFiles.map((file, index) => (
+                <li key={file.url} className={styles.fileItem}>
+                  <div
+                    onClick={() => {
+                      if (isSelectMode) onSelectionChange(file.url);
+                      else onFileClick(file, index);
+                    }}
+                    className={`${styles.filePreview} ${isSelectMode ? styles.clickable : ""}`}
+                  >
+                    {renderPreview(file, folderKey)}
+
+                    {isSelectMode && (
+                      <div className={`${styles.selectionOverlay} ${isSelected(file.url) ? styles.selected : ""}`}>
+                        {isSelected(file.url) && (
+                          <FontAwesomeIcon icon={faCheck} className={styles.checkIcon} />
+                        )}
+                      </div>
+                    )}
+                  </div>
+                  <div className={styles.fileName} title={file.fileName}>
+                    {truncateFileName(file.fileName)}
+                  </div>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <table className={styles.fileTable}>
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {displayedFiles.map((file, index) => (
+                  <tr key={file.url}>
+                    <td onClick={() => onFileClick(file, index)}>{file.fileName}</td>
+                    <td>
+                      <button
+                        className={styles.iconButton}
+                        onClick={() => onDownloadSingle(file.url)}
+                        aria-label="Download file"
+                      >
+                        <FontAwesomeIcon icon={faDownload} />
+                      </button>
+                      {canDelete && (
+                        <button
+                          className={styles.iconButton}
+                          onClick={() => onDeleteSingle(file.url)}
+                          aria-label="Delete file"
+                        >
+                          <FontAwesomeIcon icon={faTrash} />
+                        </button>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </>
+      )}
+    </div>
+  );
+};
+
+export default FileManagerContent;

--- a/frontend/src/features/project/components/FileManagerFooter.tsx
+++ b/frontend/src/features/project/components/FileManagerFooter.tsx
@@ -1,0 +1,83 @@
+import type React from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faCheck, faDownload, faTrash, faUpload, faXmark } from "@fortawesome/free-solid-svg-icons";
+import styles from "./file-manager.module.css";
+
+interface FileManagerFooterProps {
+  selectedFilesCount: number;
+  canUpload: boolean;
+  canDelete: boolean;
+  isSelectMode: boolean;
+  fileInputRef: React.RefObject<HTMLInputElement>;
+  onFileSelect: React.ChangeEventHandler<HTMLInputElement>;
+  onToggleSelectMode: () => void;
+  onBulkDownload: () => void;
+  onDeleteSelected: () => void;
+  onCancelSelection: () => void;
+}
+
+export const FileManagerFooter = ({
+  selectedFilesCount,
+  canUpload,
+  canDelete,
+  isSelectMode,
+  fileInputRef,
+  onFileSelect,
+  onToggleSelectMode,
+  onBulkDownload,
+  onDeleteSelected,
+  onCancelSelection,
+}: FileManagerFooterProps) => {
+  const renderUploadControl = () =>
+    canUpload ? (
+      <>
+        <input
+          type="file"
+          multiple
+          onChange={onFileSelect}
+          ref={fileInputRef}
+          className={styles.hiddenInput}
+        />
+        <button
+          className={styles.iconButton}
+          onClick={() => fileInputRef.current?.click()}
+          aria-label="Upload files"
+        >
+          <FontAwesomeIcon icon={faUpload} /> Upload
+        </button>
+      </>
+    ) : null;
+
+  return (
+    <div className={styles.modalFooter}>
+      {selectedFilesCount === 0 ? (
+        <>{renderUploadControl()}</>
+      ) : isSelectMode ? (
+        <>
+          <button className={styles.iconButton} onClick={onBulkDownload} aria-label="Download selected">
+            <FontAwesomeIcon icon={faDownload} />
+          </button>
+          {canDelete && (
+            <button className={styles.iconButton} onClick={onDeleteSelected} aria-label="Delete selected">
+              <FontAwesomeIcon icon={faTrash} />
+            </button>
+          )}
+          <button className={styles.iconButton} onClick={onCancelSelection} aria-label="Cancel selection">
+            <FontAwesomeIcon icon={faXmark} />
+          </button>
+        </>
+      ) : (
+        <>
+          {selectedFilesCount > 0 && (
+            <button className={styles.iconButton} onClick={onToggleSelectMode} aria-label="Select files">
+              <FontAwesomeIcon icon={faCheck} /> Select
+            </button>
+          )}
+          {renderUploadControl()}
+        </>
+      )}
+    </div>
+  );
+};
+
+export default FileManagerFooter;

--- a/frontend/src/features/project/components/FileManagerToolbar.tsx
+++ b/frontend/src/features/project/components/FileManagerToolbar.tsx
@@ -1,0 +1,83 @@
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faXmark } from "@fortawesome/free-solid-svg-icons";
+import type { IconDefinition } from "@fortawesome/fontawesome-svg-core";
+import Dropdown from "./Dropdown";
+import type { FilterValue, FolderOption, SortOption } from "./fileManagerTypes";
+import styles from "./file-manager.module.css";
+
+interface FileManagerToolbarProps {
+  folderKey: string;
+  systemFolders: FolderOption[];
+  onFolderChange: (key: string) => void;
+  searchTerm: string;
+  onSearchChange: (value: string) => void;
+  filterOption: FilterValue;
+  filterOptions: Array<{ value: FilterValue; label: string }>;
+  onFilterChange: (value: FilterValue) => void;
+  sortOption: SortOption;
+  sortOptions: Array<{ value: SortOption; label: string }>;
+  onSortChange: (value: SortOption) => void;
+  onToggleView: () => void;
+  layoutIcon: IconDefinition;
+  onClose: () => void;
+  renderFolderIcon: (key: string, size?: number) => React.ReactNode;
+}
+
+export const FileManagerToolbar = ({
+  folderKey,
+  systemFolders,
+  onFolderChange,
+  searchTerm,
+  onSearchChange,
+  filterOption,
+  filterOptions,
+  onFilterChange,
+  sortOption,
+  sortOptions,
+  onSortChange,
+  onToggleView,
+  layoutIcon,
+  onClose,
+  renderFolderIcon,
+}: FileManagerToolbarProps) => {
+  return (
+    <div className={styles.modalHeader}>
+      <div className={styles.folderTabs}>
+        {systemFolders.map((folder) => (
+          <button
+            key={folder.key}
+            className={`${styles.tabButton} ${folderKey === folder.key ? styles.activeTab : ""}`}
+            onClick={() => onFolderChange(folder.key)}
+          >
+            {renderFolderIcon(folder.key, 16)} {folder.name}
+          </button>
+        ))}
+      </div>
+
+      <div className={styles.actions}>
+        <input
+          type="text"
+          placeholder="Search"
+          value={searchTerm}
+          onChange={(e) => onSearchChange(e.target.value)}
+          className={styles.searchInput}
+        />
+        <Dropdown
+          label="Filter files"
+          options={filterOptions}
+          value={filterOption}
+          onChange={onFilterChange}
+        />
+        <Dropdown label="Sort files" options={sortOptions} value={sortOption} onChange={onSortChange} />
+        <button className={styles.iconButton} onClick={onToggleView} aria-label="Toggle view">
+          <FontAwesomeIcon icon={layoutIcon} />
+        </button>
+        <button className={styles.iconButton} onClick={onClose} aria-label="Close">
+          <FontAwesomeIcon icon={faXmark} />
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default FileManagerToolbar;

--- a/frontend/src/features/project/components/FilePreviewModal.tsx
+++ b/frontend/src/features/project/components/FilePreviewModal.tsx
@@ -1,0 +1,98 @@
+import type React from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faDownload, faXmark } from "@fortawesome/free-solid-svg-icons";
+import Modal from "../../../shared/ui/ModalWithStack";
+import { fileUrlsToKeys, getFileUrl } from "../../../shared/utils/api";
+import PDFPreview from "./PDFPreview";
+import type { FileItem } from "./fileManagerTypes";
+import { getFilePreviewIcon, isPreviewableImage } from "./fileManagerUtils";
+import styles from "./file-manager.module.css";
+
+interface FilePreviewModalProps {
+  isOpen: boolean;
+  onRequestClose: () => void;
+  displayedFiles: FileItem[];
+  currentIndex: number | null;
+  selectedImage: string | null;
+  onTouchStart: (event: React.TouchEvent) => void;
+  onTouchMove: (event: React.TouchEvent) => void;
+  onTouchEnd: () => void;
+}
+
+export const FilePreviewModal = ({
+  isOpen,
+  onRequestClose,
+  displayedFiles,
+  currentIndex,
+  selectedImage,
+  onTouchStart,
+  onTouchMove,
+  onTouchEnd,
+}: FilePreviewModalProps) => {
+  const currentFile = currentIndex !== null ? displayedFiles[currentIndex] : undefined;
+  const extension = currentFile?.fileName.split(".").pop()?.toLowerCase();
+  const downloadUrl = selectedImage ? getFileUrl(fileUrlsToKeys([selectedImage])[0]) : "";
+
+  const renderContent = () => {
+    if (!currentFile) return null;
+    if (isPreviewableImage(currentFile)) {
+      return (
+        <img
+          src={selectedImage ? getFileUrl(fileUrlsToKeys([selectedImage])[0]) : ""}
+          alt="Selected"
+          onError={(e) => {
+            (e.target as HTMLImageElement).src = selectedImage || "";
+          }}
+          className={styles.fullImage}
+        />
+      );
+    }
+    if (extension === "pdf") {
+      return (
+        <PDFPreview url={selectedImage ?? ""} className={styles.pdfPreview} title={currentFile.fileName} />
+      );
+    }
+    return (
+      <div className={styles.filePlaceholder}>
+        <div className={styles.placeholderIcon}>{getFilePreviewIcon(extension)}</div>
+        <div className={styles.imageInfo}>{currentFile.fileName}</div>
+      </div>
+    );
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onRequestClose={onRequestClose}
+      contentLabel="Image Preview Modal"
+      className={{
+        base: styles.imageModalContent,
+        afterOpen: styles.imageModalContentAfterOpen,
+        beforeClose: styles.imageModalContentBeforeClose,
+      }}
+      overlayClassName={{
+        base: styles.imageModalOverlay,
+        afterOpen: styles.imageModalOverlayAfterOpen,
+        beforeClose: styles.imageModalOverlayBeforeClose,
+      }}
+      closeTimeoutMS={300}
+    >
+      {selectedImage && currentFile && (
+        <div className={styles.imageWrapper} onTouchStart={onTouchStart} onTouchMove={onTouchMove} onTouchEnd={onTouchEnd}>
+          {renderContent()}
+
+          <div className={styles.imageTopBar}>
+            <button onClick={onRequestClose} className={styles.iconButton} aria-label="Close image">
+              <FontAwesomeIcon icon={faXmark} />
+            </button>
+            <a href={downloadUrl} download className={styles.iconButton} aria-label="Download image">
+              <FontAwesomeIcon icon={faDownload} />
+            </a>
+          </div>
+        </div>
+      )}
+    </Modal>
+  );
+};
+
+export default FilePreviewModal;

--- a/frontend/src/features/project/components/fileManagerTypes.ts
+++ b/frontend/src/features/project/components/fileManagerTypes.ts
@@ -1,0 +1,43 @@
+import type React from "react";
+
+export interface FileManagerProps {
+  folder?: string;
+  displayName?: string;
+  style?: React.CSSProperties;
+  showTrigger?: boolean;
+  isOpen?: boolean;
+  onRequestClose?: () => void;
+}
+
+export interface FileItem {
+  fileName: string;
+  url: string;
+  lastModified?: number;
+  size?: number;
+  kind?: string;
+  [key: string]: unknown;
+}
+
+export interface FolderOption {
+  key: string;
+  name: string;
+}
+
+export type ViewMode = "grid" | "list";
+
+export type SortOption =
+  | "name-asc"
+  | "name-desc"
+  | "date-asc"
+  | "date-desc"
+  | "kind-asc"
+  | "kind-desc";
+
+export type FilterValue = "all" | string;
+
+export type Project = Record<string, unknown>;
+
+export interface FileManagerRef {
+  open: () => Promise<void> | void;
+  close: () => void;
+}

--- a/frontend/src/features/project/components/fileManagerUtils.tsx
+++ b/frontend/src/features/project/components/fileManagerUtils.tsx
@@ -1,0 +1,59 @@
+import { FaCube, FaDraftingCompass, FaFileAlt, FaFileExcel, FaFilePdf } from "react-icons/fa";
+import { SiAdobe, SiHtml5, SiSvg } from "react-icons/si";
+import type { FileItem } from "./fileManagerTypes";
+
+export const encodeS3Key = (key: string = "") =>
+  key
+    .split("/")
+    .map((segment) => encodeURIComponent(segment).replace(/\+/g, "%20"))
+    .join("/");
+
+export const getFileKind = (fileName: string | undefined): string => {
+  if (!fileName) return "";
+  const ext = fileName.split(".").pop()?.toLowerCase() || "";
+  if (["jpg", "jpeg", "png", "gif", "bmp", "webp"].includes(ext)) return "image";
+  if (ext === "pdf") return "pdf";
+  if (ext === "svg") return "svg";
+  if (["html", "htm"].includes(ext)) return "html";
+  if (ext === "txt") return "text";
+  if (["xls", "xlsx", "csv"].includes(ext)) return "spreadsheet";
+  if (["dwg", "vwx"].includes(ext)) return "drawing";
+  if (["c4d", "obj"].includes(ext)) return "model";
+  if (["ai", "afdesign"].includes(ext)) return "adobe";
+  return ext;
+};
+
+export const getThumbnailUrl = (url: string, key: string) =>
+  url.replace(`/${key}/`, `/${key}_thumbnails/`);
+
+export const truncateFileName = (fileName?: string, maxLength = 12) => {
+  if (!fileName) return "";
+  const parts = fileName.split(".");
+  if (parts.length < 2) return fileName;
+  const extension = parts.pop()!;
+  const baseName = parts.join(".");
+  if (baseName.length <= maxLength) return `${baseName}.${extension}`;
+  return `${baseName.substring(0, maxLength)}(..).${extension}`;
+};
+
+export const isPreviewableImage = (file: FileItem) => {
+  const ext = file.fileName.split(".").pop()?.toLowerCase();
+  return Boolean(ext && ["jpg", "jpeg", "png"].includes(ext));
+};
+
+export const getFilePreviewIcon = (extension: string | undefined) => {
+  const ext = extension?.toLowerCase();
+  if (!ext) return <FaFileAlt size={50} color="blue" />;
+  if (["jpg", "jpeg", "png", "gif", "bmp", "webp"].includes(ext)) {
+    return null;
+  }
+  if (ext === "pdf") return <FaFilePdf size={50} color="red" />;
+  if (ext === "svg") return <SiSvg size={50} color="purple" />;
+  if (ext === "html") return <SiHtml5 size={50} color="orange" />;
+  if (ext === "txt") return <FaFileAlt size={50} color="gray" />;
+  if (["xls", "xlsx", "csv"].includes(ext)) return <FaFileExcel size={50} color="green" />;
+  if (["dwg", "vwx"].includes(ext)) return <FaDraftingCompass size={50} color="brown" />;
+  if (["c4d", "obj"].includes(ext)) return <FaCube size={50} color="purple" />;
+  if (["ai", "afdesign"].includes(ext)) return <SiAdobe size={50} color="orange" />;
+  return <FaFileAlt size={50} color="blue" />;
+};

--- a/frontend/src/features/project/components/hooks/useFileManagerState.ts
+++ b/frontend/src/features/project/components/hooks/useFileManagerState.ts
@@ -1,0 +1,324 @@
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { faList, faThLarge } from "@fortawesome/free-solid-svg-icons";
+import type {
+  FileItem,
+  FileManagerProps,
+  FilterValue,
+  Project,
+  SortOption,
+  ViewMode,
+} from "../fileManagerTypes";
+
+interface UseFileManagerStateParams
+  extends Pick<FileManagerProps, "folder" | "displayName" | "isOpen" | "onRequestClose"> {
+  activeProject?: Project;
+}
+
+const SORT_OPTIONS: Array<{ value: SortOption; label: string }> = [
+  { value: "name-asc", label: "Name (A-Z)" },
+  { value: "name-desc", label: "Name (Z-A)" },
+  { value: "date-desc", label: "Newest" },
+  { value: "date-asc", label: "Oldest" },
+  { value: "kind-asc", label: "Type (A-Z)" },
+  { value: "kind-desc", label: "Type (Z-A)" },
+];
+
+export const useFileManagerState = ({
+  folder = "uploads",
+  displayName,
+  isOpen,
+  onRequestClose,
+  activeProject,
+}: UseFileManagerStateParams) => {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const scrollerRef = useRef<HTMLDivElement | null>(null);
+  const [folderKey, setFolderKey] = useState<string>(folder);
+  const [selectedFiles, setSelectedFiles] = useState<FileItem[]>([]);
+  const [isFilesModalOpen, setFilesModalOpen] = useState<boolean>(Boolean(isOpen));
+  const [isImageModalOpen, setImageModalOpen] = useState<boolean>(false);
+  const [selectedImage, setSelectedImage] = useState<string | null>(null);
+  const [currentIndex, setCurrentIndex] = useState<number | null>(null);
+  const [selectedItems, setSelectedItems] = useState<Set<string>>(new Set());
+  const [isSelectMode, setIsSelectMode] = useState<boolean>(false);
+  const [isConfirmingDelete, setIsConfirmingDelete] = useState<boolean>(false);
+  const [isDragging, setIsDragging] = useState<boolean>(false);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [searchTerm, setSearchTerm] = useState<string>("");
+  const [viewMode, setViewMode] = useState<ViewMode>(() =>
+    typeof window !== "undefined"
+      ? ((localStorage.getItem("fileManagerViewMode") as ViewMode) || "grid")
+      : "grid"
+  );
+  const [sortOption, setSortOption] = useState<SortOption>("name-asc");
+  const [filterOption, setFilterOption] = useState<FilterValue>("all");
+  const [localActiveProject, setLocalActiveProject] = useState<Project>(activeProject || {});
+
+  const renderedName = useMemo(
+    () => displayName || folderKey.charAt(0).toUpperCase() + folderKey.slice(1),
+    [displayName, folderKey]
+  );
+
+  useEffect(() => {
+    setFolderKey(folder);
+  }, [folder]);
+
+  useEffect(() => {
+    setLocalActiveProject(activeProject || {});
+  }, [activeProject]);
+
+  useEffect(() => {
+    if (typeof isOpen === "boolean") {
+      if (isOpen) setFilesModalOpen(true);
+      else {
+        setFilesModalOpen(false);
+        onRequestClose?.();
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen]);
+
+  useEffect(() => {
+    return () => {
+      selectedFiles.forEach((f) => {
+        if (f.url && f.url.startsWith("blob:")) {
+          URL.revokeObjectURL(f.url);
+        }
+      });
+    };
+  }, [selectedFiles]);
+
+  useLayoutEffect(() => {
+    const y = sessionStorage.getItem("files.scrollY");
+    if (y && scrollerRef.current) scrollerRef.current.scrollTop = +y;
+  }, []);
+
+  useEffect(() => {
+    const el = scrollerRef.current;
+    const onScroll = () => sessionStorage.setItem("files.scrollY", String(el?.scrollTop ?? 0));
+    el?.addEventListener("scroll", onScroll);
+    return () => el?.removeEventListener("scroll", onScroll);
+  }, []);
+
+  const kindOptions = useMemo(() => {
+    const kinds = new Set(selectedFiles.map((f) => f.kind));
+    return Array.from(kinds).sort();
+  }, [selectedFiles]);
+
+  const filterOptionsList = useMemo(
+    () => [
+      { value: "all", label: "All types" },
+      ...kindOptions.map((kind) => ({
+        value: kind,
+        label: kind ? kind.charAt(0).toUpperCase() + kind.slice(1) : "Unknown",
+      })),
+    ],
+    [kindOptions]
+  );
+
+  const sortFiles = useCallback(
+    (files: FileItem[]) => {
+      return [...files].sort((a, b) => {
+        switch (sortOption) {
+          case "name-desc":
+            return a.fileName.localeCompare(b.fileName) * -1;
+          case "date-asc":
+            return (a.lastModified || 0) - (b.lastModified || 0);
+          case "date-desc":
+            return (b.lastModified || 0) - (a.lastModified || 0);
+          case "kind-asc":
+            return (a.kind || "").localeCompare(b.kind || "");
+          case "kind-desc":
+            return (b.kind || "").localeCompare(a.kind || "");
+          case "name-asc":
+          default:
+            return a.fileName.localeCompare(b.fileName);
+        }
+      });
+    },
+    [sortOption]
+  );
+
+  const displayedFiles = useMemo(() => {
+    const filtered = selectedFiles.filter(
+      (f) =>
+        f.fileName.toLowerCase().includes(searchTerm.toLowerCase()) &&
+        (filterOption === "all" || f.kind === filterOption)
+    );
+    return sortFiles(filtered);
+  }, [selectedFiles, searchTerm, filterOption, sortFiles]);
+
+  const toggleViewMode = useCallback(() => {
+    const newMode: ViewMode = viewMode === "grid" ? "list" : "grid";
+    setViewMode(newMode);
+    if (typeof window !== "undefined") {
+      localStorage.setItem("fileManagerViewMode", newMode);
+    }
+  }, [viewMode]);
+
+  const toggleSelectMode = useCallback(() => {
+    setIsSelectMode((s) => {
+      if (s) setSelectedItems(new Set());
+      return !s;
+    });
+  }, []);
+
+  const handleSelectionChange = useCallback(
+    (url: string) => {
+      setSelectedItems((prev) => {
+        const newSelected = new Set(prev);
+        if (newSelected.has(url)) newSelected.delete(url);
+        else newSelected.add(url);
+        return newSelected;
+      });
+    },
+    []
+  );
+
+  const handleSelectAll = useCallback(() => {
+    setSelectedItems((prev) => {
+      if (prev.size === selectedFiles.length) return new Set();
+      return new Set(selectedFiles.map((u) => u.url));
+    });
+  }, [selectedFiles]);
+
+  const isSelected = useCallback((url: string) => selectedItems.has(url), [selectedItems]);
+
+  const closeFilesModal = useCallback(() => {
+    setFilesModalOpen(false);
+    onRequestClose?.();
+  }, [onRequestClose]);
+
+  const closeImageModal = useCallback(() => setImageModalOpen(false), []);
+
+  const handleNextImage = useCallback(() => {
+    if (!displayedFiles.length || currentIndex === null) return;
+    const nextIndex = (currentIndex + 1) % displayedFiles.length;
+    setCurrentIndex(nextIndex);
+    setSelectedImage(displayedFiles[nextIndex].url);
+  }, [displayedFiles, currentIndex]);
+
+  const handlePrevImage = useCallback(() => {
+    if (!displayedFiles.length || currentIndex === null) return;
+    const prevIndex = (currentIndex - 1 + displayedFiles.length) % displayedFiles.length;
+    setCurrentIndex(prevIndex);
+    setSelectedImage(displayedFiles[prevIndex].url);
+  }, [displayedFiles, currentIndex]);
+
+  const handleFileClick = useCallback(
+    (file: FileItem, index: number) => {
+      if (isSelectMode) {
+        handleSelectionChange(file.url);
+      } else {
+        const extension = file.fileName.split(".").pop()?.toLowerCase();
+        if (extension === "html") {
+          window.open(file.url, "_blank", "noopener,noreferrer");
+          return;
+        }
+        setCurrentIndex(index);
+        setSelectedImage(file.url);
+        setImageModalOpen(true);
+      }
+    },
+    [handleSelectionChange, isSelectMode]
+  );
+
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key !== "Escape") return;
+      if (isImageModalOpen) closeImageModal();
+      else if (isFilesModalOpen) closeFilesModal();
+    };
+    window.addEventListener("keydown", handleEscape);
+    return () => window.removeEventListener("keydown", handleEscape);
+  }, [isFilesModalOpen, isImageModalOpen, closeFilesModal, closeImageModal]);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (!isImageModalOpen) return;
+      if (e.key === "ArrowRight") handleNextImage();
+      else if (e.key === "ArrowLeft") handlePrevImage();
+      else if (e.key === "Escape") closeImageModal();
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [isImageModalOpen, handleNextImage, handlePrevImage, closeImageModal]);
+
+  const [touchStartX, setTouchStartX] = useState(0);
+  const [touchEndX, setTouchEndX] = useState(0);
+  const SWIPE_THRESHOLD = 50;
+
+  const handleTouchStart = useCallback((e: React.TouchEvent) => setTouchStartX(e.touches[0].clientX), []);
+  const handleTouchMove = useCallback((e: React.TouchEvent) => setTouchEndX(e.touches[0].clientX), []);
+  const handleTouchEnd = useCallback(() => {
+    if (touchStartX - touchEndX > SWIPE_THRESHOLD) handleNextImage();
+    else if (touchEndX - touchStartX > SWIPE_THRESHOLD) handlePrevImage();
+  }, [touchStartX, touchEndX, handleNextImage, handlePrevImage]);
+
+  const layoutIconToUse = viewMode === "grid" ? faList : faThLarge;
+
+  return {
+    fileInputRef,
+    scrollerRef,
+    folderKey,
+    setFolderKey,
+    renderedName,
+    selectedFiles,
+    setSelectedFiles,
+    isFilesModalOpen,
+    setFilesModalOpen,
+    closeFilesModal,
+    isImageModalOpen,
+    setImageModalOpen,
+    selectedImage,
+    setSelectedImage,
+    currentIndex,
+    setCurrentIndex,
+    selectedItems,
+    setSelectedItems,
+    isSelectMode,
+    setIsSelectMode,
+    toggleSelectMode,
+    isConfirmingDelete,
+    setIsConfirmingDelete,
+    isDragging,
+    setIsDragging,
+    isLoading,
+    setIsLoading,
+    searchTerm,
+    setSearchTerm,
+    viewMode,
+    toggleViewMode,
+    layoutIconToUse,
+    sortOption,
+    setSortOption,
+    filterOption,
+    setFilterOption,
+    filterOptionsList,
+    displayedFiles,
+    sortFiles,
+    handleSelectionChange,
+    handleSelectAll,
+    isSelected,
+    handleFileClick,
+    handleNextImage,
+    handlePrevImage,
+    closeImageModal,
+    selectedFilesCount: selectedFiles.length,
+    localActiveProject,
+    setLocalActiveProject,
+    handleTouchStart,
+    handleTouchMove,
+    handleTouchEnd,
+    setFilesModalOpenDirect: setFilesModalOpen,
+    sortOptionsList: SORT_OPTIONS,
+  };
+};
+
+export type UseFileManagerStateReturn = ReturnType<typeof useFileManagerState>;

--- a/frontend/src/features/project/components/hooks/useFileMessenger.ts
+++ b/frontend/src/features/project/components/hooks/useFileMessenger.ts
@@ -1,0 +1,100 @@
+import { useCallback } from "react";
+import { API_BASE_URL, apiFetch } from "../../../../shared/utils/api";
+import { normalizeMessage } from "../../../../shared/utils/websocketUtils";
+import type { Message } from "../../../../app/contexts/DataProvider";
+import type { Project } from "../fileManagerTypes";
+
+interface UseFileMessengerParams {
+  activeProject: Project;
+  localActiveProject: Project;
+  setLocalActiveProject: React.Dispatch<React.SetStateAction<Project>>;
+  projectMessages: Record<string, Message[]>;
+  setProjectMessages: (updater: (prev: Record<string, Message[]>) => Record<string, Message[]>) => void;
+  user: { userId?: string };
+  ws?: WebSocket;
+}
+
+const escapeRegExp = (str: string) => str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+export const useFileMessenger = ({
+  activeProject,
+  localActiveProject,
+  setLocalActiveProject,
+  projectMessages,
+  setProjectMessages,
+  user,
+  ws,
+}: UseFileMessengerParams) => {
+  const removeReferences = useCallback(
+    async (urls: string[], messagesList: Message[]) => {
+      let description: string = (localActiveProject.description as string) || "";
+      let descChanged = false;
+
+      for (const url of urls) {
+        const regex = new RegExp(`<img[^>]*src=["']${escapeRegExp(url)}["'][^>]*>`, "g");
+        if (regex.test(description)) {
+          description = description.replace(regex, "");
+          descChanged = true;
+        }
+
+        const referencing = messagesList.filter(
+          (m) => (m.text && m.text.includes(url)) || ((m.file as { url?: string })?.url && (m.file as { url?: string }).url.includes(url))
+        );
+
+        for (const msg of referencing) {
+          if (msg.messageId) {
+            try {
+              if (ws && ws.readyState === WebSocket.OPEN) {
+                const editPayload = {
+                  action: "editMessage",
+                  conversationType: "project",
+                  conversationId: `project#${activeProject.projectId}`,
+                  projectId: activeProject.projectId,
+                  messageId: msg.messageId,
+                  text: "File deleted.",
+                  timestamp: msg.timestamp,
+                  editedAt: new Date().toISOString(),
+                  editedBy: user.userId,
+                };
+                ws.send(JSON.stringify(normalizeMessage(editPayload, "editMessage")));
+              }
+
+              msg.text = "File deleted.";
+              delete msg.file;
+
+              setProjectMessages((prev: Record<string, Message[]>) => {
+                const msgs = Array.isArray(prev[activeProject.projectId]) ? prev[activeProject.projectId] : [];
+                return {
+                  ...prev,
+                  [activeProject.projectId]: msgs.map((m) =>
+                    m.messageId === msg.messageId ? { ...m, text: "File deleted.", file: undefined } : m
+                  ),
+                };
+              });
+            } catch (err) {
+              console.error("Failed to strip file from message", err);
+            }
+          }
+        }
+      }
+
+      if (descChanged) {
+        try {
+          await apiFetch(`${API_BASE_URL}/editProject?projectId=${activeProject.projectId}`, {
+            method: "PUT",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ description }),
+          });
+          setLocalActiveProject((prev: Project) => ({ ...prev, description }));
+        } catch (err) {
+          console.error("Failed to update description", err);
+        }
+      }
+    },
+    [activeProject, localActiveProject.description, setLocalActiveProject, setProjectMessages, user.userId, ws]
+  );
+
+  return { removeReferences };
+};
+
+export type UseFileMessengerReturn = ReturnType<typeof useFileMessenger>;

--- a/frontend/src/features/project/components/hooks/useFileTransfers.ts
+++ b/frontend/src/features/project/components/hooks/useFileTransfers.ts
@@ -1,0 +1,413 @@
+import { useCallback, useEffect, useMemo, useRef } from "react";
+import type React from "react";
+import { uploadData, list } from "aws-amplify/storage";
+import {
+  API_BASE_URL,
+  DELETE_FILE_FROM_S3_URL,
+  ZIP_FILES_URL,
+  apiFetch,
+  fileUrlsToKeys,
+  getFileUrl,
+  normalizeFileUrl,
+} from "../../../../shared/utils/api";
+import { notify, notifyLoading, updateNotification } from "../../../../shared/ui/ToastNotifications";
+import pLimit from "../../../../shared/utils/pLimit";
+import type { Message } from "../../../../app/contexts/DataProvider";
+import type { FileItem, Project } from "../fileManagerTypes";
+import { encodeS3Key, getFileKind } from "../fileManagerUtils";
+
+interface UseFileTransfersParams {
+  activeProject: Project;
+  folderKey: string;
+  selectedItems: Set<string>;
+  setSelectedFiles: React.Dispatch<React.SetStateAction<FileItem[]>>;
+  setSelectedItems: React.Dispatch<React.SetStateAction<Set<string>>>;
+  setIsSelectMode: React.Dispatch<React.SetStateAction<boolean>>;
+  setIsLoading: (value: boolean) => void;
+  setIsConfirmingDelete: React.Dispatch<React.SetStateAction<boolean>>;
+  setIsDragging: (value: boolean) => void;
+  setLocalActiveProject: React.Dispatch<React.SetStateAction<Project>>;
+  removeReferences: (urls: string[], messages: Message[]) => Promise<void>;
+  projectMessages: Record<string, Message[]>;
+  canDelete: boolean;
+}
+
+export const useFileTransfers = ({
+  activeProject,
+  folderKey,
+  selectedItems,
+  setSelectedFiles,
+  setSelectedItems,
+  setIsSelectMode,
+  setIsLoading,
+  setIsConfirmingDelete,
+  setIsDragging,
+  setLocalActiveProject,
+  removeReferences,
+  projectMessages,
+  canDelete,
+}: UseFileTransfersParams) => {
+  const uploadQueue = useMemo(() => pLimit(3), []);
+  const editQueue = useMemo(() => pLimit(1), []);
+  const pendingUpdateRef = useRef<Array<{ fileName: string; url: string }> | null>(null);
+  const updateTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const normalizeFiles = useCallback((files: FileItem[] = []) => {
+    return files.map((f) => ({
+      ...f,
+      lastModified: f.lastModified ? new Date(f.lastModified).getTime() : 0,
+      kind: getFileKind(f.fileName),
+    }));
+  }, []);
+
+  const updateFolderFiles = useCallback(
+    (projectId: string, updatedFiles: Array<{ fileName: string; url: string }>) =>
+      editQueue(async () => {
+        const apiUrl = `${API_BASE_URL}/editProject?projectId=${projectId}`;
+        const payload: Record<string, unknown> = { [folderKey]: updatedFiles };
+        await apiFetch(apiUrl, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        });
+      }),
+    [folderKey, editQueue]
+  );
+
+  const scheduleFolderUpdate = useCallback(
+    (filesPayload: Array<{ fileName: string; url: string }>) => {
+      if (folderKey === "uploads") return;
+      pendingUpdateRef.current = filesPayload;
+
+      if (updateTimeoutRef.current) clearTimeout(updateTimeoutRef.current);
+      updateTimeoutRef.current = setTimeout(() => {
+        const pending = pendingUpdateRef.current;
+        pendingUpdateRef.current = null;
+        if (pending && activeProject?.projectId) {
+          updateFolderFiles(activeProject.projectId as string, pending).catch((err: unknown) =>
+            console.error("Error updating files:", err)
+          );
+        }
+      }, 500);
+    },
+    [folderKey, activeProject?.projectId, updateFolderFiles]
+  );
+
+  const fetchS3Files = useCallback(async (): Promise<FileItem[]> => {
+    const projectId = activeProject?.projectId as string | undefined;
+    if (!projectId) return [];
+    const prefixes =
+      folderKey === "uploads"
+        ? ["uploads/", "lexical/", "chat_uploads/"].map((dir) => `projects/${projectId}/${dir}`)
+        : [`projects/${projectId}/${folderKey}/`];
+
+    try {
+      setIsLoading(true);
+      const lists = await Promise.all(prefixes.map((prefix) => list({ prefix, options: { accessLevel: "guest" } })));
+
+      const files: FileItem[] = lists
+        .flatMap((res: { items?: unknown[] }) => res?.items || [])
+        .filter((item: unknown) => (item as { key?: string }).key && !(item as { key?: string }).key!.endsWith("/"))
+        .map((item: unknown) => {
+          const key = (item as { key: string }).key;
+          const name: string = key.split("/").pop()!;
+          const fullKey = key.startsWith("public/") ? key : `public/${key}`;
+          const url = getFileUrl(encodeS3Key(fullKey));
+          return {
+            fileName: name,
+            url: normalizeFileUrl(url),
+            lastModified: (item as { lastModified?: string | Date }).lastModified
+              ? new Date((item as { lastModified?: string | Date }).lastModified!).getTime()
+              : 0,
+            kind: getFileKind(name),
+          };
+        });
+
+      const merged = Array.from(new Map(files.map((f) => [f.url, f])).values());
+      setSelectedFiles(merged);
+      return merged;
+    } catch (err) {
+      console.error("Error listing S3 files:", err);
+      notify("warning", "Could not load files from storage.");
+      return [];
+    } finally {
+      setIsLoading(false);
+    }
+  }, [activeProject?.projectId, folderKey, setIsLoading, setSelectedFiles]);
+
+  const loadFiles = useCallback(async () => {
+    const files = await fetchS3Files();
+    if (!files.length) {
+      const rawFiles = (activeProject?.[folderKey] as FileItem[]) || [];
+      const normalized = normalizeFiles(rawFiles);
+      setSelectedFiles(normalized);
+      return normalized;
+    }
+    return files;
+  }, [fetchS3Files, activeProject, folderKey, normalizeFiles, setSelectedFiles]);
+
+  const initiateDownload = (url: string) => {
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = "";
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+  };
+
+  const getZippedFiles = useCallback(async (fileUrls: string[]): Promise<string> => {
+    const fileKeys = fileUrlsToKeys(fileUrls);
+    const response = await apiFetch<{ zipFileUrl: string }>(ZIP_FILES_URL, {
+      method: "POST",
+      body: JSON.stringify({ fileKeys }),
+      headers: { "Content-Type": "application/json" },
+    });
+    return response.zipFileUrl;
+  }, []);
+
+  const uploadFileToS3 = useCallback(
+    (projectId: string, file: File) =>
+      uploadQueue(async () => {
+        const filename = `projects/${projectId}/${folderKey}/${file.name}`;
+        await uploadData({
+          key: filename,
+          data: file,
+          options: { accessLevel: "guest" },
+        });
+        await new Promise((resolve) => setTimeout(resolve, 2000));
+        const fileUrl = getFileUrl(encodeS3Key(filename));
+        return { fileName: file.name, url: fileUrl };
+      }),
+    [folderKey, uploadQueue]
+  );
+
+  const uploadFiles = useCallback(
+    async (files: File[]) => {
+      setIsLoading(true);
+      if (!files.length) {
+        setIsLoading(false);
+        return;
+      }
+      const notificationId = notifyLoading("Uploading files...");
+
+      const placeholders: (FileItem | null)[] = files.map((file) => ({
+        fileName: file.name,
+        url: URL.createObjectURL(file),
+        lastModified: file.lastModified || Date.now(),
+        kind: getFileKind(file.name),
+      }));
+
+      setSelectedFiles((prev) => [...prev, ...(placeholders as FileItem[])]);
+
+      const projectId = activeProject?.projectId as string;
+      await Promise.all(
+        files.map((file, idx) =>
+          uploadFileToS3(projectId, file)
+            .then((info) => {
+              const oldUrl = placeholders[idx]!.url;
+              placeholders[idx]!.url = info.url;
+              if (oldUrl.startsWith("blob:")) URL.revokeObjectURL(oldUrl);
+            })
+            .catch((error) => {
+              console.error("Upload failed:", error);
+              notify("error", `Upload failed for ${file.name}`);
+              const oldUrl = placeholders[idx]?.url;
+              if (oldUrl && oldUrl.startsWith("blob:")) URL.revokeObjectURL(oldUrl);
+              placeholders[idx] = null;
+            })
+        )
+      );
+
+      const completed = placeholders.filter(Boolean) as FileItem[];
+
+      let finalFiles: FileItem[] = [];
+      setSelectedFiles((prev) => {
+        const names = new Set(placeholders.map((p) => p?.fileName).filter(Boolean) as string[]);
+        finalFiles = [...prev.filter((f) => !names.has(f.fileName)), ...completed];
+        return finalFiles;
+      });
+
+      if (folderKey !== "uploads") {
+        setLocalActiveProject((prev: Project) => ({ ...prev, [folderKey]: finalFiles }));
+      }
+
+      updateNotification(notificationId, "success", "Files uploaded successfully");
+
+      if (folderKey !== "uploads") {
+        const payload = finalFiles.map((f) => ({ fileName: f.fileName, url: f.url }));
+        try {
+          await updateFolderFiles(activeProject.projectId as string, payload);
+        } catch (error) {
+          console.error("Error updating file metadata:", error);
+          notify("warning", "Files uploaded but metadata update failed");
+        }
+      }
+      setIsLoading(false);
+    },
+    [
+      activeProject.projectId,
+      folderKey,
+      setIsLoading,
+      setLocalActiveProject,
+      setSelectedFiles,
+      updateFolderFiles,
+      uploadFileToS3,
+    ]
+  );
+
+  const handleFileSelect: React.ChangeEventHandler<HTMLInputElement> = useCallback(
+    async (event) => {
+      const files = Array.from(event.target.files || []);
+      await uploadFiles(files);
+      event.target.value = "";
+    },
+    [uploadFiles]
+  );
+
+  const handleDragOver = useCallback(
+    (event: React.DragEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      setIsDragging(true);
+    },
+    [setIsDragging]
+  );
+
+  const handleDragLeave = useCallback(
+    (event: React.DragEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      setIsDragging(false);
+    },
+    [setIsDragging]
+  );
+
+  const handleDrop = useCallback(
+    async (event: React.DragEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      setIsDragging(false);
+      const files = Array.from(event.dataTransfer.files || []);
+      await uploadFiles(files);
+      if (folderKey === "uploads") {
+        await fetchS3Files();
+      }
+    },
+    [fetchS3Files, folderKey, setIsDragging, uploadFiles]
+  );
+
+  const handleBulkDownload = useCallback(async () => {
+    const fileUrls = Array.from(selectedItems);
+    if (fileUrls.length === 0) {
+      notify("warning", "No files selected for download.");
+      return;
+    }
+    const notificationId = notifyLoading("Preparing archive...");
+    try {
+      const zipFileUrl = await getZippedFiles(fileUrls);
+      updateNotification(notificationId, "success", "Archive ready! Downloading now...");
+      initiateDownload(zipFileUrl);
+      setSelectedItems(new Set());
+      setIsSelectMode(false);
+    } catch (error) {
+      console.error("Error during bulk download:", error);
+      updateNotification(notificationId, "error", "Failed to prepare archive. Try again.");
+    }
+  }, [getZippedFiles, selectedItems, setIsSelectMode, setSelectedItems]);
+
+  const handleDelete = useCallback(() => {
+    if (!canDelete) {
+      notify("error", "Only authorized users can delete files.");
+      return;
+    }
+    setIsConfirmingDelete(true);
+  }, [canDelete, setIsConfirmingDelete]);
+
+  const performDelete = useCallback(async () => {
+    const fileUrlsToDelete = Array.from(selectedItems);
+    if (!fileUrlsToDelete.length) return;
+    const fileKeysToDelete = fileUrlsToKeys(fileUrlsToDelete);
+    setIsConfirmingDelete(false);
+
+    const messages = projectMessages[activeProject.projectId as string] || [];
+    await removeReferences(fileUrlsToDelete, messages);
+
+    const notificationId = notifyLoading("Deleting files...");
+    try {
+      await apiFetch(DELETE_FILE_FROM_S3_URL, {
+        method: "POST",
+        body: JSON.stringify({
+          projectId: activeProject.projectId,
+          field: folderKey,
+          fileKeys: fileKeysToDelete,
+        }),
+        headers: { "Content-Type": "application/json" },
+      });
+
+      let remaining: FileItem[] = [];
+      setSelectedFiles((prev) => {
+        remaining = prev.filter((u) => !fileUrlsToDelete.includes(u.url));
+        return remaining;
+      });
+
+      if (folderKey !== "uploads") {
+        setLocalActiveProject((prev: Project) => ({ ...prev, [folderKey]: remaining }));
+      }
+      scheduleFolderUpdate(remaining.map((u) => ({ fileName: u.fileName, url: u.url })));
+
+      setSelectedItems(new Set());
+      setIsSelectMode(false);
+      updateNotification(notificationId, "success", "Files deleted successfully");
+    } catch (error) {
+      console.error("Error during deletion:", error);
+      updateNotification(notificationId, "error", "Failed to delete selected files. Please try again.");
+    }
+  }, [
+    activeProject.projectId,
+    folderKey,
+    projectMessages,
+    removeReferences,
+    scheduleFolderUpdate,
+    selectedItems,
+    setIsConfirmingDelete,
+    setIsSelectMode,
+    setLocalActiveProject,
+    setSelectedFiles,
+    setSelectedItems,
+  ]);
+
+  const handleDeleteSingle = useCallback(
+    (url: string) => {
+      setSelectedItems(new Set([url]));
+      handleDelete();
+    },
+    [handleDelete, setSelectedItems]
+  );
+
+  const handleDownloadSingle = useCallback((url: string) => initiateDownload(url), []);
+
+  useEffect(
+    () => () => {
+      if (updateTimeoutRef.current) clearTimeout(updateTimeoutRef.current);
+    },
+    []
+  );
+
+  useEffect(() => {
+    void loadFiles();
+  }, [loadFiles]);
+
+  return {
+    loadFiles,
+    fetchS3Files,
+    uploadFiles,
+    handleFileSelect,
+    handleDragOver,
+    handleDragLeave,
+    handleDrop,
+    handleBulkDownload,
+    handleDelete,
+    performDelete,
+    handleDeleteSingle,
+    handleDownloadSingle,
+  };
+};
+
+export type UseFileTransfersReturn = ReturnType<typeof useFileTransfers>;


### PR DESCRIPTION
## Summary
- refactor FileManager into a coordinator component that composes toolbar, content, footer, and preview modal subcomponents while using dedicated hooks for state, messaging, and transfers
- add new FileManagerContent, FileManagerToolbar, FileManagerFooter, FilePreviewModal, type, util, and hook modules to encapsulate UI and logic responsibilities
- keep the existing FileManager vitest suite green against the reorganized structure

## Testing
- npm test -- FileManager

------
https://chatgpt.com/codex/tasks/task_e_68cb8b239b488324adba8fa3706da58b