### PR TITLE
Use squircle wrappers for project thumbnails

### DIFF
--- a/frontend/src/dashboard/home/components/AllProjects.tsx
+++ b/frontend/src/dashboard/home/components/AllProjects.tsx
@@ -12,7 +12,6 @@ import { useNavigate } from 'react-router-dom';
 import SVGThumbnail from './SvgThumbnail';
 import Spinner from '../../../shared/ui/Spinner';
 import AvatarStack from '../../../shared/ui/AvatarStack';
-import { ProjectsIconsStrip } from './ProjectsIconsStrip';
 import { ProjectsFilterMenu } from './ProjectsFilterMenu';
 import { useProjectFilters } from './hooks/useProjectFilters';
 import {
@@ -161,15 +160,18 @@ const AllProjects: React.FC = () => {
     }
   }, [isLoading, projects.length, projectsError, fetchProjects]);
 
-  const onSelectProject = (project: Project): void => {
-    navigate(getProjectDashboardPath(project.projectId, project.title));
+  const onSelectProject = useCallback(
+    (project: Project): void => {
+      navigate(getProjectDashboardPath(project.projectId, project.title));
 
-    const fetchPromise = fetchProjectDetails(project.projectId).catch((err) => {
-      console.error('Error loading project', err);
-    });
+      const fetchPromise = fetchProjectDetails(project.projectId).catch((err) => {
+        console.error('Error loading project', err);
+      });
 
-    void fetchPromise;
-  };
+      void fetchPromise;
+    },
+    [navigate, fetchProjectDetails],
+  );
 
   // Preload project thumbnails
   useEffect(() => {
@@ -190,9 +192,12 @@ const AllProjects: React.FC = () => {
     return map;
   }, [allUsers]);
 
-  const handleProjectClick = (project: Project): void => {
-    onSelectProject(project);
-  };
+  const handleProjectClick = useCallback(
+    (project: Project): void => {
+      onSelectProject(project);
+    },
+    [onSelectProject],
+  );
 
   const handleKeyDown = (e: React.KeyboardEvent, project: Project): void => {
     if (e.key === 'Enter') {
@@ -207,7 +212,7 @@ const AllProjects: React.FC = () => {
         handleProjectClick(proj);
       }
     },
-    [projects],
+    [projects, handleProjectClick],
   );
 
   useEffect(() => {

--- a/frontend/src/dashboard/home/components/AllProjectsCalendar.css
+++ b/frontend/src/dashboard/home/components/AllProjectsCalendar.css
@@ -325,13 +325,20 @@
 .all-projects-calendar-wrapper .tooltip-initial {
   width: 16px;
   height: 16px;
-  border-radius: 4px;
   object-fit: cover;
   display: flex;
   align-items: center;
   justify-content: center;
   background: rgba(255, 255, 255, 0.2);
   font-size: 0.6rem;
+}
+
+.all-projects-calendar-wrapper .tooltip-thumb-image,
+.all-projects-calendar-wrapper .tooltip-thumb-placeholder {
+  width: 100%;
+  height: 100%;
+  display: block;
+  object-fit: cover;
 }
 
 .all-projects-calendar-wrapper .tooltip-text {

--- a/frontend/src/dashboard/home/components/AllProjectsCalendar.tsx
+++ b/frontend/src/dashboard/home/components/AllProjectsCalendar.tsx
@@ -17,6 +17,8 @@ import { faClock } from "@fortawesome/free-solid-svg-icons";
 import { WeekWidget } from "./WeekWidget";
 import { getFileUrl } from "../../../shared/utils/api";
 import { getProjectDashboardPath } from "@/shared/utils/projectUrl";
+import Squircle from "@/shared/ui/Squircle";
+import SVGThumbnail from "./SvgThumbnail";
 
 // --- Types ---
 type Project = {
@@ -383,13 +385,20 @@ const AllProjectsCalendar: React.FC = () => {
                   className="tooltip-item"
                   onClick={() => handleProjectClick({ projectId: item.projectId, title: item.title } as Project)}
                 >
-                  {item.thumbnail ? (
-                    <img
-                      src={getFileUrl(item.thumbnail)}
-                      alt={item.title ?? "thumbnail"}
-                      className="tooltip-thumb"
-                    />
-                  ) : null}
+                  <Squircle as="span" className="tooltip-thumb" aria-hidden radius={6}>
+                    {item.thumbnail ? (
+                      <img
+                        src={getFileUrl(item.thumbnail)}
+                        alt={item.title ?? "thumbnail"}
+                        className="tooltip-thumb-image"
+                      />
+                    ) : (
+                      <SVGThumbnail
+                        initial={(item.title ?? "Untitled").trim().charAt(0).toUpperCase() || "#"}
+                        className="tooltip-thumb-placeholder"
+                      />
+                    )}
+                  </Squircle>
                   <div className="tooltip-text">
                     <div className="tooltip-header">
                       <span className="tooltip-title">{item.title ?? "Untitled"}</span>

--- a/frontend/src/dashboard/home/components/Collaborators.module.css
+++ b/frontend/src/dashboard/home/components/Collaborators.module.css
@@ -144,8 +144,6 @@
 .projectIcon {
   width: 24px;
   height: 24px;
-  border-radius: 50%;
-  object-fit: cover;
   border: 2px solid #0c0c0c;
 }
 

--- a/frontend/src/dashboard/home/components/GlobalSearch.css
+++ b/frontend/src/dashboard/home/components/GlobalSearch.css
@@ -153,7 +153,6 @@
 .global-search-thumbnail {
   width: 48px;
   height: 48px;
-  border-radius: 8px;
   background: rgba(255, 255, 255, 0.08);
   overflow: hidden;
   display: flex;
@@ -170,8 +169,8 @@
 }
 
 .global-search-thumbnail-placeholder {
-  width: 48px;
-  height: 48px;
+  width: 100%;
+  height: 100%;
   display: block;
 }
 

--- a/frontend/src/dashboard/home/components/GlobalSearch.tsx
+++ b/frontend/src/dashboard/home/components/GlobalSearch.tsx
@@ -9,6 +9,7 @@ import { getFileUrl } from '@/shared/utils/api';
 import type { AppUser } from '@/dashboard/features/messages/types';
 import { getUserDisplayName, getUserThumbnail } from '@/dashboard/features/messages/utils/userHelpers';
 import SVGThumbnail from './SvgThumbnail';
+import Squircle from '@/shared/ui/Squircle';
 
 interface HighlightPart {
   text: string;
@@ -675,7 +676,12 @@ const GlobalSearch: React.FC<GlobalSearchProps> = ({ className = '', onNavigate 
                 className={resultClasses}
               >
                 {isProject ? (
-                  <div className="global-search-thumbnail" aria-hidden>
+                  <Squircle
+                    as="div"
+                    className="global-search-thumbnail"
+                    aria-hidden
+                    radius={12}
+                  >
                     {result.thumbnailUrl && !imageErrors[result.id] ? (
                       <img
                         src={result.thumbnailUrl}
@@ -691,7 +697,7 @@ const GlobalSearch: React.FC<GlobalSearchProps> = ({ className = '', onNavigate 
                         className="global-search-thumbnail-placeholder"
                       />
                     )}
-                  </div>
+                  </Squircle>
                 ) : isCollaborator ? (
                   <div className="global-search-thumbnail collaborator-thumbnail" aria-hidden>
                     {result.thumbnailUrl && !imageErrors[result.id] ? (

--- a/frontend/src/dashboard/home/components/ProjectsPanelMobile.tsx
+++ b/frontend/src/dashboard/home/components/ProjectsPanelMobile.tsx
@@ -9,6 +9,7 @@ import styles from "./projects-panel.module.css";
 import { useProjectKpis, type ProjectLike } from "../hooks/useProjectKpis";
 import { getFileUrl } from "../../../shared/utils/api";
 import { MICRO_WOBBLE_SCALE, SPRING_FAST } from "@/shared/ui/motionTokens";
+import Squircle from "@/shared/ui/Squircle";
 
 type Props = {
   onOpenProject: (projectId: string) => void;
@@ -250,17 +251,19 @@ const ProjectsPanelMobile: React.FC<Props> = ({ onOpenProject }) => {
                       ? p.thumbnails[0]
                       : undefined;
                   return (
-                    <button
+                    <Squircle
                       key={`icon-${id}`}
+                      as="button"
                       type="button"
                       className={styles.iconBtnSm}
                       aria-label={`Open project ${title}`}
                       title={title}
                       onClick={() => handleOpen(id)}
+                      radius={8}
                     >
                       {thumb && !imgError[id] ? (
                         <img
-                          className={styles.thumbSm}
+                          className={`${styles.thumbSm} ${styles.thumbSquircle}`}
                           src={getFileUrl(thumb)}
                           alt=""
                           onError={() =>
@@ -275,10 +278,10 @@ const ProjectsPanelMobile: React.FC<Props> = ({ onOpenProject }) => {
                               .charAt(0)
                               .toUpperCase() || "#"
                           }
-                          className={styles.thumbSm}
+                          className={`${styles.thumbSm} ${styles.thumbSquircle}`}
                         />
                       )}
-                    </button>
+                    </Squircle>
                   );
                 })}
                 {more > 0 && (
@@ -431,10 +434,10 @@ const ProjectsPanelMobile: React.FC<Props> = ({ onOpenProject }) => {
                   onKeyDown={onKey}
                   aria-label={`Open project ${title}`}
                 >
-                  <div className={styles.icon} aria-hidden>
+                  <Squircle as="div" className={styles.icon} aria-hidden radius={10}>
                     {thumb && !imgError[id] ? (
                       <img
-                        className={styles.thumb}
+                        className={`${styles.thumb} ${styles.thumbSquircle}`}
                         src={getFileUrl(thumb)}
                         alt=""
                         onError={() =>
@@ -446,10 +449,10 @@ const ProjectsPanelMobile: React.FC<Props> = ({ onOpenProject }) => {
                         initial={
                           title.charAt(0).toUpperCase() || "#"
                         }
-                        className={styles.thumb}
+                        className={`${styles.thumb} ${styles.thumbSquircle}`}
                       />
                     )}
-                  </div>
+                  </Squircle>
                   <div className={styles.meta}>
                     <div className={styles.titleRow}>
                       <div className={styles.titleLeft}>

--- a/frontend/src/dashboard/home/components/ProjectsRecentsCard.tsx
+++ b/frontend/src/dashboard/home/components/ProjectsRecentsCard.tsx
@@ -170,10 +170,10 @@ const ProjectsRecentsCard: React.FC<Props> = ({ onOpenProject }) => {
                   onKeyDown={onKey}
                   aria-label={`Open project ${title}`}
                 >
-                  <div className="prc-icon" aria-hidden>
+                  <Squircle as="div" className="prc-icon" aria-hidden radius={10}>
                     {thumb && !imgError[id] ? (
                       <img
-                        className="prc-thumb"
+                        className="prc-thumb prc-thumbSquircle"
                         src={getFileUrl(thumb)}
                         alt=""
                         onError={() => setImgError((m) => ({ ...m, [id]: true }))}
@@ -181,7 +181,7 @@ const ProjectsRecentsCard: React.FC<Props> = ({ onOpenProject }) => {
                     ) : (
                       <ProjectCard size={16} color="#fff" />
                     )}
-                  </div>
+                  </Squircle>
                   <div className="prc-meta">
                     <div className="prc-title-row">
                       <div className="prc-title-left">

--- a/frontend/src/dashboard/home/components/projects-panel.module.css
+++ b/frontend/src/dashboard/home/components/projects-panel.module.css
@@ -53,7 +53,6 @@
 .iconBtnSm {
   width: 22px;
   height: 22px;
-  border-radius: 6px;
   border: 1px solid rgba(255, 255, 255, .16);
   background: var(--bg, #0c0c0c);
   display: inline-flex;
@@ -61,6 +60,7 @@
   justify-content: center;
   padding: 0;
   cursor: pointer;
+  overflow: hidden;
 }
 
 .iconBtnSm:hover {
@@ -76,7 +76,6 @@
   width: 100%;
   height: 100%;
   object-fit: cover;
-  border-radius: 5px;
   display: block;
 }
 
@@ -343,19 +342,17 @@
 .icon {
   width: 32px; /* extra compact */
   height: 32px; /* extra compact */
-  border-radius: 6px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   background: var(--bg, #0c0c0c);
- 
+  overflow: hidden;
 }
 
 .thumb {
   width: 100%;
   height: 100%;
   object-fit: cover;
-  border-radius: 6px;
   display: block;
 }
 

--- a/frontend/src/dashboard/home/styles/components/notification-preview.css
+++ b/frontend/src/dashboard/home/styles/components/notification-preview.css
@@ -34,8 +34,6 @@
 .notification-avatar {
   width: 28px;
   height: 28px;
-  border-radius: 50%;
-  object-fit: cover;
   margin-right: 8px;
   flex-shrink: 0;
 }

--- a/frontend/src/dashboard/home/styles/components/projects-recents-card.css
+++ b/frontend/src/dashboard/home/styles/components/projects-recents-card.css
@@ -90,21 +90,23 @@
 .prc-icon {
   width: 32px;
   height: 32px;
-  border-radius: 8px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   background: var(--bg, #0c0c0c);
   border: 1px solid var(--stroke-strong, rgba(255, 255, 255, 0.16));
-  
+  overflow: hidden;
 }
 
 .prc-thumb {
   width: 100%;
   height: 100%;
   object-fit: cover;
-  border-radius: 6px;
   display: block;
+}
+
+.prc-thumbSquircle {
+  border-radius: 0;
 }
 
 .prc-meta {

--- a/frontend/src/shared/ui/Notifications.css
+++ b/frontend/src/shared/ui/Notifications.css
@@ -43,8 +43,6 @@
 .notification-avatar {
   width: 32px;
   height: 32px;
-  border-radius: 6px;
-  object-fit: cover;
   flex-shrink: 0;
 }
 
@@ -225,7 +223,6 @@
 .dropdown-avatar {
   width: 20px;
   height: 20px;
-  border-radius: 4px;
   margin-right: 8px;
 }
 

--- a/frontend/src/shared/ui/ProjectAvatar.tsx
+++ b/frontend/src/shared/ui/ProjectAvatar.tsx
@@ -1,28 +1,46 @@
 import React from 'react';
 import SVGThumbnail from '../../dashboard/home/components/SvgThumbnail';
 import { getFileUrl } from '../utils/api';
+import Squircle from './Squircle';
+import './project-avatar.css';
 
 interface ProjectAvatarProps {
   thumb?: string;
   name?: string;
   initial?: string;
   className?: string;
+  radius?: number;
 }
+
+const DEFAULT_RADIUS = 10;
 
 const ProjectAvatar: React.FC<ProjectAvatarProps> = ({
   thumb,
   name = '',
   initial = '',
   className = '',
-}) =>
-  thumb ? (
-    <img src={getFileUrl(thumb)} alt={name} className={className} />
-  ) : (
-    <SVGThumbnail
-      initial={(initial || name.charAt(0)).toUpperCase()}
-      className={className}
-    />
+  radius = DEFAULT_RADIUS,
+}) => {
+  const wrapperClassName = ['project-avatar', className].filter(Boolean).join(' ').trim() || undefined;
+  const displayInitial = (initial || name.charAt(0)).toUpperCase() || '#';
+
+  return (
+    <Squircle as="span" className={wrapperClassName} radius={radius} aria-hidden={!name && !initial}>
+      {thumb ? (
+        <img
+          src={getFileUrl(thumb)}
+          alt={name}
+          className="project-avatar__media"
+        />
+      ) : (
+        <SVGThumbnail
+          initial={displayInitial}
+          className="project-avatar__media"
+        />
+      )}
+    </Squircle>
   );
+};
 
 export default ProjectAvatar;
 

--- a/frontend/src/shared/ui/project-avatar.css
+++ b/frontend/src/shared/ui/project-avatar.css
@@ -1,0 +1,14 @@
+.project-avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  background: var(--bg, #0c0c0c);
+}
+
+.project-avatar__media {
+  width: 100%;
+  height: 100%;
+  display: block;
+  object-fit: cover;
+}


### PR DESCRIPTION
## Summary
- update mobile projects panel icons and list rows to render thumbnails with the shared Squircle component
- wrap project thumbnails in recents cards, global search results, and calendar tooltips with Squircle and adjust supporting styles
- convert the shared ProjectAvatar to use Squircle and align dependent styles while memoizing AllProjects navigation callbacks for lint compliance

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc9a471e848324b8098869d12da106