### PR TITLE
Adjust AllProjects filter button and panel alignment

### DIFF
--- a/frontend/src/dashboard/home/components/AllProjects.tsx
+++ b/frontend/src/dashboard/home/components/AllProjects.tsx
@@ -562,6 +562,9 @@ const AllProjects: React.FC = () => {
             sortOptions={sortOptions}
             sortTriggerLabel={sortTriggerLabel}
             sortDropdown={sortDropdown}
+            triggerLabel="Filter"
+            showScopeSelector={false}
+            popoverAlign="start"
           />
 
           <div

--- a/frontend/src/dashboard/home/components/ProjectsFilterMenu.test.tsx
+++ b/frontend/src/dashboard/home/components/ProjectsFilterMenu.test.tsx
@@ -124,6 +124,37 @@ describe("ProjectsFilterMenu", () => {
     expect(screen.getByText("active")).toBeInTheDocument();
     expect(screen.getByText("Title (A-Z)")).toBeInTheDocument();
   });
+
+  it("supports custom labels and hides the scope selector when disabled", () => {
+    const statusDropdown = createDropdownStub<string>();
+    const sortDropdown = createDropdownStub<SortOption>();
+
+    render(
+      <ProjectsFilterMenu
+        filtersOpen
+        filtersRef={createRef<HTMLDivElement>()}
+        filtersId="filters"
+        scope="all"
+        onScopeChange={vi.fn()}
+        query=""
+        onQueryChange={vi.fn()}
+        toggleFilters={vi.fn()}
+        statusOptions={[{ value: "", label: "All statuses" }]}
+        statusTriggerLabel="All statuses"
+        statusDropdown={statusDropdown}
+        showStatusDropdown={false}
+        sortOptions={[{ value: "dateNewest", label: "Date (Newest)" }]}
+        sortTriggerLabel="Date (Newest)"
+        sortDropdown={sortDropdown}
+        triggerLabel="Filter"
+        showScopeSelector={false}
+        popoverAlign="start"
+      />
+    );
+
+    expect(screen.getByRole("button", { name: /filter/i })).toBeInTheDocument();
+    expect(screen.queryByRole("group", { name: /scope/i })).not.toBeInTheDocument();
+  });
 });
 
 

--- a/frontend/src/dashboard/home/components/ProjectsFilterMenu.tsx
+++ b/frontend/src/dashboard/home/components/ProjectsFilterMenu.tsx
@@ -23,6 +23,9 @@ type ProjectsFilterMenuProps = {
   sortOptions: DropdownOption<SortOption>[];
   sortTriggerLabel: string;
   sortDropdown: DropdownHelpers<SortOption>;
+  triggerLabel?: string;
+  showScopeSelector?: boolean;
+  popoverAlign?: "start" | "end";
 };
 
 export const ProjectsFilterMenu: FC<ProjectsFilterMenuProps> = ({
@@ -41,10 +44,19 @@ export const ProjectsFilterMenu: FC<ProjectsFilterMenuProps> = ({
   sortOptions,
   sortTriggerLabel,
   sortDropdown,
+  triggerLabel,
+  showScopeSelector = true,
+  popoverAlign = "end",
 }) => {
   const handleQueryChange = (event: ChangeEvent<HTMLInputElement>) => {
     onQueryChange(event.target.value);
   };
+
+  const buttonLabel = triggerLabel ?? (scope === "recents" ? "Recents" : "All projects");
+  const popoverClassName =
+    popoverAlign === "start"
+      ? `${mobileStyles.filterPop} ${mobileStyles.filterPopStart}`
+      : mobileStyles.filterPop;
 
   return (
     <div className={mobileStyles.recentsWrap} ref={filtersRef}>
@@ -56,31 +68,33 @@ export const ProjectsFilterMenu: FC<ProjectsFilterMenuProps> = ({
         aria-controls={filtersId}
         onClick={toggleFilters}
       >
-        {scope === "recents" ? "Recents" : "All projects"} <ChevronDown size={14} aria-hidden />
+        {buttonLabel} <ChevronDown size={14} aria-hidden />
       </button>
       {filtersOpen && (
-        <div className={mobileStyles.filterPop} role="menu" id={filtersId}>
+        <div className={popoverClassName} role="menu" id={filtersId}>
           <div className={mobileStyles.filterSection}>
-            <div className={mobileStyles.scopeBtns} role="group" aria-label="Scope">
-              <button
-                type="button"
-                className={`${mobileStyles.scopeBtn} ${
-                  scope === "recents" ? mobileStyles.scopeBtnActive : ""
-                }`}
-                onClick={() => onScopeChange("recents")}
-              >
-                Recents
-              </button>
-              <button
-                type="button"
-                className={`${mobileStyles.scopeBtn} ${
-                  scope === "all" ? mobileStyles.scopeBtnActive : ""
-                }`}
-                onClick={() => onScopeChange("all")}
-              >
-                All projects
-              </button>
-            </div>
+            {showScopeSelector && (
+              <div className={mobileStyles.scopeBtns} role="group" aria-label="Scope">
+                <button
+                  type="button"
+                  className={`${mobileStyles.scopeBtn} ${
+                    scope === "recents" ? mobileStyles.scopeBtnActive : ""
+                  }`}
+                  onClick={() => onScopeChange("recents")}
+                >
+                  Recents
+                </button>
+                <button
+                  type="button"
+                  className={`${mobileStyles.scopeBtn} ${
+                    scope === "all" ? mobileStyles.scopeBtnActive : ""
+                  }`}
+                  onClick={() => onScopeChange("all")}
+                >
+                  All projects
+                </button>
+              </div>
+            )}
 
             <div className={desktopStyles.filterField}>
               <Search size={16} aria-hidden className={desktopStyles.filterFieldIcon} />

--- a/frontend/src/dashboard/home/components/projects-panel.module.css
+++ b/frontend/src/dashboard/home/components/projects-panel.module.css
@@ -488,6 +488,11 @@
   color-scheme: dark;
 }
 
+.filterPopStart {
+  left: 0;
+  right: auto;
+}
+
 .filterSection {
   display: grid;
   gap: 8px;


### PR DESCRIPTION
## Summary
- update AllProjects filter trigger to display a simple "Filter" label without scope toggles
- add configuration options to ProjectsFilterMenu to support the new label and popover alignment
- align the filter popover to open from the left edge when requested and cover it with tests

## Testing
- `npm run test -- ProjectsFilterMenu`


------
https://chatgpt.com/codex/tasks/task_e_68cca6bc1eec832496b7ae7383689548