### PR TITLE
Refactor projects panel into modular components with reusable hooks

### DIFF
--- a/frontend/src/features/projects/ProjectsFilterMenu.test.tsx
+++ b/frontend/src/features/projects/ProjectsFilterMenu.test.tsx
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { createRef } from "react";
+
+import { ProjectsFilterMenu } from "./ProjectsFilterMenu";
+import type { DropdownHelpers } from "./hooks/useDropdown";
+import type { SortOption } from "./hooks/useProjectFilters";
+import type { DropdownOption } from "./hooks/useDropdown";
+import "@testing-library/jest-dom";
+
+const createDropdownStub = <T,>(): DropdownHelpers<T> => ({
+  dropdownRef: createRef<HTMLDivElement>(),
+  isOpen: false,
+  open: vi.fn(),
+  close: vi.fn(),
+  toggle: vi.fn(),
+  listId: "list-id",
+  activeOptionId: undefined,
+  highlightIndex: -1,
+  handleTriggerKeyDown: vi.fn(),
+  getOptionRenderState: vi.fn((option: DropdownOption<T>, index: number) => ({
+    id: `option-${index}`,
+    isSelected: false,
+    isActive: false,
+  })),
+  getOptionButtonProps: vi.fn(() => ({
+    type: "button" as const,
+    onClick: vi.fn(),
+    onMouseEnter: vi.fn(),
+    onFocus: vi.fn(),
+  })),
+});
+
+describe("ProjectsFilterMenu", () => {
+  it("renders scope toggle and triggers toggle handler", () => {
+    const toggleFilters = vi.fn();
+    const statusDropdown = createDropdownStub<string>();
+    const sortDropdown = createDropdownStub<SortOption>();
+
+    render(
+      <ProjectsFilterMenu
+        filtersOpen={false}
+        filtersRef={createRef<HTMLDivElement>()}
+        filtersId="filters"
+        scope="recents"
+        onScopeChange={vi.fn()}
+        query=""
+        onQueryChange={vi.fn()}
+        toggleFilters={toggleFilters}
+        statusOptions={[{ value: "", label: "All statuses" }]}
+        statusTriggerLabel="All statuses"
+        statusDropdown={statusDropdown}
+        showStatusDropdown={false}
+        sortOptions={[{ value: "dateNewest", label: "Date (Newest)" }]}
+        sortTriggerLabel="Date (Newest)"
+        sortDropdown={sortDropdown}
+      />
+    );
+
+    const scopeButton = screen.getByRole("button", { name: /recents/i });
+    fireEvent.click(scopeButton);
+    expect(toggleFilters).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+
+  it("shows dropdown options when open", () => {
+    const statusDropdown = createDropdownStub<string>();
+    statusDropdown.isOpen = true;
+    statusDropdown.getOptionRenderState = vi.fn((option, index) => ({
+      id: `status-${index}`,
+      isSelected: index === 0,
+      isActive: index === 0,
+    }));
+    statusDropdown.getOptionButtonProps = vi.fn(() => ({
+      type: "button" as const,
+      onClick: vi.fn(),
+      onMouseEnter: vi.fn(),
+      onFocus: vi.fn(),
+    }));
+
+    const sortDropdown = createDropdownStub<SortOption>();
+    sortDropdown.isOpen = true;
+    sortDropdown.getOptionRenderState = vi.fn((option, index) => ({
+      id: `sort-${index}`,
+      isSelected: index === 0,
+      isActive: index === 0,
+    }));
+    sortDropdown.getOptionButtonProps = vi.fn(() => ({
+      type: "button" as const,
+      onClick: vi.fn(),
+      onMouseEnter: vi.fn(),
+      onFocus: vi.fn(),
+    }));
+
+    render(
+      <ProjectsFilterMenu
+        filtersOpen
+        filtersRef={createRef<HTMLDivElement>()}
+        filtersId="filters"
+        scope="all"
+        onScopeChange={vi.fn()}
+        query=""
+        onQueryChange={vi.fn()}
+        toggleFilters={vi.fn()}
+        statusOptions={[
+          { value: "", label: "All statuses" },
+          { value: "active", label: "active" },
+        ]}
+        statusTriggerLabel="All statuses"
+        statusDropdown={statusDropdown}
+        showStatusDropdown
+        sortOptions={[
+          { value: "dateNewest", label: "Date (Newest)" },
+          { value: "titleAsc", label: "Title (A-Z)" },
+        ]}
+        sortTriggerLabel="Date (Newest)"
+        sortDropdown={sortDropdown}
+      />
+    );
+
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    const options = screen.getAllByRole("option");
+    expect(options).toHaveLength(4);
+    expect(screen.getByText("active")).toBeInTheDocument();
+    expect(screen.getByText("Title (A-Z)")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/projects/ProjectsFilterMenu.tsx
+++ b/frontend/src/features/projects/ProjectsFilterMenu.tsx
@@ -1,0 +1,189 @@
+import type { ChangeEvent, FC, RefObject } from "react";
+
+import { CalendarDays, ChevronDown, Search } from "lucide-react";
+
+import desktopStyles from "./ProjectsPanelDesktop.module.css";
+import mobileStyles from "@/features/dashboard/components/projects-panel.module.css";
+import type { DropdownHelpers, DropdownOption } from "./hooks/useDropdown";
+import type { SortOption } from "./hooks/useProjectFilters";
+
+type ProjectsFilterMenuProps = {
+  filtersOpen: boolean;
+  filtersRef: RefObject<HTMLDivElement>;
+  filtersId: string;
+  scope: "recents" | "all";
+  onScopeChange: (scope: "recents" | "all") => void;
+  query: string;
+  onQueryChange: (value: string) => void;
+  toggleFilters: () => void;
+  statusOptions: DropdownOption<string>[];
+  statusTriggerLabel: string;
+  statusDropdown: DropdownHelpers<string>;
+  showStatusDropdown: boolean;
+  sortOptions: DropdownOption<SortOption>[];
+  sortTriggerLabel: string;
+  sortDropdown: DropdownHelpers<SortOption>;
+};
+
+export const ProjectsFilterMenu: FC<ProjectsFilterMenuProps> = ({
+  filtersOpen,
+  filtersRef,
+  filtersId,
+  scope,
+  onScopeChange,
+  query,
+  onQueryChange,
+  toggleFilters,
+  statusOptions,
+  statusTriggerLabel,
+  statusDropdown,
+  showStatusDropdown,
+  sortOptions,
+  sortTriggerLabel,
+  sortDropdown,
+}) => {
+  const handleQueryChange = (event: ChangeEvent<HTMLInputElement>) => {
+    onQueryChange(event.target.value);
+  };
+
+  return (
+    <div className={mobileStyles.recentsWrap} ref={filtersRef}>
+      <button
+        type="button"
+        className={mobileStyles.recents}
+        aria-expanded={filtersOpen}
+        aria-haspopup="menu"
+        aria-controls={filtersId}
+        onClick={toggleFilters}
+      >
+        {scope === "recents" ? "Recents" : "All projects"} <ChevronDown size={14} aria-hidden />
+      </button>
+      {filtersOpen && (
+        <div className={mobileStyles.filterPop} role="menu" id={filtersId}>
+          <div className={mobileStyles.filterSection}>
+            <div className={mobileStyles.scopeBtns} role="group" aria-label="Scope">
+              <button
+                type="button"
+                className={`${mobileStyles.scopeBtn} ${
+                  scope === "recents" ? mobileStyles.scopeBtnActive : ""
+                }`}
+                onClick={() => onScopeChange("recents")}
+              >
+                Recents
+              </button>
+              <button
+                type="button"
+                className={`${mobileStyles.scopeBtn} ${
+                  scope === "all" ? mobileStyles.scopeBtnActive : ""
+                }`}
+                onClick={() => onScopeChange("all")}
+              >
+                All projects
+              </button>
+            </div>
+
+            <div className={desktopStyles.filterField}>
+              <Search size={16} aria-hidden className={desktopStyles.filterFieldIcon} />
+              <input
+                className={desktopStyles.filterInput}
+                placeholder="Filter by title..."
+                value={query}
+                onChange={handleQueryChange}
+                aria-label="Filter projects by title"
+              />
+            </div>
+
+            {showStatusDropdown && (
+              <div className={desktopStyles.statusDropdown} ref={statusDropdown.dropdownRef}>
+                <button
+                  type="button"
+                  className={desktopStyles.statusTrigger}
+                  aria-haspopup="listbox"
+                  aria-expanded={statusDropdown.isOpen}
+                  aria-controls={statusDropdown.listId}
+                  aria-activedescendant={statusDropdown.activeOptionId}
+                  onClick={statusDropdown.toggle}
+                  onKeyDown={statusDropdown.handleTriggerKeyDown}
+                >
+                  <span className={desktopStyles.triggerLabel}>
+                    <span className={desktopStyles.triggerLabelText}>{statusTriggerLabel}</span>
+                  </span>
+                  <ChevronDown size={14} aria-hidden className={desktopStyles.triggerChevron} />
+                </button>
+                {statusDropdown.isOpen && (
+                  <ul className={desktopStyles.statusOptions} role="listbox" id={statusDropdown.listId}>
+                    {statusOptions.map((option, index) => {
+                      const { id, isSelected, isActive } = statusDropdown.getOptionRenderState(
+                        option,
+                        index
+                      );
+                      const buttonProps = statusDropdown.getOptionButtonProps(option, index);
+                      return (
+                        <li key={`${option.value || "all"}-${index}`} role="option" id={id} aria-selected={isSelected}>
+                          <button
+                            {...buttonProps}
+                            className={`${desktopStyles.statusOptionButton} ${
+                              isSelected ? desktopStyles.statusOptionSelected : ""
+                            } ${isActive ? desktopStyles.statusOptionActive : ""}`}
+                          >
+                            {option.label}
+                          </button>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                )}
+              </div>
+            )}
+
+            <div className={desktopStyles.statusDropdown} ref={sortDropdown.dropdownRef}>
+              <button
+                type="button"
+                className={desktopStyles.statusTrigger}
+                aria-haspopup="listbox"
+                aria-expanded={sortDropdown.isOpen}
+                aria-controls={sortDropdown.listId}
+                aria-activedescendant={sortDropdown.activeOptionId}
+                onClick={sortDropdown.toggle}
+                onKeyDown={sortDropdown.handleTriggerKeyDown}
+              >
+                <span className={desktopStyles.triggerLabel}>
+                  <CalendarDays
+                    size={16}
+                    aria-hidden
+                    className={desktopStyles.triggerLabelIcon}
+                  />
+                  <span className={desktopStyles.triggerLabelText}>{sortTriggerLabel}</span>
+                </span>
+                <ChevronDown size={14} aria-hidden className={desktopStyles.triggerChevron} />
+              </button>
+              {sortDropdown.isOpen && (
+                <ul className={desktopStyles.statusOptions} role="listbox" id={sortDropdown.listId}>
+                  {sortOptions.map((option, index) => {
+                    const { id, isSelected, isActive } = sortDropdown.getOptionRenderState(
+                      option,
+                      index
+                    );
+                    const buttonProps = sortDropdown.getOptionButtonProps(option, index);
+                    return (
+                      <li key={`${option.value}-${index}`} role="option" id={id} aria-selected={isSelected}>
+                        <button
+                          {...buttonProps}
+                          className={`${desktopStyles.statusOptionButton} ${
+                            isSelected ? desktopStyles.statusOptionSelected : ""
+                          } ${isActive ? desktopStyles.statusOptionActive : ""}`}
+                        >
+                          {option.label}
+                        </button>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/features/projects/ProjectsIconsStrip.test.tsx
+++ b/frontend/src/features/projects/ProjectsIconsStrip.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import { ProjectsIconsStrip } from "./ProjectsIconsStrip";
+import type { ProjectLike } from "@/features/dashboard/hooks/useProjectKpis";
+import "@testing-library/jest-dom";
+
+describe("ProjectsIconsStrip", () => {
+  const createProjects = (count: number): ProjectLike[] =>
+    Array.from({ length: count }, (_, index) => ({
+      projectId: `project-${index + 1}`,
+      title: `Project ${index + 1}`,
+      thumbnails: [],
+    })) as ProjectLike[];
+
+  it("calls onOpenProject when an icon is clicked", () => {
+    const onOpenProject = vi.fn();
+
+    render(
+      <ProjectsIconsStrip
+        projects={createProjects(2)}
+        imgError={{}}
+        onImageError={vi.fn()}
+        onOpenProject={onOpenProject}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /project 1/i }));
+    expect(onOpenProject).toHaveBeenCalledWith("project-1");
+  });
+
+  it("shows a badge when more projects are available", () => {
+    render(
+      <ProjectsIconsStrip
+        projects={createProjects(9)}
+        imgError={{}}
+        onImageError={vi.fn()}
+        onOpenProject={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText("+2")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/projects/ProjectsIconsStrip.tsx
+++ b/frontend/src/features/projects/ProjectsIconsStrip.tsx
@@ -1,0 +1,69 @@
+import type { FC } from "react";
+
+import type { ProjectLike } from "@/features/dashboard/hooks/useProjectKpis";
+import SVGThumbnail from "@/features/dashboard/components/SvgThumbnail";
+import { getFileUrl } from "@/shared/utils/api";
+
+import mobileStyles from "@/features/dashboard/components/projects-panel.module.css";
+
+type ProjectsIconsStripProps = {
+  projects: ProjectLike[];
+  imgError: Record<string, boolean>;
+  onImageError: (projectId: string) => void;
+  onOpenProject: (projectId: string) => void;
+};
+
+const MAX_ICONS = 7;
+
+export const ProjectsIconsStrip: FC<ProjectsIconsStripProps> = ({
+  projects,
+  imgError,
+  onImageError,
+  onOpenProject,
+}) => {
+  const shown = projects.slice(0, MAX_ICONS);
+  const more = Math.max(0, projects.length - shown.length);
+
+  return (
+    <div className={mobileStyles.iconsStrip} aria-label="Quick projects">
+      {shown.map((project) => {
+        const id = project.projectId;
+        const title = (project.title || "Untitled project").trim();
+        const thumb =
+          Array.isArray(project.thumbnails) && project.thumbnails[0]
+            ? project.thumbnails[0]
+            : undefined;
+
+        return (
+          <button
+            key={`icon-${id}`}
+            type="button"
+            className={mobileStyles.iconBtnSm}
+            aria-label={`Open project ${title}`}
+            title={title}
+            onClick={() => onOpenProject(id)}
+          >
+            {thumb && !imgError[id] ? (
+              <img
+                className={mobileStyles.thumbSm}
+                src={getFileUrl(thumb)}
+                alt=""
+                onError={() => onImageError(id)}
+              />
+            ) : (
+              <SVGThumbnail
+                initial={title.charAt(0).toUpperCase() || "#"}
+                className={mobileStyles.thumbSm}
+              />
+            )}
+          </button>
+        );
+      })}
+      {more > 0 && (
+        <span className={mobileStyles.iconsMore} aria-hidden>
+          +{more}
+        </span>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/features/projects/ProjectsPanelDesktop.tsx
+++ b/frontend/src/features/projects/ProjectsPanelDesktop.tsx
@@ -1,21 +1,20 @@
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
 import { motion, useReducedMotion } from "framer-motion";
 import { useNavigate } from "react-router-dom";
-import { CalendarDays, ChevronDown, Search } from "lucide-react";
+
 import { useData } from "@/app/contexts/useData";
 import type { UserLite } from "@/app/contexts/DataProvider";
 import { useProjectKpis, type ProjectLike } from "@/features/dashboard/hooks/useProjectKpis";
-import SVGThumbnail from "@/features/dashboard/components/SvgThumbnail";
-import { getFileUrl } from "@/shared/utils/api";
+import { MICRO_WOBBLE_SCALE, SPRING_FAST } from "@/shared/ui/motionTokens";
+
 import desktopStyles from "./ProjectsPanelDesktop.module.css";
 import mobileStyles from "@/features/dashboard/components/projects-panel.module.css";
-import { MICRO_WOBBLE_SCALE, SPRING_FAST } from "@/shared/ui/motionTokens";
+import { ProjectsIconsStrip } from "./ProjectsIconsStrip";
+import ProjectsTable from "./ProjectsTable";
+import { ProjectsFilterMenu } from "./ProjectsFilterMenu";
+import { useProjectFilters } from "./hooks/useProjectFilters";
+import type { ProjectWithMeta } from "./types";
 
 import "@/features/dashboard/components/week-widget.css";
 
@@ -25,56 +24,9 @@ export type ProjectsPanelDesktopProps = {
   onOpenProject?: (projectId: string) => void;
 };
 
-type SortOption = "titleAsc" | "titleDesc" | "dateNewest" | "dateOldest";
-
-type ProjectWithMeta = ProjectLike & {
-  _activity: number;
-  _created: number;
-  team?: Array<{ userId?: string; firstName?: string; lastName?: string; email?: string }>;
-  unreadCount?: number;
-};
-
-const formatShortDate = (iso?: string): string | undefined => {
-  if (!iso) return undefined;
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return undefined;
-  return d.toLocaleString(undefined, { month: "short", day: "numeric" });
-};
-
-const getProjectActivityTs = (p: ProjectLike): number => {
-  const candidates: (string | undefined)[] = [
-    p.updatedAt,
-    p.dateUpdated,
-    p.lastModified,
-    p.date,
-    p.dateCreated,
-  ];
-  if (Array.isArray(p.timelineEvents)) {
-    for (const ev of p.timelineEvents) {
-      if (ev?.timestamp) candidates.push(ev.timestamp);
-      if (ev?.date) candidates.push(ev.date);
-    }
-  }
-  const timestamps = candidates
-    .filter(Boolean)
-    .map((s) => new Date(s as string).getTime())
-    .filter((n) => Number.isFinite(n));
-  return timestamps.length ? Math.max(...timestamps) : 0;
-};
-
-function sanitizeId(raw: string) {
-  return raw.replace(/[^a-zA-Z0-9_-]/g, "");
-}
-
 const ProjectsPanelDesktop: React.FC<ProjectsPanelDesktopProps> = ({ onOpenProject }) => {
   const reduceMotion = useReducedMotion();
-  const {
-    projects = [],
-    isLoading,
-    projectsError,
-    fetchProjects,
-    allUsers,
-  } = useData() as {
+  const { projects = [], isLoading, projectsError, fetchProjects, allUsers } = useData() as {
     projects: ProjectLike[];
     isLoading: boolean;
     projectsError: boolean;
@@ -84,26 +36,6 @@ const ProjectsPanelDesktop: React.FC<ProjectsPanelDesktopProps> = ({ onOpenProje
   const navigate = useNavigate();
 
   const [imgError, setImgError] = useState<Record<string, boolean>>({});
-  const [filtersOpen, setFiltersOpen] = useState(false);
-  const filtersRef = useRef<HTMLDivElement | null>(null);
-  const filtersIdRef = useRef(`projects-filters-${sanitizeId(Math.random().toString(36).slice(2))}`);
-  const statusDropdownRef = useRef<HTMLDivElement | null>(null);
-  const statusListIdRef = useRef(
-    `projects-status-${sanitizeId(Math.random().toString(36).slice(2))}`
-  );
-  const sortDropdownRef = useRef<HTMLDivElement | null>(null);
-  const sortListIdRef = useRef(
-    `projects-sort-${sanitizeId(Math.random().toString(36).slice(2))}`
-  );
-
-  const [sortOption, setSortOption] = useState<SortOption>("dateNewest");
-  const [statusFilter, setStatusFilter] = useState<string>("");
-  const [query, setQuery] = useState<string>("");
-  const [scope, setScope] = useState<"recents" | "all">("recents");
-  const [statusDropdownOpen, setStatusDropdownOpen] = useState(false);
-  const [statusHighlightIndex, setStatusHighlightIndex] = useState<number>(-1);
-  const [sortDropdownOpen, setSortDropdownOpen] = useState(false);
-  const [sortHighlightIndex, setSortHighlightIndex] = useState<number>(-1);
 
   useEffect(() => {
     if (!isLoading && projects.length === 0 && !projectsError) {
@@ -111,193 +43,12 @@ const ProjectsPanelDesktop: React.FC<ProjectsPanelDesktopProps> = ({ onOpenProje
     }
   }, [isLoading, projects.length, projectsError, fetchProjects]);
 
-  useEffect(() => {
-    const onDocClick = (e: MouseEvent) => {
-      if (!filtersOpen) return;
-      if (
-        filtersRef.current &&
-        e.target instanceof Node &&
-        !filtersRef.current.contains(e.target)
-      ) {
-        setFiltersOpen(false);
-      }
-    };
-    document.addEventListener("click", onDocClick);
-    return () => document.removeEventListener("click", onDocClick);
-  }, [filtersOpen]);
-
-  useEffect(() => {
-    if (!statusDropdownOpen) return;
-
-    const handlePointer = (event: MouseEvent) => {
-      if (
-        statusDropdownRef.current &&
-        event.target instanceof Node &&
-        !statusDropdownRef.current.contains(event.target)
-      ) {
-        setStatusDropdownOpen(false);
-      }
-    };
-
-    const handleKey = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        setStatusDropdownOpen(false);
-      }
-    };
-
-    document.addEventListener("mousedown", handlePointer);
-    document.addEventListener("keydown", handleKey);
-
-    return () => {
-      document.removeEventListener("mousedown", handlePointer);
-      document.removeEventListener("keydown", handleKey);
-    };
-  }, [statusDropdownOpen]);
-
-  useEffect(() => {
-    if (!sortDropdownOpen) return;
-
-    const handlePointer = (event: MouseEvent) => {
-      if (
-        sortDropdownRef.current &&
-        event.target instanceof Node &&
-        !sortDropdownRef.current.contains(event.target)
-      ) {
-        setSortDropdownOpen(false);
-      }
-    };
-
-    const handleKey = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        setSortDropdownOpen(false);
-      }
-    };
-
-    document.addEventListener("mousedown", handlePointer);
-    document.addEventListener("keydown", handleKey);
-
-    return () => {
-      document.removeEventListener("mousedown", handlePointer);
-      document.removeEventListener("keydown", handleKey);
-    };
-  }, [sortDropdownOpen]);
-
-  useEffect(() => {
-    if (!filtersOpen) {
-      setStatusDropdownOpen(false);
-      setSortDropdownOpen(false);
-    }
-  }, [filtersOpen]);
-
-  const statuses = useMemo(() => {
-    try {
-      return Array.from(
-        new Set(
-          projects
-            .map((p) => String(p.status || "").toLowerCase())
-            .filter(Boolean)
-        )
-      );
-    } catch {
-      return [] as string[];
-    }
-  }, [projects]);
-
-  const statusOptions = useMemo(
-    () => [{ value: "", label: "All statuses" }, ...statuses.map((s) => ({ value: s, label: s }))],
-    [statuses]
-  );
-
-  useEffect(() => {
-    if (!statusDropdownOpen) {
-      setStatusHighlightIndex(-1);
-      return;
-    }
-
-    const selectedIndex = statusOptions.findIndex((opt) => opt.value === statusFilter);
-    setStatusHighlightIndex(selectedIndex >= 0 ? selectedIndex : 0);
-  }, [statusDropdownOpen, statusFilter, statusOptions]);
-
-  const sortOptions = useMemo(
-    () => [
-      { value: "titleAsc" as SortOption, label: "Title (A-Z)" },
-      { value: "titleDesc" as SortOption, label: "Title (Z-A)" },
-      { value: "dateNewest" as SortOption, label: "Date (Newest)" },
-      { value: "dateOldest" as SortOption, label: "Date (Oldest)" },
-    ],
-    []
-  );
-
-  useEffect(() => {
-    if (!sortDropdownOpen) {
-      setSortHighlightIndex(-1);
-      return;
-    }
-
-    const selectedIndex = sortOptions.findIndex((opt) => opt.value === sortOption);
-    setSortHighlightIndex(selectedIndex >= 0 ? selectedIndex : 0);
-  }, [sortDropdownOpen, sortOption, sortOptions]);
-
-  const items = useMemo(() => {
-    const list: ProjectWithMeta[] = (projects as ProjectLike[]).map((p) => ({
-      ...(p as ProjectWithMeta),
-      _activity: getProjectActivityTs(p),
-      _created: new Date(p.dateCreated || p.date || 0).getTime() || 0,
-    }));
-
-    let ordered = list.slice();
-    if (scope === "recents") {
-      ordered.sort((a, b) => b._activity - a._activity);
-    }
-
-    const q = query.trim().toLowerCase();
-    if (q) {
-      ordered = ordered.filter((p) => (p.title || "").toLowerCase().includes(q));
-    }
-    if (statusFilter) {
-      ordered = ordered.filter(
-        (p) => String(p.status || "").toLowerCase() === statusFilter
-      );
-    }
-
-    const byTitle = (a: ProjectLike, b: ProjectLike) =>
-      (a.title || "").localeCompare(b.title || "", undefined, {
-        sensitivity: "base",
-      });
-    const byCreated = (a: ProjectWithMeta, b: ProjectWithMeta) => b._created - a._created;
-    const byCreatedAsc = (a: ProjectWithMeta, b: ProjectWithMeta) => a._created - b._created;
-
-    switch (sortOption) {
-      case "titleAsc":
-        ordered.sort(byTitle);
-        break;
-      case "titleDesc":
-        ordered.sort((a, b) => -byTitle(a, b));
-        break;
-      case "dateOldest":
-        ordered.sort(byCreatedAsc);
-        break;
-      case "dateNewest":
-      default:
-        ordered.sort(byCreated);
-        break;
-    }
-
-    if (scope === "recents") {
-      return ordered.slice(0, DEFAULT_DESKTOP_ROWS);
-    }
-    return ordered;
-  }, [projects, scope, query, statusFilter, sortOption]);
-
-  const kpis = useProjectKpis(projects as ProjectLike[]);
-
-  const usersById = useMemo(() => {
-    const map = new Map<string, UserLite>();
-    (Array.isArray(allUsers) ? allUsers : []).forEach((u: UserLite) => {
-      if (u?.userId) map.set(u.userId, u);
+  const handleImageError = useCallback((projectId: string) => {
+    setImgError((prev) => {
+      if (prev[projectId]) return prev;
+      return { ...prev, [projectId]: true };
     });
-    return map;
-  }, [allUsers]);
+  }, []);
 
   const handleOpen = useCallback(
     (projectId: string) => {
@@ -310,337 +61,37 @@ const ProjectsPanelDesktop: React.FC<ProjectsPanelDesktopProps> = ({ onOpenProje
     [onOpenProject, navigate]
   );
 
-  const statusTriggerLabel = useMemo(() => {
-    const found = statusOptions.find((opt) => opt.value === statusFilter);
-    return found ? found.label : "All statuses";
-  }, [statusFilter, statusOptions]);
-
-  const statusActiveOptionId =
-    statusDropdownOpen && statusHighlightIndex >= 0
-      ? `${statusListIdRef.current}-option-${statusHighlightIndex}`
-      : undefined;
-
-  const sortTriggerLabel = useMemo(() => {
-    const found = sortOptions.find((opt) => opt.value === sortOption);
-    return found ? found.label : sortOptions[0]?.label || "Sort";
-  }, [sortOption, sortOptions]);
-
-  const sortActiveOptionId =
-    sortDropdownOpen && sortHighlightIndex >= 0
-      ? `${sortListIdRef.current}-option-${sortHighlightIndex}`
-      : undefined;
-
-  const updateHighlight = useCallback(
-    (direction: 1 | -1) => {
-      setStatusHighlightIndex((current) => {
-        if (!statusOptions.length) return -1;
-        const next = current < 0 ? 0 : current + direction;
-        if (next < 0) return statusOptions.length - 1;
-        if (next >= statusOptions.length) return 0;
-        return next;
-      });
-    },
-    [statusOptions.length]
-  );
-
-  const handleStatusSelect = useCallback(
-    (value: string) => {
-      setStatusFilter(value);
-      setStatusDropdownOpen(false);
-    },
-    []
-  );
-
-  const handleStatusTriggerKeyDown = useCallback(
-    (event: React.KeyboardEvent<HTMLButtonElement>) => {
-      if (!statusOptions.length) return;
-
-      switch (event.key) {
-        case "ArrowDown": {
-          event.preventDefault();
-          if (!statusDropdownOpen) {
-            setStatusDropdownOpen(true);
-            return;
-          }
-          updateHighlight(1);
-          break;
-        }
-        case "ArrowUp": {
-          event.preventDefault();
-          if (!statusDropdownOpen) {
-            setStatusDropdownOpen(true);
-            return;
-          }
-          updateHighlight(-1);
-          break;
-        }
-        case "Home": {
-          if (!statusDropdownOpen) return;
-          event.preventDefault();
-          setStatusHighlightIndex(statusOptions.length ? 0 : -1);
-          break;
-        }
-        case "End": {
-          if (!statusDropdownOpen) return;
-          event.preventDefault();
-          setStatusHighlightIndex(statusOptions.length ? statusOptions.length - 1 : -1);
-          break;
-        }
-        case "Enter":
-        case " ": {
-          event.preventDefault();
-          if (statusDropdownOpen && statusHighlightIndex >= 0) {
-            const option = statusOptions[statusHighlightIndex];
-            if (option) {
-              handleStatusSelect(option.value);
-            }
-          } else {
-            setStatusDropdownOpen((open) => !open);
-          }
-          break;
-        }
-        case "Escape": {
-          if (statusDropdownOpen) {
-            event.preventDefault();
-            setStatusDropdownOpen(false);
-          }
-          break;
-        }
-        default:
-          break;
-      }
-    },
-    [handleStatusSelect, statusDropdownOpen, statusHighlightIndex, statusOptions, updateHighlight]
-  );
-
-  const updateSortHighlight = useCallback(
-    (direction: 1 | -1) => {
-      setSortHighlightIndex((current) => {
-        if (!sortOptions.length) return -1;
-        const next = current < 0 ? 0 : current + direction;
-        if (next < 0) return sortOptions.length - 1;
-        if (next >= sortOptions.length) return 0;
-        return next;
-      });
-    },
-    [sortOptions.length]
-  );
-
-  const handleSortSelect = useCallback((value: SortOption) => {
-    setSortOption(value);
-    setSortDropdownOpen(false);
-  }, []);
-
-  const handleSortTriggerKeyDown = useCallback(
-    (event: React.KeyboardEvent<HTMLButtonElement>) => {
-      if (!sortOptions.length) return;
-
-      switch (event.key) {
-        case "ArrowDown": {
-          event.preventDefault();
-          if (!sortDropdownOpen) {
-            setSortDropdownOpen(true);
-            return;
-          }
-          updateSortHighlight(1);
-          break;
-        }
-        case "ArrowUp": {
-          event.preventDefault();
-          if (!sortDropdownOpen) {
-            setSortDropdownOpen(true);
-            return;
-          }
-          updateSortHighlight(-1);
-          break;
-        }
-        case "Home": {
-          if (!sortDropdownOpen) return;
-          event.preventDefault();
-          setSortHighlightIndex(sortOptions.length ? 0 : -1);
-          break;
-        }
-        case "End": {
-          if (!sortDropdownOpen) return;
-          event.preventDefault();
-          setSortHighlightIndex(sortOptions.length ? sortOptions.length - 1 : -1);
-          break;
-        }
-        case "Enter":
-        case " ": {
-          event.preventDefault();
-          if (sortDropdownOpen && sortHighlightIndex >= 0) {
-            const option = sortOptions[sortHighlightIndex];
-            if (option) {
-              handleSortSelect(option.value);
-            }
-          } else {
-            setSortDropdownOpen((open) => !open);
-          }
-          break;
-        }
-        case "Escape": {
-          if (sortDropdownOpen) {
-            event.preventDefault();
-            setSortDropdownOpen(false);
-          }
-          break;
-        }
-        default:
-          break;
-      }
-    },
-    [handleSortSelect, sortDropdownOpen, sortHighlightIndex, sortOptions, updateSortHighlight]
-  );
-
-  const handleRowKeyDown = (e: React.KeyboardEvent<HTMLTableRowElement>, id: string) => {
-    if (e.key === "Enter" || e.key === " ") {
-      e.preventDefault();
-      handleOpen(id);
-    }
-  };
-
-  const getOwnerName = (project: ProjectWithMeta): string => {
-    const team = Array.isArray(project.team) ? project.team : [];
-    if (team.length === 0) return "—";
-    const primary = team[0];
-    const user = primary?.userId ? usersById.get(primary.userId) : undefined;
-    const first = user?.firstName ?? primary?.firstName ?? "";
-    const last = user?.lastName ?? primary?.lastName ?? "";
-    const full = `${first} ${last}`.trim();
-    if (full) return full;
-    return user?.email || user?.username || primary?.email || primary?.userId || "—";
-  };
-
-  const renderIconsStrip = () => {
-    const allProjects = projects as ProjectLike[];
-    const maxIcons = 7;
-    const shown = allProjects.slice(0, maxIcons);
-    const more = Math.max(0, allProjects.length - shown.length);
-
-    return (
-      <div className={mobileStyles.iconsStrip} aria-label="Quick projects">
-        {shown.map((p) => {
-          const id = p.projectId;
-          const title = (p.title || "Untitled project").trim();
-          const thumb = Array.isArray(p.thumbnails) && p.thumbnails[0] ? p.thumbnails[0] : undefined;
-          return (
-            <button
-              key={`icon-${id}`}
-              type="button"
-              className={mobileStyles.iconBtnSm}
-              aria-label={`Open project ${title}`}
-              title={title}
-              onClick={() => handleOpen(id)}
-            >
-              {thumb && !imgError[id] ? (
-                <img
-                  className={mobileStyles.thumbSm}
-                  src={getFileUrl(thumb)}
-                  alt=""
-                  onError={() => setImgError((m) => ({ ...m, [id]: true }))}
-                />
-              ) : (
-                <SVGThumbnail
-                  initial={title.charAt(0).toUpperCase() || "#"}
-                  className={mobileStyles.thumbSm}
-                />
-              )}
-            </button>
-          );
-        })}
-        {more > 0 && (
-          <span className={mobileStyles.iconsMore} aria-hidden>
-            +{more}
-          </span>
-        )}
-      </div>
-    );
-  };
-
-  const tableRows = items.map((p) => {
-    const id = p.projectId;
-    const title = (p.title || "Untitled project").trim();
-    const thumb = Array.isArray(p.thumbnails) && p.thumbnails[0] ? p.thumbnails[0] : undefined;
-    const deadline = formatShortDate(p.finishline);
-    const status = p.status ? String(p.status) : "—";
-    const unread = Number.isFinite(p.unreadCount as number) ? Number(p.unreadCount) : Number((p as { unreadCount?: number }).unreadCount ?? 0);
-    const owner = getOwnerName(p);
-
-    return (
-      <tr
-        key={id}
-        tabIndex={0}
-        onClick={() => handleOpen(id)}
-        onKeyDown={(event) => handleRowKeyDown(event, id)}
-        aria-label={`Open project ${title}`}
-      >
-        <td>
-          <div className={desktopStyles.projectCell}>
-            <span className={desktopStyles.thumb} aria-hidden>
-              {thumb && !imgError[id] ? (
-                <img
-                  className={mobileStyles.thumb}
-                  src={getFileUrl(thumb)}
-                  alt=""
-                  onError={() => setImgError((m) => ({ ...m, [id]: true }))}
-                />
-              ) : (
-                <SVGThumbnail
-                  initial={title.charAt(0).toUpperCase() || "#"}
-                  className={mobileStyles.thumb}
-                />
-              )}
-            </span>
-            <span className={desktopStyles.projectName}>{title}</span>
-          </div>
-        </td>
-        <td>
-          <span className={desktopStyles.statusBadge}>{status}</span>
-        </td>
-        <td>
-          <span className={desktopStyles.deadline}>{deadline ?? "—"}</span>
-        </td>
-        <td>
-          <span className={desktopStyles.owner}>{owner}</span>
-        </td>
-        <td>
-          <span className={desktopStyles.unreadPill}>{unread}</span>
-        </td>
-      </tr>
-    );
+  const {
+    filtersOpen,
+    filtersRef,
+    filtersId,
+    toggleFilters,
+    scope,
+    setScope,
+    query,
+    setQuery,
+    statusOptions,
+    statusTriggerLabel,
+    statusDropdown,
+    showStatusDropdown,
+    sortOptions,
+    sortTriggerLabel,
+    sortDropdown,
+    filteredProjects,
+  } = useProjectFilters({
+    projects: projects as ProjectLike[],
+    recentsLimit: DEFAULT_DESKTOP_ROWS,
   });
 
-  const errorText = projectsError ? "Failed to load projects." : undefined;
+  const kpis = useProjectKpis(projects as ProjectLike[]);
 
-  let bodyContent: React.ReactNode;
-
-  if (errorText) {
-    bodyContent = <div className={desktopStyles.errorState}>{errorText}</div>;
-  } else {
-    bodyContent = (
-      <div className={desktopStyles.tableWrap}>
-        {isLoading ? (
-          <div className={desktopStyles.emptyState}>Loading projects…</div>
-        ) : items.length === 0 ? (
-          <div className={desktopStyles.emptyState}>No projects match filters.</div>
-        ) : (
-          <table className={desktopStyles.table} aria-label="Projects table">
-            <thead>
-              <tr>
-                <th scope="col">Project</th>
-                <th scope="col">Status</th>
-                <th scope="col">Deadline</th>
-                <th scope="col">Owner</th>
-                <th scope="col">Unread</th>
-              </tr>
-            </thead>
-            <tbody>{tableRows}</tbody>
-          </table>
-        )}
-      </div>
-    );
-  }
+  const usersById = useMemo(() => {
+    const map = new Map<string, UserLite>();
+    (Array.isArray(allUsers) ? allUsers : []).forEach((user: UserLite) => {
+      if (user?.userId) map.set(user.userId, user);
+    });
+    return map;
+  }, [allUsers]);
 
   return (
     <section
@@ -651,183 +102,32 @@ const ProjectsPanelDesktop: React.FC<ProjectsPanelDesktopProps> = ({ onOpenProje
         <div className={desktopStyles.headerTop}>
           <div className={mobileStyles.titleWrap}>
             <h3 className={mobileStyles.title}>Projects</h3>
-            {renderIconsStrip()}
+            <ProjectsIconsStrip
+              projects={projects as ProjectLike[]}
+              imgError={imgError}
+              onImageError={handleImageError}
+              onOpenProject={handleOpen}
+            />
           </div>
         </div>
 
-        <div className={mobileStyles.recentsWrap} ref={filtersRef}>
-          <button
-            type="button"
-            className={mobileStyles.recents}
-            aria-expanded={filtersOpen}
-            aria-haspopup="menu"
-            aria-controls={filtersIdRef.current}
-            onClick={() => setFiltersOpen((v) => !v)}
-          >
-            {scope === "recents" ? "Recents" : "All projects"} <ChevronDown size={14} aria-hidden />
-          </button>
-          {filtersOpen && (
-            <div className={mobileStyles.filterPop} role="menu" id={filtersIdRef.current}>
-              <div className={mobileStyles.filterSection}>
-                <div
-                  className={mobileStyles.scopeBtns}
-                  role="group"
-                  aria-label="Scope"
-                >
-                  <button
-                    type="button"
-                    className={`${mobileStyles.scopeBtn} ${
-                      scope === "recents" ? mobileStyles.scopeBtnActive : ""
-                    }`}
-                    onClick={() => setScope("recents")}
-                  >
-                    Recents
-                  </button>
-                  <button
-                    type="button"
-                    className={`${mobileStyles.scopeBtn} ${
-                      scope === "all" ? mobileStyles.scopeBtnActive : ""
-                    }`}
-                    onClick={() => setScope("all")}
-                  >
-                    All projects
-                  </button>
-                </div>
-
-                <div className={desktopStyles.filterField}>
-                  <Search size={16} aria-hidden className={desktopStyles.filterFieldIcon} />
-                  <input
-                    className={desktopStyles.filterInput}
-                    placeholder="Filter by title..."
-                    value={query}
-                    onChange={(e) => setQuery(e.target.value)}
-                    aria-label="Filter projects by title"
-                  />
-                </div>
-
-                {statuses.length > 0 && (
-                  <div
-                    className={desktopStyles.statusDropdown}
-                    ref={statusDropdownRef}
-                  >
-                    <button
-                      type="button"
-                      className={desktopStyles.statusTrigger}
-                      aria-haspopup="listbox"
-                      aria-expanded={statusDropdownOpen}
-                      aria-controls={statusListIdRef.current}
-                      aria-activedescendant={statusActiveOptionId}
-                      onClick={() => setStatusDropdownOpen((open) => !open)}
-                      onKeyDown={handleStatusTriggerKeyDown}
-                    >
-                      <span className={desktopStyles.triggerLabel}>
-                        <span className={desktopStyles.triggerLabelText}>{statusTriggerLabel}</span>
-                      </span>
-                      <ChevronDown
-                        size={14}
-                        aria-hidden
-                        className={desktopStyles.triggerChevron}
-                      />
-                    </button>
-                    {statusDropdownOpen && (
-                      <ul
-                        className={desktopStyles.statusOptions}
-                        role="listbox"
-                        id={statusListIdRef.current}
-                      >
-                        {statusOptions.map((option, index) => {
-                          const optionId = `${statusListIdRef.current}-option-${index}`;
-                          const isSelected = statusFilter === option.value;
-                          const isActive = statusHighlightIndex === index;
-                          return (
-                            <li
-                              key={`${option.value || "all"}-${index}`}
-                              role="option"
-                              id={optionId}
-                              aria-selected={isSelected}
-                            >
-                              <button
-                                type="button"
-                                className={`${desktopStyles.statusOptionButton} ${
-                                  isSelected ? desktopStyles.statusOptionSelected : ""
-                                } ${isActive ? desktopStyles.statusOptionActive : ""}`}
-                                onClick={() => handleStatusSelect(option.value)}
-                                onMouseEnter={() => setStatusHighlightIndex(index)}
-                                onFocus={() => setStatusHighlightIndex(index)}
-                              >
-                                {option.label}
-                              </button>
-                            </li>
-                          );
-                        })}
-                      </ul>
-                    )}
-                  </div>
-                )}
-
-                <div className={desktopStyles.statusDropdown} ref={sortDropdownRef}>
-                  <button
-                    type="button"
-                    className={desktopStyles.statusTrigger}
-                    aria-haspopup="listbox"
-                    aria-expanded={sortDropdownOpen}
-                    aria-controls={sortListIdRef.current}
-                    aria-activedescendant={sortActiveOptionId}
-                    onClick={() => setSortDropdownOpen((open) => !open)}
-                    onKeyDown={handleSortTriggerKeyDown}
-                  >
-                    <span className={desktopStyles.triggerLabel}>
-                      <CalendarDays
-                        size={16}
-                        aria-hidden
-                        className={desktopStyles.triggerLabelIcon}
-                      />
-                      <span className={desktopStyles.triggerLabelText}>{sortTriggerLabel}</span>
-                    </span>
-                    <ChevronDown
-                      size={14}
-                      aria-hidden
-                      className={desktopStyles.triggerChevron}
-                    />
-                  </button>
-                  {sortDropdownOpen && (
-                    <ul
-                      className={desktopStyles.statusOptions}
-                      role="listbox"
-                      id={sortListIdRef.current}
-                    >
-                      {sortOptions.map((option, index) => {
-                        const optionId = `${sortListIdRef.current}-option-${index}`;
-                        const isSelected = sortOption === option.value;
-                        const isActive = sortHighlightIndex === index;
-                        return (
-                          <li
-                            key={`${option.value}-${index}`}
-                            role="option"
-                            id={optionId}
-                            aria-selected={isSelected}
-                          >
-                            <button
-                              type="button"
-                              className={`${desktopStyles.statusOptionButton} ${
-                                isSelected ? desktopStyles.statusOptionSelected : ""
-                              } ${isActive ? desktopStyles.statusOptionActive : ""}`}
-                              onClick={() => handleSortSelect(option.value)}
-                              onMouseEnter={() => setSortHighlightIndex(index)}
-                              onFocus={() => setSortHighlightIndex(index)}
-                            >
-                              {option.label}
-                            </button>
-                          </li>
-                        );
-                      })}
-                    </ul>
-                  )}
-                </div>
-              </div>
-            </div>
-          )}
-        </div>
+        <ProjectsFilterMenu
+          filtersOpen={filtersOpen}
+          filtersRef={filtersRef}
+          filtersId={filtersId}
+          scope={scope}
+          onScopeChange={setScope}
+          query={query}
+          onQueryChange={setQuery}
+          toggleFilters={toggleFilters}
+          statusOptions={statusOptions}
+          statusTriggerLabel={statusTriggerLabel}
+          statusDropdown={statusDropdown}
+          showStatusDropdown={showStatusDropdown}
+          sortOptions={sortOptions}
+          sortTriggerLabel={sortTriggerLabel}
+          sortDropdown={sortDropdown}
+        />
 
         <div className={mobileStyles.kpis}>
           <motion.span
@@ -861,7 +161,17 @@ const ProjectsPanelDesktop: React.FC<ProjectsPanelDesktopProps> = ({ onOpenProje
         </div>
       </header>
 
-      <div className={desktopStyles.content}>{bodyContent}</div>
+      <div className={desktopStyles.content}>
+        <ProjectsTable
+          projects={filteredProjects as ProjectWithMeta[]}
+          isLoading={isLoading}
+          projectsError={projectsError}
+          onOpenProject={handleOpen}
+          onImageError={handleImageError}
+          imgError={imgError}
+          usersById={usersById}
+        />
+      </div>
 
       <div className={desktopStyles.footer}>
         <button

--- a/frontend/src/features/projects/ProjectsTable.test.tsx
+++ b/frontend/src/features/projects/ProjectsTable.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import ProjectsTable from "./ProjectsTable";
+import type { ProjectWithMeta } from "./types";
+import type { UserLite } from "@/app/contexts/DataProvider";
+import "@testing-library/jest-dom";
+
+const createProject = (overrides: Partial<ProjectWithMeta> = {}): ProjectWithMeta => ({
+  projectId: "project-1",
+  title: "Example Project",
+  status: "active",
+  finishline: "2024-06-15",
+  thumbnails: [],
+  team: [{ userId: "user-1" }],
+  unreadCount: 2,
+  dateCreated: "2024-05-01",
+  _activity: Date.now(),
+  _created: Date.now(),
+  ...overrides,
+});
+
+describe("ProjectsTable", () => {
+  const usersById = new Map<string, UserLite>([
+    [
+      "user-1",
+      {
+        userId: "user-1",
+        firstName: "Pat",
+        lastName: "Manager",
+        email: "pat@example.com",
+      } as UserLite,
+    ],
+  ]);
+
+  it("renders error state", () => {
+    render(
+      <ProjectsTable
+        projects={[]}
+        isLoading={false}
+        projectsError
+        onOpenProject={vi.fn()}
+        onImageError={vi.fn()}
+        imgError={{}}
+        usersById={usersById}
+      />
+    );
+
+    expect(screen.getByText(/failed to load projects/i)).toBeInTheDocument();
+  });
+
+  it("shows loading placeholder", () => {
+    render(
+      <ProjectsTable
+        projects={[]}
+        isLoading
+        projectsError={false}
+        onOpenProject={vi.fn()}
+        onImageError={vi.fn()}
+        imgError={{}}
+        usersById={usersById}
+      />
+    );
+
+    expect(screen.getByText(/loading projects/i)).toBeInTheDocument();
+  });
+
+  it("renders project rows and handles activation", () => {
+    const onOpenProject = vi.fn();
+    const project = createProject({ projectId: "project-123", title: "Launch Plan" });
+
+    render(
+      <ProjectsTable
+        projects={[project]}
+        isLoading={false}
+        projectsError={false}
+        onOpenProject={onOpenProject}
+        onImageError={vi.fn()}
+        imgError={{}}
+        usersById={usersById}
+      />
+    );
+
+    expect(screen.getByRole("table")).toBeInTheDocument();
+    expect(screen.getByText("Launch Plan")).toBeInTheDocument();
+    expect(screen.getByText("Pat Manager")).toBeInTheDocument();
+
+    const row = screen.getByRole("row", { name: /open project launch plan/i });
+    fireEvent.click(row);
+    expect(onOpenProject).toHaveBeenCalledWith("project-123");
+  });
+});

--- a/frontend/src/features/projects/ProjectsTable.tsx
+++ b/frontend/src/features/projects/ProjectsTable.tsx
@@ -1,0 +1,140 @@
+import type { FC, KeyboardEvent as ReactKeyboardEvent } from "react";
+
+import desktopStyles from "./ProjectsPanelDesktop.module.css";
+import mobileStyles from "@/features/dashboard/components/projects-panel.module.css";
+import SVGThumbnail from "@/features/dashboard/components/SvgThumbnail";
+import { getFileUrl } from "@/shared/utils/api";
+import type { UserLite } from "@/app/contexts/DataProvider";
+import type { ProjectWithMeta } from "./types";
+import { formatShortDate } from "./utils";
+
+type ProjectsTableProps = {
+  projects: ProjectWithMeta[];
+  isLoading: boolean;
+  projectsError: boolean;
+  onOpenProject: (projectId: string) => void;
+  onImageError: (projectId: string) => void;
+  imgError: Record<string, boolean>;
+  usersById: Map<string, UserLite>;
+};
+
+const getOwnerName = (project: ProjectWithMeta, usersById: Map<string, UserLite>): string => {
+  const team = Array.isArray(project.team) ? project.team : [];
+  if (team.length === 0) return "—";
+  const primary = team[0];
+  const user = primary?.userId ? usersById.get(primary.userId) : undefined;
+  const first = user?.firstName ?? primary?.firstName ?? "";
+  const last = user?.lastName ?? primary?.lastName ?? "";
+  const full = `${first} ${last}`.trim();
+  if (full) return full;
+  return user?.email || user?.username || primary?.email || primary?.userId || "—";
+};
+
+const ProjectsTable: FC<ProjectsTableProps> = ({
+  projects,
+  isLoading,
+  projectsError,
+  onOpenProject,
+  onImageError,
+  imgError,
+  usersById,
+}) => {
+  const handleRowKeyDown = (
+    event: ReactKeyboardEvent<HTMLTableRowElement>,
+    projectId: string
+  ) => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      onOpenProject(projectId);
+    }
+  };
+
+  const errorText = projectsError ? "Failed to load projects." : undefined;
+
+  if (errorText) {
+    return <div className={desktopStyles.errorState}>{errorText}</div>;
+  }
+
+  return (
+    <div className={desktopStyles.tableWrap}>
+      {isLoading ? (
+        <div className={desktopStyles.emptyState}>Loading projects…</div>
+      ) : projects.length === 0 ? (
+        <div className={desktopStyles.emptyState}>No projects match filters.</div>
+      ) : (
+        <table className={desktopStyles.table} aria-label="Projects table">
+          <thead>
+            <tr>
+              <th scope="col">Project</th>
+              <th scope="col">Status</th>
+              <th scope="col">Deadline</th>
+              <th scope="col">Owner</th>
+              <th scope="col">Unread</th>
+            </tr>
+          </thead>
+          <tbody>
+            {projects.map((project) => {
+              const id = project.projectId;
+              const title = (project.title || "Untitled project").trim();
+              const thumb =
+                Array.isArray(project.thumbnails) && project.thumbnails[0]
+                  ? project.thumbnails[0]
+                  : undefined;
+              const deadline = formatShortDate(project.finishline);
+              const status = project.status ? String(project.status) : "—";
+              const unread = Number.isFinite(project.unreadCount as number)
+                ? Number(project.unreadCount)
+                : Number((project as { unreadCount?: number }).unreadCount ?? 0);
+              const owner = getOwnerName(project, usersById);
+
+              return (
+                <tr
+                  key={id}
+                  tabIndex={0}
+                  onClick={() => onOpenProject(id)}
+                  onKeyDown={(event) => handleRowKeyDown(event, id)}
+                  aria-label={`Open project ${title}`}
+                >
+                  <td>
+                    <div className={desktopStyles.projectCell}>
+                      <span className={desktopStyles.thumb} aria-hidden>
+                        {thumb && !imgError[id] ? (
+                          <img
+                            className={mobileStyles.thumb}
+                            src={getFileUrl(thumb)}
+                            alt=""
+                            onError={() => onImageError(id)}
+                          />
+                        ) : (
+                          <SVGThumbnail
+                            initial={title.charAt(0).toUpperCase() || "#"}
+                            className={mobileStyles.thumb}
+                          />
+                        )}
+                      </span>
+                      <span className={desktopStyles.projectName}>{title}</span>
+                    </div>
+                  </td>
+                  <td>
+                    <span className={desktopStyles.statusBadge}>{status}</span>
+                  </td>
+                  <td>
+                    <span className={desktopStyles.deadline}>{deadline ?? "—"}</span>
+                  </td>
+                  <td>
+                    <span className={desktopStyles.owner}>{owner}</span>
+                  </td>
+                  <td>
+                    <span className={desktopStyles.unreadPill}>{unread}</span>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+};
+
+export default ProjectsTable;

--- a/frontend/src/features/projects/hooks/useDropdown.ts
+++ b/frontend/src/features/projects/hooks/useDropdown.ts
@@ -1,0 +1,226 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type RefObject,
+} from "react";
+
+import { createRandomId } from "../utils";
+
+type DropdownOption<T> = {
+  value: T;
+  label: string;
+};
+
+type UseDropdownParams<T> = {
+  options: DropdownOption<T>[];
+  selectedValue: T;
+  onSelect: (value: T) => void;
+  idPrefix: string;
+};
+
+type DropdownOptionRenderState = {
+  id: string;
+  isSelected: boolean;
+  isActive: boolean;
+};
+
+type DropdownOptionButtonProps = {
+  type: "button";
+  onClick: () => void;
+  onMouseEnter: () => void;
+  onFocus: () => void;
+};
+
+export type DropdownHelpers<T> = {
+  dropdownRef: RefObject<HTMLDivElement>;
+  isOpen: boolean;
+  open: () => void;
+  close: () => void;
+  toggle: () => void;
+  listId: string;
+  activeOptionId?: string;
+  highlightIndex: number;
+  handleTriggerKeyDown: (event: ReactKeyboardEvent<HTMLButtonElement>) => void;
+  getOptionRenderState: (option: DropdownOption<T>, index: number) => DropdownOptionRenderState;
+  getOptionButtonProps: (option: DropdownOption<T>, index: number) => DropdownOptionButtonProps;
+};
+
+export const useDropdown = <T,>({
+  options,
+  selectedValue,
+  onSelect,
+  idPrefix,
+}: UseDropdownParams<T>): DropdownHelpers<T> => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [highlightIndex, setHighlightIndex] = useState(-1);
+  const dropdownRef = useRef<HTMLDivElement | null>(null);
+
+  const listId = useMemo(() => createRandomId(idPrefix), [idPrefix]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handlePointer = (event: MouseEvent) => {
+      if (
+        dropdownRef.current &&
+        event.target instanceof Node &&
+        !dropdownRef.current.contains(event.target)
+      ) {
+        setIsOpen(false);
+      }
+    };
+
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handlePointer);
+    document.addEventListener("keydown", handleKey);
+
+    return () => {
+      document.removeEventListener("mousedown", handlePointer);
+      document.removeEventListener("keydown", handleKey);
+    };
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setHighlightIndex(-1);
+      return;
+    }
+
+    const selectedIndex = options.findIndex((option) => option.value === selectedValue);
+    setHighlightIndex(selectedIndex >= 0 ? selectedIndex : 0);
+  }, [isOpen, options, selectedValue]);
+
+  const close = useCallback(() => setIsOpen(false), []);
+  const open = useCallback(() => setIsOpen(true), []);
+  const toggle = useCallback(() => setIsOpen((prev) => !prev), []);
+
+  const selectOption = useCallback(
+    (value: T) => {
+      onSelect(value);
+      setIsOpen(false);
+    },
+    [onSelect]
+  );
+
+  const updateHighlight = useCallback(
+    (direction: 1 | -1) => {
+      setHighlightIndex((current) => {
+        if (!options.length) return -1;
+        const next = current < 0 ? 0 : current + direction;
+        if (next < 0) return options.length - 1;
+        if (next >= options.length) return 0;
+        return next;
+      });
+    },
+    [options.length]
+  );
+
+  const handleTriggerKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLButtonElement>) => {
+      if (!options.length) return;
+
+      switch (event.key) {
+        case "ArrowDown": {
+          event.preventDefault();
+          if (!isOpen) {
+            open();
+            return;
+          }
+          updateHighlight(1);
+          break;
+        }
+        case "ArrowUp": {
+          event.preventDefault();
+          if (!isOpen) {
+            open();
+            return;
+          }
+          updateHighlight(-1);
+          break;
+        }
+        case "Home": {
+          if (!isOpen) return;
+          event.preventDefault();
+          setHighlightIndex(options.length ? 0 : -1);
+          break;
+        }
+        case "End": {
+          if (!isOpen) return;
+          event.preventDefault();
+          setHighlightIndex(options.length ? options.length - 1 : -1);
+          break;
+        }
+        case "Enter":
+        case " ": {
+          event.preventDefault();
+          if (isOpen && highlightIndex >= 0) {
+            const option = options[highlightIndex];
+            if (option) selectOption(option.value);
+          } else {
+            toggle();
+          }
+          break;
+        }
+        case "Escape": {
+          if (isOpen) {
+            event.preventDefault();
+            close();
+          }
+          break;
+        }
+        default:
+          break;
+      }
+    },
+    [close, highlightIndex, isOpen, open, options, selectOption, toggle, updateHighlight]
+  );
+
+  const activeOptionId = useMemo(() => {
+    if (!isOpen || highlightIndex < 0) return undefined;
+    return `${listId}-option-${highlightIndex}`;
+  }, [highlightIndex, isOpen, listId]);
+
+  const getOptionRenderState = useCallback(
+    (option: DropdownOption<T>, index: number): DropdownOptionRenderState => ({
+      id: `${listId}-option-${index}`,
+      isSelected: option.value === selectedValue,
+      isActive: highlightIndex === index,
+    }),
+    [highlightIndex, listId, selectedValue]
+  );
+
+  const getOptionButtonProps = useCallback(
+    (option: DropdownOption<T>, index: number): DropdownOptionButtonProps => ({
+      type: "button" as const,
+      onClick: () => selectOption(option.value),
+      onMouseEnter: () => setHighlightIndex(index),
+      onFocus: () => setHighlightIndex(index),
+    }),
+    [selectOption]
+  );
+
+  return {
+    dropdownRef,
+    isOpen,
+    open,
+    close,
+    toggle,
+    listId,
+    activeOptionId,
+    highlightIndex,
+    handleTriggerKeyDown,
+    getOptionRenderState,
+    getOptionButtonProps,
+  };
+};
+
+export type { DropdownOption };

--- a/frontend/src/features/projects/hooks/useProjectFilters.test.ts
+++ b/frontend/src/features/projects/hooks/useProjectFilters.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+import { useProjectFilters } from "./useProjectFilters";
+import type { ProjectLike } from "@/features/dashboard/hooks/useProjectKpis";
+
+describe("useProjectFilters", () => {
+  const projects: ProjectLike[] = [
+    {
+      projectId: "alpha",
+      title: "Alpha Roadmap",
+      status: "Active",
+      updatedAt: "2024-06-01T00:00:00Z",
+      dateCreated: "2024-03-01T00:00:00Z",
+    },
+    {
+      projectId: "beta",
+      title: "Beta Launch",
+      status: "Archived",
+      updatedAt: "2024-06-05T00:00:00Z",
+      dateCreated: "2024-04-01T00:00:00Z",
+    },
+    {
+      projectId: "gamma",
+      title: "Gamma Planning",
+      status: "Active",
+      updatedAt: "2024-05-28T00:00:00Z",
+      dateCreated: "2024-05-01T00:00:00Z",
+    },
+  ] as ProjectLike[];
+
+  it("limits recents by activity timestamp", () => {
+    const { result } = renderHook(() =>
+      useProjectFilters({ projects, recentsLimit: 2 })
+    );
+
+    expect(result.current.filteredProjects).toHaveLength(2);
+    expect(result.current.filteredProjects[0]?.projectId).toBe("gamma");
+  });
+
+  it("filters projects by query and scope", () => {
+    const { result } = renderHook(() =>
+      useProjectFilters({ projects, recentsLimit: 2 })
+    );
+
+    act(() => {
+      result.current.setQuery("gamma");
+    });
+
+    expect(result.current.filteredProjects).toHaveLength(1);
+    expect(result.current.filteredProjects[0]?.projectId).toBe("gamma");
+
+    act(() => {
+      result.current.setScope("all");
+      result.current.setQuery("");
+    });
+
+    expect(result.current.filteredProjects).toHaveLength(3);
+  });
+
+  it("exposes normalized status options and selection", () => {
+    const { result } = renderHook(() =>
+      useProjectFilters({ projects, recentsLimit: 3 })
+    );
+
+    expect(result.current.statusOptions.map((option) => option.label)).toEqual([
+      "All statuses",
+      "active",
+      "archived",
+    ]);
+
+    act(() => {
+      const option = result.current.statusOptions[1];
+      result.current
+        .statusDropdown
+        .getOptionButtonProps(option, 1)
+        .onClick();
+    });
+
+    expect(result.current.filteredProjects.every((project) => project.status === "Active")).toBe(true);
+  });
+});

--- a/frontend/src/features/projects/hooks/useProjectFilters.ts
+++ b/frontend/src/features/projects/hooks/useProjectFilters.ts
@@ -1,0 +1,218 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type RefObject,
+} from "react";
+
+import type { ProjectLike } from "@/features/dashboard/hooks/useProjectKpis";
+
+import { createRandomId, getProjectActivityTs } from "../utils";
+import { useDropdown, type DropdownHelpers, type DropdownOption } from "./useDropdown";
+import type { ProjectWithMeta } from "../types";
+
+export type SortOption = "titleAsc" | "titleDesc" | "dateNewest" | "dateOldest";
+
+type UseProjectFiltersArgs = {
+  projects: ProjectLike[];
+  recentsLimit: number;
+};
+
+type UseProjectFiltersResult = {
+  filtersOpen: boolean;
+  toggleFilters: () => void;
+  closeFilters: () => void;
+  filtersRef: RefObject<HTMLDivElement>;
+  filtersId: string;
+  scope: "recents" | "all";
+  setScope: (scope: "recents" | "all") => void;
+  query: string;
+  setQuery: (value: string) => void;
+  statusFilter: string;
+  statusOptions: DropdownOption<string>[];
+  statusTriggerLabel: string;
+  statusDropdown: DropdownHelpers<string>;
+  showStatusDropdown: boolean;
+  sortOption: SortOption;
+  sortOptions: DropdownOption<SortOption>[];
+  sortTriggerLabel: string;
+  sortDropdown: DropdownHelpers<SortOption>;
+  filteredProjects: ProjectWithMeta[];
+};
+
+const SORT_OPTIONS: DropdownOption<SortOption>[] = [
+  { value: "titleAsc", label: "Title (A-Z)" },
+  { value: "titleDesc", label: "Title (Z-A)" },
+  { value: "dateNewest", label: "Date (Newest)" },
+  { value: "dateOldest", label: "Date (Oldest)" },
+];
+
+export const useProjectFilters = ({
+  projects,
+  recentsLimit,
+}: UseProjectFiltersArgs): UseProjectFiltersResult => {
+  const [filtersOpen, setFiltersOpen] = useState(false);
+  const [scope, setScope] = useState<"recents" | "all">("recents");
+  const [query, setQuery] = useState("");
+  const [statusFilter, setStatusFilter] = useState("");
+  const [sortOption, setSortOption] = useState<SortOption>("dateNewest");
+
+  const filtersRef = useRef<HTMLDivElement | null>(null);
+  const filtersId = useMemo(() => createRandomId("projects-filters"), []);
+
+  useEffect(() => {
+    const handleDocumentClick = (event: MouseEvent) => {
+      if (!filtersOpen) return;
+      if (
+        filtersRef.current &&
+        event.target instanceof Node &&
+        !filtersRef.current.contains(event.target)
+      ) {
+        setFiltersOpen(false);
+      }
+    };
+
+    document.addEventListener("click", handleDocumentClick);
+    return () => document.removeEventListener("click", handleDocumentClick);
+  }, [filtersOpen]);
+
+  const toggleFilters = useCallback(() => {
+    setFiltersOpen((prev) => !prev);
+  }, []);
+
+  const closeFilters = useCallback(() => {
+    setFiltersOpen(false);
+  }, []);
+
+  const statuses = useMemo(() => {
+    try {
+      return Array.from(
+        new Set(
+          projects
+            .map((project) => String(project.status || "").toLowerCase())
+            .filter(Boolean)
+        )
+      );
+    } catch {
+      return [] as string[];
+    }
+  }, [projects]);
+
+  const statusOptions = useMemo<DropdownOption<string>[]>(() => {
+    if (!statuses.length) return [{ value: "", label: "All statuses" }];
+    return [{ value: "", label: "All statuses" }, ...statuses.map((value) => ({ value, label: value }))];
+  }, [statuses]);
+
+  const statusDropdown = useDropdown({
+    options: statusOptions,
+    selectedValue: statusFilter,
+    onSelect: setStatusFilter,
+    idPrefix: "projects-status",
+  });
+
+  const sortOptions = SORT_OPTIONS;
+
+  const sortDropdown = useDropdown({
+    options: sortOptions,
+    selectedValue: sortOption,
+    onSelect: setSortOption,
+    idPrefix: "projects-sort",
+  });
+
+  const { close: closeStatusDropdown } = statusDropdown;
+  const { close: closeSortDropdown } = sortDropdown;
+
+  useEffect(() => {
+    if (!filtersOpen) {
+      closeStatusDropdown();
+      closeSortDropdown();
+    }
+  }, [closeSortDropdown, closeStatusDropdown, filtersOpen]);
+
+  const filteredProjects = useMemo<ProjectWithMeta[]>(() => {
+    const list: ProjectWithMeta[] = projects.map((project) => ({
+      ...(project as ProjectWithMeta),
+      _activity: getProjectActivityTs(project),
+      _created: new Date(project.dateCreated || project.date || 0).getTime() || 0,
+    }));
+
+    let ordered = list.slice();
+    if (scope === "recents") {
+      ordered.sort((a, b) => b._activity - a._activity);
+    }
+
+    const q = query.trim().toLowerCase();
+    if (q) {
+      ordered = ordered.filter((project) => (project.title || "").toLowerCase().includes(q));
+    }
+
+    if (statusFilter) {
+      ordered = ordered.filter(
+        (project) => String(project.status || "").toLowerCase() === statusFilter
+      );
+    }
+
+    const byTitle = (a: ProjectLike, b: ProjectLike) =>
+      (a.title || "").localeCompare(b.title || "", undefined, {
+        sensitivity: "base",
+      });
+    const byCreatedDesc = (a: ProjectWithMeta, b: ProjectWithMeta) => b._created - a._created;
+    const byCreatedAsc = (a: ProjectWithMeta, b: ProjectWithMeta) => a._created - b._created;
+
+    switch (sortOption) {
+      case "titleAsc":
+        ordered.sort(byTitle);
+        break;
+      case "titleDesc":
+        ordered.sort((a, b) => -byTitle(a, b));
+        break;
+      case "dateOldest":
+        ordered.sort(byCreatedAsc);
+        break;
+      case "dateNewest":
+      default:
+        ordered.sort(byCreatedDesc);
+        break;
+    }
+
+    if (scope === "recents") {
+      return ordered.slice(0, recentsLimit);
+    }
+
+    return ordered;
+  }, [projects, scope, query, statusFilter, sortOption, recentsLimit]);
+
+  const statusTriggerLabel = useMemo(() => {
+    const found = statusOptions.find((option) => option.value === statusFilter);
+    return found ? found.label : "All statuses";
+  }, [statusFilter, statusOptions]);
+
+  const sortTriggerLabel = useMemo(() => {
+    const found = sortOptions.find((option) => option.value === sortOption);
+    return found ? found.label : sortOptions[0]?.label || "Sort";
+  }, [sortOption, sortOptions]);
+
+  return {
+    filtersOpen,
+    toggleFilters,
+    closeFilters,
+    filtersRef,
+    filtersId,
+    scope,
+    setScope,
+    query,
+    setQuery,
+    statusFilter,
+    statusOptions,
+    statusTriggerLabel,
+    statusDropdown,
+    showStatusDropdown: statuses.length > 0,
+    sortOption,
+    sortOptions,
+    sortTriggerLabel,
+    sortDropdown,
+    filteredProjects,
+  };
+};

--- a/frontend/src/features/projects/types.ts
+++ b/frontend/src/features/projects/types.ts
@@ -1,0 +1,13 @@
+import type { ProjectLike } from "@/features/dashboard/hooks/useProjectKpis";
+
+export type ProjectWithMeta = ProjectLike & {
+  _activity: number;
+  _created: number;
+  team?: Array<{
+    userId?: string;
+    firstName?: string;
+    lastName?: string;
+    email?: string;
+  }>;
+  unreadCount?: number;
+};

--- a/frontend/src/features/projects/utils.ts
+++ b/frontend/src/features/projects/utils.ts
@@ -1,0 +1,35 @@
+import type { ProjectLike } from "@/features/dashboard/hooks/useProjectKpis";
+
+export const createRandomId = (prefix: string) =>
+  `${prefix}-${Math.random().toString(36).slice(2, 10)}`;
+
+export const formatShortDate = (iso?: string): string | undefined => {
+  if (!iso) return undefined;
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return undefined;
+  return d.toLocaleString(undefined, { month: "short", day: "numeric" });
+};
+
+export const getProjectActivityTs = (project: ProjectLike): number => {
+  const candidates: (string | undefined)[] = [
+    project.updatedAt,
+    project.dateUpdated,
+    project.lastModified,
+    project.date,
+    project.dateCreated,
+  ];
+
+  if (Array.isArray(project.timelineEvents)) {
+    for (const event of project.timelineEvents) {
+      if (event?.timestamp) candidates.push(event.timestamp);
+      if (event?.date) candidates.push(event.date);
+    }
+  }
+
+  const timestamps = candidates
+    .filter(Boolean)
+    .map((value) => new Date(value as string).getTime())
+    .filter((value) => Number.isFinite(value));
+
+  return timestamps.length ? Math.max(...timestamps) : 0;
+};


### PR DESCRIPTION
## Summary
- refactor `ProjectsPanelDesktop` to delegate rendering to new `ProjectsIconsStrip`, `ProjectsFilterMenu`, and `ProjectsTable` components powered by shared styles
- introduce reusable `useDropdown` and `useProjectFilters` hooks plus supporting utilities/types to manage filter state consistently
- add focused unit tests for the new components and hook to protect the extracted behaviour

## Testing
- `npx vitest run src/features/projects/ProjectsFilterMenu.test.tsx src/features/projects/ProjectsTable.test.tsx src/features/projects/ProjectsIconsStrip.test.tsx src/features/projects/hooks/useProjectFilters.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68cb8b24a2388324825d31cde90e1f26