### PR TITLE
Add mobile project header and shared UI primitives

### DIFF
--- a/frontend/src/components/ui/avatar.css
+++ b/frontend/src/components/ui/avatar.css
@@ -1,0 +1,17 @@
+.ui-avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 9999px;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.12);
+  color: #ffffff;
+  font-weight: 600;
+  font-size: 0.7rem;
+}
+
+.ui-avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}

--- a/frontend/src/components/ui/avatar.tsx
+++ b/frontend/src/components/ui/avatar.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { cn } from "./utils";
+import "./avatar.css";
+
+export interface AvatarProps
+  extends React.HTMLAttributes<HTMLDivElement> {
+  src?: string | null;
+  alt?: string;
+  fallback?: string;
+}
+
+export const Avatar = React.forwardRef<HTMLDivElement, AvatarProps>(
+  ({ className, src, alt, fallback, children, ...props }, ref) => {
+    const content = src ? (
+      <img src={src} alt={alt} />
+    ) : children ? (
+      children
+    ) : fallback ? (
+      <span>{fallback}</span>
+    ) : null;
+
+    return (
+      <div ref={ref} className={cn("ui-avatar", className)} {...props}>
+        {content}
+      </div>
+    );
+  }
+);
+
+Avatar.displayName = "Avatar";

--- a/frontend/src/components/ui/badge.css
+++ b/frontend/src/components/ui/badge.css
@@ -1,0 +1,23 @@
+.ui-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 9999px;
+  border: 1px solid transparent;
+  font-size: 0.7rem;
+  padding: 0.1rem 0.5rem;
+  line-height: 1.2;
+  background: rgba(255, 255, 255, 0.1);
+  color: #ffffff;
+  font-weight: 500;
+}
+
+.ui-badge--outline {
+  background: transparent;
+  border-color: rgba(255, 255, 255, 0.25);
+}
+
+.ui-badge--success {
+  border-color: #22c55e;
+  color: #22c55e;
+}

--- a/frontend/src/components/ui/badge.tsx
+++ b/frontend/src/components/ui/badge.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { cn } from "./utils";
+import "./badge.css";
+
+type BadgeVariant = "default" | "outline" | "success";
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLSpanElement> {
+  variant?: BadgeVariant;
+}
+
+export const Badge = React.forwardRef<HTMLSpanElement, BadgeProps>(
+  ({ className, variant = "default", ...props }, ref) => {
+    const classes = cn(
+      "ui-badge",
+      variant !== "default" ? `ui-badge--${variant}` : undefined,
+      className
+    );
+
+    return <span ref={ref} className={classes} {...props} />;
+  }
+);
+
+Badge.displayName = "Badge";

--- a/frontend/src/components/ui/button.css
+++ b/frontend/src/components/ui/button.css
@@ -1,0 +1,65 @@
+.ui-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 9999px;
+  border: 1px solid transparent;
+  font-size: 0.75rem;
+  font-weight: 500;
+  padding: 0.25rem 0.75rem;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease,
+    opacity 0.15s ease;
+  line-height: 1.2;
+}
+
+.ui-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.ui-button--default {
+  background: #ffffff;
+  color: #0c0c0c;
+}
+
+.ui-button--default:hover {
+  background: #e5e5e5;
+}
+
+.ui-button--outline {
+  border-color: rgba(255, 255, 255, 0.25);
+  color: #ffffff;
+}
+
+.ui-button--outline:hover {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.ui-button--ghost {
+  color: #ffffff;
+}
+
+.ui-button--ghost:hover {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.ui-button--sm {
+  font-size: 0.75rem;
+  padding: 0.25rem 0.75rem;
+  height: 28px;
+}
+
+.ui-button--icon {
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border-radius: 9999px;
+}
+
+.ui-button--icon svg {
+  width: 20px;
+  height: 20px;
+}

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { cn } from "./utils";
+import "./button.css";
+
+type ButtonVariant = "default" | "outline" | "ghost";
+type ButtonSize = "sm" | "icon" | "md";
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+}
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  (
+    {
+      className,
+      variant = "default",
+      size = "md",
+      type = "button",
+      ...props
+    },
+    ref
+  ) => {
+    const classes = cn(
+      "ui-button",
+      variant ? `ui-button--${variant}` : undefined,
+      size !== "md" ? `ui-button--${size}` : undefined,
+      className
+    );
+
+    return <button ref={ref} type={type} className={classes} {...props} />;
+  }
+);
+
+Button.displayName = "Button";

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -1,0 +1,4 @@
+export * from "./avatar";
+export * from "./badge";
+export * from "./button";
+export * from "./popover";

