### PR TITLE
Replace calendar dots with event pill badge

### DIFF
--- a/frontend/src/dashboard/project/components/Shared/CalendarOverviewCard.tsx
+++ b/frontend/src/dashboard/project/components/Shared/CalendarOverviewCard.tsx
@@ -31,6 +31,7 @@ import {
 // Frontend no longer persists timeline events directly; backend handles persistence
 import { useBudget } from "@/dashboard/project/features/budget/context/BudgetContext";
 import { notify } from "@/shared/ui/ToastNotifications";
+import EventPill from "./EventPill";
 
 type TimelineEvent = {
   id: string;
@@ -107,11 +108,6 @@ const UNIT_OPTIONS = [
   "SQFT",
   "KG",
 ] as const;
-
-const DOT_SIZE = 10;
-const DOT_STROKE = 2;
-const DOT_MAX_VISIBLE = 4;
-const DOT_OVERLAP_PX = 3;
 
 const MOBILE_QUERY = "(max-width: 640px)";
 const POPPER_GAP = 12;
@@ -272,6 +268,7 @@ const CalendarDayButton = React.forwardRef<HTMLButtonElement, CalendarDayButtonP
       isSelected ? "selected" : "",
       isFlashing ? "tile-highlight" : "",
       inRange ? "in-range" : "",
+      hasEvents ? "has-badge" : "",
     ]
       .filter(Boolean)
       .join(" ");
@@ -1599,7 +1596,6 @@ const CalendarOverviewCard: React.FC<CalendarOverviewCardProps> = ({
 
                   {week.map(({ date, key, inMonth }) => {
                     const dayEvents = eventsByDate[key] || [];
-                    const dayDots = dayEvents.map((e, idx) => project?.color || getColor(e.description || String(idx)));
                     const isSelected = selectedKey === key;
                     const isToday = todayKey === key;
                     const isFlashing = flashKey === key;
@@ -1609,6 +1605,7 @@ const CalendarOverviewCard: React.FC<CalendarOverviewCardProps> = ({
                       (sum, ev) => sum + Number(ev.hours || 0),
                       0
                     );
+                    const eventCount = dayEvents.length;
                     const label = formatDateLabel(date);
                     const dayStyle = isSelected
                       ? ({
@@ -1637,29 +1634,7 @@ const CalendarOverviewCard: React.FC<CalendarOverviewCardProps> = ({
                         >
                           <div className="tile-date-number">{date.getDate()}</div>
 
-                          <div className="day-dots">
-                            {dayDots.slice(0, DOT_MAX_VISIBLE).map((color, idx) => (
-                              <svg
-                                key={`${key}-dot-${idx}`}
-                                width={DOT_SIZE}
-                                height={DOT_SIZE}
-                                viewBox="0 0 24 24"
-                                style={{
-                                  marginLeft: idx ? -DOT_OVERLAP_PX : 0,
-                                  filter: "drop-shadow(0 1px 1px rgba(0,0,0,.45))",
-                                  zIndex: 20 - idx,
-                                }}
-                                aria-hidden
-                              >
-                                <circle cx="12" cy="12" r="10" fill="rgba(0,0,0,0.65)" />
-                                <circle cx="12" cy="12" r={10 - DOT_STROKE} fill="none" stroke={color} strokeWidth={DOT_STROKE} />
-                                <path d="M12 7v5l3 2" stroke={color} strokeWidth={DOT_STROKE} fill="none" strokeLinecap="round" />
-                              </svg>
-                            ))}
-                            {dayDots.length > DOT_MAX_VISIBLE && (
-                              <span className="day-dot-more">+{dayDots.length - DOT_MAX_VISIBLE}</span>
-                            )}
-                          </div>
+                          <EventPill count={eventCount} color={project?.color} />
 
                           {isHovered && dayEvents.length > 0 && (
                             <div className="tile-tooltip visible">

--- a/frontend/src/dashboard/project/components/Shared/EventPill.tsx
+++ b/frontend/src/dashboard/project/components/Shared/EventPill.tsx
@@ -1,0 +1,75 @@
+import React from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faClock } from "@fortawesome/free-solid-svg-icons";
+
+interface EventPillProps {
+  count?: number;
+  color?: string;
+  className?: string;
+}
+
+function toAlphaColor(color: string | undefined, alpha: number): string {
+  if (!color) {
+    return `rgba(250, 51, 86, ${alpha})`;
+  }
+
+  const trimmed = color.trim();
+
+  if (trimmed.startsWith("#")) {
+    let hex = trimmed.slice(1);
+    if (hex.length === 3) {
+      hex = hex
+        .split("")
+        .map((char) => char + char)
+        .join("");
+    }
+    if (/^[0-9a-fA-F]{6}$/.test(hex)) {
+      const r = parseInt(hex.slice(0, 2), 16);
+      const g = parseInt(hex.slice(2, 4), 16);
+      const b = parseInt(hex.slice(4, 6), 16);
+      return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+    }
+  }
+
+  const rgbMatch = trimmed.match(/^rgba?\(([^)]+)\)$/i);
+  if (rgbMatch) {
+    const parts = rgbMatch[1]
+      .split(",")
+      .slice(0, 3)
+      .map((part) => Number(part.trim()));
+
+    if (parts.every((value) => Number.isFinite(value))) {
+      const [r, g, b] = parts;
+      return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+    }
+  }
+
+  return `rgba(250, 51, 86, ${alpha})`;
+}
+
+const EventPill: React.FC<EventPillProps> = ({ count = 0, color, className }) => {
+  if (!count || count <= 0) {
+    return null;
+  }
+
+  const tone = color && color.trim() ? color : "#FA3356";
+  const fillColor = toAlphaColor(tone, 0.1);
+  const pillClass = ["event-pill", className].filter(Boolean).join(" ");
+
+  return (
+    <div
+      className={pillClass}
+      style={{
+        color: tone,
+        borderColor: tone,
+        backgroundColor: fillColor,
+      }}
+      aria-label={`${count} event${count === 1 ? "" : "s"}`}
+    >
+      <FontAwesomeIcon icon={faClock} aria-hidden />
+      <span className="event-pill-count">{count}</span>
+    </div>
+  );
+};
+
+export default EventPill;

--- a/frontend/src/dashboard/project/components/Shared/calendar-overview-card.css
+++ b/frontend/src/dashboard/project/components/Shared/calendar-overview-card.css
@@ -496,6 +496,9 @@
   outline: none;
   appearance: none;
 }
+.calendar-overview-card-wrapper .calendar-day.has-badge {
+  padding-right: 18px;
+}
 .calendar-overview-card-wrapper .calendar-day:hover {
   background: rgba(255, 255, 255, 0.05);
   border-color: rgba(255, 255, 255, 0.14);
@@ -540,6 +543,32 @@
   gap: 4px;
 }
 
+.calendar-overview-card-wrapper .event-pill {
+  position: absolute;
+  right: 8px;
+  bottom: 6px;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 6px;
+  border-radius: 999px;
+  font-size: 0.65rem;
+  font-weight: 600;
+  line-height: 1;
+  border-width: 1px;
+  border-style: solid;
+  pointer-events: none;
+}
+
+.calendar-overview-card-wrapper .event-pill svg {
+  font-size: 0.6rem;
+}
+
+.calendar-overview-card-wrapper .event-pill-count {
+  display: inline-block;
+  font-variant-numeric: tabular-nums;
+}
+
 
 /* Contiguous capsule behind a week row */
 .calendar-overview-card-wrapper .calendar-week-track {
@@ -574,6 +603,12 @@
   }
   .calendar-overview-card-wrapper .day-dots {
     bottom: 5px;
+  }
+  .calendar-overview-card-wrapper .event-pill {
+    bottom: 5px;
+    right: 6px;
+    font-size: 0.6rem;
+    padding: 2px 5px;
   }
   .calendar-overview-card-wrapper .tile-date-number {
     font-size: 0.85rem;

--- a/frontend/src/dashboard/project/features/calendar/ProjectCalendar.tsx
+++ b/frontend/src/dashboard/project/features/calendar/ProjectCalendar.tsx
@@ -31,6 +31,7 @@ import {
 // Frontend no longer persists timeline events directly; backend handles persistence
 import { useBudget } from "@/dashboard/project/features/budget/context/BudgetContext";
 import { notify } from "@/shared/ui/ToastNotifications";
+import EventPill from "../../components/Shared/EventPill";
 
 type TimelineEvent = {
   id: string;
@@ -106,11 +107,6 @@ const UNIT_OPTIONS = [
   "SQFT",
   "KG",
 ] as const;
-
-const DOT_SIZE = 10;
-const DOT_STROKE = 2;
-const DOT_MAX_VISIBLE = 4;
-const DOT_OVERLAP_PX = 3;
 
 const MOBILE_QUERY = "(max-width: 640px)";
 const POPPER_GAP = 12;
@@ -269,6 +265,7 @@ const CalendarDayButton = React.forwardRef<HTMLButtonElement, CalendarDayButtonP
       isSelected ? "selected" : "",
       isFlashing ? "tile-highlight" : "",
       inRange ? "in-range" : "",
+      hasEvents ? "has-badge" : "",
     ]
       .filter(Boolean)
       .join(" ");
@@ -1523,7 +1520,6 @@ const ProjectCalendar: React.FC<ProjectCalendarProps> = ({
 
                   {week.map(({ date, key, inMonth }) => {
                     const dayEvents = eventsByDate[key] || [];
-                    const dayDots = dayEvents.map((e, idx) => project?.color || getColor(e.description || String(idx)));
                     const isSelected = selectedKey === key;
                     const isToday = todayKey === key;
                     const isFlashing = flashKey === key;
@@ -1533,6 +1529,7 @@ const ProjectCalendar: React.FC<ProjectCalendarProps> = ({
                       (sum, ev) => sum + Number(ev.hours || 0),
                       0
                     );
+                    const eventCount = dayEvents.length;
                     const label = formatDateLabel(date);
 
                     return (
@@ -1553,29 +1550,7 @@ const ProjectCalendar: React.FC<ProjectCalendarProps> = ({
                         >
                           <div className="tile-date-number">{date.getDate()}</div>
 
-                          <div className="day-dots">
-                            {dayDots.slice(0, DOT_MAX_VISIBLE).map((color, idx) => (
-                              <svg
-                                key={`${key}-dot-${idx}`}
-                                width={DOT_SIZE}
-                                height={DOT_SIZE}
-                                viewBox="0 0 24 24"
-                                style={{
-                                  marginLeft: idx ? -DOT_OVERLAP_PX : 0,
-                                  filter: "drop-shadow(0 1px 1px rgba(0,0,0,.45))",
-                                  zIndex: 20 - idx,
-                                }}
-                                aria-hidden
-                              >
-                                <circle cx="12" cy="12" r="10" fill="rgba(0,0,0,0.65)" />
-                                <circle cx="12" cy="12" r={10 - DOT_STROKE} fill="none" stroke={color} strokeWidth={DOT_STROKE} />
-                                <path d="M12 7v5l3 2" stroke={color} strokeWidth={DOT_STROKE} fill="none" strokeLinecap="round" />
-                              </svg>
-                            ))}
-                            {dayDots.length > DOT_MAX_VISIBLE && (
-                              <span className="day-dot-more">+{dayDots.length - DOT_MAX_VISIBLE}</span>
-                            )}
-                          </div>
+                          <EventPill count={eventCount} color={project?.color} />
 
                           {isHovered && dayEvents.length > 0 && (
                             <div className="tile-tooltip visible">

--- a/frontend/src/dashboard/project/features/calendar/project-calendar.css
+++ b/frontend/src/dashboard/project/features/calendar/project-calendar.css
@@ -419,6 +419,9 @@
   outline: none;
   appearance: none;
 }
+.project-calendar-wrapper .calendar-day.has-badge {
+  padding-right: 18px;
+}
 .project-calendar-wrapper .calendar-day:hover {
   background: rgba(255, 255, 255, 0.05);
   border-color: rgba(255, 255, 255, 0.14);
@@ -457,6 +460,32 @@
   gap: 4px;
 }
 
+.project-calendar-wrapper .event-pill {
+  position: absolute;
+  right: 8px;
+  bottom: 6px;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 6px;
+  border-radius: 999px;
+  font-size: 0.65rem;
+  font-weight: 600;
+  line-height: 1;
+  border-width: 1px;
+  border-style: solid;
+  pointer-events: none;
+}
+
+.project-calendar-wrapper .event-pill svg {
+  font-size: 0.6rem;
+}
+
+.project-calendar-wrapper .event-pill-count {
+  display: inline-block;
+  font-variant-numeric: tabular-nums;
+}
+
 
 .project-calendar-wrapper .calendar-week-track {
   position: absolute;
@@ -487,6 +516,12 @@
   }
   .project-calendar-wrapper .day-dots {
     bottom: 5px;
+  }
+  .project-calendar-wrapper .event-pill {
+    bottom: 5px;
+    right: 6px;
+    font-size: 0.6rem;
+    padding: 2px 5px;
   }
   .project-calendar-wrapper .tile-date-number {
     font-size: 0.85rem;


### PR DESCRIPTION
## Summary
- add a reusable `EventPill` component that renders a clock icon badge when events exist for a calendar tile
- update project calendar and overview card tiles to use the pill, including badge-aware button classes
- tweak calendar styles so tiles reserve space for the badge and position the pill in the bottom-right corner

## Testing
- `npm run lint`
- `npm run typecheck` *(fails: existing type errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68ce687a3b488324a735859f11b7c378