### PR TITLE
Replace calendar dots with event pill

### DIFF
--- a/frontend/src/dashboard/project/components/Shared/CalendarOverviewCard.tsx
+++ b/frontend/src/dashboard/project/components/Shared/CalendarOverviewCard.tsx
@@ -17,6 +17,7 @@ import { useData } from "../../../../app/contexts/useData";
 import { useSocket } from "../../../../app/contexts/useSocket";
 import { normalizeMessage } from "../../../../shared/utils/websocketUtils";
 import { getColor, withAlpha } from "../../../../shared/utils/colorUtils";
+import EventPill from "./EventPill";
 import { startOfWeek, endOfWeek, addDays, rangePct } from "@/dashboard/home/utils/dateUtils";
 import { createBudgetItem, updateBudgetItem, createEvent as createEventApi, updateEvent as updateEventApi, deleteEvent as deleteEventApi } from "../../../../shared/utils/api";
 import { slugify } from "../../../../shared/utils/slug";
@@ -107,11 +108,6 @@ const UNIT_OPTIONS = [
   "SQFT",
   "KG",
 ] as const;
-
-const DOT_SIZE = 10;
-const DOT_STROKE = 2;
-const DOT_MAX_VISIBLE = 4;
-const DOT_OVERLAP_PX = 3;
 
 const MOBILE_QUERY = "(max-width: 640px)";
 const POPPER_GAP = 12;
@@ -237,6 +233,7 @@ interface CalendarDayButtonProps {
   isFlashing: boolean;
   inRange: boolean;
   hasEvents: boolean;
+  hasBadge?: boolean;
   label: string;
   onOpen: (anchor: HTMLButtonElement, meta: { date: Date; dayKey: string; inMonth: boolean }) => void;
   onMouseEnter?: () => void;
@@ -256,6 +253,7 @@ const CalendarDayButton = React.forwardRef<HTMLButtonElement, CalendarDayButtonP
       isFlashing,
       inRange,
       hasEvents,
+      hasBadge,
       label,
       onOpen,
       onMouseEnter,
@@ -272,6 +270,7 @@ const CalendarDayButton = React.forwardRef<HTMLButtonElement, CalendarDayButtonP
       isSelected ? "selected" : "",
       isFlashing ? "tile-highlight" : "",
       inRange ? "in-range" : "",
+      hasBadge ? "has-badge" : "",
     ]
       .filter(Boolean)
       .join(" ");