--- a/frontend/src/components/ui/popover.css
+++ b/frontend/src/components/ui/popover.css
@@ -1,0 +1,17 @@
+.ui-popover {
+  position: relative;
+  display: inline-flex;
+}
+
+.ui-popover-content {
+  position: absolute;
+  top: calc(100% + 0.25rem);
+  right: 0;
+  min-width: 8rem;
+  background: #1a1a1a;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 0.75rem;
+  padding: 0.5rem;
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.35);
+  z-index: 50;
+}

--- a/frontend/src/components/ui/popover.tsx
+++ b/frontend/src/components/ui/popover.tsx
@@ -1,0 +1,175 @@
+import React from "react";
+import { cn } from "./utils";
+import "./popover.css";
+
+type PopoverContextValue = {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  triggerRef: React.RefObject<HTMLElement>;
+  contentRef: React.RefObject<HTMLDivElement>;
+};
+
+const PopoverContext = React.createContext<PopoverContextValue | null>(null);
+
+const usePopoverContext = () => {
+  const context = React.useContext(PopoverContext);
+  if (!context) {
+    throw new Error("Popover components must be used within <Popover>");
+  }
+  return context;
+};
+
+interface PopoverProps {
+  children: React.ReactNode;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}
+
+export const Popover: React.FC<PopoverProps> = ({
+  children,
+  open: controlledOpen,
+  onOpenChange,
+}) => {
+  const triggerRef = React.useRef<HTMLElement>(null);
+  const contentRef = React.useRef<HTMLDivElement>(null);
+  const isControlled = controlledOpen !== undefined;
+  const [uncontrolledOpen, setUncontrolledOpen] = React.useState(false);
+
+  const open = isControlled ? controlledOpen : uncontrolledOpen;
+
+  const setOpen = React.useCallback(
+    (next: boolean) => {
+      if (!isControlled) {
+        setUncontrolledOpen(next);
+      }
+      onOpenChange?.(next);
+    },
+    [isControlled, onOpenChange]
+  );
+
+  React.useEffect(() => {
+    if (!open) return;
+
+    const handleClick = (event: MouseEvent) => {
+      const target = event.target as Node;
+      if (
+        triggerRef.current &&
+        !triggerRef.current.contains(target) &&
+        contentRef.current &&
+        !contentRef.current.contains(target)
+      ) {
+        setOpen(false);
+      }
+    };
+
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handleClick);
+    document.addEventListener("keydown", handleKey);
+
+    return () => {
+      document.removeEventListener("mousedown", handleClick);
+      document.removeEventListener("keydown", handleKey);
+    };
+  }, [open, setOpen]);
+
+  const contextValue = React.useMemo(
+    () => ({ open, setOpen, triggerRef, contentRef }),
+    [open, setOpen]
+  );
+
+  return (
+    <PopoverContext.Provider value={contextValue}>
+      <div className="ui-popover">{children}</div>
+    </PopoverContext.Provider>
+  );
+};
+
+interface PopoverTriggerProps {
+  children: React.ReactElement;
+  asChild?: boolean;
+}
+
+export const PopoverTrigger = React.forwardRef<HTMLElement, PopoverTriggerProps>(
+  ({ children, asChild = false }, forwardedRef) => {
+    const { open, setOpen, triggerRef } = usePopoverContext();
+
+    const child = asChild
+      ? children
+      : React.cloneElement(children, { type: "button" });
+
+    const refCallback = (node: HTMLElement | null) => {
+      triggerRef.current = node;
+      if (typeof forwardedRef === "function") {
+        forwardedRef(node);
+      } else if (forwardedRef) {
+        (forwardedRef as React.MutableRefObject<HTMLElement | null>).current =
+          node;
+      }
+    };
+
+    const handleClick = (event: React.MouseEvent<HTMLElement>) => {
+      child.props.onClick?.(event);
+      if (!event.defaultPrevented) {
+        setOpen(!open);
+      }
+    };
+
+    return React.cloneElement(child, {
+      ref: refCallback,
+      "aria-expanded": open,
+      onClick: handleClick,
+    });
+  }
+);
+
+PopoverTrigger.displayName = "PopoverTrigger";
+
+interface PopoverContentProps
+  extends React.HTMLAttributes<HTMLDivElement> {
+  align?: "start" | "center" | "end";
+}
+
+export const PopoverContent = React.forwardRef<HTMLDivElement, PopoverContentProps>(
+  ({ className, style, align = "end", children, ...props }, forwardedRef) => {
+    const { open, contentRef } = usePopoverContext();
+
+    if (!open) return null;
+
+    const refCallback = (node: HTMLDivElement | null) => {
+      contentRef.current = node;
+      if (typeof forwardedRef === "function") {
+        forwardedRef(node);
+      } else if (forwardedRef) {
+        (forwardedRef as React.MutableRefObject<HTMLDivElement | null>).current =
+          node;
+      }
+    };
+
+    const alignStyle: React.CSSProperties =
+      align === "start"
+        ? { left: 0, right: "auto" }
+        : align === "center"
+        ? { left: "50%", transform: "translateX(-50%)" }
+        : { right: 0 };
+
+    return (
+      <div
+        ref={refCallback}
+        className={cn("ui-popover-content", className)}
+        style={{ ...alignStyle, ...style }}
+        role="menu"
+        {...props}
+      >
+        {children}
+      </div>
+    );
+  }
+);
+
+PopoverContent.displayName = "PopoverContent";
+

