### PR TITLE
Make budget pie slices interactive

### DIFF
--- a/frontend/src/features/budget/components/BudgetOverviewCard.tsx
+++ b/frontend/src/features/budget/components/BudgetOverviewCard.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useCallback } from "react";
+import React, { useState, useMemo, useCallback, useEffect } from "react";
 
 import { CircleDollarSign } from "lucide-react";
 import { useNavigate } from "react-router-dom";
@@ -9,7 +9,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faFileInvoiceDollar, faSpinner } from "@fortawesome/free-solid-svg-icons";
 import ClientInvoicePreviewModal from "@/features/project/components/ClientInvoicePreviewModal";
 import { useBudget } from "@/features/budget/context/BudgetContext";
-import VisxPieChart from "@/features/budget/components/VisxPieChart";
+import VisxPieChart, { SliceInteractionType } from "@/features/budget/components/VisxPieChart";
 import { generateSequentialPalette, getColor } from "@/shared/utils/colorUtils";
 
 
@@ -39,6 +39,9 @@ const BudgetOverviewCard: React.FC<BudgetOverviewCardProps> = ({ projectId }) =>
   const [groupBy] = useState<"invoiceGroup" | "none">("invoiceGroup");
   const [isInvoicePreviewOpen, setIsInvoicePreviewOpen] = useState(false);
   const [invoiceRevision, setInvoiceRevision] = useState<BudgetHeaderData | null>(null);
+  const [hoverSliceName, setHoverSliceName] = useState<string | null>(null);
+  const [persistentSliceName, setPersistentSliceName] = useState<string | null>(null);
+  const [hasUserSelection, setHasUserSelection] = useState(false);
 
   // Use context selectors for memoized data
   const stats = getStats();
