### PR TITLE
Update AllProjects filter trigger

### DIFF
--- a/frontend/src/dashboard/home/components/ProjectsFilterMenu.test.tsx
+++ b/frontend/src/dashboard/home/components/ProjectsFilterMenu.test.tsx
@@ -32,7 +32,7 @@ const createDropdownStub = <T,>(): DropdownHelpers<T> => ({
 });
 
 describe("ProjectsFilterMenu", () => {
-  it("renders scope toggle and triggers toggle handler", () => {
+  it("renders filter trigger and toggles menu", () => {
     const toggleFilters = vi.fn();
     const statusDropdown = createDropdownStub<string>();
     const sortDropdown = createDropdownStub<SortOption>();
@@ -42,8 +42,6 @@ describe("ProjectsFilterMenu", () => {
         filtersOpen={false}
         filtersRef={createRef<HTMLDivElement>()}
         filtersId="filters"
-        scope="recents"
-        onScopeChange={vi.fn()}
         query=""
         onQueryChange={vi.fn()}
         toggleFilters={toggleFilters}
@@ -57,8 +55,8 @@ describe("ProjectsFilterMenu", () => {
       />
     );
 
-    const scopeButton = screen.getByRole("button", { name: /recents/i });
-    fireEvent.click(scopeButton);
+    const filterButton = screen.getByRole("button", { name: /filter/i });
+    fireEvent.click(filterButton);
     expect(toggleFilters).toHaveBeenCalledTimes(1);
     expect(screen.queryByRole("menu")).not.toBeInTheDocument();
   });
@@ -97,8 +95,6 @@ describe("ProjectsFilterMenu", () => {
         filtersOpen
         filtersRef={createRef<HTMLDivElement>()}
         filtersId="filters"
-        scope="all"
-        onScopeChange={vi.fn()}
         query=""
         onQueryChange={vi.fn()}
         toggleFilters={vi.fn()}

--- a/frontend/src/dashboard/home/components/ProjectsFilterMenu.tsx
+++ b/frontend/src/dashboard/home/components/ProjectsFilterMenu.tsx
@@ -11,8 +11,6 @@ type ProjectsFilterMenuProps = {
   filtersOpen: boolean;
   filtersRef: RefObject<HTMLDivElement>;
   filtersId: string;
-  scope: "recents" | "all";
-  onScopeChange: (scope: "recents" | "all") => void;
   query: string;
   onQueryChange: (value: string) => void;
   toggleFilters: () => void;
@@ -29,8 +27,6 @@ export const ProjectsFilterMenu: FC<ProjectsFilterMenuProps> = ({
   filtersOpen,
   filtersRef,
   filtersId,
-  scope,
-  onScopeChange,
   query,
   onQueryChange,
   toggleFilters,
@@ -56,32 +52,11 @@ export const ProjectsFilterMenu: FC<ProjectsFilterMenuProps> = ({
         aria-controls={filtersId}
         onClick={toggleFilters}
       >
-        {scope === "recents" ? "Recents" : "All projects"} <ChevronDown size={14} aria-hidden />
+        Filter <ChevronDown size={14} aria-hidden />
       </button>
       {filtersOpen && (
         <div className={mobileStyles.filterPop} role="menu" id={filtersId}>
           <div className={mobileStyles.filterSection}>
-            <div className={mobileStyles.scopeBtns} role="group" aria-label="Scope">
-              <button
-                type="button"
-                className={`${mobileStyles.scopeBtn} ${
-                  scope === "recents" ? mobileStyles.scopeBtnActive : ""
-                }`}
-                onClick={() => onScopeChange("recents")}
-              >
-                Recents
-              </button>
-              <button
-                type="button"
-                className={`${mobileStyles.scopeBtn} ${
-                  scope === "all" ? mobileStyles.scopeBtnActive : ""
-                }`}
-                onClick={() => onScopeChange("all")}
-              >
-                All projects
-              </button>
-            </div>
-
             <div className={desktopStyles.filterField}>
               <Search size={16} aria-hidden className={desktopStyles.filterFieldIcon} />
               <input

--- a/frontend/src/dashboard/home/components/ProjectsPanelDesktop.tsx
+++ b/frontend/src/dashboard/home/components/ProjectsPanelDesktop.tsx
@@ -66,8 +66,6 @@ const ProjectsPanelDesktop: React.FC<ProjectsPanelDesktopProps> = ({ onOpenProje
     filtersRef,
     filtersId,
     toggleFilters,
-    scope,
-    setScope,
     query,
     setQuery,
     statusOptions,
@@ -115,8 +113,6 @@ const ProjectsPanelDesktop: React.FC<ProjectsPanelDesktopProps> = ({ onOpenProje
           filtersOpen={filtersOpen}
           filtersRef={filtersRef}
           filtersId={filtersId}
-          scope={scope}
-          onScopeChange={setScope}
           query={query}
           onQueryChange={setQuery}
           toggleFilters={toggleFilters}

--- a/frontend/src/dashboard/home/components/ProjectsPanelMobile.tsx
+++ b/frontend/src/dashboard/home/components/ProjectsPanelMobile.tsx
@@ -74,7 +74,6 @@ const ProjectsPanelMobile: React.FC<Props> = ({ onOpenProject }) => {
   const [sortOption, setSortOption] = useState<SortOption>("dateNewest");
   const [statusFilter, setStatusFilter] = useState<string>("");
   const [query, setQuery] = useState<string>("");
-  const [scope, setScope] = useState<"recents" | "all">("recents");
   // Icons-only strip lives next to the title; main list remains compact list rows
 
   useEffect(() => {
@@ -141,11 +140,8 @@ const ProjectsPanelMobile: React.FC<Props> = ({ onOpenProject }) => {
       _created: new Date(p.dateCreated || p.date || 0).getTime() || 0,
     }));
 
-    // Base ordering by scope
+    // Base ordering
     let ordered = list.slice();
-    if (scope === "recents") {
-      ordered.sort((a, b) => b._activity - a._activity);
-    }
 
     // Filters
     const q = query.trim().toLowerCase();
@@ -187,7 +183,7 @@ const ProjectsPanelMobile: React.FC<Props> = ({ onOpenProject }) => {
     }
 
     return ordered;
-  }, [projects, sortOption, statusFilter, query, scope]);
+  }, [projects, sortOption, statusFilter, query]);
 
   const kpis = useProjectKpis(projects as ProjectLike[]);
 
@@ -223,8 +219,6 @@ const ProjectsPanelMobile: React.FC<Props> = ({ onOpenProject }) => {
     if (action === "open") handleOpen(id);
     setMenuOpenId(null);
   };
-
-  const scopeLabel = scope === "recents" ? "Recents" : "All projects";
 
   return (
     <section
@@ -298,36 +292,11 @@ const ProjectsPanelMobile: React.FC<Props> = ({ onOpenProject }) => {
             aria-haspopup="menu"
             onClick={() => setFiltersOpen((v) => !v)}
           >
-            {scopeLabel} <ChevronDown size={14} aria-hidden />
+            Filter <ChevronDown size={14} aria-hidden />
           </button>
           {filtersOpen && (
             <div className={styles.filterPop} role="menu">
               <div className={styles.filterSection}>
-                <div
-                  className={styles.scopeBtns}
-                  role="group"
-                  aria-label="Scope"
-                >
-                  <button
-                    type="button"
-                    className={`${styles.scopeBtn} ${
-                      scope === "recents" ? styles.scopeBtnActive : ""
-                    }`}
-                    onClick={() => setScope("recents")}
-                  >
-                    Recents
-                  </button>
-                  <button
-                    type="button"
-                    className={`${styles.scopeBtn} ${
-                      scope === "all" ? styles.scopeBtnActive : ""
-                    }`}
-                    onClick={() => setScope("all")}
-                  >
-                    All projects
-                  </button>
-                </div>
-
                 <input
                   className={styles.input}
                   placeholder="Filter projects..."


### PR DESCRIPTION
## Summary
- label the filter trigger button as "Filter" and drop the recents/all scope toggle from `ProjectsFilterMenu`
- update the desktop and mobile projects panels to use the simplified trigger text
- refresh the filter menu tests to cover the streamlined behaviour

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68cc93d781448324af7f59ce375c3522