### PR TITLE
Add mobile project chat trigger

### DIFF
--- a/frontend/src/dashboard/project/components/Shared/ChatPanel.tsx
+++ b/frontend/src/dashboard/project/components/Shared/ChatPanel.tsx
@@ -12,6 +12,7 @@ type ChatPanelProps = {
   initialFloating?: boolean;
   onFloatingChange?: (floating: boolean) => void;
   initialOpen?: boolean;
+  openSignal?: number;
 };
 
 type Size = { width: number; height: number };
@@ -25,15 +26,20 @@ const ChatPanel: React.FC<ChatPanelProps> = ({
   projectId,
   initialFloating = false,
   onFloatingChange,
-  initialOpen = true,
+  initialOpen,
+  openSignal = 0,
 }) => {
   const isNarrowScreen =
     typeof window !== "undefined" ? window.innerWidth < 768 : false;
 
   const [isMobile, setIsMobile] = useState<boolean>(isNarrowScreen);
-  const [open, setOpen] = useState<boolean>(
-    isNarrowScreen ? false : Boolean(initialOpen)
-  );
+  const [open, setOpen] = useState<boolean>(() => {
+    if (isNarrowScreen) {
+      return Boolean(initialOpen);
+    }
+    const resolvedInitialOpen = initialOpen ?? true;
+    return Boolean(resolvedInitialOpen);
+  });
 
   const prevHeightRef = useRef<number>(400);
   const [floating, setFloating] = useState<boolean>(
@@ -93,6 +99,12 @@ const ChatPanel: React.FC<ChatPanelProps> = ({
       /* ignore write errors */
     }
   }, [size]);
+
+  useEffect(() => {
+    if (openSignal > 0) {
+      setOpen(true);
+    }
+  }, [openSignal]);
 
   useEffect(() => {
     const handleResize = () => {

--- a/frontend/src/dashboard/project/components/Shared/MobileProjectHeader.tsx
+++ b/frontend/src/dashboard/project/components/Shared/MobileProjectHeader.tsx
@@ -4,6 +4,7 @@ import {
   Folder,
   Link as LinkIcon,
   MoreVertical,
+  MessageSquare,
   Settings,
 } from "lucide-react";
 import { Avatar } from "@/components/ui/avatar";
@@ -33,6 +34,7 @@ interface MobileProjectHeaderProps {
   onOpenFinishLine: () => void;
   onOpenStatus: () => void;
   onOpenThumbnail: () => void;
+  onOpenChat?: () => void;
   tabs: ProjectTabItem[];
   activeTabKey?: string;
   onSelectTab: (tab: ProjectTabItem) => void;
@@ -53,6 +55,7 @@ const MobileProjectHeader: React.FC<MobileProjectHeaderProps> = ({
   onOpenFinishLine,
   onOpenStatus,
   onOpenThumbnail,
+  onOpenChat,
   tabs,
   activeTabKey,
   onSelectTab,
@@ -79,6 +82,17 @@ const MobileProjectHeader: React.FC<MobileProjectHeaderProps> = ({
   const handleBackToDashboard = React.useCallback(() => {
     navigate("/dashboard");
   }, [navigate]);
+
+  const handleOpenChat = React.useCallback(() => {
+    if (onOpenChat) {
+      onOpenChat();
+      return;
+    }
+
+    if (typeof window !== "undefined") {
+      window.dispatchEvent(new CustomEvent("project-open-chat"));
+    }
+  }, [onOpenChat]);
 
   const statusBadgeLabel = React.useMemo(() => {
     if (Number.isFinite(progressValue)) {
@@ -179,6 +193,17 @@ const MobileProjectHeader: React.FC<MobileProjectHeaderProps> = ({
               </div>
             ) : null}
           </button>
+
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className={styles.chatButton}
+            onClick={handleOpenChat}
+            aria-label="Open project chat"
+          >
+            <MessageSquare />
+          </Button>
 
           <Popover open={menuOpen} onOpenChange={setMenuOpen}>
             <PopoverTrigger asChild>

--- a/frontend/src/dashboard/project/components/Shared/ProjectPageLayout.tsx
+++ b/frontend/src/dashboard/project/components/Shared/ProjectPageLayout.tsx
@@ -27,6 +27,7 @@ type ChatPanelProps = {
   projectId: string;
   initialFloating?: boolean;
   onFloatingChange?: (floating: boolean) => void;
+  openSignal?: number;
 };
 
 // (If your imported components already export types, remove these lines)
@@ -93,6 +94,7 @@ const ProjectPageLayout: React.FC<ProjectPageLayoutProps> = ({
       return false;
     }
   });
+  const [chatOpenSignal, setChatOpenSignal] = React.useState<number>(0);
 
   const [isNavCollapsed, setIsNavCollapsed] = useNavCollapsed("project");
 
@@ -156,6 +158,28 @@ const ProjectPageLayout: React.FC<ProjectPageLayoutProps> = ({
       /* ignore write errors */
     }
   }, [floatingThread]);
+
+  React.useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const handleOpenChat = () => {
+      setFloatingThread((prev) => {
+        if (!prev) {
+          return true;
+        }
+        return prev;
+      });
+      setChatOpenSignal((prev) => prev + 1);
+    };
+
+    window.addEventListener("project-open-chat", handleOpenChat);
+
+    return () => {
+      window.removeEventListener("project-open-chat", handleOpenChat);
+    };
+  }, [setFloatingThread, setChatOpenSignal]);
 
   const startResize = (e: React.MouseEvent<HTMLDivElement>) => {
     e.preventDefault();
@@ -258,6 +282,7 @@ const ProjectPageLayout: React.FC<ProjectPageLayoutProps> = ({
           projectId={safeProjectId}
           initialFloating
           onFloatingChange={setFloatingThread}
+          openSignal={chatOpenSignal}
         />
       )}
     </div>

--- a/frontend/src/dashboard/project/components/Shared/mobile-project-header.module.css
+++ b/frontend/src/dashboard/project/components/Shared/mobile-project-header.module.css
@@ -120,6 +120,15 @@
   gap: 8px;
 }
 
+.chatButton {
+  color: #ffffff;
+}
+
+.chatButton :global(svg) {
+  width: 18px;
+  height: 18px;
+}
+
 .avatarGroup {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- add a chat button to the mobile project header and dispatch a custom event when it is clicked
- listen for the chat open event inside the project layout so the floating chat panel is shown and focused
- adjust ChatPanel defaults so it can react to the open signal on mobile and add styling for the new chat control

## Testing
- pnpm --dir frontend lint

------
https://chatgpt.com/codex/tasks/task_e_68cccbe4719c83248f6d0098160e6651