### PR TITLE
Use squircle masks for dashboard project icons

### DIFF
--- a/frontend/src/dashboard/home/components/ProjectsIconsStrip.tsx
+++ b/frontend/src/dashboard/home/components/ProjectsIconsStrip.tsx
@@ -2,6 +2,7 @@ import type { FC } from "react";
 
 import type { ProjectLike } from "@/dashboard/home/hooks/useProjectKpis";
 import SVGThumbnail from "@/dashboard/home/components/SvgThumbnail";
+import Squircle from "@/shared/ui/Squircle";
 import { getFileUrl } from "@/shared/utils/api";
 
 import mobileStyles from "@/dashboard/home/components/projects-panel.module.css";
@@ -35,17 +36,19 @@ export const ProjectsIconsStrip: FC<ProjectsIconsStripProps> = ({
             : undefined;
 
         return (
-          <button
+          <Squircle
             key={`icon-${id}`}
+            as="button"
             type="button"
             className={mobileStyles.iconBtnSm}
             aria-label={`Open project ${title}`}
             title={title}
             onClick={() => onOpenProject(id)}
+            radius={8}
           >
             {thumb && !imgError[id] ? (
               <img
-                className={mobileStyles.thumbSm}
+                className={`${mobileStyles.thumbSm} ${mobileStyles.thumbSquircle}`}
                 src={getFileUrl(thumb)}
                 alt=""
                 onError={() => onImageError(id)}
@@ -53,10 +56,10 @@ export const ProjectsIconsStrip: FC<ProjectsIconsStripProps> = ({
             ) : (
               <SVGThumbnail
                 initial={title.charAt(0).toUpperCase() || "#"}
-                className={mobileStyles.thumbSm}
+                className={`${mobileStyles.thumbSm} ${mobileStyles.thumbSquircle}`}
               />
             )}
-          </button>
+          </Squircle>
         );
       })}
       {more > 0 && (

--- a/frontend/src/dashboard/home/components/ProjectsTable.tsx
+++ b/frontend/src/dashboard/home/components/ProjectsTable.tsx
@@ -3,6 +3,7 @@ import type { FC, KeyboardEvent as ReactKeyboardEvent } from "react";
 import desktopStyles from "./ProjectsPanelDesktop.module.css";
 import mobileStyles from "@/dashboard/home/components/projects-panel.module.css";
 import SVGThumbnail from "@/dashboard/home/components/SvgThumbnail";
+import Squircle from "@/shared/ui/Squircle";
 import { getFileUrl } from "@/shared/utils/api";
 import type { UserLite } from "@/app/contexts/DataProvider";
 import type { ProjectWithMeta } from "../utils/types";
@@ -97,10 +98,15 @@ const ProjectsTable: FC<ProjectsTableProps> = ({
                 >
                   <td>
                     <div className={desktopStyles.projectCell}>
-                      <span className={desktopStyles.thumb} aria-hidden>
+                      <Squircle
+                        as="span"
+                        className={desktopStyles.thumb}
+                        aria-hidden
+                        radius={12}
+                      >
                         {thumb && !imgError[id] ? (
                           <img
-                            className={mobileStyles.thumb}
+                            className={`${mobileStyles.thumb} ${mobileStyles.thumbSquircle}`}
                             src={getFileUrl(thumb)}
                             alt=""
                             onError={() => onImageError(id)}
@@ -108,10 +114,10 @@ const ProjectsTable: FC<ProjectsTableProps> = ({
                         ) : (
                           <SVGThumbnail
                             initial={title.charAt(0).toUpperCase() || "#"}
-                            className={mobileStyles.thumb}
+                            className={`${mobileStyles.thumb} ${mobileStyles.thumbSquircle}`}
                           />
                         )}
-                      </span>
+                      </Squircle>
                       <span className={desktopStyles.projectName}>{title}</span>
                     </div>
                   </td>

--- a/frontend/src/dashboard/home/components/projects-panel.module.css
+++ b/frontend/src/dashboard/home/components/projects-panel.module.css
@@ -80,6 +80,10 @@
   display: block;
 }
 
+.thumbSquircle {
+  border-radius: 0;
+}
+
 .iconsMore {
   font-size: 11px;
   opacity: .85;


### PR DESCRIPTION
## Summary
- wrap the quick project buttons in `<Squircle>` so the icons use the shared squircle mask
- apply the squircle wrapper to project thumbnails in the desktop table and add a helper class for mask-friendly images

## Testing
- npm run test -- ProjectsIconsStrip

------
https://chatgpt.com/codex/tasks/task_e_68cc7c1c21488324966d02638ea3080e