@@ -52,6 +55,61 @@ const BudgetOverviewCard: React.FC<BudgetOverviewCardProps> = ({ projectId }) =>
   const pieDataSorted = useMemo(
     () => [...pieData].sort((a, b) => b.value - a.value),
     [pieData]
+  );
+
+  const fallbackSliceName = useMemo(() => pieDataSorted[0]?.name ?? null, [pieDataSorted]);
+
+  useEffect(() => {
+    setPersistentSliceName((prev) => {
+      if (prev && pieDataSorted.some((d) => d.name === prev)) {
+        return prev;
+      }
+      return fallbackSliceName;
+    });
+  }, [pieDataSorted, fallbackSliceName]);
+
+  useEffect(() => {
+    setHasUserSelection((prev) => {
+      if (!prev) return prev;
+      if (!persistentSliceName) return false;
+      return pieDataSorted.some((d) => d.name === persistentSliceName);
+    });
+  }, [pieDataSorted, persistentSliceName]);
+
+  const displayedSliceName = hoverSliceName ?? persistentSliceName ?? fallbackSliceName;
+  const chartActiveSliceName = hoverSliceName ?? (hasUserSelection ? persistentSliceName : null);
+  const activeIndex = useMemo(
+    () => (displayedSliceName ? pieDataSorted.findIndex((d) => d.name === displayedSliceName) : -1),
+    [displayedSliceName, pieDataSorted]
+  );
+  const activeDatum = activeIndex >= 0 ? pieDataSorted[activeIndex] : undefined;
+  const activeColor = activeIndex >= 0 && colors.length > 0 ? colors[activeIndex % colors.length] : undefined;
+  const activePercent = activeDatum && totalPieValue > 0 ? (activeDatum.value / totalPieValue) * 100 : null;
+
+  const formattedPercent = useMemo(() => {
+    if (activePercent == null) return null;
+    const digits = activePercent >= 10 ? 0 : 1;
+    return `${activePercent.toFixed(digits)}% of total`;
+  }, [activePercent]);
+
+  const handleSliceInteraction = useCallback(
+    (datum: PieDatum | null, interactionType: SliceInteractionType) => {
+      if (interactionType === "hover") {
+        setHoverSliceName(datum?.name ?? null);
+        return;
+      }
+
+      setHoverSliceName(null);
+
+      if (datum) {
+        setPersistentSliceName(datum.name);
+        setHasUserSelection(true);
+      } else {
+        setPersistentSliceName(fallbackSliceName);
+        setHasUserSelection(false);
+      }
+    },
+    [fallbackSliceName]
   );
 
   const colors = useMemo(() => {
@@ -207,20 +265,35 @@ const BudgetOverviewCard: React.FC<BudgetOverviewCardProps> = ({ projectId }) =>
                   colors={colors}
                   formatTooltip={formatTooltip}
                   colorMode="sequential"
+                  activeSliceName={chartActiveSliceName}
+                  onActiveSliceChange={handleSliceInteraction}
                 />
               </div>
-
-              <ul className="budget-legend">
-                {pieDataSorted.map((m, i) => (
-                  <li key={m.name} className="budget-legend-item">
+              <div className="budget-active-summary" aria-live="polite">
+                <div className="budget-active-title">
+                  {activeColor && (
                     <span
-                      className="budget-legend-dot"
-                      style={{ background: colors[i % colors.length] }}
+                      className="budget-legend-dot budget-active-dot"
+                      style={{ background: activeColor }}
                     />
-                    {m.name}
-                  </li>
-                ))}
-              </ul>
+                  )}
+                  <span>{activeDatum ? activeDatum.name : "Explore budget"}</span>
+                </div>
+                {activeDatum ? (
+                  <>
+                    <span className="budget-active-value">
+                      {formatUSD(Math.round(activeDatum.value))}
+                    </span>
+                    {formattedPercent && (
+                      <span className="budget-active-percent">{formattedPercent}</span>
+                    )}
+                  </>
+                ) : (
+                  <span className="budget-active-placeholder">
+                    Hover or tap a slice to see details.
+                  </span>
+                )}
+              </div>
             </div>
           </>
         )

--- a/frontend/src/features/budget/components/VisxPieChart.tsx
+++ b/frontend/src/features/budget/components/VisxPieChart.tsx
@@ -15,6 +15,16 @@ import { useData } from "@/app/contexts/useData";
 
 const EXPLODE_PX = 8;
 
+type HoverPointerType = "mouse" | "pen";
+
+const HOVER_POINTERS: HoverPointerType[] = ["mouse", "pen"];
+
+function isHoverPointer(pointerType: string): pointerType is HoverPointerType {
+  return HOVER_POINTERS.includes(pointerType as HoverPointerType);
+}
+
+export type SliceInteractionType = "hover" | "touch" | "keyboard";
+
 export type PieDatum = {
   name: string;
   value: number;
@@ -36,6 +46,8 @@ interface AnimatedArcProps {
   clampTooltip: (x: number, y: number, tooltipWidth?: number, tooltipHeight?: number) => ClampResult;
   rafRef: React.MutableRefObject<number | null>;
   explodePx?: number;
+  isActive: boolean;
+  onInteraction?: (datum: PieDatum | null, type: SliceInteractionType) => void;
 }
 
 function AnimatedArc({
@@ -48,6 +60,8 @@ function AnimatedArc({
   clampTooltip,
   rafRef,
   explodePx = EXPLODE_PX,
+  isActive,
+  onInteraction,
 }: AnimatedArcProps) {
   const [springs, api] = useSpring(() => ({
     startAngle: 0,
@@ -56,64 +70,112 @@ function AnimatedArc({
     y: 0,
   }));
 
+  const [cx, cy] = React.useMemo(() => pie.path.centroid(arc), [pie, arc]);
+  const len = Math.max(1, Math.hypot(cx, cy));
+  const isSingle = pie.arcs.length === 1;
+
   React.useEffect(() => {
-    api.start({ startAngle: arc.startAngle, endAngle: arc.endAngle });
-  }, [arc, api]);
+    if (isSingle) {
+      api.start({
+        startAngle: arc.startAngle + (isActive ? -0.01 : 0),
+        endAngle: arc.endAngle + (isActive ? 0.01 : 0),
+        x: 0,
+        y: 0,
+      });
+      return;
+    }
+
+    api.start({
+      startAngle: arc.startAngle,
+      endAngle: arc.endAngle,
+      x: isActive ? (cx / len) * explodePx : 0,
+      y: isActive ? (cy / len) * explodePx : 0,
+    });
+  }, [api, arc, cx, cy, len, explodePx, isActive, isSingle]);
 
   const pathD = springTo(
     [springs.startAngle as SpringValue<number>, springs.endAngle as SpringValue<number>],
     (startAngle, endAngle) => pie.path({ ...arc, startAngle, endAngle })
   );
 
-  const [cx, cy] = React.useMemo(() => pie.path.centroid(arc), [pie, arc]);
-  const len = Math.max(1, Math.hypot(cx, cy));
   const translate = springTo(
     [springs.x as SpringValue<number>, springs.y as SpringValue<number>],
     (x, y) => `translate(${x}, ${y})`
   );
-  const isSingle = pie.arcs.length === 1;
+  const showHoverTooltip = React.useCallback(
+    (event: React.PointerEvent<SVGGElement>) => {
+      if (!isHoverPointer(event.pointerType)) {
+        return;
+      }
+
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+      rafRef.current = requestAnimationFrame(() => {
+        const pt = localPoint(event) || { x: 0, y: 0 };
+        const host = containerRef.current;
+        if (host) {
+          const rect = host.getBoundingClientRect();
+          const screenX = rect.left + pt.x;
+          const screenY = rect.top + pt.y;
+          const { left, top } = clampTooltip(screenX, screenY);
+          showTooltip({
+            tooltipData: arc.data,
+            tooltipLeft: left,
+            tooltipTop: top,
+          });
+        }
+      });
+    },
+    [arc.data, clampTooltip, containerRef, rafRef, showTooltip]
+  );
+
+  const clearHoverTooltip = React.useCallback(() => {
+    if (rafRef.current) cancelAnimationFrame(rafRef.current);
+    hideTooltip();
+  }, [hideTooltip, rafRef]);
 
   return (
     <animated.g
       transform={translate}
-      onMouseEnter={() => {
-        if (isSingle) {
-          api.start({
-            startAngle: arc.startAngle - 0.01,
-            endAngle: arc.endAngle + 0.01,
-          });
-        } else {
-          api.start({ x: (cx / len) * explodePx, y: (cy / len) * explodePx });
+      onPointerDown={(event) => {
+        event.stopPropagation();
+      }}
+      onPointerUp={(event) => {
+        event.stopPropagation();
+        if (event.pointerType === "touch") {
+          onInteraction?.(isActive ? null : arc.data, "touch");
         }
       }}
-      onMouseMove={(e) => {
-        if (rafRef.current) cancelAnimationFrame(rafRef.current);
-        rafRef.current = requestAnimationFrame(() => {
-          const pt = localPoint(e) || { x: 0, y: 0 };
-          const host = containerRef.current;
-          if (host) {
-            const rect = host.getBoundingClientRect();
-            const screenX = rect.left + pt.x;
-            const screenY = rect.top + pt.y;
-            const { left, top } = clampTooltip(screenX, screenY);
-            showTooltip({
-              tooltipData: arc.data,
-              tooltipLeft: left,
-              tooltipTop: top,
-            });
-          }
-        });
+      onPointerEnter={(event) => {
+        if (isHoverPointer(event.pointerType)) {
+          onInteraction?.(arc.data, "hover");
+          showHoverTooltip(event);
+        }
       }}
-      onMouseLeave={() => {
-        if (rafRef.current) cancelAnimationFrame(rafRef.current);
-        api.start(
-          isSingle
-            ? { startAngle: arc.startAngle, endAngle: arc.endAngle }
-            : { x: 0, y: 0 }
-        );
-        hideTooltip();
+      onPointerMove={showHoverTooltip}
+      onPointerLeave={(event) => {
+        if (isHoverPointer(event.pointerType)) {
+          onInteraction?.(null, "hover");
+        }
+        clearHoverTooltip();
+      }}
+      onFocus={() => {
+        onInteraction?.(arc.data, "keyboard");
+      }}
+      onBlur={() => {
+        onInteraction?.(null, "keyboard");
+        clearHoverTooltip();
+      }}
+      onKeyDown={(event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          event.stopPropagation();
+          onInteraction?.(isActive ? null : arc.data, "keyboard");
+        }
       }}
       style={{ cursor: "pointer" }}
+      role="button"
+      tabIndex={0}
+      aria-pressed={isActive}
     >
       <animated.path
         d={pathD}
@@ -139,6 +201,8 @@ export interface VisxPieChartProps {
   baseColor?: string;
   colorMode?: "sequential" | "categorical";
   projectId?: string;
+  activeSliceName?: string | null;
+  onActiveSliceChange?: (datum: PieDatum | null, type: SliceInteractionType) => void;
 }
 
 // Generic pie/donut chart rendered with visx. Used by budget components and header summaries.
@@ -151,6 +215,8 @@ function VisxPieChart({
   baseColor,
   colorMode = "sequential",
   projectId,
+  activeSliceName = null,
+  onActiveSliceChange,
 }: VisxPieChartProps) {
   const { activeProject } = useData();
   const projectBase: string = String(
@@ -246,6 +312,8 @@ function VisxPieChart({
                         clampTooltip={clampTooltip}
                         rafRef={rafRef}
                         explodePx={EXPLODE_PX}
+                        isActive={Boolean(activeSliceName && arc.data.name === activeSliceName)}
+                        onInteraction={onActiveSliceChange}
                       />
                     ))
                   }
@@ -311,7 +379,9 @@ export default memo(VisxPieChart, (prevProps, nextProps) => {
     prevProps.donutRatio !== nextProps.donutRatio ||
     prevProps.baseColor !== nextProps.baseColor ||
     prevProps.colorMode !== nextProps.colorMode ||
-    prevProps.projectId !== nextProps.projectId
+    prevProps.projectId !== nextProps.projectId ||
+    prevProps.activeSliceName !== nextProps.activeSliceName ||
+    prevProps.onActiveSliceChange !== nextProps.onActiveSliceChange
   ) {
     return false;
   }

--- a/frontend/src/features/dashboard/styles/components/dashboard-cards.css
+++ b/frontend/src/features/dashboard/styles/components/dashboard-cards.css
@@ -86,12 +86,51 @@
   display: flex;
   align-items: center;
   margin-left: 10px;
+  gap: 16px;
 }
 
 .budget-chart {
   width: min(40vh, 40vw, 220px);
   height: min(40vh, 40vw, 220px);
   position: relative;
+}
+
+.budget-active-summary {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+  min-width: 0;
+  font-size: clamp(0.72rem, 1.6vw, 0.9rem);
+  gap: 4px;
+}
+
+.budget-active-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+  font-size: clamp(0.85rem, 1.8vw, 1rem);
+}
+
+.budget-active-dot {
+  width: clamp(6px, 1vh, 8px);
+  height: clamp(6px, 1vh, 8px);
+}
+
+.budget-active-value {
+  font-size: clamp(1rem, 2vw, 1.25rem);
+  font-weight: 600;
+}
+
+.budget-active-percent {
+  font-size: clamp(0.7rem, 1.4vw, 0.85rem);
+  opacity: 0.8;
+}
+
+.budget-active-placeholder {
+  font-size: clamp(0.7rem, 1.4vw, 0.85rem);
+  opacity: 0.7;
 }
 
 .budget-legend {
@@ -151,6 +190,14 @@
     flex-direction: column;
     align-items: center;
     margin-left: 0;
+    gap: 12px;
+  }
+  .budget-active-summary {
+    align-items: center;
+    text-align: center;
+  }
+  .budget-active-title {
+    justify-content: center;
   }
   .budget-legend {
     flex-direction: row;


### PR DESCRIPTION
## Summary
- replace the static budget legend with an interactive summary that reacts to hovered or tapped slices
- teach the Visx pie chart to track an active slice, offset the arc, and surface events for hover, touch, and keyboard interactions
- polish dashboard styles to support the new active summary layout and responsive spacing

## Testing
- npm run lint *(fails: existing @typescript-eslint/no-explicit-any errors in BudgetProvider.test.tsx and TasksComponent.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68cdfac8f5e88324b40de48f98a6f7b2