### PR TITLE
refactor: restyle all projects header

### DIFF
--- a/frontend/src/features/dashboard/components/AllProjects.tsx
+++ b/frontend/src/features/dashboard/components/AllProjects.tsx
@@ -20,6 +20,22 @@ import {
 } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { getFileUrl } from '../../../shared/utils/api';
+import {
+  DashboardPanelHeader,
+  DashboardPanelTitleWrap,
+  DashboardPanelTitle,
+  DashboardPanelActions,
+  DashboardPanelPills,
+  DashboardPanelPillButton,
+  DashboardPanelSortWrapper,
+  DashboardPanelSortMenu,
+  DashboardPanelActionGroup,
+  DashboardPanelSearchContainer,
+  DashboardPanelSearchInput,
+  DashboardPanelViewToggle,
+  DashboardPanelViewToggleButton,
+} from './DashboardPanelHeader';
+import { dashboardPanelPillUnderlineClass } from './dashboard-panel-header.constants';
 
 interface Project {
   projectId: string;
@@ -544,109 +560,127 @@ const AllProjects: React.FC = () => {
 
   return (
     <div className="welcome project-view">
-      <div className="projects-header">
-        <div className="projects-title">Projects</div>
-        <div className="project-pills">
-          {[{ key: 'all', label: `All Projects (${projects.length})` },
-            ...statusOptions.map((s) => ({
-              key: s,
-              label: `${s.charAt(0).toUpperCase() + s.slice(1)} (${statusCounts[s] || 0})`,
-            })),
-          ].map((p) => {
-            const active =
-              (p.key === 'all' && !statusFilter) || statusFilter === p.key;
-            return (
-              <button
-                key={p.key}
-                className={`pill ${active ? 'active' : ''}`}
-                onClick={() =>
-                  setStatusFilter(p.key === 'all' ? '' : p.key.toString())
-                }
+      <DashboardPanelHeader>
+        <DashboardPanelTitleWrap>
+          <DashboardPanelTitle>Projects</DashboardPanelTitle>
+        </DashboardPanelTitleWrap>
+        <DashboardPanelActions>
+          <DashboardPanelPills>
+            {[{ key: 'all', label: `All Projects (${projects.length})` },
+              ...statusOptions.map((s) => ({
+                key: s,
+                label: `${s.charAt(0).toUpperCase() + s.slice(1)} (${statusCounts[s] || 0})`,
+              })),
+            ].map((p) => {
+              const active =
+                (p.key === 'all' && !statusFilter) || statusFilter === p.key;
+              return (
+                <DashboardPanelPillButton
+                  key={p.key}
+                  active={active}
+                  onClick={() =>
+                    setStatusFilter(p.key === 'all' ? '' : p.key.toString())
+                  }
+                >
+                  {p.label}
+                  {active && (
+                    <motion.div
+                      layoutId="pill-underline"
+                      className={dashboardPanelPillUnderlineClass}
+                    />
+                  )}
+                </DashboardPanelPillButton>
+              );
+            })}
+            <DashboardPanelSortWrapper ref={sortRef}>
+              <DashboardPanelPillButton
+                active={sortOpen}
+                variant="sort"
+                onClick={() => setSortOpen((o) => !o)}
+                aria-expanded={sortOpen}
+                aria-haspopup="menu"
               >
-                {p.label}
-                {active && (
+                {`Sort (${sortLabels[sortOption]})`}
+                {sortOpen && (
                   <motion.div
                     layoutId="pill-underline"
-                    className="pill-underline"
+                    className={dashboardPanelPillUnderlineClass}
                   />
                 )}
-              </button>
-            );
-          })}
-          <div className="sort-wrapper" ref={sortRef}>
-            <button
-              type="button"
-              className={`pill sort-pill ${sortOpen ? 'active' : ''}`}
-              onClick={() => setSortOpen((o) => !o)}
-            >
-              {`Sort (${sortLabels[sortOption]})`}
+              </DashboardPanelPillButton>
               {sortOpen && (
-                <motion.div
-                  layoutId="pill-underline"
-                  className="pill-underline"
-                />
+                <DashboardPanelSortMenu role="menu">
+                  {Object.entries(sortLabels).map(([value, label]) => (
+                    <button
+                      key={value}
+                      type="button"
+                      onClick={() => {
+                        setSortOption(value as SortOption);
+                        setSortOpen(false);
+                      }}
+                    >
+                      {label}
+                    </button>
+                  ))}
+                </DashboardPanelSortMenu>
               )}
-            </button>
-            {sortOpen && (
-              <div className="sort-menu" role="menu">
-                {Object.entries(sortLabels).map(([value, label]) => (
-                  <button
-                    key={value}
-                    onClick={() => {
-                      setSortOption(value as SortOption);
-                      setSortOpen(false);
-                    }}
+            </DashboardPanelSortWrapper>
+          </DashboardPanelPills>
+          <DashboardPanelActionGroup>
+            <DashboardPanelSearchContainer>
+              <AnimatePresence initial={false}>
+                {searchOpen ? (
+                  <motion.div
+                    key="input"
+                    initial={{ width: 0, opacity: 0 }}
+                    animate={{ width: 160, opacity: 1 }}
+                    exit={{ width: 0, opacity: 0 }}
+                    style={{ overflow: 'hidden' }}
                   >
-                    {label}
-                  </button>
-                ))}
-              </div>
-            )}
-          </div>
-          <div className="search-pill">
-            <AnimatePresence initial={false}>
-              {searchOpen ? (
-                <motion.input
-                  key="input"
-                  className="search-input"
-                  initial={{ width: 0, opacity: 0 }}
-                  animate={{ width: 140, opacity: 1 }}
-                  exit={{ width: 0, opacity: 0 }}
-                  value={filterQuery}
-                  onChange={(e) => setFilterQuery(e.target.value)}
-                  onBlur={() => setSearchOpen(false)}
-                  placeholder="Search"
-                />
-              ) : (
-                <motion.button
-                  key="button"
-                  type="button"
-                  className="pill icon-pill"
-                  onClick={() => setSearchOpen(true)}
-                >
-                  <Search size={14} />
-                </motion.button>
-              )}
-            </AnimatePresence>
-          </div>
-          <div className="view-toggle">
-            <button
-              className={viewMode === 'grid' ? 'active' : ''}
-              onClick={() => setViewMode('grid')}
-              aria-label="Grid view"
-            >
-              <LayoutGrid size={16} />
-            </button>
-            <button
-              className={viewMode === 'list' ? 'active' : ''}
-              onClick={() => setViewMode('list')}
-              aria-label="List view"
-            >
-              <List size={16} />
-            </button>
-          </div>
-        </div>
-      </div>
+                    <DashboardPanelSearchInput
+                      value={filterQuery}
+                      onChange={(e) => setFilterQuery(e.target.value)}
+                      onBlur={() => setSearchOpen(false)}
+                      placeholder="Search"
+                    />
+                  </motion.div>
+                ) : (
+                  <motion.div
+                    key="button"
+                    initial={{ scale: 0.9, opacity: 0 }}
+                    animate={{ scale: 1, opacity: 1 }}
+                    exit={{ scale: 0.9, opacity: 0 }}
+                  >
+                    <DashboardPanelPillButton
+                      variant="icon"
+                      onClick={() => setSearchOpen(true)}
+                      aria-label="Open search"
+                    >
+                      <Search size={14} />
+                    </DashboardPanelPillButton>
+                  </motion.div>
+                )}
+              </AnimatePresence>
+            </DashboardPanelSearchContainer>
+            <DashboardPanelViewToggle>
+              <DashboardPanelViewToggleButton
+                active={viewMode === 'grid'}
+                onClick={() => setViewMode('grid')}
+                aria-label="Grid view"
+              >
+                <LayoutGrid size={16} />
+              </DashboardPanelViewToggleButton>
+              <DashboardPanelViewToggleButton
+                active={viewMode === 'list'}
+                onClick={() => setViewMode('list')}
+                aria-label="List view"
+              >
+                <List size={16} />
+              </DashboardPanelViewToggleButton>
+            </DashboardPanelViewToggle>
+          </DashboardPanelActionGroup>
+        </DashboardPanelActions>
+      </DashboardPanelHeader>
       {content}
     </div>
   );

--- a/frontend/src/features/dashboard/components/DashboardPanelHeader.tsx
+++ b/frontend/src/features/dashboard/components/DashboardPanelHeader.tsx
@@ -1,0 +1,141 @@
+import React, {
+  forwardRef,
+  type ButtonHTMLAttributes,
+  type HTMLAttributes,
+  type InputHTMLAttributes,
+} from "react";
+import styles from "./dashboard-panel-header.module.css";
+
+const cx = (...values: Array<string | null | undefined | false>): string =>
+  values.filter(Boolean).join(" ");
+
+type HeaderProps = HTMLAttributes<HTMLElement>;
+
+export const DashboardPanelHeader = forwardRef<HTMLElement, HeaderProps>(
+  ({ className, ...props }, ref) => (
+    <header ref={ref} className={cx(styles.header, className)} {...props} />
+  ),
+);
+DashboardPanelHeader.displayName = "DashboardPanelHeader";
+
+type TitleWrapProps = HTMLAttributes<HTMLDivElement>;
+
+export const DashboardPanelTitleWrap = ({ className, ...props }: TitleWrapProps) => (
+  <div className={cx(styles.titleWrap, className)} {...props} />
+);
+
+export const DashboardPanelTitle = ({
+  className,
+  ...props
+}: HTMLAttributes<HTMLHeadingElement>) => (
+  <h2 className={cx(styles.title, className)} {...props} />
+);
+
+type ActionsProps = HTMLAttributes<HTMLDivElement>;
+
+export const DashboardPanelActions = ({ className, ...props }: ActionsProps) => (
+  <div className={cx(styles.actions, className)} {...props} />
+);
+
+type PillsProps = HTMLAttributes<HTMLDivElement>;
+
+export const DashboardPanelPills = ({ className, ...props }: PillsProps) => (
+  <div className={cx(styles.pills, className)} {...props} />
+);
+
+type PillButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  active?: boolean;
+  variant?: "default" | "sort" | "icon";
+};
+
+export const DashboardPanelPillButton = forwardRef<HTMLButtonElement, PillButtonProps>(
+  ({ active = false, variant = "default", className, type, ...props }, ref) => {
+    const variantClass =
+      variant === "sort"
+        ? styles.pillSort
+        : variant === "icon"
+        ? styles.pillIcon
+        : undefined;
+    return (
+      <button
+        ref={ref}
+        type={type ?? "button"}
+        className={cx(styles.pill, variantClass, active && styles.pillActive, className)}
+        {...props}
+      />
+    );
+  },
+);
+DashboardPanelPillButton.displayName = "DashboardPanelPillButton";
+
+type SortWrapperProps = HTMLAttributes<HTMLDivElement>;
+
+export const DashboardPanelSortWrapper = forwardRef<HTMLDivElement, SortWrapperProps>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cx(styles.sortWrapper, className)} {...props} />
+  ),
+);
+DashboardPanelSortWrapper.displayName = "DashboardPanelSortWrapper";
+
+export const DashboardPanelSortMenu = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cx(styles.sortMenu, className)} {...props} />
+  ),
+);
+DashboardPanelSortMenu.displayName = "DashboardPanelSortMenu";
+
+type ActionGroupProps = HTMLAttributes<HTMLDivElement>;
+
+export const DashboardPanelActionGroup = ({
+  className,
+  ...props
+}: ActionGroupProps) => (
+  <div className={cx(styles.rightControls, className)} {...props} />
+);
+
+type SearchContainerProps = HTMLAttributes<HTMLDivElement>;
+
+export const DashboardPanelSearchContainer = ({
+  className,
+  ...props
+}: SearchContainerProps) => (
+  <div className={cx(styles.searchContainer, className)} {...props} />
+);
+
+type SearchInputProps = InputHTMLAttributes<HTMLInputElement>;
+
+export const DashboardPanelSearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
+  ({ className, type, ...props }, ref) => (
+    <input
+      ref={ref}
+      type={type ?? "search"}
+      className={cx(styles.searchInput, className)}
+      {...props}
+    />
+  ),
+);
+DashboardPanelSearchInput.displayName = "DashboardPanelSearchInput";
+
+type ViewToggleProps = HTMLAttributes<HTMLDivElement>;
+
+export const DashboardPanelViewToggle = ({ className, ...props }: ViewToggleProps) => (
+  <div className={cx(styles.viewToggle, className)} {...props} />
+);
+
+type ViewToggleButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  active?: boolean;
+};
+
+export const DashboardPanelViewToggleButton = forwardRef<
+  HTMLButtonElement,
+  ViewToggleButtonProps
+>(({ active = false, className, type, ...props }, ref) => (
+  <button
+    ref={ref}
+    type={type ?? "button"}
+    className={cx(styles.viewToggleButton, active && styles.viewToggleButtonActive, className)}
+    {...props}
+  />
+));
+DashboardPanelViewToggleButton.displayName = "DashboardPanelViewToggleButton";
+

