### PR TITLE
Refactor dashboard project URLs to use project IDs

### DIFF
--- a/frontend/src/app/routes.tsx
+++ b/frontend/src/app/routes.tsx
@@ -165,8 +165,8 @@ const ActualRoutes: React.FC<ActualRoutesProps> = ({ location }) => {
           } 
         />
         
-        <Route 
-          path="/dashboard/*" 
+        <Route
+          path="/dashboard/*"
           element={
             <ProtectedRoute>
               <Dashboard />
@@ -174,13 +174,25 @@ const ActualRoutes: React.FC<ActualRoutesProps> = ({ location }) => {
           }
         >
           <Route
-            path="projects/:projectSlug"
+            path="projects/:projectId/:projectName?"
             element={<DashboardSingleProject key={location.key} />}
           />
-          <Route path="projects/:projectSlug/budget" element={<DashboardBudgetPage />} />
-          <Route path="projects/:projectSlug/calendar" element={<DashboardCalendarPage />} />
-          <Route path="projects/:projectSlug/moodboard" element={<DashboardMoodboardPage />} />
-          <Route path="projects/:projectSlug/editor" element={<DashboardEditorPage />} />
+          <Route
+            path="projects/:projectId/:projectName?/budget"
+            element={<DashboardBudgetPage />}
+          />
+          <Route
+            path="projects/:projectId/:projectName?/calendar"
+            element={<DashboardCalendarPage />}
+          />
+          <Route
+            path="projects/:projectId/:projectName?/moodboard"
+            element={<DashboardMoodboardPage />}
+          />
+          <Route
+            path="projects/:projectId/:projectName?/editor"
+            element={<DashboardEditorPage />}
+          />
           <Route path="new" element={<DashboardNewProject />} />
           <Route path="welcome/*" element={<Navigate to=".." replace />} />
           <Route path="*" element={<DashboardWelcome />} />

--- a/frontend/src/dashboard/home/components/AllProjects.tsx
+++ b/frontend/src/dashboard/home/components/AllProjects.tsx
@@ -8,7 +8,7 @@ import SVGThumbnail from './SvgThumbnail';
 import { useData } from '@/app/contexts/useData';
 import Spinner from '../../../shared/ui/Spinner';
 import { useNavigate } from 'react-router-dom';
-import { slugify } from '../../../shared/utils/slug';
+import { getProjectDashboardPath } from '@/shared/utils/projectUrl';
 import AvatarStack from '../../../shared/ui/AvatarStack';
 import type { UserLite, TeamMember } from '../../../app/contexts/DataProvider';
 import {
@@ -117,12 +117,7 @@ const AllProjects: React.FC = () => {
   }, [isLoading, projects.length, projectsError, fetchProjects]);
 
   const onSelectProject = (project: Project): void => {
-    const safeTitle =
-      (project.title && project.title.trim()) ||
-      `project-${project.projectId.slice(0, 6)}`;
-    const slug = slugify(safeTitle);
-
-    navigate(`/dashboard/projects/${slug}`);
+    navigate(getProjectDashboardPath(project.projectId, project.title));
 
     const fetchPromise = fetchProjectDetails(project.projectId).catch((err) => {
       console.error('Error loading project', err);

--- a/frontend/src/dashboard/home/components/AllProjectsCalendar.tsx
+++ b/frontend/src/dashboard/home/components/AllProjectsCalendar.tsx
@@ -10,13 +10,13 @@ import "react-calendar/dist/Calendar.css";
 import { useData } from "@/app/contexts/useData";
 import "./AllProjectsCalendar.css";
 import { useNavigate } from "react-router-dom";
-import { slugify } from "@/shared/utils/slug";
 import { getColor } from "@/shared/utils/colorUtils";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import type { TimelineEvent } from "@/shared/utils/api";
 import { faClock } from "@fortawesome/free-solid-svg-icons";
 import { WeekWidget } from "./WeekWidget";
 import { getFileUrl } from "../../../shared/utils/api";
+import { getProjectDashboardPath } from "@/shared/utils/projectUrl";
 
 // --- Types ---
 type Project = {
@@ -99,8 +99,7 @@ const AllProjectsCalendar: React.FC = () => {
 
   const handleProjectClick = async (project: Project, flashDate?: string) => {
     await fetchProjectDetails(project.projectId);
-    const slug = slugify(project.title ?? "");
-    navigate(`/dashboard/projects/${slug}`, {
+    navigate(getProjectDashboardPath(project.projectId, project.title), {
       state: flashDate ? { flashDate } : undefined,
     });
   };

--- a/frontend/src/dashboard/home/components/GlobalSearch.tsx
+++ b/frontend/src/dashboard/home/components/GlobalSearch.tsx
@@ -3,6 +3,7 @@ import { Search, X, FileText, FolderOpen, MessageSquare, User } from 'lucide-rea
 import { useData } from '@/app/contexts/useData';
 import { useNavigate } from 'react-router-dom';
 import { slugify } from '@/shared/utils/slug';
+import { getProjectDashboardPath } from '@/shared/utils/projectUrl';
 import type { Project, Message, UserLite } from '@/app/contexts/DataProvider';
 import { getFileUrl } from '@/shared/utils/api';
 import type { AppUser } from '@/dashboard/features/messages/types';
@@ -531,8 +532,8 @@ const GlobalSearch: React.FC<GlobalSearchProps> = ({ className = '', onNavigate 
           await fetchProjectDetails(result.projectId);
         }
         const project = projects?.find((p: Project) => p.projectId === result.projectId);
-        const slug = slugify(project?.title || result.title);
-        navigate(`/dashboard/projects/${slug}`);
+        const path = getProjectDashboardPath(result.projectId, project?.title ?? result.title);
+        navigate(path);
       } catch (error) {
         console.error('Error navigating to project:', error);
       }
@@ -542,8 +543,8 @@ const GlobalSearch: React.FC<GlobalSearchProps> = ({ className = '', onNavigate 
           await fetchProjectDetails(result.projectId);
         }
         const project = projects?.find((p: Project) => p.projectId === result.projectId);
-        const slug = slugify(project?.title || 'project');
-        navigate(`/dashboard/projects/${slug}`, {
+        const path = getProjectDashboardPath(result.projectId, project?.title ?? result.title);
+        navigate(path, {
           state: { highlightMessage: result.messageId }
         });
       } catch (error) {

--- a/frontend/src/dashboard/home/hooks/useTasksOverview.ts
+++ b/frontend/src/dashboard/home/hooks/useTasksOverview.ts
@@ -5,7 +5,7 @@ import { useData } from "@/app/contexts/useData";
 import type { Project } from "@/app/contexts/DataProvider";
 import { fetchTasks } from "@/shared/utils/api";
 import { getColor } from "@/shared/utils/colorUtils";
-import { slugify } from "@/shared/utils/slug";
+import { getProjectDashboardPath } from "@/shared/utils/projectUrl";
 import pLimit from "@/shared/utils/pLimit";
 import { endOfWeek, startOfWeek } from "@/dashboard/home/utils/dateUtils";
 
@@ -231,17 +231,6 @@ export function useTasksOverview() {
     };
   }, [projects]);
 
-  const projectSlugMap = useMemo(() => {
-    const map = new Map<string, string>();
-    projects.forEach((project) => {
-      if (project?.projectId) {
-        const slug = slugify(project.title || project.projectId);
-        map.set(project.projectId, slug);
-      }
-    });
-    return map;
-  }, [projects]);
-
   const { completed, dueSoon, overdue, groups, primaryProjectId } = useMemo(() => {
     const now = new Date();
     const weekStart = startOfWeek(now);
@@ -348,9 +337,9 @@ export function useTasksOverview() {
       return;
     }
 
-    const slug = projectSlugMap.get(primaryProjectId) ?? primaryProjectId;
-    navigate(`/dashboard/projects/${slug}`);
-  }, [navigate, primaryProjectId, projectSlugMap]);
+    const project = projectMap.get(primaryProjectId);
+    navigate(getProjectDashboardPath(primaryProjectId, project?.title));
+  }, [navigate, primaryProjectId, projectMap]);
 
   const handleViewAll = useCallback(() => {
     navigate("/dashboard/projects");

--- a/frontend/src/dashboard/home/pages/DashboardHome.tsx
+++ b/frontend/src/dashboard/home/pages/DashboardHome.tsx
@@ -3,6 +3,7 @@ import { useLocation, useNavigate } from "react-router-dom";
 import { useData } from "@/app/contexts/useData";
 import { UserLite } from "@/app/contexts/DataProvider";
 import { slugify } from "@/shared/utils/slug";
+import { getProjectDashboardPath } from "@/shared/utils/projectUrl";
 import { prefetchBudgetData } from "@/dashboard/project/features/budget/context/useBudget";
 import WelcomeHeader from "@/dashboard/home/components/WelcomeHeader";
 import AllProjects from "@/dashboard/home/components/AllProjects";
@@ -220,8 +221,7 @@ const WelcomeScreen: React.FC = () => {
     }
 
     const proj = projects.find((p: Project) => p.projectId === projectId);
-    const slug = proj ? slugify(proj.title) : projectId;
-    const path = `/dashboard/projects/${slug}`;
+    const path = getProjectDashboardPath(projectId, proj?.title);
 
     navigate(path);
 

--- a/frontend/src/dashboard/project/components/ProjectHeader.tsx
+++ b/frontend/src/dashboard/project/components/ProjectHeader.tsx
@@ -33,7 +33,7 @@ import { uploadData } from "aws-amplify/storage";
 import { useData } from "@/app/contexts/useData";
 import { useSocket } from "@/app/contexts/useSocket";
 import { useNavigate, useParams, useLocation } from "react-router-dom";
-import { slugify, findProjectBySlug } from "@/shared/utils/slug";
+import { getProjectDashboardPath } from "@/shared/utils/projectUrl";
 import { HexColorPicker, HexColorInput } from "react-colorful";
 import styles from "@/dashboard/home/components/finish-line-component.module.css";
 
@@ -116,7 +116,7 @@ const ProjectHeader: React.FC<ProjectHeaderProps> = ({
   const { ws } = useSocket() || {};
   const { refreshUser } = useData();
   const navigate = useNavigate();
-  const { projectSlug = "" } = useParams();
+  const { projectId = "" } = useParams<{ projectId: string }>();
 
   const handleKeyDown = (e: React.KeyboardEvent, action: () => void) => {
     if (e.key === "Enter" || e.key === " ") {
@@ -152,22 +152,25 @@ const ProjectHeader: React.FC<ProjectHeaderProps> = ({
     setClientEmail(toString(activeProject?.clientEmail));
   }, [activeProject]);
 
-  // Update URL slug when project title changes locally or via WebSocket
+  // Update URL when project title changes locally or via WebSocket
   useEffect(() => {
     if (!localActiveProject?.title || !localActiveProject.projectId) return;
-    const slug = slugify(localActiveProject.title);
-    if (slug !== projectSlug) {
-      const project = findProjectBySlug(projects, projectSlug);
-      if (!project || project.projectId === localActiveProject.projectId) {
-        navigate(`/dashboard/projects/${slug}`, { replace: true });
-      }
-    }
+    if (!projectId || localActiveProject.projectId !== projectId) return;
+
+    const canonicalPath = getProjectDashboardPath(
+      localActiveProject.projectId,
+      localActiveProject.title
+    );
+    const currentPath = location.pathname.split(/[?#]/)[0];
+    if (currentPath === canonicalPath) return;
+
+    navigate(canonicalPath, { replace: true });
   }, [
     localActiveProject?.title,
     localActiveProject?.projectId,
-    projectSlug,
-    projects,
+    projectId,
     navigate,
+    location.pathname,
   ]);
 
   // Derive project initial
@@ -1061,7 +1064,10 @@ const ProjectHeader: React.FC<ProjectHeaderProps> = ({
 
           <div className="right-side">
             <div className="project-nav-tabs" style={{ padding: "0 10px 10px" }}>
-              <ProjectTabs projectSlug={projectSlug} />
+              <ProjectTabs
+                projectId={localActiveProject?.projectId || projectId}
+                projectTitle={localActiveProject?.title}
+              />
             </div>
           </div>
         </div>
@@ -1683,7 +1689,12 @@ const ProjectHeader: React.FC<ProjectHeaderProps> = ({
 // -----------------------
 // Project Tabs Component
 // -----------------------
-const ProjectTabs: React.FC<{ projectSlug: string }> = ({ projectSlug }) => {
+interface ProjectTabsProps {
+  projectId: string;
+  projectTitle?: string | null;
+}
+
+const ProjectTabs: React.FC<ProjectTabsProps> = ({ projectId, projectTitle }) => {
   const navigate = useNavigate();
   const location = useLocation();
   const tabRefs = useRef<HTMLButtonElement[]>([]);
@@ -1691,7 +1702,7 @@ const ProjectTabs: React.FC<{ projectSlug: string }> = ({ projectSlug }) => {
     { width: 0, left: 0 }
   );
   const [transitionEnabled, setTransitionEnabled] = useState(false);
-  const storageKey = `project-tabs-prev:${projectSlug}`;
+  const storageKey = `project-tabs-prev:${projectId || "unknown"}`;
 
   const { user } = useData();
   const isAdmin = user?.role === "admin";
@@ -1701,7 +1712,22 @@ const ProjectTabs: React.FC<{ projectSlug: string }> = ({ projectSlug }) => {
   const showMoodboardTab = isAdmin || isDesigner;
   const showEditorTab = isAdmin || isDesigner;
 
-  const basePath = `/dashboard/projects/${projectSlug}`;
+  const hasProject = Boolean(projectId);
+  const basePath = hasProject
+    ? getProjectDashboardPath(projectId, projectTitle ?? undefined)
+    : "/dashboard/projects";
+  const budgetPath = hasProject
+    ? getProjectDashboardPath(projectId, projectTitle ?? undefined, "/budget")
+    : "/dashboard/projects";
+  const calendarPath = hasProject
+    ? getProjectDashboardPath(projectId, projectTitle ?? undefined, "/calendar")
+    : "/dashboard/projects";
+  const moodboardPath = hasProject
+    ? getProjectDashboardPath(projectId, projectTitle ?? undefined, "/moodboard")
+    : "/dashboard/projects";
+  const editorPath = hasProject
+    ? getProjectDashboardPath(projectId, projectTitle ?? undefined, "/editor")
+    : "/dashboard/projects";
 
   const tabs = useMemo(
     () =>
@@ -1718,33 +1744,33 @@ const ProjectTabs: React.FC<{ projectSlug: string }> = ({ projectSlug }) => {
           key: "budget",
           label: "Budget",
           icon: <Coins size={16} />,
-          path: `${basePath}/budget`,
+          path: budgetPath,
           visible: showBudgetTab,
-          matches: (pathname: string) => pathname.startsWith(`${basePath}/budget`),
+          matches: (pathname: string) => pathname.startsWith(budgetPath),
         },
         {
           key: "calendar",
           label: "Calendar",
           icon: <CalendarIcon size={16} />,
-          path: `${basePath}/calendar`,
+          path: calendarPath,
           visible: showCalendarTab,
-          matches: (pathname: string) => pathname.startsWith(`${basePath}/calendar`),
+          matches: (pathname: string) => pathname.startsWith(calendarPath),
         },
         {
           key: "moodboard",
           label: "Moodboard",
           icon: <StickyNote size={16} />,
-          path: `${basePath}/moodboard`,
+          path: moodboardPath,
           visible: showMoodboardTab,
-          matches: (pathname: string) => pathname.startsWith(`${basePath}/moodboard`),
+          matches: (pathname: string) => pathname.startsWith(moodboardPath),
         },
         {
           key: "editor",
           label: "Editor",
           icon: <PenTool size={16} />,
-          path: `${basePath}/editor`,
+          path: editorPath,
           visible: showEditorTab,
-          matches: (pathname: string) => pathname.startsWith(`${basePath}/editor`),
+          matches: (pathname: string) => pathname.startsWith(editorPath),
         },
       ].filter((tab) => tab.visible),
     [

--- a/frontend/src/dashboard/project/features/budget/components/BudgetOverviewCard.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetOverviewCard.tsx
@@ -4,7 +4,7 @@ import { CircleDollarSign } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { useData } from "@/app/contexts/useData";
 import { formatUSD } from "@/shared/utils/budgetUtils";
-import { slugify } from "@/shared/utils/slug";
+import { getProjectDashboardPath } from "@/shared/utils/projectUrl";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faFileInvoiceDollar, faSpinner } from "@fortawesome/free-solid-svg-icons";
 import ClientInvoicePreviewModal from "@/dashboard/project/components/ClientInvoicePreviewModal";
@@ -100,8 +100,9 @@ const BudgetOverviewCard: React.FC<BudgetOverviewCardProps> = ({ projectId }) =>
   };
   const openBudgetPage = () => {
     if (!activeProject || !isAdmin) return;
-    const slug = slugify(activeProject.title ?? "");
-    navigate(`/dashboard/projects/${slug}/budget`);
+    navigate(
+      getProjectDashboardPath(activeProject.projectId, activeProject.title, "/budget")
+    );
   };
 
 

--- a/frontend/src/dashboard/project/features/budget/pages/BudgetPage.tsx
+++ b/frontend/src/dashboard/project/features/budget/pages/BudgetPage.tsx
@@ -31,7 +31,7 @@ import { BudgetProvider} from "@/dashboard/project/features/budget/context/Budge
 import { useBudget } from "@/dashboard/project/features/budget/context/BudgetContext";
 import { useData } from "@/app/contexts/useData";
 import type { Project, TimelineEvent } from "@/app/contexts/DataProvider";
-import { findProjectBySlug, slugify } from "@/shared/utils/slug";
+import { getProjectDashboardPath } from "@/shared/utils/projectUrl";
 import { useProjectPalette } from "@/dashboard/project/hooks/useProjectPalette";
 import { resolveProjectCoverUrl } from "@/dashboard/project/utils/theme";
 import {
@@ -48,12 +48,11 @@ const TABLE_BOTTOM_MARGIN = 20;
 
 // Inner component that uses the budget context
 const BudgetPageContent = () => {
-  const { projectSlug } = useParams();
+  const { projectId } = useParams<{ projectId: string }>();
   const navigate = useNavigate();
   const location = useLocation();
   const {
     activeProject: initialActiveProject,
-    projects,
     fetchProjectDetails,
     user,
     userId,
@@ -122,25 +121,40 @@ const BudgetPageContent = () => {
   }, [initialActiveProject]);
 
   useEffect(() => {
-    if (!initialActiveProject) return;
-    if (slugify(initialActiveProject.title) !== projectSlug) {
-      const proj = findProjectBySlug(projects, projectSlug);
-      if (proj) {
-        fetchProjectDetails(proj.projectId as string);
-      } else {
-        navigate(`/dashboard/projects/${slugify(initialActiveProject.title)}`);
-      }
+    if (!projectId) return;
+    if (!initialActiveProject || initialActiveProject.projectId !== projectId) {
+      fetchProjectDetails(projectId);
     }
+  }, [projectId, initialActiveProject?.projectId, fetchProjectDetails]);
+
+  useEffect(() => {
+    if (!projectId) return;
+    const title = activeProject?.title ?? initialActiveProject?.title;
+    if (!title) return;
+
+    const currentPath = location.pathname.split(/[?#]/)[0];
+    if (!currentPath.includes("/budget")) return;
+
+    const canonicalPath = getProjectDashboardPath(projectId, title, "/budget");
+    if (currentPath === canonicalPath) return;
+
+    navigate(canonicalPath, { replace: true });
   }, [
-    projectSlug,
-    projects,
-    initialActiveProject,
+    projectId,
+    activeProject?.title,
+    initialActiveProject?.title,
+    location.pathname,
     navigate,
-    fetchProjectDetails,
   ]);
 
   const handleBack = () => {
-    navigate(`/dashboard/projects/${projectSlug}`);
+    if (!projectId) {
+      navigate("/dashboard/projects");
+      return;
+    }
+
+    const title = activeProject?.title ?? initialActiveProject?.title;
+    navigate(getProjectDashboardPath(projectId, title));
   };
 
   const parseStatusToNumber = (statusString) => {

--- a/frontend/src/dashboard/project/features/calendar/calendar.tsx
+++ b/frontend/src/dashboard/project/features/calendar/calendar.tsx
@@ -7,8 +7,8 @@ import QuickLinksComponent from '@/dashboard/project/components/QuickLinksCompon
 import FileManagerComponent from '@/dashboard/project/components/FileManager';
 import { useData } from '@/app/contexts/useData';
 import { useSocket } from '@/app/contexts/SocketContext';
-import { useNavigate, useParams } from 'react-router-dom';
-import { findProjectBySlug, slugify } from '@/shared/utils/slug';
+import { useNavigate, useParams, useLocation } from 'react-router-dom';
+import { getProjectDashboardPath } from '@/shared/utils/projectUrl';
 import { BudgetProvider } from '@/dashboard/project/features/budget/context/BudgetProvider';
 import type { Project } from '@/app/contexts/DataProvider';
 import type { QuickLinksRef } from '@/dashboard/project/components/QuickLinksComponent';
@@ -46,12 +46,12 @@ type ProjectCalendarProject = {
 };
 
 const CalendarPage: React.FC = () => {
-  const { projectSlug } = useParams<{ projectSlug: string }>();
+  const { projectId } = useParams<{ projectId: string }>();
   const navigate = useNavigate();
+  const location = useLocation();
 
   const {
     activeProject: initialActiveProject,
-    projects,
     fetchProjectDetails,
     setProjects,
     setSelectedProjects,
@@ -73,17 +73,32 @@ const CalendarPage: React.FC = () => {
   }, [initialActiveProject]);
 
   useEffect(() => {
-    if (!initialActiveProject) return;
-
-    if (slugify((initialActiveProject as Project).title) !== projectSlug) {
-      const proj = findProjectBySlug(projects, projectSlug || '');
-      if (proj) {
-        fetchProjectDetails(proj.projectId);
-      } else {
-        navigate(`/dashboard/projects/${slugify((initialActiveProject as Project).title)}`);
-      }
+    if (!projectId) return;
+    if (!initialActiveProject || (initialActiveProject as Project).projectId !== projectId) {
+      fetchProjectDetails(projectId);
     }
-  }, [projectSlug, projects, initialActiveProject, navigate, fetchProjectDetails]);
+  }, [projectId, initialActiveProject, fetchProjectDetails]);
+
+  useEffect(() => {
+    if (!projectId) return;
+    const title =
+      (activeProject as Project | null)?.title || (initialActiveProject as Project | null)?.title;
+    if (!title) return;
+
+    const currentPath = location.pathname.split(/[?#]/)[0];
+    if (!currentPath.includes('/calendar')) return;
+
+    const canonicalPath = getProjectDashboardPath(projectId, title, '/calendar');
+    if (currentPath === canonicalPath) return;
+
+    navigate(canonicalPath, { replace: true });
+  }, [
+    projectId,
+    activeProject,
+    initialActiveProject,
+    location.pathname,
+    navigate,
+  ]);
 
   useEffect(() => {
     if (!ws || !activeProject?.projectId) return;
@@ -126,7 +141,14 @@ const CalendarPage: React.FC = () => {
   };
 
   const handleBack = () => {
-    navigate(`/dashboard/projects/${projectSlug}`);
+    if (!projectId) {
+      navigate('/dashboard/projects');
+      return;
+    }
+
+    const title =
+      (activeProject as Project | null)?.title || (initialActiveProject as Project | null)?.title;
+    navigate(getProjectDashboardPath(projectId, title));
   };
 
   const coverImage = useMemo(() => resolveProjectCoverUrl(activeProject), [activeProject]);

--- a/frontend/src/dashboard/project/features/editor/pages/editorpage.tsx
+++ b/frontend/src/dashboard/project/features/editor/pages/editorpage.tsx
@@ -12,19 +12,18 @@ import LexicalEditor from "@/dashboard/project/features/editor/components/Brief/
 import { useData } from "@/app/contexts/useData";
 import { Project } from "@/app/contexts/DataProvider";
 import { useSocket } from "@/app/contexts/useSocket";
-import { findProjectBySlug, slugify } from "@/shared/utils/slug";
+import { getProjectDashboardPath } from "@/shared/utils/projectUrl";
 import { notify } from "@/shared/ui/ToastNotifications";
 import { useProjectPalette } from "@/dashboard/project/hooks/useProjectPalette";
 import { resolveProjectCoverUrl } from "@/dashboard/project/utils/theme";
 
 const EditorPage: React.FC = () => {
-  const { projectSlug } = useParams<{ projectSlug: string }>();
+  const { projectId } = useParams<{ projectId: string }>();
   const navigate = useNavigate();
   const location = useLocation();
 
   const {
     activeProject: initialActiveProject,
-    projects,
     fetchProjectDetails,
     setProjects,
     setSelectedProjects,
@@ -87,16 +86,31 @@ const EditorPage: React.FC = () => {
   }, [activeProject?.description]);
 
   useEffect(() => {
-    if (!initialActiveProject) return;
-    if (slugify(initialActiveProject.title) !== projectSlug) {
-      const proj = findProjectBySlug(projects, projectSlug);
-      if (proj) {
-        fetchProjectDetails(proj.projectId as string);
-      } else {
-        navigate(`/dashboard/projects/${slugify(initialActiveProject.title)}`);
-      }
+    if (!projectId) return;
+    if (!initialActiveProject || initialActiveProject.projectId !== projectId) {
+      fetchProjectDetails(projectId);
     }
-  }, [projectSlug, projects, initialActiveProject, navigate, fetchProjectDetails]);
+  }, [projectId, initialActiveProject?.projectId, fetchProjectDetails]);
+
+  useEffect(() => {
+    if (!projectId) return;
+    const title = activeProject?.title ?? initialActiveProject?.title;
+    if (!title) return;
+
+    const currentPath = location.pathname.split(/[?#]/)[0];
+    if (!currentPath.includes('/editor')) return;
+
+    const canonicalPath = getProjectDashboardPath(projectId, title, '/editor');
+    if (currentPath === canonicalPath) return;
+
+    navigate(canonicalPath, { replace: true });
+  }, [
+    projectId,
+    activeProject?.title,
+    initialActiveProject?.title,
+    location.pathname,
+    navigate,
+  ]);
 
   const lastFetchedId = useRef<string | null>(null);
   useEffect(() => {
@@ -144,7 +158,13 @@ const EditorPage: React.FC = () => {
   };
 
   const handleBack = () => {
-    navigate(`/dashboard/projects/${projectSlug}`);
+    if (!projectId) {
+      navigate('/dashboard/projects');
+      return;
+    }
+
+    const title = activeProject?.title ?? initialActiveProject?.title;
+    navigate(getProjectDashboardPath(projectId, title));
   };
 
   const handleSelectTool = () => designerRef.current?.changeMode("select");

--- a/frontend/src/dashboard/project/features/moodboard/pages/MoodboardPage.tsx
+++ b/frontend/src/dashboard/project/features/moodboard/pages/MoodboardPage.tsx
@@ -1,21 +1,21 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams, useLocation } from "react-router-dom";
 import { AnimatePresence, motion } from "framer-motion";
 import ProjectPageLayout from "@/dashboard/project/components/ProjectPageLayout";
 import ProjectHeader from "@/dashboard/project/components/ProjectHeader";
 import MoodboardCanvas from "../components/MoodboardCanvas";
 import { useData } from "@/app/contexts/useData";
-import { findProjectBySlug, slugify } from "@/shared/utils/slug";
+import { getProjectDashboardPath } from "@/shared/utils/projectUrl";
 import type { Project } from "@/app/contexts/DataProvider";
 import { useProjectPalette } from "@/dashboard/project/hooks/useProjectPalette";
 import { resolveProjectCoverUrl } from "@/dashboard/project/utils/theme";
 
 const MoodboardPage: React.FC = () => {
-  const { projectSlug = "" } = useParams<{ projectSlug: string }>();
+  const { projectId } = useParams<{ projectId: string }>();
   const navigate = useNavigate();
+  const location = useLocation();
   const {
     activeProject: initialProject,
-    projects,
     fetchProjectDetails,
     setProjects,
     setSelectedProjects,
@@ -32,27 +32,30 @@ const MoodboardPage: React.FC = () => {
   }, [initialProject]);
 
   useEffect(() => {
-    if (!projectSlug) return;
-    const matchesSlug =
-      activeProject?.title && slugify(activeProject.title) === projectSlug;
-    if (matchesSlug) return;
-    const fromList = findProjectBySlug(projects, projectSlug);
-    if (fromList && fromList.projectId) {
-      void fetchProjectDetails(fromList.projectId);
-    } else if (initialProject?.title) {
-      navigate(`/dashboard/projects/${slugify(initialProject.title)}/moodboard`, {
-        replace: true,
-      });
-    } else {
-      navigate("/dashboard/projects");
+    if (!projectId) return;
+    if (!initialProject || initialProject.projectId !== projectId) {
+      void fetchProjectDetails(projectId);
     }
+  }, [projectId, initialProject?.projectId, fetchProjectDetails]);
+
+  useEffect(() => {
+    if (!projectId) return;
+    const title = activeProject?.title ?? initialProject?.title;
+    if (!title) return;
+
+    const currentPath = location.pathname.split(/[?#]/)[0];
+    if (!currentPath.includes("/moodboard")) return;
+
+    const canonicalPath = getProjectDashboardPath(projectId, title, "/moodboard");
+    if (currentPath === canonicalPath) return;
+
+    navigate(canonicalPath, { replace: true });
   }, [
+    projectId,
     activeProject?.title,
-    fetchProjectDetails,
     initialProject?.title,
+    location.pathname,
     navigate,
-    projectSlug,
-    projects,
   ]);
 
   useEffect(() => {
@@ -84,33 +87,33 @@ const MoodboardPage: React.FC = () => {
     navigate("/dashboard");
   }, [navigate]);
 
-  const projectId = activeProject?.projectId ?? "";
+  const resolvedProjectId = activeProject?.projectId ?? "";
   const currentUserId = userId ?? "";
 
   const board = useMemo(
     () => (
       <AnimatePresence mode="wait">
         <motion.div
-          key={projectId || "moodboard"}
+          key={resolvedProjectId || "moodboard"}
           initial={{ opacity: 0, y: 24 }}
           animate={{ opacity: 1, y: 0 }}
           exit={{ opacity: 0, y: -24 }}
           transition={{ duration: 0.25 }}
         >
           <MoodboardCanvas
-            projectId={projectId}
+            projectId={resolvedProjectId}
             userId={currentUserId}
             palette={projectPalette}
           />
         </motion.div>
       </AnimatePresence>
     ),
-    [currentUserId, projectId, projectPalette]
+    [currentUserId, resolvedProjectId, projectPalette]
   );
 
   return (
     <ProjectPageLayout
-      projectId={projectId}
+      projectId={resolvedProjectId}
       theme={projectPalette}
       header={
         <ProjectHeader

--- a/frontend/src/dashboard/project/pages/NewProject.tsx
+++ b/frontend/src/dashboard/project/pages/NewProject.tsx
@@ -11,8 +11,8 @@ import NewProjectDescription from "@/dashboard/project/components/NewProjectDesc
 import { useData } from "@/app/contexts/useData";
 import { useNavigate } from "react-router-dom";
 import { FaArrowLeft } from "react-icons/fa";
-import { slugify } from "@/shared/utils/slug";
 import { parseBudget } from "@/shared/utils/budgetUtils";
+import { getProjectDashboardPath } from "@/shared/utils/projectUrl";
 import {
   POST_PROJECTS_URL,
   POST_PROJECT_TO_USER_URL,
@@ -280,8 +280,7 @@ const NewProject: React.FC = () => {
 
     // Set active & navigate
     setActiveProject(newProject);
-    const slug = slugify(newProject.title);
-    navigate(`/dashboard/projects/${slug}`);
+    navigate(getProjectDashboardPath(newProject.projectId, newProject.title));
   };
 
   useEffect(() => {

--- a/frontend/src/dashboard/project/pages/project.tsx
+++ b/frontend/src/dashboard/project/pages/project.tsx
@@ -17,10 +17,10 @@ import { useData } from "@/app/contexts/useData";
 import { useSocket } from "@/app/contexts/useSocket";
 import { useParams, useNavigate, useLocation } from "react-router-dom";
 import { AnimatePresence, motion } from "framer-motion";
-import { findProjectBySlug, slugify } from "@/shared/utils/slug";
 import type { Project } from "@/app/contexts/DataProvider";
 import { useProjectPalette } from "@/dashboard/project/hooks/useProjectPalette";
 import { resolveProjectCoverUrl } from "@/dashboard/project/utils/theme";
+import { getProjectDashboardPath } from "@/shared/utils/projectUrl";
 
 interface QuickLinksRef {
   openModal: () => void;
@@ -34,7 +34,6 @@ const SingleProject: React.FC = () => {
   const {
     activeProject,
     userId,
-    projects,
     fetchProjectDetails,
     setProjects,
     setSelectedProjects,
@@ -44,18 +43,27 @@ const SingleProject: React.FC = () => {
   const location = useLocation();
   const flashDate = (location.state as LocationState)?.flashDate;
 
-  const { projectSlug } = useParams<{ projectSlug: string }>();
+  const { projectId } = useParams<{ projectId: string }>();
   const [filesOpen, setFilesOpen] = useState<boolean>(false);
   const quickLinksRef = useRef<QuickLinksRef>(null);
   const { ws } = useSocket();
 
+  const projectNameFromPath = useMemo(() => {
+    const segments = location.pathname.split("/").filter(Boolean);
+    const projectsIdx = segments.indexOf("projects");
+    if (projectsIdx === -1) return undefined;
+    const rawSegment = segments[projectsIdx + 2];
+    if (!rawSegment) return undefined;
+    const cleanSegment = rawSegment.split(/[?#]/)[0] ?? "";
+    try {
+      return decodeURIComponent(cleanSegment);
+    } catch {
+      return cleanSegment;
+    }
+  }, [location.pathname]);
+
   // Stable helpers
   const noop = useCallback(() => {}, []);
-
-  const currentSlug = useMemo(
-    () => (activeProject?.title ? slugify(activeProject.title) : null),
-    [activeProject?.title]
-  );
 
   const parseStatusToNumber = useCallback((status: unknown): number => {
     if (status === undefined || status === null) return 0;
@@ -73,8 +81,9 @@ const SingleProject: React.FC = () => {
 
   const openCalendarPage = useCallback(() => {
     if (!activeProject) return;
-    const slug = slugify(activeProject.title);
-    navigate(`/dashboard/projects/${slug}/calendar`);
+    navigate(
+      getProjectDashboardPath(activeProject.projectId, activeProject.title, "/calendar")
+    );
   }, [activeProject, navigate]);
 
   const handleProjectDeleted = useCallback(
@@ -96,25 +105,34 @@ const SingleProject: React.FC = () => {
     [fetchProjectDetails]
   );
 
-  // Keep URL and active project in sync with the slug the user visited.
+  // Keep the active project in sync with the ID from the route.
   useEffect(() => {
-    if (!projectSlug) return;
+    if (!projectId) return;
+    if (activeProject?.projectId === projectId) return;
+    fetchProjectDetails(projectId);
+  }, [projectId, activeProject?.projectId, fetchProjectDetails]);
 
-    // If we're already viewing the right project, nothing to do.
-    if (currentSlug === projectSlug) return;
+  useEffect(() => {
+    if (!projectId) return;
+    if (activeProject?.projectId !== projectId) return;
 
-    // Try to locate the project by slug and load it if it's different from the active one.
-    const proj = findProjectBySlug(projects, projectSlug);
-    if (proj && proj.projectId !== activeProject?.projectId) {
-      fetchProjectDetails(proj.projectId as string);
-    }
+    const title = activeProject?.title;
+    if (!title) return;
+
+    if (projectNameFromPath === title) return;
+
+    const canonicalPath = getProjectDashboardPath(projectId, title);
+    const currentPath = location.pathname.split(/[?#]/)[0];
+    if (currentPath === canonicalPath) return;
+
+    navigate(canonicalPath, { replace: true });
   }, [
-    projectSlug,
-    currentSlug,
-    projects,
-    fetchProjectDetails,
+    projectId,
     activeProject?.projectId,
-    location.key,
+    activeProject?.title,
+    projectNameFromPath,
+    navigate,
+    location.pathname,
   ]);
 
   // Ensure team/details are loaded for the current project.

--- a/frontend/src/shared/ui/NotificationsDrawer.tsx
+++ b/frontend/src/shared/ui/NotificationsDrawer.tsx
@@ -8,6 +8,7 @@ import { useNotificationSocket } from '../../app/contexts/useNotificationSocket'
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useData } from '../../app/contexts/useData';
 import { slugify } from '../utils/slug';
+import { getProjectDashboardPath } from '@/shared/utils/projectUrl';
 import { prefetchBudgetData } from '@/dashboard/project/features/budget/context/useBudget';
 import { useSocket } from '../../app/contexts/useSocket';
 import { MESSAGES_THREADS_URL, apiFetch } from '../utils/api';
@@ -149,8 +150,7 @@ const NotificationsDrawer: React.FC<NotificationsDrawerProps> = ({
       if (!confirmLeave) return;
     }
     const proj = projects.find((p) => p.projectId === projectId);
-    const slug = proj ? slugify(proj.title || projectId) : projectId;
-    const path = `/dashboard/projects/${slug}`;
+    const path = getProjectDashboardPath(projectId, proj?.title || projectId);
     if (location.pathname !== path) {
       await Promise.all([
         fetchProjectDetails(projectId),

--- a/frontend/src/shared/utils/projectUrl.ts
+++ b/frontend/src/shared/utils/projectUrl.ts
@@ -1,0 +1,23 @@
+export function getProjectDashboardPath(
+  projectId: string,
+  title?: string | null,
+  suffix = ""
+): string {
+  const trimmedTitle = typeof title === "string" ? title.trim() : "";
+  const encodedTitle = trimmedTitle ? `/${encodeURIComponent(trimmedTitle)}` : "";
+  return `/dashboard/projects/${projectId}${encodedTitle}${suffix}`;
+}
+
+export function extractProjectNameFromPath(pathname: string): string | undefined {
+  const segments = pathname.split("/").filter(Boolean);
+  const projectsIdx = segments.indexOf("projects");
+  if (projectsIdx === -1) return undefined;
+  const rawSegment = segments[projectsIdx + 2];
+  if (!rawSegment) return undefined;
+  const cleanSegment = rawSegment.split(/[?#]/)[0] ?? "";
+  try {
+    return decodeURIComponent(cleanSegment);
+  } catch {
+    return cleanSegment;
+  }
+}


### PR DESCRIPTION
## Summary
- switch dashboard project routes to `/dashboard/projects/:projectId/:projectName?` and remove slug-based variants
- add a shared `getProjectDashboardPath` helper and update navigation surfaces to build URLs from project IDs
- load project detail/budget/calendar/moodboard/editor pages by `projectId` and rewrite URLs to the canonical ID + encoded title when needed

## Testing
- `npm test` *(fails: existing FileManager.test.tsx esbuild transform error "MOCK_S3_BASE" already declared)*

------
https://chatgpt.com/codex/tasks/task_e_68cbaecbc99883248b3dd225378cf04a