--- a/frontend/src/components/ui/utils.ts
+++ b/frontend/src/components/ui/utils.ts
@@ -1,0 +1,5 @@
+export function cn(
+  ...classes: Array<string | false | null | undefined>
+): string {
+  return classes.filter(Boolean).join(" ");
+}

--- a/frontend/src/dashboard/home/components/AllProjects.tsx
+++ b/frontend/src/dashboard/home/components/AllProjects.tsx
@@ -12,7 +12,6 @@ import { useNavigate } from 'react-router-dom';
 import SVGThumbnail from './SvgThumbnail';
 import Spinner from '../../../shared/ui/Spinner';
 import AvatarStack from '../../../shared/ui/AvatarStack';
-import { ProjectsIconsStrip } from './ProjectsIconsStrip';
 import { ProjectsFilterMenu } from './ProjectsFilterMenu';
 import { useProjectFilters } from './hooks/useProjectFilters';
 import {

--- a/frontend/src/dashboard/project/components/Shared/MobileProjectHeader.tsx
+++ b/frontend/src/dashboard/project/components/Shared/MobileProjectHeader.tsx
@@ -1,0 +1,233 @@
+import React from "react";
+import {
+  MoreVertical,
+  Settings,
+  Link as LinkIcon,
+  Folder,
+} from "lucide-react";
+import { Avatar } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { cn } from "@/components/ui/utils";
+import { getFileUrl } from "@/shared/utils/api";
+import type { TeamMember } from "./types";
+import type { ProjectTabItem } from "./useProjectTabs";
+import styles from "./mobile-project-header.module.css";
+
+interface MobileProjectHeaderProps {
+  projectName?: string;
+  projectInitial: string;
+  thumbnailKey?: string | null;
+  statusLabel: string;
+  progressValue: number;
+  rangeLabel?: string;
+  teamMembers: TeamMember[];
+  onOpenQuickLinks: () => void;
+  onOpenFiles: () => void;
+  onOpenSettings: () => void;
+  onOpenTeam: () => void;
+  onOpenFinishLine: () => void;
+  onOpenStatus: () => void;
+  onOpenThumbnail: () => void;
+  tabs: ProjectTabItem[];
+  activeTabKey?: string;
+  onSelectTab: (tab: ProjectTabItem) => void;
+}
+
+const MobileProjectHeader: React.FC<MobileProjectHeaderProps> = ({
+  projectName = "Summary",
+  projectInitial,
+  thumbnailKey,
+  statusLabel,
+  progressValue,
+  rangeLabel,
+  teamMembers,
+  onOpenQuickLinks,
+  onOpenFiles,
+  onOpenSettings,
+  onOpenTeam,
+  onOpenFinishLine,
+  onOpenStatus,
+  onOpenThumbnail,
+  tabs,
+  activeTabKey,
+  onSelectTab,
+}) => {
+  const [menuOpen, setMenuOpen] = React.useState(false);
+
+  const displayedMembers = React.useMemo(
+    () => teamMembers.slice(0, 3),
+    [teamMembers]
+  );
+
+  const remainingCount = Math.max(teamMembers.length - displayedMembers.length, 0);
+
+  const thumbnailSrc = React.useMemo(
+    () => (thumbnailKey ? getFileUrl(thumbnailKey) : undefined),
+    [thumbnailKey]
+  );
+
+  const handleSelectTab = (tab: ProjectTabItem) => {
+    onSelectTab(tab);
+  };
+
+  const statusBadgeLabel = React.useMemo(() => {
+    if (Number.isFinite(progressValue)) {
+      return statusLabel;
+    }
+    return statusLabel;
+  }, [progressValue, statusLabel]);
+
+  return (
+    <div className={styles.wrapper}>
+      <div className={styles.topRow}>
+        <div className={styles.projectSection}>
+          <button
+            type="button"
+            onClick={onOpenThumbnail}
+            className={styles.logoWrapper}
+            aria-label="Change project thumbnail"
+          >
+            {thumbnailSrc ? (
+              <img src={thumbnailSrc} alt={projectName} />
+            ) : (
+              <span>{projectInitial.toUpperCase()}</span>
+            )}
+          </button>
+
+          <div className={styles.projectMeta}>
+            <div className={styles.infoGroup}>
+              <h1 className={styles.projectName}>{projectName}</h1>
+              <button
+                type="button"
+                onClick={onOpenStatus}
+                className="reset"
+                style={{ border: "none", background: "transparent", padding: 0 }}
+                aria-label="Update project status"
+              >
+                <Badge variant="outline" className={styles.progressBadge}>
+                  {statusBadgeLabel}
+                </Badge>
+              </button>
+            </div>
+
+            {rangeLabel ? (
+              <button
+                type="button"
+                onClick={onOpenFinishLine}
+                className="reset"
+                style={{
+                  border: "none",
+                  background: "transparent",
+                  padding: 0,
+                  textAlign: "left",
+                  cursor: "pointer",
+                }}
+                aria-label="Edit project schedule"
+              >
+                <div className={styles.dateText}>{rangeLabel}</div>
+              </button>
+            ) : null}
+          </div>
+        </div>
+
+        <div className={styles.rightGroup}>
+          <button
+            type="button"
+            onClick={onOpenTeam}
+            className={cn(styles.avatarGroup, "reset")}
+            style={{ border: "none", background: "transparent", padding: 0 }}
+            aria-label="View project team"
+          >
+            {displayedMembers.map((member) => {
+              const fallback = `${(member.firstName?.[0] || "").toUpperCase()}${(
+                member.lastName?.[0] || ""
+              ).toUpperCase()}`.trim();
+              return (
+                <Avatar
+                  key={member.userId}
+                  src={member.thumbnail ? getFileUrl(member.thumbnail) : undefined}
+                  alt={`${member.firstName} ${member.lastName}`.trim()}
+                  fallback={fallback || projectInitial.toUpperCase()}
+                  className={cn(styles.avatarOverlap)}
+                />
+              );
+            })}
+            {remainingCount > 0 ? (
+              <div className={cn(styles.moreCount, styles.avatarOverlap)}>
+                +{remainingCount}
+              </div>
+            ) : null}
+          </button>
+
+          <Popover open={menuOpen} onOpenChange={setMenuOpen}>
+            <PopoverTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                aria-label="Open project actions"
+              >
+                <MoreVertical />
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent className={styles.menuList} role="menu">
+              <button
+                type="button"
+                className={styles.menuItem}
+                onClick={() => {
+                  setMenuOpen(false);
+                  onOpenQuickLinks();
+                }}
+              >
+                <LinkIcon />
+                Links
+              </button>
+              <button
+                type="button"
+                className={styles.menuItem}
+                onClick={() => {
+                  setMenuOpen(false);
+                  onOpenFiles();
+                }}
+              >
+                <Folder />
+                Files
+              </button>
+              <button
+                type="button"
+                className={styles.menuItem}
+                onClick={() => {
+                  setMenuOpen(false);
+                  onOpenSettings();
+                }}
+              >
+                <Settings />
+                Settings
+              </button>
+            </PopoverContent>
+          </Popover>
+        </div>
+      </div>
+
+      <div className={cn(styles.tabs)}>
+        {tabs.map((tab) => {
+          const isActive = tab.key === activeTabKey;
+          return (
+            <Button
+              key={tab.key}
+              variant={isActive ? "default" : "outline"}
+              size="sm"
+              className={cn(styles.tabButton, isActive && styles.tabButtonActive)}
+              onClick={() => handleSelectTab(tab)}
+            >
+              {tab.label}
+            </Button>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default MobileProjectHeader;

--- a/frontend/src/dashboard/project/components/Shared/ProjectHeader.tsx
+++ b/frontend/src/dashboard/project/components/Shared/ProjectHeader.tsx
@@ -23,11 +23,6 @@ import {
   Image as ImageIcon,
   Palette,
   Trash,
-  PenTool,
-  LayoutDashboard,
-  Coins,
-  Calendar as CalendarIcon,
-  StickyNote,
 } from "lucide-react";
 import { uploadData } from "aws-amplify/storage";
 import { useData } from "@/app/contexts/useData";
@@ -50,19 +45,14 @@ import AvatarStack from "@/shared/ui/AvatarStack";
 import TeamModal from "@/dashboard/project/components/Shared/TeamModal";
 import { enqueueProjectUpdate } from "@/shared/utils/requestQueue";
 import type { Project } from "@/app/contexts/DataProvider";
+import MobileProjectHeader from "./MobileProjectHeader";
+import { useProjectTabs } from "./useProjectTabs";
+import type { TeamMember } from "./types";
 
 // Helper function for safe string conversion
 function toString(value: unknown): string {
   return typeof value === "string" ? value : "";
 }
-
-// ---------- Types ----------
-type TeamMember = {
-  userId: string;
-  firstName: string;
-  lastName: string;
-  thumbnail: string | null;
-};
 
 interface ProjectHeaderProps {
   title?: string; // not used directly but kept for parity
@@ -117,6 +107,27 @@ const ProjectHeader: React.FC<ProjectHeaderProps> = ({
   const navigate = useNavigate();
   const location = useLocation();
   const { projectId = "" } = useParams<{ projectId: string }>();
+
+  const [isMobile, setIsMobile] = useState(() => {
+    if (typeof window === "undefined") {
+      return false;
+    }
+    return window.innerWidth < 768;
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return () => {};
+    }
+    const handleResize = () => {
+      setIsMobile(window.innerWidth < 768);
+    };
+
+    window.addEventListener("resize", handleResize);
+    return () => {
+      window.removeEventListener("resize", handleResize);
+    };
+  }, []);
 
   const handleKeyDown = (e: React.KeyboardEvent, action: () => void) => {
     if (e.key === "Enter" || e.key === " ") {
@@ -252,6 +263,28 @@ const ProjectHeader: React.FC<ProjectHeaderProps> = ({
     const endStr = endDate.toLocaleDateString(undefined, opts);
     return `${startStr} – ${endStr} | ${totalPart}`;
   }, [startDate, endDate, totalHoursForProject]);
+
+  const resolvedProjectId =
+    (localActiveProject?.projectId as string | undefined) || projectId || "";
+
+  const { tabs, getActiveIndex, confirmNavigate } = useProjectTabs(
+    resolvedProjectId,
+    localActiveProject?.title
+  );
+
+  const activeTabIndex = getActiveIndex();
+  const activeTabKey = tabs[activeTabIndex]?.key ?? tabs[0]?.key;
+
+  const mobileRangeLabel = useMemo(() => {
+    if (!rangeLabel) return "";
+    const parts = rangeLabel.split("|").map((part) => part.trim());
+    if (parts.length === 2) {
+      const [datesPart, hoursPart] = parts;
+      const normalizedHours = hoursPart.replace(/^Hrs Total:\s*/i, "").trim();
+      return `${datesPart} · ${normalizedHours}`;
+    }
+    return rangeLabel.replace(/^Hrs Total:\s*/i, "").trim();
+  }, [rangeLabel]);
 
   // --------------------------
   // Modal state
@@ -889,7 +922,28 @@ const ProjectHeader: React.FC<ProjectHeaderProps> = ({
     <div>
       {saving && <div style={{ color: "#FA3356" }}>Saving...</div>}
 
-      <div className="project-header">
+      {isMobile ? (
+        <MobileProjectHeader
+          projectName={localActiveProject ? localActiveProject.title : "Summary"}
+          projectInitial={projectInitial}
+          thumbnailKey={localActiveProject?.thumbnails?.[0] as string | undefined}
+          statusLabel={displayStatus}
+          progressValue={parseStatusToNumber(localActiveProject?.status)}
+          rangeLabel={mobileRangeLabel || undefined}
+          teamMembers={teamMembers}
+          onOpenQuickLinks={onOpenQuickLinks}
+          onOpenFiles={onOpenFiles}
+          onOpenSettings={openSettingsModal}
+          onOpenTeam={openTeamModal}
+          onOpenFinishLine={openFinishLineModal}
+          onOpenStatus={openEditStatusModal}
+          onOpenThumbnail={() => openThumbnailModal(false)}
+          tabs={tabs}
+          activeTabKey={activeTabKey}
+          onSelectTab={(tab) => confirmNavigate(tab.path)}
+        />
+      ) : (
+        <div className="project-header">
         <div className="header-content">
           <div className="left-side">
             <FontAwesomeIcon
@@ -1109,6 +1163,7 @@ const ProjectHeader: React.FC<ProjectHeaderProps> = ({
           </div>
         </div>
       </div>
+      )}
 
       {/* Edit Name */}
       <Modal
@@ -1732,113 +1787,18 @@ interface ProjectTabsProps {
 }
 
 const ProjectTabs: React.FC<ProjectTabsProps> = ({ projectId, projectTitle }) => {
-  const navigate = useNavigate();
-  const location = useLocation();
   const tabRefs = useRef<HTMLButtonElement[]>([]);
   const [sliderStyle, setSliderStyle] = useState<{ width: number; left: number }>(
     { width: 0, left: 0 }
   );
   const [transitionEnabled, setTransitionEnabled] = useState(false);
-  const storageKey = `project-tabs-prev:${projectId || "unknown"}`;
 
-  const { user } = useData();
-  const isAdmin = user?.role === "admin";
-  const isDesigner = user?.role === "designer";
-  const showBudgetTab = isAdmin;
-  const showCalendarTab = isAdmin || isDesigner;
-  const showMoodboardTab = isAdmin || isDesigner;
-  const showEditorTab = isAdmin || isDesigner;
-
-  const hasProject = Boolean(projectId);
-  const basePath = hasProject
-    ? getProjectDashboardPath(projectId, projectTitle ?? undefined)
-    : "/dashboard/projects";
-  const budgetPath = hasProject
-    ? getProjectDashboardPath(projectId, projectTitle ?? undefined, "/budget")
-    : "/dashboard/projects";
-  const calendarPath = hasProject
-    ? getProjectDashboardPath(projectId, projectTitle ?? undefined, "/calendar")
-    : "/dashboard/projects";
-  const moodboardPath = hasProject
-    ? getProjectDashboardPath(projectId, projectTitle ?? undefined, "/moodboard")
-    : "/dashboard/projects";
-  const editorPath = hasProject
-    ? getProjectDashboardPath(projectId, projectTitle ?? undefined, "/editor")
-    : "/dashboard/projects";
-
-  const tabs = useMemo(
-    () =>
-      [
-        {
-          key: "overview",
-          label: "Overview",
-          icon: <LayoutDashboard size={16} />,
-          path: basePath,
-          visible: true,
-          matches: (pathname: string) => pathname === basePath,
-        },
-        {
-          key: "budget",
-          label: "Budget",
-          icon: <Coins size={16} />,
-          path: budgetPath,
-          visible: showBudgetTab,
-          matches: (pathname: string) => pathname.startsWith(budgetPath),
-        },
-        {
-          key: "calendar",
-          label: "Calendar",
-          icon: <CalendarIcon size={16} />,
-          path: calendarPath,
-          visible: showCalendarTab,
-          matches: (pathname: string) => pathname.startsWith(calendarPath),
-        },
-        {
-          key: "moodboard",
-          label: "Moodboard",
-          icon: <StickyNote size={16} />,
-          path: moodboardPath,
-          visible: showMoodboardTab,
-          matches: (pathname: string) => pathname.startsWith(moodboardPath),
-        },
-        {
-          key: "editor",
-          label: "Editor",
-          icon: <PenTool size={16} />,
-          path: editorPath,
-          visible: showEditorTab,
-          matches: (pathname: string) => pathname.startsWith(editorPath),
-        },
-      ].filter((tab) => tab.visible),
-    [
-      basePath,
-      budgetPath,
-      calendarPath,
-      moodboardPath,
-      editorPath,
-      showBudgetTab,
-      showCalendarTab,
-      showEditorTab,
-      showMoodboardTab,
-    ]
-  );
+  const { tabs, storageKey, getActiveIndex, getFromIndex, confirmNavigate } =
+    useProjectTabs(projectId, projectTitle);
 
   useEffect(() => {
     tabRefs.current = tabRefs.current.slice(0, tabs.length);
   }, [tabs.length]);
-
-  const getActiveIndex = useCallback(() => {
-    const index = tabs.findIndex((tab) => tab.matches(location.pathname));
-    return index === -1 ? 0 : index;
-  }, [location.pathname, tabs]);
-
-  const getFromIndex = useCallback(() => {
-    if (location.state?.fromTab !== undefined) {
-      return location.state.fromTab as number;
-    }
-    const stored = sessionStorage.getItem(storageKey);
-    return stored !== null ? Number(stored) : getActiveIndex();
-  }, [location.state, storageKey, getActiveIndex]);
 
   const updateSlider = useCallback(() => {
     const current = getActiveIndex();
@@ -1846,7 +1806,9 @@ const ProjectTabs: React.FC<ProjectTabsProps> = ({ projectId, projectTitle }) =>
     if (el) {
       setSliderStyle({ width: el.offsetWidth, left: el.offsetLeft });
     }
-    sessionStorage.setItem(storageKey, String(current));
+    if (typeof window !== "undefined") {
+      sessionStorage.setItem(storageKey, String(current));
+    }
   }, [getActiveIndex, storageKey]);
 
   useLayoutEffect(() => {
@@ -1865,26 +1827,12 @@ const ProjectTabs: React.FC<ProjectTabsProps> = ({ projectId, projectTitle }) =>
   }, [updateSlider]);
 
   useEffect(() => {
+    if (typeof window === "undefined") return undefined;
     window.addEventListener("resize", updateSlider);
     return () => window.removeEventListener("resize", updateSlider);
   }, [updateSlider]);
 
-  const confirmNavigate = useCallback(
-    (path: string) => {
-      const hasUnsaved =
-        (typeof window.hasUnsavedChanges === "function" &&
-          window.hasUnsavedChanges()) ||
-        window.unsavedChanges === true;
-      if (hasUnsaved) {
-        const proceed = window.confirm(
-          "You have unsaved changes, continue?"
-        );
-        if (!proceed) return;
-      }
-      navigate(path, { state: { fromTab: getActiveIndex() } });
-    },
-    [navigate, getActiveIndex]
-  );
+  const activeIndex = getActiveIndex();
 
   return (
     <div
@@ -1902,8 +1850,8 @@ const ProjectTabs: React.FC<ProjectTabsProps> = ({ projectId, projectTitle }) =>
         aria-hidden="true"
       />
 
-      {tabs.map((tab, index) => {
-        const isActive = tab.matches(location.pathname);
+        {tabs.map((tab, index) => {
+          const isActive = index === activeIndex;
         return (
           <button
             key={tab.key}

--- a/frontend/src/dashboard/project/components/Shared/mobile-project-header.module.css
+++ b/frontend/src/dashboard/project/components/Shared/mobile-project-header.module.css
@@ -1,0 +1,173 @@
+.wrapper {
+  width: 100%;
+  background: #0c0c0c;
+  color: #ffffff;
+  padding: 12px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.topRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.projectSection {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+  flex: 1;
+}
+
+.logoWrapper {
+  width: 40px;
+  height: 40px;
+  border-radius: 9999px;
+  overflow: hidden;
+  background: #ffffff;
+  color: #0c0c0c;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  flex-shrink: 0;
+}
+
+.logoWrapper img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.infoGroup {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+.projectName {
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 0;
+  max-width: 160px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.rightGroup {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.avatarGroup {
+  display: flex;
+  align-items: center;
+}
+
+.avatarGroup :global(.ui-avatar) {
+  width: 24px;
+  height: 24px;
+  border: 1px solid #0c0c0c;
+}
+
+.avatarOverlap:not(:first-child) {
+  margin-left: -8px;
+}
+
+.moreCount {
+  width: 24px;
+  height: 24px;
+  border-radius: 9999px;
+  background: rgba(255, 255, 255, 0.12);
+  border: 1px solid #0c0c0c;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.65rem;
+  font-weight: 600;
+  color: #ffffff;
+}
+
+.dateText {
+  font-size: 0.75rem;
+  color: #f87171;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tabs {
+  display: flex;
+  gap: 6px;
+  overflow-x: auto;
+  padding-bottom: 2px;
+}
+
+.tabs::-webkit-scrollbar {
+  display: none;
+}
+
+.tabs {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+
+.tabButton {
+  white-space: nowrap;
+  font-size: 0.75rem;
+}
+
+.tabButtonActive {
+  background: #ffffff;
+  color: #0c0c0c;
+  border-color: #ffffff;
+}
+
+.menuList {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.menuItem {
+  width: 100%;
+  border: none;
+  background: transparent;
+  color: #ffffff;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 8px;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 0.85rem;
+  text-align: left;
+}
+
+.menuItem:hover {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.menuItem svg {
+  width: 16px;
+  height: 16px;
+}
+
+.projectMeta {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.progressBadge {
+  border-color: #22c55e;
+  color: #22c55e;
+}

--- a/frontend/src/dashboard/project/components/Shared/types.ts
+++ b/frontend/src/dashboard/project/components/Shared/types.ts
@@ -1,0 +1,6 @@
+export type TeamMember = {
+  userId: string;
+  firstName: string;
+  lastName: string;
+  thumbnail: string | null;
+};

--- a/frontend/src/dashboard/project/components/Shared/useProjectTabs.tsx
+++ b/frontend/src/dashboard/project/components/Shared/useProjectTabs.tsx
@@ -1,0 +1,207 @@
+import React from "react";
+import { useNavigate, useLocation } from "react-router-dom";
+import {
+  LayoutDashboard,
+  Coins,
+  Calendar as CalendarIcon,
+  StickyNote,
+  PenTool,
+} from "lucide-react";
+import { useData } from "@/app/contexts/useData";
+import { getProjectDashboardPath } from "@/shared/utils/projectUrl";
+
+export type ProjectTabItem = {
+  key: string;
+  label: string;
+  icon: React.ReactNode;
+  path: string;
+  matches: (pathname: string) => boolean;
+};
+
+type UseProjectTabsResult = {
+  tabs: ProjectTabItem[];
+  storageKey: string;
+  getActiveIndex: () => number;
+  getFromIndex: () => number;
+  confirmNavigate: (path: string) => void;
+};
+
+export const useProjectTabs = (
+  projectId: string,
+  projectTitle?: string | null
+): UseProjectTabsResult => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { user } = useData();
+
+  const isAdmin = user?.role === "admin";
+  const isDesigner = user?.role === "designer";
+
+  const showBudgetTab = isAdmin;
+  const showCalendarTab = isAdmin || isDesigner;
+  const showMoodboardTab = isAdmin || isDesigner;
+  const showEditorTab = isAdmin || isDesigner;
+
+  const hasProject = Boolean(projectId);
+
+  const basePath = React.useMemo(
+    () =>
+      hasProject
+        ? getProjectDashboardPath(projectId, projectTitle ?? undefined)
+        : "/dashboard/projects",
+    [hasProject, projectId, projectTitle]
+  );
+
+  const budgetPath = React.useMemo(
+    () =>
+      hasProject
+        ? getProjectDashboardPath(
+            projectId,
+            projectTitle ?? undefined,
+            "/budget"
+          )
+        : "/dashboard/projects",
+    [hasProject, projectId, projectTitle]
+  );
+
+  const calendarPath = React.useMemo(
+    () =>
+      hasProject
+        ? getProjectDashboardPath(
+            projectId,
+            projectTitle ?? undefined,
+            "/calendar"
+          )
+        : "/dashboard/projects",
+    [hasProject, projectId, projectTitle]
+  );
+
+  const moodboardPath = React.useMemo(
+    () =>
+      hasProject
+        ? getProjectDashboardPath(
+            projectId,
+            projectTitle ?? undefined,
+            "/moodboard"
+          )
+        : "/dashboard/projects",
+    [hasProject, projectId, projectTitle]
+  );
+
+  const editorPath = React.useMemo(
+    () =>
+      hasProject
+        ? getProjectDashboardPath(
+            projectId,
+            projectTitle ?? undefined,
+            "/editor"
+          )
+        : "/dashboard/projects",
+    [hasProject, projectId, projectTitle]
+  );
+
+  const tabs = React.useMemo(
+    () =>
+      [
+        {
+          key: "overview",
+          label: "Overview",
+          icon: <LayoutDashboard size={16} />,
+          path: basePath,
+          visible: true,
+          matches: (pathname: string) => pathname === basePath,
+        },
+        {
+          key: "budget",
+          label: "Budget",
+          icon: <Coins size={16} />,
+          path: budgetPath,
+          visible: showBudgetTab,
+          matches: (pathname: string) => pathname.startsWith(budgetPath),
+        },
+        {
+          key: "calendar",
+          label: "Calendar",
+          icon: <CalendarIcon size={16} />,
+          path: calendarPath,
+          visible: showCalendarTab,
+          matches: (pathname: string) => pathname.startsWith(calendarPath),
+        },
+        {
+          key: "moodboard",
+          label: "Moodboard",
+          icon: <StickyNote size={16} />,
+          path: moodboardPath,
+          visible: showMoodboardTab,
+          matches: (pathname: string) => pathname.startsWith(moodboardPath),
+        },
+        {
+          key: "editor",
+          label: "Editor",
+          icon: <PenTool size={16} />,
+          path: editorPath,
+          visible: showEditorTab,
+          matches: (pathname: string) => pathname.startsWith(editorPath),
+        },
+      ].filter((tab) => tab.visible),
+    [
+      basePath,
+      budgetPath,
+      calendarPath,
+      moodboardPath,
+      editorPath,
+      showBudgetTab,
+      showCalendarTab,
+      showMoodboardTab,
+      showEditorTab,
+    ]
+  );
+
+  const storageKey = React.useMemo(
+    () => `project-tabs-prev:${projectId || "unknown"}`,
+    [projectId]
+  );
+
+  const getActiveIndex = React.useCallback(() => {
+    const index = tabs.findIndex((tab) => tab.matches(location.pathname));
+    return index === -1 ? 0 : index;
+  }, [location.pathname, tabs]);
+
+  const getFromIndex = React.useCallback(() => {
+    const locationState = location.state as { fromTab?: number } | undefined;
+    if (locationState?.fromTab !== undefined) {
+      return locationState.fromTab;
+    }
+
+    if (typeof window === "undefined") {
+      return getActiveIndex();
+    }
+
+    const stored = sessionStorage.getItem(storageKey);
+    return stored !== null ? Number(stored) : getActiveIndex();
+  }, [location.state, storageKey, getActiveIndex]);
+
+  const confirmNavigate = React.useCallback(
+    (path: string) => {
+      if (typeof window !== "undefined") {
+        const hasUnsaved =
+          (typeof window.hasUnsavedChanges === "function" &&
+            window.hasUnsavedChanges()) ||
+          (window as typeof window & { unsavedChanges?: boolean }).unsavedChanges ===
+            true;
+
+        if (hasUnsaved) {
+          const proceed = window.confirm("You have unsaved changes, continue?");
+          if (!proceed) {
+            return;
+          }
+        }
+      }
+
+      navigate(path, { state: { fromTab: getActiveIndex() } });
+    },
+    [navigate, getActiveIndex]
+  );
+
+  return { tabs, storageKey, getActiveIndex, getFromIndex, confirmNavigate };
+};


### PR DESCRIPTION
## Summary
- introduce a responsive MobileProjectHeader that ties into existing project data, team membership, and navigation
- share tab state logic via a new useProjectTabs hook and reuse it for both desktop and mobile headers
- add lightweight ui primitives (button, badge, avatar, popover) and supporting styles for the mobile header
- clean up an unused ProjectsIconsStrip import flagged by lint

## Testing
- npm run lint


------
https://chatgpt.com/codex/tasks/task_e_68cca0d951f08324ab9ee79572e74499