### PR TITLE
Add mobile navigation toggle to project header

### DIFF
--- a/frontend/src/dashboard/project/components/Shared/MobileProjectHeader.tsx
+++ b/frontend/src/dashboard/project/components/Shared/MobileProjectHeader.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import {
+  Menu,
   MoreVertical,
   Settings,
   Link as LinkIcon,
@@ -34,6 +35,9 @@ interface MobileProjectHeaderProps {
   tabs: ProjectTabItem[];
   activeTabKey?: string;
   onSelectTab: (tab: ProjectTabItem) => void;
+  onOpenNavigation?: () => void;
+  navigationDrawerId?: string;
+  isNavigationOpen?: boolean;
 }
 
 const MobileProjectHeader: React.FC<MobileProjectHeaderProps> = ({
@@ -54,6 +58,9 @@ const MobileProjectHeader: React.FC<MobileProjectHeaderProps> = ({
   tabs,
   activeTabKey,
   onSelectTab,
+  onOpenNavigation,
+  navigationDrawerId,
+  isNavigationOpen,
 }) => {
   const [menuOpen, setMenuOpen] = React.useState(false);
 
@@ -84,6 +91,18 @@ const MobileProjectHeader: React.FC<MobileProjectHeaderProps> = ({
     <div className={styles.wrapper}>
       <div className={styles.topRow}>
         <div className={styles.projectSection}>
+          {onOpenNavigation ? (
+            <button
+              type="button"
+              className={styles.navToggle}
+              onClick={onOpenNavigation}
+              aria-label="Open navigation"
+              aria-controls={navigationDrawerId}
+              aria-expanded={isNavigationOpen ?? false}
+            >
+              <Menu />
+            </button>
+          ) : null}
           <Squircle
             as="button"
             type="button"

--- a/frontend/src/dashboard/project/components/Shared/ProjectHeader.tsx
+++ b/frontend/src/dashboard/project/components/Shared/ProjectHeader.tsx
@@ -5,7 +5,8 @@ import React, {
   useCallback,
   useLayoutEffect,
   useMemo,
- 
+  useId,
+
   FormEvent,
 } from "react";
 import "./project-header.css";
@@ -46,6 +47,7 @@ import TeamModal from "@/dashboard/project/components/Shared/TeamModal";
 import { enqueueProjectUpdate } from "@/shared/utils/requestQueue";
 import type { Project } from "@/app/contexts/DataProvider";
 import MobileProjectHeader from "./MobileProjectHeader";
+import NavigationDrawer from "@/shared/ui/NavigationDrawer";
 import { useProjectTabs } from "./useProjectTabs";
 import type { TeamMember } from "./types";
 
@@ -114,6 +116,12 @@ const ProjectHeader: React.FC<ProjectHeaderProps> = ({
     }
     return window.innerWidth < 768;
   });
+  const [isNavigationOpen, setIsNavigationOpen] = useState(false);
+  const rawNavigationDrawerId = useId();
+  const navigationDrawerId = useMemo(
+    () => `project-nav-${rawNavigationDrawerId.replace(/[^a-zA-Z0-9_-]/g, "")}`,
+    [rawNavigationDrawerId]
+  );
 
   useEffect(() => {
     if (typeof window === "undefined") {
@@ -127,6 +135,25 @@ const ProjectHeader: React.FC<ProjectHeaderProps> = ({
     return () => {
       window.removeEventListener("resize", handleResize);
     };
+  }, []);
+
+  useEffect(() => {
+    if (!isMobile) {
+      setIsNavigationOpen(false);
+    }
+  }, [isMobile]);
+
+  const handleOpenNavigation = useCallback(() => {
+    setIsNavigationOpen(true);
+  }, []);
+
+  const handleCloseNavigation = useCallback(() => {
+    setIsNavigationOpen(false);
+  }, []);
+
+  const handleSetNavigationView = useCallback((view: string) => {
+    void view;
+    // Project pages don't maintain a dashboard view state, so this is a no-op.
   }, []);
 
   const handleKeyDown = (e: React.KeyboardEvent, action: () => void) => {
@@ -923,25 +950,36 @@ const ProjectHeader: React.FC<ProjectHeaderProps> = ({
       {saving && <div style={{ color: "#FA3356" }}>Saving...</div>}
 
       {isMobile ? (
-        <MobileProjectHeader
-          projectName={localActiveProject ? localActiveProject.title : "Summary"}
-          projectInitial={projectInitial}
-          thumbnailKey={localActiveProject?.thumbnails?.[0] as string | undefined}
-          statusLabel={displayStatus}
-          progressValue={parseStatusToNumber(localActiveProject?.status)}
-          rangeLabel={mobileRangeLabel || undefined}
-          teamMembers={teamMembers}
-          onOpenQuickLinks={onOpenQuickLinks}
-          onOpenFiles={onOpenFiles}
-          onOpenSettings={openSettingsModal}
-          onOpenTeam={openTeamModal}
-          onOpenFinishLine={openFinishLineModal}
-          onOpenStatus={openEditStatusModal}
-          onOpenThumbnail={() => openThumbnailModal(false)}
-          tabs={tabs}
-          activeTabKey={activeTabKey}
-          onSelectTab={(tab) => confirmNavigate(tab.path)}
-        />
+        <>
+          <NavigationDrawer
+            open={isNavigationOpen}
+            onClose={handleCloseNavigation}
+            setActiveView={handleSetNavigationView}
+            drawerId={navigationDrawerId}
+          />
+          <MobileProjectHeader
+            projectName={localActiveProject ? localActiveProject.title : "Summary"}
+            projectInitial={projectInitial}
+            thumbnailKey={localActiveProject?.thumbnails?.[0] as string | undefined}
+            statusLabel={displayStatus}
+            progressValue={parseStatusToNumber(localActiveProject?.status)}
+            rangeLabel={mobileRangeLabel || undefined}
+            teamMembers={teamMembers}
+            onOpenQuickLinks={onOpenQuickLinks}
+            onOpenFiles={onOpenFiles}
+            onOpenSettings={openSettingsModal}
+            onOpenTeam={openTeamModal}
+            onOpenFinishLine={openFinishLineModal}
+            onOpenStatus={openEditStatusModal}
+            onOpenThumbnail={() => openThumbnailModal(false)}
+            tabs={tabs}
+            activeTabKey={activeTabKey}
+            onSelectTab={(tab) => confirmNavigate(tab.path)}
+            onOpenNavigation={handleOpenNavigation}
+            navigationDrawerId={navigationDrawerId}
+            isNavigationOpen={isNavigationOpen}
+          />
+        </>
       ) : (
         <div className="project-header">
         <div className="header-content">

--- a/frontend/src/dashboard/project/components/Shared/mobile-project-header.module.css
+++ b/frontend/src/dashboard/project/components/Shared/mobile-project-header.module.css
@@ -25,6 +25,36 @@
   flex: 1;
 }
 
+.navToggle {
+  width: 40px;
+  height: 40px;
+  border-radius: 12px;
+  border: none;
+  background: rgba(255, 255, 255, 0.08);
+  color: #ffffff;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: transform 0.2s ease, background-color 0.2s ease;
+  flex-shrink: 0;
+}
+
+.navToggle:hover {
+  background: rgba(255, 255, 255, 0.12);
+  transform: scale(1.02);
+}
+
+.navToggle:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.45);
+  outline-offset: 2px;
+}
+
+.navToggle svg {
+  width: 20px;
+  height: 20px;
+}
+
 .logoWrapper {
   --shape-radius: 18px;
   --shape-smoothing: 0.88;


### PR DESCRIPTION
## Summary
- add a hamburger navigation trigger to the mobile project header and plumb navigation drawer props
- manage mobile navigation drawer state in the project header so the menu can open from project pages
- style the new navigation toggle button to match the existing mobile header visuals

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ccb924f34083249710071b4accd332