### PR TITLE
Add project file deletion endpoint and update clients

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -39,6 +39,7 @@ Serverless backend using AWS Lambda, API Gateway (HTTP API v2), and WebSocket AP
   - `/projects` - Projects endpoints
   - `/projects/{proxy+}` - Projects proxy routes
   - `/projects/health` - Health check
+  - `/projects/{projectId}/files/delete` - Delete one or more project files
   - `/budgets/{proxy+}` - Budget endpoints
 
 - **User Service**: `https://gy8dq7w0a3.execute-api.us-west-2.amazonaws.com`

--- a/backend/projects/router.mjs
+++ b/backend/projects/router.mjs
@@ -2,10 +2,12 @@
 import { corsHeadersFromEvent, preflightFromEvent, json } from "/opt/nodejs/utils/cors.mjs";
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocument } from "@aws-sdk/lib-dynamodb";
+import { DeleteObjectsCommand, S3Client } from "@aws-sdk/client-s3";
 import { v4 as uuidv4 } from "uuid";
 
 /* ------------ ENV ------------ */
 const REGION = process.env.AWS_REGION || "us-west-2";
+const FILE_BUCKET = process.env.FILE_BUCKET || "mylg-files-v12";
 
 // Core projects table
 const PROJECTS_TABLE = process.env.PROJECTS_TABLE || "Projects";
@@ -40,6 +42,8 @@ const SCANS_ALLOWED = (process.env.SCANS_ALLOWED || "true").toLowerCase() === "t
 const ddb = DynamoDBDocument.from(new DynamoDBClient({ region: REGION }), {
   marshallOptions: { removeUndefinedValues: true },
 });
+
+const s3 = new S3Client({ region: REGION });
 
 /* ------------ utils ------------ */
 const M = (e) => e?.requestContext?.http?.method?.toUpperCase?.() || e?.httpMethod?.toUpperCase?.() || "GET";
@@ -681,6 +685,43 @@ const deleteEvent = async (_e, C, { projectId, eventId }) => {
   return json(204, C, "");
 };
 
