### PR TITLE
feat: add nav collapsed hook

### DIFF
--- a/frontend/src/dashboard/home/pages/DashboardHome.tsx
+++ b/frontend/src/dashboard/home/pages/DashboardHome.tsx
@@ -22,6 +22,7 @@ import NavigationDrawer from "@/shared/ui/NavigationDrawer";
 import DashboardNavPanel from "@/shared/ui/DashboardNavPanel";
 import ProjectsPanelDesktop from "@/dashboard/home/components/ProjectsPanelDesktop";
 import { getColor } from "@/shared/utils/colorUtils";
+import { useNavCollapsed } from "@/shared/hooks/useNavCollapsed";
 
 import "./dashboard-styles.css";
 
@@ -176,7 +177,7 @@ const WelcomeScreen: React.FC = () => {
     computeViewportFlags()
   );
   const [isNavigationOpen, setIsNavigationOpen] = useState(false);
-  const [isNavCollapsed, setIsNavCollapsed] = useState(false);
+  const [isNavCollapsed, setIsNavCollapsed] = useNavCollapsed("dashboard");
   const rawDrawerId = useId();
   const drawerId = React.useMemo(
     () => `dashboard-nav-${rawDrawerId.replace(/[^a-zA-Z0-9_-]/g, "")}`,
@@ -207,7 +208,7 @@ const WelcomeScreen: React.FC = () => {
     if (!isDesktop) {
       setIsNavCollapsed(false);
     }
-  }, [isDesktop]);
+  }, [isDesktop, setIsNavCollapsed]);
 
   const handleNavigateToProject = async ({
     projectId,

--- a/frontend/src/dashboard/project/components/Shared/ProjectPageLayout.tsx
+++ b/frontend/src/dashboard/project/components/Shared/ProjectPageLayout.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import ProjectMessagesThread from "@/dashboard/features/messages/ProjectMessagesThread";
 import DashboardNavPanel from "@/shared/ui/DashboardNavPanel";
+import { useNavCollapsed } from "@/shared/hooks/useNavCollapsed";
 import ChatPanel from "./ChatPanel";
 import type { ProjectAccentPalette } from "@/dashboard/project/hooks/useProjectPalette";
 
@@ -93,7 +94,7 @@ const ProjectPageLayout: React.FC<ProjectPageLayoutProps> = ({
     }
   });
 
-  const [isNavCollapsed, setIsNavCollapsed] = React.useState<boolean>(false);
+  const [isNavCollapsed, setIsNavCollapsed] = useNavCollapsed("project");
 
   // Measure global + project header heights
   React.useLayoutEffect(() => {
@@ -179,7 +180,7 @@ const ProjectPageLayout: React.FC<ProjectPageLayoutProps> = ({
   const handleSetActiveView = React.useCallback(() => {}, []);
   const handleToggleNavigationCollapse = React.useCallback(() => {
     setIsNavCollapsed((prev) => !prev);
-  }, []);
+  }, [setIsNavCollapsed]);
 
   const mainContent = (
     <div

--- a/frontend/src/shared/hooks/useNavCollapsed.ts
+++ b/frontend/src/shared/hooks/useNavCollapsed.ts
@@ -1,0 +1,59 @@
+import { Dispatch, SetStateAction, useCallback, useEffect, useState } from "react";
+
+type NavPage = "dashboard" | "project";
+
+type UseNavCollapsedReturn = [boolean, Dispatch<SetStateAction<boolean>>];
+
+const STORAGE_KEYS: Record<NavPage, string> = {
+  dashboard: "nav-collapsed-dashboard",
+  project: "nav-collapsed-project",
+};
+
+const DEFAULTS: Record<NavPage, boolean> = {
+  dashboard: false,
+  project: true,
+};
+
+export function useNavCollapsed(page: NavPage): UseNavCollapsedReturn {
+  const storageKey = STORAGE_KEYS[page];
+  const defaultValue = DEFAULTS[page];
+
+  const readValue = useCallback(() => {
+    if (typeof window === "undefined") {
+      return defaultValue;
+    }
+
+    try {
+      const storedValue = window.localStorage.getItem(storageKey);
+      if (storedValue === null) {
+        return defaultValue;
+      }
+
+      return storedValue === "true";
+    } catch {
+      return defaultValue;
+    }
+  }, [defaultValue, storageKey]);
+
+  const [collapsed, setCollapsed] = useState<boolean>(() => readValue());
+
+  useEffect(() => {
+    setCollapsed(readValue());
+  }, [readValue]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    try {
+      window.localStorage.setItem(storageKey, collapsed ? "true" : "false");
+    } catch {
+      // ignore storage write errors
+    }
+  }, [collapsed, storageKey]);
+
+  return [collapsed, setCollapsed];
+}
+
+export default useNavCollapsed;


### PR DESCRIPTION
## Summary
- add a reusable hook that reads and persists navigation collapse state per dashboard and project contexts
- update dashboard and project layouts to consume the hook so collapse preferences survive reloads

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc8ff738ac8324b10cdacc478700cf