### PR TITLE
feat: add interactive budget pie slices

### DIFF
--- a/frontend/src/dashboard/home/styles/components/dashboard-cards.css
+++ b/frontend/src/dashboard/home/styles/components/dashboard-cards.css
@@ -88,8 +88,9 @@
 
 .chart-legend-container {
   display: flex;
-  align-items: center;
+  align-items: stretch;
   margin-left: 10px;
+  gap: 12px;
 }
 
 .budget-chart {
@@ -99,34 +100,57 @@
 }
 
 .budget-legend {
-  list-style: none;
-  padding: 0;
-  margin: 0 0 0 8px;
   display: flex;
   flex-direction: column;
-  gap: 0;
+  justify-content: center;
+  padding: 0;
+  margin: 0 0 0 8px;
+  min-width: clamp(120px, 16vw, 180px);
+  gap: 6px;
 }
 
-.budget-legend-item {
+.budget-legend-header {
   display: flex;
   align-items: center;
-  margin-bottom: 0;
-  font-size: clamp(0.6rem, 1.2vh, 0.75rem);
-  line-height: 1.2;
+  gap: 6px;
 }
 
 .budget-legend-dot {
-  width: clamp(4px, 0.8vh, 6px);
-  height: clamp(4px, 0.8vh, 6px);
+  width: clamp(6px, 1vh, 8px);
+  height: clamp(6px, 1vh, 8px);
   border-radius: 50%;
   display: inline-block;
-  margin-right: 4px;
+}
+
+.budget-legend-title {
+  font-size: clamp(0.7rem, 1.5vh, 0.9rem);
+  font-weight: 600;
+}
+
+.budget-legend-value {
+  font-size: clamp(0.75rem, 1.7vh, 1rem);
+  font-weight: 600;
+}
+
+.budget-legend-percent {
+  font-size: clamp(0.65rem, 1.3vh, 0.85rem);
+  color: #9ca3af;
+}
+
+.budget-legend-placeholder {
+  font-size: clamp(0.68rem, 1.4vh, 0.85rem);
+  color: #9ca3af;
+  line-height: 1.35;
+  max-width: clamp(120px, 18vw, 200px);
 }
 
 @media (max-height: 750px) {
   .budget-chart {
     width: min(30vh, 40vw, 180px);
     height: min(30vh, 40vw, 180px);
+  }
+  .budget-legend {
+    min-width: clamp(110px, 22vw, 160px);
   }
   .dashboard-item.budget {
     min-height: clamp(160px, 25vh, 220px);

--- a/frontend/src/dashboard/project/features/budget/components/BudgetOverviewCard.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetOverviewCard.tsx
@@ -39,6 +39,7 @@ const BudgetOverviewCard: React.FC<BudgetOverviewCardProps> = ({ projectId }) =>
   const [groupBy] = useState<"invoiceGroup" | "none">("invoiceGroup");
   const [isInvoicePreviewOpen, setIsInvoicePreviewOpen] = useState(false);
   const [invoiceRevision, setInvoiceRevision] = useState<BudgetHeaderData | null>(null);
+  const [activeSlice, setActiveSlice] = useState<{ datum: PieDatum; index: number } | null>(null);
 
   // Use context selectors for memoized data
   const stats = getStats();
@@ -63,14 +64,41 @@ const BudgetOverviewCard: React.FC<BudgetOverviewCardProps> = ({ projectId }) =>
     return generateSequentialPalette(base, pieDataSorted.length).reverse();
   }, [pieDataSorted.length, projectId, activeProject?.color]);
 
-  const formatTooltip = useCallback(
+  const formatDatumValue = useCallback(
     (d: PieDatum) => {
       const isPercent = groupBy === "none" && d.name === "Effective Markup";
       const rounded = Math.round(d.value);
-      return `${d.name}: ${isPercent ? `${rounded}%` : formatUSD(rounded)}`;
+      return isPercent ? `${rounded}%` : formatUSD(rounded);
     },
     [groupBy]
   );
+
+  const formatTooltip = useCallback(
+    (d: PieDatum) => `${d.name}: ${formatDatumValue(d)}`,
+    [formatDatumValue]
+  );
+
+  const handleSliceChange = useCallback(
+    (slice: { datum: PieDatum; index: number } | null) => {
+      setActiveSlice(slice);
+    },
+    []
+  );
+
+  const activeColor = useMemo(() => {
+    if (!activeSlice) return null;
+    return colors[activeSlice.index % colors.length] ?? null;
+  }, [activeSlice, colors]);
+
+  const activePercent = useMemo(() => {
+    if (!activeSlice || !totalPieValue) return null;
+    const percent = (activeSlice.datum.value / totalPieValue) * 100;
+    if (percent >= 10) {
+      return `${Math.round(percent)}`;
+    }
+    const rounded = Math.round(percent * 10) / 10;
+    return `${rounded}`.replace(/\.0$/, "");
+  }, [activeSlice, totalPieValue]);
 
   const openInvoicePreview = async (): Promise<void> => {
     if (!projectId) return;
@@ -208,20 +236,31 @@ const BudgetOverviewCard: React.FC<BudgetOverviewCardProps> = ({ projectId }) =>
                   colors={colors}
                   formatTooltip={formatTooltip}
                   colorMode="sequential"
+                  onActiveSliceChange={handleSliceChange}
                 />
               </div>
 
-              <ul className="budget-legend">
-                {pieDataSorted.map((m, i) => (
-                  <li key={m.name} className="budget-legend-item">
-                    <span
-                      className="budget-legend-dot"
-                      style={{ background: colors[i % colors.length] }}
-                    />
-                    {m.name}
-                  </li>
-                ))}
-              </ul>
+              <div className="budget-legend" aria-live="polite">
+                {activeSlice ? (
+                  <>
+                    <div className="budget-legend-header">
+                      <span
+                        className="budget-legend-dot"
+                        style={{ background: activeColor ?? "transparent" }}
+                      />
+                      <span className="budget-legend-title">{activeSlice.datum.name}</span>
+                    </div>
+                    <div className="budget-legend-value">{formatDatumValue(activeSlice.datum)}</div>
+                    {activePercent !== null && (
+                      <div className="budget-legend-percent">{`${activePercent}% of total`}</div>
+                    )}
+                  </>
+                ) : (
+                  <span className="budget-legend-placeholder">
+                    Hover or tap a slice to see budget details
+                  </span>
+                )}
+              </div>
             </div>
           </>
         )

--- a/frontend/src/dashboard/project/features/budget/components/VisxPieChart.test.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/VisxPieChart.test.tsx
@@ -26,15 +26,23 @@ vi.mock("@visx/event", () => ({
   localPoint: vi.fn(),
 }));
 
-vi.mock("@react-spring/web", () => ({
-  animated: {
-    path: "path",
-    circle: "circle",
-    text: "text",
-  },
-  useSpring: vi.fn(() => ({})),
-  to: vi.fn(),
-}));
+vi.mock("@react-spring/web", () => {
+  const start = vi.fn();
+  return {
+    animated: {
+      path: "path",
+      circle: "circle",
+      text: "text",
+      g: "g",
+    },
+    useSpring: vi.fn(() => [
+      { startAngle: 0, endAngle: 0, x: 0, y: 0 },
+      { start },
+    ]),
+    to: vi.fn(),
+    SpringValue: class {},
+  };
+});
 
 vi.mock("@/shared/utils/budgetUtils", () => ({
   formatUSD: (value: number) => `$${value}`,

--- a/frontend/src/dashboard/project/features/budget/components/VisxPieChart.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/VisxPieChart.tsx
@@ -15,6 +15,8 @@ import { useData } from "@/app/contexts/useData";
 
 const EXPLODE_PX = 8;
 
+type InteractionMode = "hover" | "touch" | "keyboard";
+
 export type PieDatum = {
   name: string;
   value: number;
@@ -36,6 +38,10 @@ interface AnimatedArcProps {
   clampTooltip: (x: number, y: number, tooltipWidth?: number, tooltipHeight?: number) => ClampResult;
   rafRef: React.MutableRefObject<number | null>;
   explodePx?: number;
+  index: number;
+  isActive: boolean;
+  onActivate: (index: number, mode: InteractionMode) => void;
+  onDeactivate: (index: number, mode: InteractionMode) => void;
 }
 
 function AnimatedArc({
@@ -48,6 +54,10 @@ function AnimatedArc({
   clampTooltip,
   rafRef,
   explodePx = EXPLODE_PX,
+  index,
+  isActive,
+  onActivate,
+  onDeactivate,
 }: AnimatedArcProps) {
   const [springs, api] = useSpring(() => ({
     startAngle: 0,
@@ -56,64 +66,114 @@ function AnimatedArc({
     y: 0,
   }));
 
+  const isSingle = pie.arcs.length === 1;
+  const [cx, cy] = React.useMemo(() => pie.path.centroid(arc), [pie, arc]);
+  const len = Math.max(1, Math.hypot(cx, cy));
+
   React.useEffect(() => {
-    api.start({ startAngle: arc.startAngle, endAngle: arc.endAngle });
-  }, [arc, api]);
+    api.start({
+      startAngle: isSingle && isActive ? arc.startAngle - 0.01 : arc.startAngle,
+      endAngle: isSingle && isActive ? arc.endAngle + 0.01 : arc.endAngle,
+      x: !isSingle ? (cx / len) * (isActive ? explodePx : 0) : 0,
+      y: !isSingle ? (cy / len) * (isActive ? explodePx : 0) : 0,
+    });
+  }, [arc, api, cx, cy, len, isSingle, isActive, explodePx]);
 
   const pathD = springTo(
     [springs.startAngle as SpringValue<number>, springs.endAngle as SpringValue<number>],
     (startAngle, endAngle) => pie.path({ ...arc, startAngle, endAngle })
   );
 
-  const [cx, cy] = React.useMemo(() => pie.path.centroid(arc), [pie, arc]);
-  const len = Math.max(1, Math.hypot(cx, cy));
   const translate = springTo(
     [springs.x as SpringValue<number>, springs.y as SpringValue<number>],
     (x, y) => `translate(${x}, ${y})`
   );
-  const isSingle = pie.arcs.length === 1;
+
+  const queueTooltip = React.useCallback(
+    (event: React.PointerEvent<SVGGElement>) => {
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+      rafRef.current = requestAnimationFrame(() => {
+        const pt = localPoint(event) || { x: 0, y: 0 };
+        const host = containerRef.current;
+        if (host) {
+          const rect = host.getBoundingClientRect();
+          const screenX = rect.left + pt.x;
+          const screenY = rect.top + pt.y;
+          const { left, top } = clampTooltip(screenX, screenY);
+          showTooltip({
+            tooltipData: arc.data,
+            tooltipLeft: left,
+            tooltipTop: top,
+          });
+        }
+      });
+    },
+    [arc.data, clampTooltip, containerRef, rafRef, showTooltip]
+  );
+
+  const clearTooltip = React.useCallback(() => {
+    if (rafRef.current) {
+      cancelAnimationFrame(rafRef.current);
+      rafRef.current = null;
+    }
+    hideTooltip();
+  }, [hideTooltip, rafRef]);
 
   return (
     <animated.g
       transform={translate}
-      onMouseEnter={() => {
-        if (isSingle) {
-          api.start({
-            startAngle: arc.startAngle - 0.01,
-            endAngle: arc.endAngle + 0.01,
-          });
-        } else {
-          api.start({ x: (cx / len) * explodePx, y: (cy / len) * explodePx });
+      onPointerEnter={(event) => {
+        if (event.pointerType === "touch") return;
+        onActivate(index, "hover");
+        queueTooltip(event);
+      }}
+      onPointerMove={(event) => {
+        if (event.pointerType === "touch") return;
+        onActivate(index, "hover");
+        queueTooltip(event);
+      }}
+      onPointerLeave={(event) => {
+        if (event.pointerType !== "touch") {
+          onDeactivate(index, "hover");
+        }
+        clearTooltip();
+      }}
+      onPointerDown={(event) => {
+        event.stopPropagation();
+        if (event.pointerType === "touch") {
+          event.preventDefault();
+          onActivate(index, "touch");
+          clearTooltip();
         }
       }}
-      onMouseMove={(e) => {
-        if (rafRef.current) cancelAnimationFrame(rafRef.current);
-        rafRef.current = requestAnimationFrame(() => {
-          const pt = localPoint(e) || { x: 0, y: 0 };
-          const host = containerRef.current;
-          if (host) {
-            const rect = host.getBoundingClientRect();
-            const screenX = rect.left + pt.x;
-            const screenY = rect.top + pt.y;
-            const { left, top } = clampTooltip(screenX, screenY);
-            showTooltip({
-              tooltipData: arc.data,
-              tooltipLeft: left,
-              tooltipTop: top,
-            });
-          }
-        });
+      onPointerUp={(event) => {
+        event.stopPropagation();
+        if (event.pointerType === "touch") {
+          clearTooltip();
+        }
       }}
-      onMouseLeave={() => {
-        if (rafRef.current) cancelAnimationFrame(rafRef.current);
-        api.start(
-          isSingle
-            ? { startAngle: arc.startAngle, endAngle: arc.endAngle }
-            : { x: 0, y: 0 }
-        );
-        hideTooltip();
+      onPointerCancel={(event) => {
+        if (event.pointerType === "touch") {
+          event.stopPropagation();
+          clearTooltip();
+          return;
+        }
+        onDeactivate(index, "hover");
+        clearTooltip();
       }}
+      onFocus={() => {
+        onActivate(index, "keyboard");
+      }}
+      onBlur={() => {
+        onDeactivate(index, "keyboard");
+        clearTooltip();
+      }}
+      onClick={(event) => event.stopPropagation()}
       style={{ cursor: "pointer" }}
+      role="button"
+      tabIndex={0}
+      aria-pressed={isActive}
+      aria-label={String(arc.data.name)}
     >
       <animated.path
         d={pathD}
@@ -139,6 +199,8 @@ export interface VisxPieChartProps {
   baseColor?: string;
   colorMode?: "sequential" | "categorical";
   projectId?: string;
+  onActiveSliceChange?: (active: { datum: PieDatum; index: number } | null) => void;
+  activeSliceIndex?: number | null;
 }
 
 // Generic pie/donut chart rendered with visx. Used by budget components and header summaries.
@@ -151,6 +213,8 @@ function VisxPieChart({
   baseColor,
   colorMode = "sequential",
   projectId,
+  onActiveSliceChange,
+  activeSliceIndex,
 }: VisxPieChartProps) {
   const { activeProject } = useData();
   const projectBase: string = String(
@@ -185,6 +249,75 @@ function VisxPieChart({
 
   // Throttle mouse move with requestAnimationFrame
   const rafRef = React.useRef<number | null>(null);
+
+  const [internalActiveIndex, setInternalActiveIndex] = React.useState<number | null>(null);
+  const derivedActiveIndex = activeSliceIndex ?? internalActiveIndex;
+  const lastInteractionRef = React.useRef<InteractionMode | null>(null);
+  const lastNotifiedIndexRef = React.useRef<number | null>(null);
+
+  const notifyActiveChange = React.useCallback(
+    (index: number | null) => {
+      if (index === lastNotifiedIndexRef.current) {
+        return;
+      }
+      lastNotifiedIndexRef.current = index;
+      if (!onActiveSliceChange) return;
+      if (index == null || index < 0 || index >= data.length) {
+        onActiveSliceChange(null);
+        return;
+      }
+      onActiveSliceChange({ datum: data[index], index });
+    },
+    [onActiveSliceChange, data]
+  );
+
+  React.useEffect(() => {
+    return () => {
+      const handle = rafRef.current;
+      if (handle) {
+        cancelAnimationFrame(handle);
+        rafRef.current = null;
+      }
+    };
+  }, [rafRef]);
+
+  const activateSlice = React.useCallback(
+    (index: number, mode: InteractionMode) => {
+      lastInteractionRef.current = mode;
+      if (activeSliceIndex === undefined) {
+        setInternalActiveIndex((prev) => (prev === index ? prev : index));
+      }
+      notifyActiveChange(index);
+    },
+    [activeSliceIndex, notifyActiveChange]
+  );
+
+  const deactivateSlice = React.useCallback(
+    (index: number, mode: InteractionMode) => {
+      const currentIndex = activeSliceIndex ?? internalActiveIndex;
+      if (currentIndex !== index) {
+        return;
+      }
+      if (mode === "hover" && lastInteractionRef.current === "touch") {
+        return;
+      }
+      if (activeSliceIndex === undefined) {
+        setInternalActiveIndex((prev) => (prev === null ? prev : null));
+      }
+      lastInteractionRef.current = null;
+      notifyActiveChange(null);
+    },
+    [activeSliceIndex, internalActiveIndex, notifyActiveChange]
+  );
+
+  React.useEffect(() => {
+    if (derivedActiveIndex != null && (derivedActiveIndex < 0 || derivedActiveIndex >= data.length)) {
+      if (activeSliceIndex === undefined) {
+        setInternalActiveIndex(null);
+      }
+      notifyActiveChange(null);
+    }
+  }, [derivedActiveIndex, data.length, activeSliceIndex, notifyActiveChange]);
 
   // Clamp tooltip to viewport
   function clampTooltip(
@@ -246,6 +379,10 @@ function VisxPieChart({
                         clampTooltip={clampTooltip}
                         rafRef={rafRef}
                         explodePx={EXPLODE_PX}
+                        index={i}
+                        isActive={derivedActiveIndex === i}
+                        onActivate={activateSlice}
+                        onDeactivate={deactivateSlice}
                       />
                     ))
                   }
@@ -311,7 +448,9 @@ export default memo(VisxPieChart, (prevProps, nextProps) => {
     prevProps.donutRatio !== nextProps.donutRatio ||
     prevProps.baseColor !== nextProps.baseColor ||
     prevProps.colorMode !== nextProps.colorMode ||
-    prevProps.projectId !== nextProps.projectId
+    prevProps.projectId !== nextProps.projectId ||
+    prevProps.onActiveSliceChange !== nextProps.onActiveSliceChange ||
+    prevProps.activeSliceIndex !== nextProps.activeSliceIndex
   ) {
     return false;
   }


### PR DESCRIPTION
## Summary
- replace the budget overview legend with an interactive active-slice readout that responds to hover or tap
- extend the shared VisxPieChart to expose active-slice callbacks and handle pointer/touch offsets and accessibility affordances
- refresh dashboard budget card styling and update VisxPieChart tests to cover the new animation mocks

## Testing
- npm run test -- VisxPieChart
- npm run lint *(fails: existing lint errors in ProjectCalendar.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68cdfd3c94648324a660106a6bf66865