+/* ---------- Project file management ---------- */
+const deleteProjectFiles = async (e, C, { projectId }) => {
+  const body = B(e);
+  const keys = Array.isArray(body.fileKeys) ? body.fileKeys.filter(Boolean) : [];
+  if (!projectId) return json(400, C, { error: "projectId is required" });
+  if (!keys.length) return json(400, C, { error: "fileKeys must be a non-empty array" });
+
+  const objects = [...new Set(keys)].map((Key) => ({ Key }));
+
+  try {
+    const result = await s3.send(
+      new DeleteObjectsCommand({
+        Bucket: FILE_BUCKET,
+        Delete: { Objects: objects },
+      }),
+    );
+
+    const deleted = (result.Deleted || []).map((item) => item.Key).filter(Boolean);
+    const errors = (result.Errors || []).map((err) => ({
+      key: err.Key,
+      code: err.Code,
+      message: err.Message,
+    }));
+
+    return json(200, C, {
+      ok: errors.length === 0,
+      projectId,
+      deleted,
+      errors,
+    });
+  } catch (err) {
+    console.error("delete_project_files_error", { projectId, keys, err });
+    const message = err?.message || "Failed to delete files";
+    return json(500, C, { error: message });
+  }
+};
+
 // Back-compat timeline shims
 const getTimeline = (e, C, g) => {
   const e2 = { ...e, queryStringParameters: { ...(Q(e) || {}), view: "timeline" } };
@@ -983,6 +1024,9 @@ const routes = [
   { m: "GET",    r: /^\/projects\/(?<projectId>[^/]+)\/tasks\/(?<taskId>[^/]+)$/i,              h: getTask },
   { m: "PATCH",  r: /^\/projects\/(?<projectId>[^/]+)\/tasks\/(?<taskId>[^/]+)$/i,              h: patchTask },
   { m: "DELETE", r: /^\/projects\/(?<projectId>[^/]+)\/tasks\/(?<taskId>[^/]+)$/i,              h: deleteTask },
+
+  // Files
+  { m: "POST",   r: /^\/projects\/(?<projectId>[^/]+)\/files\/delete$/i,                       h: deleteProjectFiles },
 
   // Events (unified)
   { m: "GET",    r: /^\/projects\/(?<projectId>[^/]+)\/events$/i,                               h: listEvents },

--- a/backend/projects/serverless.yml
+++ b/backend/projects/serverless.yml
@@ -73,6 +73,12 @@ provider:
             - arn:aws:dynamodb:${aws:region}:${aws:accountId}:table/${env:GALLERIES_TABLE}
             - arn:aws:dynamodb:${aws:region}:${aws:accountId}:table/${env:GALLERIES_TABLE}/index/*
 
+        - Effect: Allow
+          Action:
+            - s3:DeleteObject
+          Resource:
+            - arn:aws:s3:::${env:FILE_BUCKET}/*
+
 functions:
   projectsRouter:
     name: ${self:custom.app}-${self:custom.ver}-projects-router-${sls:stage}
@@ -116,6 +122,11 @@ functions:
       - httpApi:
           path: /projects/{proxy+}
           method: DELETE
+          authorizer:
+            name: jwtAuthorizer
+      - httpApi:
+          path: /projects/{projectId}/files/delete
+          method: POST
           authorizer:
             name: jwtAuthorizer
       - httpApi:

--- a/backend/serverless.common.yml
+++ b/backend/serverless.common.yml
@@ -42,6 +42,7 @@ env:
   # ---- Galleries / uploads
   GALLERIES_TABLE: Galleries
   GALLERIES_PROJECT_GSI: projectId-index
+  FILE_BUCKET: mylg-files-v12
 
   # ---- WebSocket
   CONNECTIONS_TABLE: Connections

--- a/frontend/src/dashboard/features/messages/ProjectMessagesThread.tsx
+++ b/frontend/src/dashboard/features/messages/ProjectMessagesThread.tsx
@@ -42,11 +42,11 @@ import PromptModal from "../../../shared/ui/PromptModal";
 import PDFPreview from "@/dashboard/project/components/Shared/PDFPreview";
 import {
   GET_PROJECT_MESSAGES_URL,
-  DELETE_FILE_FROM_S3_URL,
   apiFetch,
   getFileUrl,
   normalizeFileUrl,
   fileUrlsToKeys,
+  projectFileDeleteUrl,
 } from "../../../shared/utils/api";
 import { getFileNameFromUrl } from "../../../shared/utils/fileUtils";
 
@@ -96,7 +96,7 @@ type GetProjectMessagesResponse =
   | { Items?: Message[] }
   | Message[];
 
-type DeleteS3FilesResponse = { ok?: boolean; [k: string]: unknown };
+type DeleteProjectFilesResponse = { ok?: boolean; deleted?: string[]; errors?: unknown };
 
 type ProjectMessagesMap = Record<string, Message[]>;
 
@@ -757,13 +757,11 @@ const ProjectMessagesThread: React.FC<ProjectMessagesThreadProps> = ({
           .filter(Boolean) ?? []),
         ...(message.file?.url ? fileUrlsToKeys([message.file.url]) : []),
       ];
-      if (fileKeys.length) {
-        await apiFetch<DeleteS3FilesResponse>(DELETE_FILE_FROM_S3_URL, {
+      if (fileKeys.length && projectId) {
+        await apiFetch<DeleteProjectFilesResponse>(projectFileDeleteUrl(projectId), {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
-            projectId,
-            field: folderKey,
             fileKeys,
           }),
         });

--- a/frontend/src/dashboard/project/components/FileManager/FileManager.test.tsx
+++ b/frontend/src/dashboard/project/components/FileManager/FileManager.test.tsx
@@ -75,13 +75,13 @@ vi.mock("@/shared/utils/api", () => {
   return {
     API_BASE_URL: "base",
     ZIP_FILES_URL: "zip",
-    DELETE_FILE_FROM_S3_URL: "delete",
     DELETE_PROJECT_MESSAGE_URL: "delMsg",
     GET_PROJECT_MESSAGES_URL: "getMsgs",
     EDIT_MESSAGE_URL: "editMsg",
     getFileUrl: buildUrl,
     normalizeFileUrl: (u: string) => buildUrl(u),
     fileUrlsToKeys: (urls: string[]) => urls.map(toKey),
+    projectFileDeleteUrl: (projectId: string) => `delete/${projectId}`,
     apiFetch: vi.fn(() =>
       Promise.resolve({ ok: true, json: vi.fn().mockResolvedValue([]) })
     ),
@@ -151,7 +151,9 @@ test.skip("deleting a file via toast confirmation updates the list without closi
   });
 
   expect(screen.getByRole("dialog")).toBeInTheDocument();
-  expect(apiFetchMock.mock.calls.some((call) => call[0] === "delete")).toBe(true);
+  expect(
+    apiFetchMock.mock.calls.some((call) => typeof call[0] === "string" && call[0].startsWith("delete/"))
+  ).toBe(true);
 });
 
 test("sorts files by selected option including kind", async () => {

--- a/frontend/src/dashboard/project/components/Shared/hooks/useFileTransfers.ts
+++ b/frontend/src/dashboard/project/components/Shared/hooks/useFileTransfers.ts
@@ -3,12 +3,12 @@ import type React from "react";
 import { uploadData, list } from "aws-amplify/storage";
 import {
   API_BASE_URL,
-  DELETE_FILE_FROM_S3_URL,
   ZIP_FILES_URL,
   apiFetch,
   fileUrlsToKeys,
   getFileUrl,
   normalizeFileUrl,
+  projectFileDeleteUrl,
 } from "../../../../../shared/utils/api";
 import { notify, notifyLoading, updateNotification } from "../../../../../shared/ui/ToastNotifications";
 import pLimit from "../../../../../shared/utils/pLimit";
@@ -325,18 +325,18 @@ export const useFileTransfers = ({
     const fileUrlsToDelete = Array.from(selectedItems);
     if (!fileUrlsToDelete.length) return;
     const fileKeysToDelete = fileUrlsToKeys(fileUrlsToDelete);
+    if (!activeProject?.projectId) return;
+    const { projectId } = activeProject;
     setIsConfirmingDelete(false);
 
-    const messages = projectMessages[activeProject.projectId as string] || [];
+    const messages = projectMessages[projectId] || [];
     await removeReferences(fileUrlsToDelete, messages);
 
     const notificationId = notifyLoading("Deleting files...");
     try {
-      await apiFetch(DELETE_FILE_FROM_S3_URL, {
+      await apiFetch(projectFileDeleteUrl(projectId), {
         method: "POST",
         body: JSON.stringify({
-          projectId: activeProject.projectId,
-          field: folderKey,
           fileKeys: fileKeysToDelete,
         }),
         headers: { "Content-Type": "application/json" },

--- a/frontend/src/dashboard/project/features/budget/components/InvoicePreviewModal.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/InvoicePreviewModal.tsx
@@ -23,10 +23,10 @@ import { uploadData, list } from "aws-amplify/storage";
 import {
   updateUserProfile,
   S3_PUBLIC_BASE,
-  DELETE_FILE_FROM_S3_URL,
   apiFetch,
   fileUrlsToKeys,
   getFileUrl,
+  projectFileDeleteUrl,
 } from "@/shared/utils/api";
 import { v4 as uuid } from "uuid";
 import { useData } from "@/app/contexts/useData";
@@ -249,15 +249,14 @@ const InvoicePreviewModal: React.FC<InvoicePreviewModalProps> = ({
     const fileUrls = Array.from(selectedInvoices);
     const fileKeys = fileUrlsToKeys(fileUrls);
     if (!fileKeys.length || !project?.projectId) return;
+    const { projectId } = project;
     setIsConfirmingDelete(false);
     const toastId = toast.loading("Deleting invoices...");
     try {
-      await apiFetch(DELETE_FILE_FROM_S3_URL, {
+      await apiFetch(projectFileDeleteUrl(projectId), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          projectId: project.projectId,
-          field: "invoices",
           fileKeys,
         }),
       });

--- a/frontend/src/shared/utils/api.ts
+++ b/frontend/src/shared/utils/api.ts
@@ -256,7 +256,6 @@ const BASE_ENDPOINTS = {
     
     // Legacy endpoints that may need special handling or removal
     NEWSLETTER_SUBSCRIBE_URL: 'https://jmmn5p5yhe.execute-api.us-west-1.amazonaws.com/default/notifyNewSubscriber',
-    DELETE_FILE_FROM_S3_URL: 'https://k6utve4soj.execute-api.us-west-1.amazonaws.com/default/DeleteFilesFromS3',
     ZIP_FILES_URL: 'https://o01t8q8mjk.execute-api.us-west-1.amazonaws.com/default/zipFiles',
   },
   staging: {},
@@ -290,7 +289,6 @@ export const {
   NEWSLETTER_SUBSCRIBE_URL,
   MESSAGES_INBOX_URL,
   MESSAGES_THREADS_URL,
-  DELETE_FILE_FROM_S3_URL,
   ZIP_FILES_URL,
   DELETE_PROJECT_MESSAGE_URL,
   GET_PROJECT_MESSAGES_URL,
@@ -314,6 +312,13 @@ export const {
   USER_INVITES_URL,
   TASKS_API_URL,
 } = API_ENDPOINTS as Record<string, string>;
+
+/**
+ * POST /projects/{projectId}/files/delete
+ * Removes one or more project files via the v1.2 projects service.
+ */
+export const projectFileDeleteUrl = (projectId: string): string =>
+  `${PROJECTS_URL}/${projectId}/files/delete`;
 
 // ───────────────────────────────────────────────────────────────────────────────
 // Helpers


### PR DESCRIPTION
## Summary
- add a POST /projects/{projectId}/files/delete handler in the projects router that deletes S3 objects via DeleteObjects
- expose the new route through serverless with the necessary S3 DeleteObject permission and document it in the backend README
- update frontend utilities and call sites to use the new endpoint instead of the legacy DeleteFilesFromS3 lambda and adjust related tests

## Testing
- npm run test -- FileManager.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68ce17cf049c8324abde2cc57486c43a