### PR TITLE
Adjust project messages layout density

### DIFF
--- a/frontend/src/dashboard/features/messages/project-messages-thread.css
+++ b/frontend/src/dashboard/features/messages/project-messages-thread.css
@@ -1,9 +1,9 @@
 .chat-messages {
   flex-grow: 1;
   overflow-y: auto;
-  padding: 10px;
+  padding: 8px;
   border-radius: 5px;
-  margin-bottom: 10px;
+  margin-bottom: 8px;
   display: flex;
   flex-direction: column;
 }
@@ -19,7 +19,7 @@
 }
 
 .message-row {
-  margin-bottom: 12px;
+  margin-bottom: 8px;
   display: flex;
   align-items: flex-end;
 }
@@ -54,13 +54,14 @@
 
 .message-bubble {
   position: relative;
-  max-width: 65%;
-  min-width: 220px;
-  padding: 8px 16px;
-  border-radius: 15px;
+  max-width: 60%;
+  min-width: 200px;
+  padding: 8px 12px;
+  border-radius: 12px;
   color: #fff;
   word-wrap: break-word;
-  line-height: 1.5;
+  line-height: 1.4;
+  font-size: 0.95rem;
   outline: none;
 }
 
@@ -70,16 +71,16 @@
 }
 
 .message-sender {
-  font-size: 12px;
+  font-size: 11px;
   opacity: 0.7;
-  margin-bottom: 5px;
+  margin-bottom: 4px;
 }
 
 .message-time {
   position: absolute;
   top: 4px;
   right: 8px;
-  font-size: 10px;
+  font-size: 9px;
   opacity: 0.6;
 }
 
@@ -90,7 +91,7 @@
 .reaction-item {
   margin-right: 4px;
   cursor: pointer;
-  font-size: 14px;
+  font-size: 13px;
 }
 
 .reaction-add {
@@ -98,7 +99,7 @@
   border: none;
   cursor: pointer;
   margin-right: 4px;
-  font-size: 14px;
+  font-size: 13px;
 }
 
 
@@ -140,32 +141,43 @@
 
 .message-input-container {
   display: flex;
-  gap: 10px;
+  gap: 8px;
   align-items: center;
-  margin-top: 10px;
+  margin-top: 8px;
   border-radius: 10px;
-  padding: 10px;
+  padding: 8px 10px;
   position: relative;
   background-color: #1c1c1c;
 }
 
 .message-input {
-  flex-grow: 1;
-  padding: 10px;
+  flex: 1 1 auto;
+  min-width: 0;
+  width: 100%;
+  padding: 8px 10px;
   border-radius: 6px;
   border: 1px solid #444;
   background: #262626;
   color: #fff;
+  font-size: 0.95rem;
+  line-height: 1.4;
   z-index: 1;
 }
 
+.message-input::placeholder {
+  color: #b5b5b5;
+  opacity: 1;
+  font-size: 0.95rem;
+}
+
 .send-button {
-  padding: 10px 15px;
+  padding: 8px 12px;
   background: #FA3356;
   border: none;
   border-radius: 6px;
   color: #fff;
   cursor: pointer;
+  font-size: 0.95rem;
   z-index: 1;
 }
 

--- a/frontend/src/dashboard/home/styles/components/messages-files.css
+++ b/frontend/src/dashboard/home/styles/components/messages-files.css
@@ -35,12 +35,13 @@
 
 /* Project messages panel */
 .project-messages {
-  flex: 3;
+  flex: 1 1 55%;
+  max-width: clamp(360px, 55%, 640px);
   min-height: 0;
   display: flex;
   flex-direction: column;
   padding-right: 5px;
-  
+
   border-radius: 20px;
   padding: 16px;
   background: rgba(255, 255, 255, 0.02);
@@ -63,6 +64,15 @@
 
 .project-messages.floating {
   min-width: 350px;
+  max-width: none;
+  flex: 0 0 auto;
+}
+
+@media (max-width: 1200px) {
+  .project-messages {
+    flex-basis: 100%;
+    max-width: 100%;
+  }
 }
 
 .project-messages .messages-inner {


### PR DESCRIPTION
## Summary
- reduce the default width of the project messages panel for a more balanced layout while keeping it responsive when floating or on smaller screens
- tighten chat spacing, bubble sizing, and input styling so the placeholder text adapts without clipping in the compact view

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc94fcfae08324929897b952d09297