### PR TITLE
feat: render project thumbnails with squircles

### DIFF
--- a/frontend/src/dashboard/home/components/AllProjects.tsx
+++ b/frontend/src/dashboard/home/components/AllProjects.tsx
@@ -25,6 +25,7 @@ import { getFileUrl } from '../../../shared/utils/api';
 import desktopStyles from './ProjectsPanelDesktop.module.css';
 import mobileStyles from '@/dashboard/home/components/projects-panel.module.css';
 import { MICRO_WOBBLE_SCALE, SPRING_FAST } from '@/shared/ui/motionTokens';
+import Squircle from '@/shared/ui/Squircle';
 
 const DEFAULT_RECENTS_LIMIT = 12;
 
@@ -257,6 +258,48 @@ const AllProjects: React.FC = () => {
 
   const isSingleProject = filteredProjects.length === 1;
 
+  const renderProjectThumbnail = useCallback(
+    (project: Project, variant: 'grid' | 'list') => {
+      const hasImage =
+        !imageErrors[project.projectId] &&
+        Array.isArray(project.thumbnails) &&
+        project.thumbnails.length > 0;
+      const thumbnailKey = hasImage ? project.thumbnails?.[0] : undefined;
+      const altText = `Thumbnail of ${project.title?.trim() || 'Untitled project'}`;
+      const baseClass = variant === 'grid' ? 'project-thumbnail' : 'project-list-thumb';
+      const mediaClass =
+        variant === 'grid' ? 'project-thumbnail-media' : 'project-list-thumb-media';
+      const radius = variant === 'grid' ? 28 : 14;
+      const smoothing = variant === 'grid' ? 0.82 : 0.88;
+
+      return (
+        <Squircle
+          radius={radius}
+          smoothing={smoothing}
+          className={baseClass}
+        >
+          {thumbnailKey ? (
+            <img
+              src={getFileUrl(thumbnailKey)}
+              alt={altText}
+              className={mediaClass}
+              loading="lazy"
+              decoding="async"
+              onError={() => handleThumbnailError(project.projectId)}
+            />
+          ) : (
+            <SVGThumbnail
+              initial={project.title?.trim()?.charAt(0)?.toUpperCase() || '#'}
+              className={mediaClass}
+              roundness={0.92}
+            />
+          )}
+        </Squircle>
+      );
+    },
+    [handleThumbnailError, imageErrors],
+  );
+
   let content: React.ReactNode;
 
   if (isLoading) {
@@ -343,27 +386,7 @@ const AllProjects: React.FC = () => {
               project.title?.trim() || 'Untitled project'
             }`}
           >
-            {!imageErrors[project.projectId] &&
-            project.thumbnails &&
-            project.thumbnails.length > 0 ? (
-              <img
-                src={getFileUrl(project.thumbnails[0])}
-                alt={`Thumbnail of ${
-                  project.title?.trim() || 'Untitled project'
-                }`}
-                className="project-thumbnail"
-                loading="lazy"
-                decoding="async"
-                onError={() => handleThumbnailError(project.projectId)}
-              />
-            ) : (
-              <SVGThumbnail
-                initial={
-                  project.title?.trim()?.charAt(0)?.toUpperCase() || '#'
-                }roundness={1} 
-                className="project-thumbnail"
-              />
-            )}
+            {renderProjectThumbnail(project, 'grid')}
             <h6 className="project-title">
               {project.title?.trim() || 'Untitled project'}
             </h6>
@@ -435,27 +458,7 @@ const AllProjects: React.FC = () => {
                 project.title?.trim() || 'Untitled project'
               }`}
             >
-              {!imageErrors[project.projectId] &&
-              project.thumbnails &&
-              project.thumbnails.length > 0 ? (
-                <img
-                  src={getFileUrl(project.thumbnails[0])}
-                  alt={`Thumbnail of ${
-                    project.title?.trim() || 'Untitled project'
-                  }`}
-                  className="project-list-thumb"
-                  loading="lazy"
-                  decoding="async"
-                  onError={() => handleThumbnailError(project.projectId)}
-                />
-              ) : (
-                <SVGThumbnail
-                  initial={
-                    project.title?.trim()?.charAt(0)?.toUpperCase() || '#'
-                  }
-                  className="project-list-thumb"
-                />
-              )}
+              {renderProjectThumbnail(project, 'list')}
               <div className="project-list-info">
                 <div className="project-title-row">
                   <span className="project-list-title">

--- a/frontend/src/dashboard/home/styles/components/project-containers.css
+++ b/frontend/src/dashboard/home/styles/components/project-containers.css
@@ -45,17 +45,33 @@
 
 .project-thumbnail,
 .new-project-thumbnail {
+  --shape-radius: clamp(22px, 6vw, 28px);
+  --shape-smoothing: 0.82;
   width: 100%;
-  border-radius: 12px; /* square with rounded corners */
-  cursor: pointer;
   aspect-ratio: 1 / 1;
-  object-fit: cover;
+  display: flex;
+  align-items: stretch;
+  justify-content: stretch;
+  cursor: pointer;
   transition: transform 0.25s ease, box-shadow 0.25s ease;
 }
 
-.project-thumbnail:hover {
+.project-thumbnail:hover,
+.new-project-thumbnail:hover {
   transform: scale(1.01);
-  box-shadow: 0 3px 12px rgba(255, 255, 255, 0.1);
+  box-shadow: 0 6px 22px rgba(0, 0, 0, 0.35);
+}
+
+.project-thumbnail-media {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.project-thumbnail svg.project-thumbnail-media {
+  width: 100%;
+  height: 100%;
 }
 
 .all-projects-container-welcome.single-item .project-container-welcome {
@@ -97,9 +113,8 @@ svg .project-title {
     margin-bottom: 10px;
   }
   .project-thumbnail,
-  .new-project-thumbnail,
-  .new-project-thumbnail svg {
-    border-radius: 10px;
+  .new-project-thumbnail {
+    --shape-radius: 20px;
   }
 }
 

--- a/frontend/src/dashboard/home/styles/components/projects-view.css
+++ b/frontend/src/dashboard/home/styles/components/projects-view.css
@@ -229,13 +229,23 @@
 }
 
 .project-list-thumb {
-  width: 48px;  /* align to 48px avatar size */
-  height: 48px;
-  border-radius: 8px;
-  object-fit: cover;
-  display: block;
+  --shape-radius: 14px;
+  --shape-smoothing: 0.86;
+  width: 52px;
+  height: 52px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: stretch;
+  justify-content: stretch;
   background: #0c0c0c;
   border: 1px solid rgba(255,255,255,.16);
+}
+
+.project-list-thumb-media {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
 }
 
 .project-list-info {

--- a/frontend/src/dashboard/project/components/Shared/MobileProjectHeader.tsx
+++ b/frontend/src/dashboard/project/components/Shared/MobileProjectHeader.tsx
@@ -14,6 +14,7 @@ import { getFileUrl } from "@/shared/utils/api";
 import type { TeamMember } from "./types";
 import type { ProjectTabItem } from "./useProjectTabs";
 import styles from "./mobile-project-header.module.css";
+import Squircle from "@/shared/ui/Squircle";
 
 interface MobileProjectHeaderProps {
   projectName?: string;
@@ -83,18 +84,21 @@ const MobileProjectHeader: React.FC<MobileProjectHeaderProps> = ({
     <div className={styles.wrapper}>
       <div className={styles.topRow}>
         <div className={styles.projectSection}>
-          <button
+          <Squircle
+            as="button"
             type="button"
             onClick={onOpenThumbnail}
             className={styles.logoWrapper}
             aria-label="Change project thumbnail"
+            radius={18}
+            smoothing={0.88}
           >
             {thumbnailSrc ? (
               <img src={thumbnailSrc} alt={projectName} />
             ) : (
-              <span>{projectInitial.toUpperCase()}</span>
+              <span className={styles.logoInitial}>{projectInitial.toUpperCase()}</span>
             )}
-          </button>
+          </Squircle>
 
           <div className={styles.projectMeta}>
             <div className={styles.infoGroup}>

--- a/frontend/src/dashboard/project/components/Shared/mobile-project-header.module.css
+++ b/frontend/src/dashboard/project/components/Shared/mobile-project-header.module.css
@@ -25,23 +25,44 @@
 }
 
 .logoWrapper {
-  width: 40px;
-  height: 40px;
-  border-radius: 9999px;
-  overflow: hidden;
-  background: #ffffff;
-  color: #0c0c0c;
-  display: flex;
+  --shape-radius: 18px;
+  --shape-smoothing: 0.88;
+  width: 52px;
+  aspect-ratio: 1 / 1;
+  border: none;
+  padding: 0;
+  background: rgba(255, 255, 255, 0.08);
+  color: #ffffff;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
   font-weight: 600;
+  font-size: 1rem;
   flex-shrink: 0;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+.logoWrapper:hover {
+  transform: scale(1.02);
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.logoWrapper:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.45);
+  outline-offset: 2px;
 }
 
 .logoWrapper img {
   width: 100%;
   height: 100%;
   object-fit: cover;
+  display: block;
+}
+
+.logoInitial {
+  font-size: 1.15rem;
+  line-height: 1;
 }
 
 .infoGroup {

--- a/frontend/src/shared/styles/components/projects.css
+++ b/frontend/src/shared/styles/components/projects.css
@@ -37,17 +37,33 @@
 
 .project-thumbnail,
 .new-project-thumbnail {
+  --shape-radius: clamp(22px, 6vw, 28px);
+  --shape-smoothing: 0.82;
   width: 100%;
-  border-radius: var(--radius-2xl);
-  cursor: pointer;
   aspect-ratio: 1 / 1;
-  object-fit: cover;
+  display: flex;
+  align-items: stretch;
+  justify-content: stretch;
+  cursor: pointer;
   transition: transform 0.25s ease, box-shadow 0.25s ease;
 }
 
-.project-thumbnail:hover {
+.project-thumbnail:hover,
+.new-project-thumbnail:hover {
   transform: scale(1.01);
-  box-shadow: 0 3px 12px rgba(255, 255, 255, 0.1);
+  box-shadow: 0 6px 22px rgba(0, 0, 0, 0.35);
+}
+
+.project-thumbnail-media {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.project-thumbnail svg.project-thumbnail-media {
+  width: 100%;
+  height: 100%;
 }
 
 .all-projects-container-welcome.single-item .project-container-welcome {
@@ -117,11 +133,8 @@
 
 @media (max-width: var(--breakpoint-md)) {
   .project-thumbnail,
-  .new-project-thumbnail,
-  .new-project-thumbnail svg {
-    width: 100%;
-    height: auto;
-    aspect-ratio: 1 / 1;
+  .new-project-thumbnail {
+    --shape-radius: 20px;
   }
   
   .project-title {


### PR DESCRIPTION
## Summary
- wrap project grid and list thumbnails in the shared Squircle component to keep icons square with rounded corners
- adjust project thumbnail styles so images and SVG fallbacks fill the squircle mask across breakpoints
- restyle the mobile project header thumbnail button to use a squircle mask and consistent sizing

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cca99043648324aa422ea1d38722cd