### PR TITLE
Add collapsible desktop navigation drawer

### DIFF
--- a/frontend/src/dashboard/home/pages/DashboardHome.tsx
+++ b/frontend/src/dashboard/home/pages/DashboardHome.tsx
@@ -176,6 +176,7 @@ const WelcomeScreen: React.FC = () => {
     computeViewportFlags()
   );
   const [isNavigationOpen, setIsNavigationOpen] = useState(false);
+  const [isNavCollapsed, setIsNavCollapsed] = useState(false);
   const rawDrawerId = useId();
   const drawerId = React.useMemo(
     () => `dashboard-nav-${rawDrawerId.replace(/[^a-zA-Z0-9_-]/g, "")}`,
@@ -199,6 +200,12 @@ const WelcomeScreen: React.FC = () => {
   useEffect(() => {
     if (isDesktop) {
       setIsNavigationOpen(false);
+    }
+  }, [isDesktop]);
+
+  useEffect(() => {
+    if (!isDesktop) {
+      setIsNavCollapsed(false);
     }
   }, [isDesktop]);
 
@@ -373,6 +380,8 @@ const WelcomeScreen: React.FC = () => {
 
   const handleOpenNavigation = () => setIsNavigationOpen(true);
   const handleCloseNavigation = () => setIsNavigationOpen(false);
+  const handleToggleNavigationCollapse = () =>
+    setIsNavCollapsed((previous) => !previous);
 
   const mainContent = (
     <main className="dashboard-main">
@@ -407,11 +416,17 @@ const WelcomeScreen: React.FC = () => {
 
   if (isDesktop) {
     return (
-      <div className="dashboard-root">
+      <div
+        className={`dashboard-root${
+          isNavCollapsed ? " dashboard-root--nav-collapsed" : ""
+        }`}
+      >
         <aside>
           <DashboardNavPanel
             variant="persistent"
             setActiveView={setActiveView}
+            isCollapsed={isNavCollapsed}
+            onToggleCollapse={handleToggleNavigationCollapse}
           />
         </aside>
         {mainContent}

--- a/frontend/src/dashboard/home/pages/dashboard-styles.css
+++ b/frontend/src/dashboard/home/pages/dashboard-styles.css
@@ -11,12 +11,20 @@
   overflow: hidden;
 }
 
+.dashboard-root--nav-collapsed {
+  grid-template-columns: 120px 1fr;
+}
+
 .dashboard-root > aside {
   position: sticky;
   top: 0;
   align-self: start;
   height: 100vh;
   display: flex;
+}
+
+.dashboard-root--nav-collapsed > aside {
+  width: 120px;
 }
 
 .dashboard-root > aside > * {

--- a/frontend/src/shared/ui/DashboardNavPanel.tsx
+++ b/frontend/src/shared/ui/DashboardNavPanel.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { X } from "lucide-react";
+import { ChevronLeft, ChevronRight, X } from "lucide-react";
 import { Link } from "react-router-dom";
 import GlobalSearch from "@/dashboard/home/components/GlobalSearch";
 import NavBadge from "./NavBadge";
@@ -14,12 +14,23 @@ type Variant = "persistent" | "overlay";
 type DashboardNavPanelProps = UseDashboardNavigationArgs & {
   variant?: Variant;
   className?: string;
+  isCollapsed?: boolean;
+  onToggleCollapse?: () => void;
 };
 
-function renderNavItem(item: DashboardNavItem) {
+function renderNavItem(item: DashboardNavItem, isCollapsed: boolean) {
   const hasBadge = typeof item.badgeCount === "number" && item.badgeCount > 0 && item.badgeLabel;
   const keyClass = item.key ? `nav-item--${item.key}` : "";
   const className = ["nav-item", keyClass, item.isAction ? "nav-item--action" : ""]
+    .filter(Boolean)
+    .join(" ");
+  const accessibilityProps = isCollapsed
+    ? {
+        "aria-label": item.label,
+        title: item.label,
+      }
+    : {};
+  const labelClass = ["nav-item__label", isCollapsed ? "nav-item__label--hidden" : ""]
     .filter(Boolean)
     .join(" ");
   const inner = (
@@ -34,7 +45,7 @@ function renderNavItem(item: DashboardNavItem) {
           />
         ) : null}
       </span>
-      <span className="nav-item__label">{item.label}</span>
+      <span className={labelClass}>{item.label}</span>
     </>
   );
 
@@ -47,6 +58,7 @@ function renderNavItem(item: DashboardNavItem) {
           target={item.external ? "_blank" : undefined}
           rel={item.external ? "noopener noreferrer" : undefined}
           onClick={item.onClick}
+          {...accessibilityProps}
         >
           {inner}
         </a>
@@ -56,7 +68,12 @@ function renderNavItem(item: DashboardNavItem) {
 
   return (
     <li key={item.key}>
-      <button type="button" className={className} onClick={item.onClick}>
+      <button
+        type="button"
+        className={className}
+        onClick={item.onClick}
+        {...accessibilityProps}
+      >
         {inner}
       </button>
     </li>
@@ -68,6 +85,8 @@ const DashboardNavPanel: React.FC<DashboardNavPanelProps> = ({
   onClose,
   variant = "persistent",
   className,
+  isCollapsed = false,
+  onToggleCollapse,
 }) => {
   const { navItems, bottomItems } = useDashboardNavigation({ setActiveView, onClose });
   const isOverlay = variant === "overlay";
@@ -76,12 +95,13 @@ const DashboardNavPanel: React.FC<DashboardNavPanelProps> = ({
   const containerClass = [
     "dashboard-nav-panel",
     `dashboard-nav-panel--${variant}`,
+    isCollapsed ? "dashboard-nav-panel--collapsed" : "",
     className,
   ]
     .filter(Boolean)
     .join(" ");
 
-     const topSection = isOverlay ? (
+  const topSection = isOverlay ? (
     <div className="navigation-drawer-search">
       <GlobalSearch onNavigate={onClose} />
     </div>
@@ -100,7 +120,7 @@ const DashboardNavPanel: React.FC<DashboardNavPanelProps> = ({
 
   return (
     <div className={containerClass}>
-        {topSection}
+      {topSection}
 
       <div className="navigation-drawer-content">
         {isPersistent ? (
@@ -113,14 +133,25 @@ const DashboardNavPanel: React.FC<DashboardNavPanelProps> = ({
               <span className="dashboard-nav-panel__brand-mark">M!</span>
               <span className="dashboard-nav-panel__brand-text">MYLG</span>
             </Link>
+            {onToggleCollapse ? (
+              <button
+                type="button"
+                className="dashboard-nav-panel__collapse-toggle"
+                onClick={onToggleCollapse}
+                aria-label={isCollapsed ? "Expand navigation" : "Collapse navigation"}
+                title={isCollapsed ? "Expand navigation" : "Collapse navigation"}
+              >
+                {isCollapsed ? <ChevronRight size={18} /> : <ChevronLeft size={18} />}
+              </button>
+            ) : null}
           </div>
         ) : null}
 
         <ul className="nav-list nav-list--primary">
-          {navItems.map((item) => renderNavItem(item))}
+          {navItems.map((item) => renderNavItem(item, isCollapsed))}
         </ul>
         <ul className="nav-list nav-list--secondary">
-          {bottomItems.map((item) => renderNavItem(item))}
+          {bottomItems.map((item) => renderNavItem(item, isCollapsed))}
         </ul>
       </div>
     </div>

--- a/frontend/src/shared/ui/navigation-drawer.css
+++ b/frontend/src/shared/ui/navigation-drawer.css
@@ -42,6 +42,32 @@
   padding-right: 0;
 }
 
+.dashboard-nav-panel__collapse-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 10px;
+  border: 1px solid var(--line, rgba(255, 255, 255, 0.06));
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  transition: background-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out,
+    transform 0.15s ease-in-out;
+}
+
+.dashboard-nav-panel__collapse-toggle:hover,
+.dashboard-nav-panel__collapse-toggle:focus-visible {
+  background: rgba(255, 255, 255, 0.06);
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.28);
+}
+
+.dashboard-nav-panel__collapse-toggle:focus-visible {
+  outline: 2px solid var(--accent, #FA3356);
+  outline-offset: 2px;
+}
+
 .dashboard-nav-panel__brand-row {
   display: flex;
   align-items: center;
@@ -114,6 +140,48 @@
   padding: 16px 32px;
   position: relative;
   isolation: isolate;
+}
+
+.dashboard-nav-panel--collapsed {
+  padding: 16px 8px;
+}
+
+.dashboard-nav-panel--collapsed .navigation-drawer-content {
+  padding: 16px 4px;
+}
+
+.dashboard-nav-panel--collapsed .dashboard-nav-panel__brand-row {
+  justify-content: center;
+  gap: 12px;
+}
+
+.dashboard-nav-panel--collapsed .dashboard-nav-panel__brand-button {
+  gap: 0;
+  justify-content: center;
+}
+
+.dashboard-nav-panel--collapsed .dashboard-nav-panel__brand-text {
+  display: none;
+}
+
+.dashboard-nav-panel--collapsed .nav-list {
+  justify-items: center;
+  padding: 8px 0;
+}
+
+.dashboard-nav-panel--collapsed .nav-item {
+  --nav-item-inline-padding: 8px;
+  grid-template-columns: 1fr;
+  justify-items: center;
+  column-gap: 0;
+  width: 56px;
+  min-height: 56px;
+  padding: 0;
+}
+
+.dashboard-nav-panel--collapsed .nav-item__icon {
+  width: 44px;
+  height: 44px;
 }
 
 /* subtle sweep + top highlight; tweak opacities as you like */
@@ -316,6 +384,7 @@
     transform 0.15s ease-in-out;
   text-align: left;
   outline: none;
+  position: relative;
 }
 
 .nav-item:hover,
@@ -383,6 +452,19 @@
   display: inline-block;
   transform-origin: left center;
   transition: transform 0.15s ease-in-out;
+}
+
+.nav-item__label--hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
 }
 
 .nav-item__badge {


### PR DESCRIPTION
## Summary
- add a collapse toggle to the persistent dashboard navigation panel and expose its state from the dashboard page
- update layout and navigation drawer styles so the desktop drawer can shrink to an icon-only rail
- preserve accessible labels while hiding text in the collapsed state

## Testing
- npm run lint *(warnings only from pre-existing exhaustive-deps checks in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cc68ffa4888324af8cf9c7e1b88e81