--- a/frontend/src/features/dashboard/components/dashboard-panel-header.constants.ts
+++ b/frontend/src/features/dashboard/components/dashboard-panel-header.constants.ts
@@ -1,0 +1,3 @@
+import styles from "./dashboard-panel-header.module.css";
+
+export const dashboardPanelPillUnderlineClass = styles.pillUnderline;

--- a/frontend/src/features/dashboard/components/dashboard-panel-header.module.css
+++ b/frontend/src/features/dashboard/components/dashboard-panel-header.module.css
@@ -1,0 +1,210 @@
+.header {
+  display: grid;
+  gap: 10px;
+  margin-bottom: 12px;
+}
+
+@media (min-width: 768px) {
+  .header {
+    grid-template-columns: 1fr auto;
+    align-items: center;
+  }
+}
+
+.titleWrap {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+.title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  line-height: 1.2;
+  color: var(--text-color, #ffffff);
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 10px;
+}
+
+.pills {
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+}
+
+.pill {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--text-color, #ffffff);
+  border-radius: 999px;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  padding: 6px 12px;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.pill:hover {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.pillActive {
+  font-weight: 600;
+  border-color: rgba(255, 255, 255, 0.16);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.pillUnderline {
+  position: absolute;
+  left: 8px;
+  right: 8px;
+  bottom: 4px;
+  height: 2px;
+  border-radius: 2px;
+  background: var(--color-focus, #EB5DFA);
+}
+
+.pillSort {
+  border-color: rgba(255, 255, 255, 0.16);
+}
+
+.pillIcon {
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  justify-content: center;
+}
+
+.sortWrapper {
+  position: relative;
+}
+
+.sortMenu {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  min-width: 160px;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: var(--bg-elevated, #0c0c0c);
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.32);
+  padding: 6px 0;
+  display: flex;
+  flex-direction: column;
+  z-index: 30;
+}
+
+.sortMenu button {
+  background: none;
+  border: none;
+  color: inherit;
+  text-align: left;
+  padding: 8px 14px;
+  font-size: 0.8125rem;
+  cursor: pointer;
+}
+
+.sortMenu button:hover {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.searchContainer {
+  display: inline-flex;
+  align-items: center;
+  position: relative;
+}
+
+.searchInput {
+  width: 160px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: var(--bg, #0c0c0c);
+  color: var(--text-color, #ffffff);
+  padding: 6px 12px;
+  font-size: 0.8125rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.searchInput::placeholder {
+  color: rgba(255, 255, 255, 0.56);
+}
+
+.searchInput:focus {
+  outline: none;
+  border-color: var(--color-focus, #EB5DFA);
+  box-shadow: 0 0 0 2px rgba(235, 93, 250, 0.18);
+}
+
+.rightControls {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.viewToggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.viewToggleButton {
+  width: 28px;
+  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  border: none;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.viewToggleButton:hover {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.viewToggleButtonActive {
+  background: #ffffff;
+  color: #0c0c0c;
+}
+
+@media (max-width: 600px) {
+  .header {
+    grid-template-columns: 1fr;
+  }
+
+  .actions {
+    justify-content: flex-start;
+  }
+
+  .rightControls {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .searchInput {
+    width: 140px;
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable dashboard panel header component set with structured layout helpers
- restyle the AllProjects header to use the shared panel header controls for pills, sorting, search, and view toggles

## Testing
- `npx eslint src/features/dashboard/components/AllProjects.tsx src/features/dashboard/components/DashboardPanelHeader.tsx src/features/dashboard/components/dashboard-panel-header.constants.ts`


------
https://chatgpt.com/codex/tasks/task_e_68cc7d8433b48324899d5dd9c19b16ea