@@ -1599,7 +1598,7 @@ const CalendarOverviewCard: React.FC<CalendarOverviewCardProps> = ({
 
                   {week.map(({ date, key, inMonth }) => {
                     const dayEvents = eventsByDate[key] || [];
-                    const dayDots = dayEvents.map((e, idx) => project?.color || getColor(e.description || String(idx)));
+                    const eventCount = dayEvents.length;
                     const isSelected = selectedKey === key;
                     const isToday = todayKey === key;
                     const isFlashing = flashKey === key;
@@ -1628,7 +1627,8 @@ const CalendarOverviewCard: React.FC<CalendarOverviewCardProps> = ({
                           isToday={isToday}
                           isFlashing={isFlashing}
                           inRange={inRange}
-                          hasEvents={dayEvents.length > 0}
+                          hasEvents={eventCount > 0}
+                          hasBadge={eventCount > 0}
                           label={`Events on ${label}`}
                           onOpen={handleDayOpen}
                           onMouseEnter={!isMobile ? () => queueHover(date) : undefined}
@@ -1637,29 +1637,7 @@ const CalendarOverviewCard: React.FC<CalendarOverviewCardProps> = ({
                         >
                           <div className="tile-date-number">{date.getDate()}</div>
 
-                          <div className="day-dots">
-                            {dayDots.slice(0, DOT_MAX_VISIBLE).map((color, idx) => (
-                              <svg
-                                key={`${key}-dot-${idx}`}
-                                width={DOT_SIZE}
-                                height={DOT_SIZE}
-                                viewBox="0 0 24 24"
-                                style={{
-                                  marginLeft: idx ? -DOT_OVERLAP_PX : 0,
-                                  filter: "drop-shadow(0 1px 1px rgba(0,0,0,.45))",
-                                  zIndex: 20 - idx,
-                                }}
-                                aria-hidden
-                              >
-                                <circle cx="12" cy="12" r="10" fill="rgba(0,0,0,0.65)" />
-                                <circle cx="12" cy="12" r={10 - DOT_STROKE} fill="none" stroke={color} strokeWidth={DOT_STROKE} />
-                                <path d="M12 7v5l3 2" stroke={color} strokeWidth={DOT_STROKE} fill="none" strokeLinecap="round" />
-                              </svg>
-                            ))}
-                            {dayDots.length > DOT_MAX_VISIBLE && (
-                              <span className="day-dot-more">+{dayDots.length - DOT_MAX_VISIBLE}</span>
-                            )}
-                          </div>
+                          <EventPill count={eventCount} color={projectColor} />
 
                           {isHovered && dayEvents.length > 0 && (
                             <div className="tile-tooltip visible">

--- a/frontend/src/dashboard/project/components/Shared/EventPill.tsx
+++ b/frontend/src/dashboard/project/components/Shared/EventPill.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faClock } from "@fortawesome/free-solid-svg-icons";
+import { withAlpha } from "@/shared/utils/colorUtils";
+
+type EventPillProps = {
+  count?: number;
+  color?: string;
+  className?: string;
+};
+
+function isHexColor(value: string) {
+  return /^#([A-Fa-f0-9]{3}|[A-Fa-f0-9]{6}|[A-Fa-f0-9]{8})$/.test(value.trim());
+}
+
+const DEFAULT_COLOR = "#FA3356";
+
+const EventPill: React.FC<EventPillProps> = ({ count = 0, color, className }) => {
+  if (!count || count <= 0) {
+    return null;
+  }
+
+  const trimmed = color?.trim();
+  const baseColor = trimmed && trimmed.length > 0 ? trimmed : DEFAULT_COLOR;
+  const fillColor = isHexColor(baseColor) ? withAlpha(baseColor, 0.1) : "rgba(255, 255, 255, 0.08)";
+
+  const label = `${count} event${count === 1 ? "" : "s"}`;
+
+  return (
+    <span
+      className={["event-pill", className].filter(Boolean).join(" ")}
+      style={{
+        color: baseColor,
+        backgroundColor: fillColor,
+        borderColor: baseColor,
+      }}
+      aria-label={label}
+    >
+      <FontAwesomeIcon icon={faClock} aria-hidden className="event-pill__icon" />
+      <span className="event-pill__count">{count}</span>
+    </span>
+  );
+};
+
+export default EventPill;

--- a/frontend/src/dashboard/project/components/Shared/calendar-overview-card.css
+++ b/frontend/src/dashboard/project/components/Shared/calendar-overview-card.css
@@ -529,15 +529,29 @@
 .calendar-overview-card-wrapper .calendar-day--muted {
   opacity: 0.5;
 }
-.calendar-overview-card-wrapper .day-dots {
+.calendar-overview-card-wrapper .calendar-day.has-badge {
+  padding-right: 18px;
+}
+.calendar-overview-card-wrapper .event-pill {
   position: absolute;
-  left: 0;
-  right: 0;
+  right: 6px;
   bottom: 6px;
-  display: flex;
-  justify-content: center;
+  display: inline-flex;
   align-items: center;
   gap: 4px;
+  padding: 2px 6px;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  font-size: 0.65rem;
+  font-weight: 600;
+  line-height: 1;
+  background: transparent;
+}
+.calendar-overview-card-wrapper .event-pill__icon {
+  font-size: 0.7rem;
+}
+.calendar-overview-card-wrapper .event-pill__count {
+  line-height: 1;
 }
 
 
@@ -572,7 +586,7 @@
     min-height: 56px;
     padding: 6px 10px 12px;
   }
-  .calendar-overview-card-wrapper .day-dots {
+  .calendar-overview-card-wrapper .event-pill {
     bottom: 5px;
   }
   .calendar-overview-card-wrapper .tile-date-number {

--- a/frontend/src/dashboard/project/features/calendar/ProjectCalendar.tsx
+++ b/frontend/src/dashboard/project/features/calendar/ProjectCalendar.tsx
@@ -17,6 +17,7 @@ import { useData } from "../../../../app/contexts/useData";
 import { useSocket } from "../../../../app/contexts/useSocket";
 import { normalizeMessage } from "../../../../shared/utils/websocketUtils";
 import { getColor } from "../../../../shared/utils/colorUtils";
+import EventPill from "../../components/Shared/EventPill";
 import { startOfWeek, endOfWeek, addDays, rangePct } from "@/dashboard/home/utils/dateUtils";
 import { createBudgetItem, updateBudgetItem, createEvent as createEventApi, updateEvent as updateEventApi, deleteEvent as deleteEventApi } from "../../../../shared/utils/api";
 import { slugify } from "../../../../shared/utils/slug";
@@ -106,11 +107,6 @@ const UNIT_OPTIONS = [
   "SQFT",
   "KG",
 ] as const;
-
-const DOT_SIZE = 10;
-const DOT_STROKE = 2;
-const DOT_MAX_VISIBLE = 4;
-const DOT_OVERLAP_PX = 3;
 
 const MOBILE_QUERY = "(max-width: 640px)";
 const POPPER_GAP = 12;
@@ -236,6 +232,7 @@ interface CalendarDayButtonProps {
   isFlashing: boolean;
   inRange: boolean;
   hasEvents: boolean;
+  hasBadge?: boolean;
   label: string;
   onOpen: (anchor: HTMLButtonElement, meta: { date: Date; dayKey: string; inMonth: boolean }) => void;
   onMouseEnter?: () => void;
@@ -254,6 +251,7 @@ const CalendarDayButton = React.forwardRef<HTMLButtonElement, CalendarDayButtonP
       isFlashing,
       inRange,
       hasEvents,
+      hasBadge,
       label,
       onOpen,
       onMouseEnter,
@@ -269,6 +267,7 @@ const CalendarDayButton = React.forwardRef<HTMLButtonElement, CalendarDayButtonP
       isSelected ? "selected" : "",
       isFlashing ? "tile-highlight" : "",
       inRange ? "in-range" : "",
+      hasBadge ? "has-badge" : "",
     ]
       .filter(Boolean)
       .join(" ");
@@ -1523,7 +1522,7 @@ const ProjectCalendar: React.FC<ProjectCalendarProps> = ({
 
                   {week.map(({ date, key, inMonth }) => {
                     const dayEvents = eventsByDate[key] || [];
-                    const dayDots = dayEvents.map((e, idx) => project?.color || getColor(e.description || String(idx)));
+                    const eventCount = dayEvents.length;
                     const isSelected = selectedKey === key;
                     const isToday = todayKey === key;
                     const isFlashing = flashKey === key;
@@ -1545,7 +1544,8 @@ const ProjectCalendar: React.FC<ProjectCalendarProps> = ({
                           isToday={isToday}
                           isFlashing={isFlashing}
                           inRange={inRange}
-                          hasEvents={dayEvents.length > 0}
+                          hasEvents={eventCount > 0}
+                          hasBadge={eventCount > 0}
                           label={`Events on ${label}`}
                           onOpen={handleDayOpen}
                           onMouseEnter={!isMobile ? () => queueHover(date) : undefined}
@@ -1553,29 +1553,7 @@ const ProjectCalendar: React.FC<ProjectCalendarProps> = ({
                         >
                           <div className="tile-date-number">{date.getDate()}</div>
 
-                          <div className="day-dots">
-                            {dayDots.slice(0, DOT_MAX_VISIBLE).map((color, idx) => (
-                              <svg
-                                key={`${key}-dot-${idx}`}
-                                width={DOT_SIZE}
-                                height={DOT_SIZE}
-                                viewBox="0 0 24 24"
-                                style={{
-                                  marginLeft: idx ? -DOT_OVERLAP_PX : 0,
-                                  filter: "drop-shadow(0 1px 1px rgba(0,0,0,.45))",
-                                  zIndex: 20 - idx,
-                                }}
-                                aria-hidden
-                              >
-                                <circle cx="12" cy="12" r="10" fill="rgba(0,0,0,0.65)" />
-                                <circle cx="12" cy="12" r={10 - DOT_STROKE} fill="none" stroke={color} strokeWidth={DOT_STROKE} />
-                                <path d="M12 7v5l3 2" stroke={color} strokeWidth={DOT_STROKE} fill="none" strokeLinecap="round" />
-                              </svg>
-                            ))}
-                            {dayDots.length > DOT_MAX_VISIBLE && (
-                              <span className="day-dot-more">+{dayDots.length - DOT_MAX_VISIBLE}</span>
-                            )}
-                          </div>
+                          <EventPill count={eventCount} color={projectColor} />
 
                           {isHovered && dayEvents.length > 0 && (
                             <div className="tile-tooltip visible">

--- a/frontend/src/dashboard/project/features/calendar/project-calendar.css
+++ b/frontend/src/dashboard/project/features/calendar/project-calendar.css
@@ -446,15 +446,32 @@
   color: #ffffff;
 }
 
-.project-calendar-wrapper .day-dots {
+.project-calendar-wrapper .calendar-day.has-badge {
+  padding-right: 18px;
+}
+
+.project-calendar-wrapper .event-pill {
   position: absolute;
-  left: 0;
-  right: 0;
+  right: 6px;
   bottom: 6px;
-  display: flex;
-  justify-content: center;
+  display: inline-flex;
   align-items: center;
   gap: 4px;
+  padding: 2px 6px;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  font-size: 0.65rem;
+  font-weight: 600;
+  line-height: 1;
+  background: transparent;
+}
+
+.project-calendar-wrapper .event-pill__icon {
+  font-size: 0.7rem;
+}
+
+.project-calendar-wrapper .event-pill__count {
+  line-height: 1;
 }
 
 
@@ -485,7 +502,7 @@
     min-height: 56px;
     padding: 6px 10px 12px;
   }
-  .project-calendar-wrapper .day-dots {
+  .project-calendar-wrapper .event-pill {
     bottom: 5px;
   }
   .project-calendar-wrapper .tile-date-number {


### PR DESCRIPTION
## Summary
- add a shared EventPill component to render a count badge inside calendar tiles
- switch project calendar and overview card tiles to use the new pill indicator and badge-aware button styling
- update calendar styles so tiles with pills add right padding and position the pill at the bottom-right

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce59a7b9bc8324aa43d259afb73f5e