### PR TITLE
Replace calendar dots with event pill badge

### DIFF
--- a/frontend/src/dashboard/project/components/Shared/CalendarOverviewCard.tsx
+++ b/frontend/src/dashboard/project/components/Shared/CalendarOverviewCard.tsx
@@ -28,6 +28,7 @@ import {
   faClock,
   faTimes,
 } from "@fortawesome/free-solid-svg-icons";
+import EventPill from "./EventPill";
 // Frontend no longer persists timeline events directly; backend handles persistence
 import { useBudget } from "@/dashboard/project/features/budget/context/BudgetContext";
 import { notify } from "@/shared/ui/ToastNotifications";
@@ -108,11 +109,6 @@ const UNIT_OPTIONS = [
   "KG",
 ] as const;
 
-const DOT_SIZE = 10;
-const DOT_STROKE = 2;
-const DOT_MAX_VISIBLE = 4;
-const DOT_OVERLAP_PX = 3;
-
 const MOBILE_QUERY = "(max-width: 640px)";
 const POPPER_GAP = 12;
 const FOCUSABLE_SELECTOR =
@@ -153,8 +149,6 @@ function getDateKey(date?: Date | null): string | null {
   const d = String(date.getDate()).padStart(2, "0");
   return `${y}-${m}-${d}`;
 }
-
-const fmt = (date: Date): string => getDateKey(date) || "";
 
 function formatDateLabel(date: Date): string {
   return date.toLocaleDateString(undefined, {
@@ -272,6 +266,7 @@ const CalendarDayButton = React.forwardRef<HTMLButtonElement, CalendarDayButtonP
       isSelected ? "selected" : "",
       isFlashing ? "tile-highlight" : "",
       inRange ? "in-range" : "",
+      hasEvents ? "has-badge" : "",
     ]
       .filter(Boolean)
       .join(" ");
@@ -1374,7 +1369,7 @@ const CalendarOverviewCard: React.FC<CalendarOverviewCardProps> = ({
   const handleDayOpen = useCallback(
     (
       anchor: HTMLButtonElement,
-      { date, dayKey, inMonth }: { date: Date; dayKey: string; inMonth: boolean }
+      { date, dayKey }: { date: Date; dayKey: string; inMonth: boolean }
     ) => {
       if (!dayKey) return;
 
@@ -1590,7 +1585,11 @@ const CalendarOverviewCard: React.FC<CalendarOverviewCardProps> = ({
 
                   {week.map(({ date, key, inMonth }) => {
                     const dayEvents = eventsByDate[key] || [];
-                    const dayDots = dayEvents.map((e, idx) => project?.color || getColor(e.description || String(idx)));
+                    const eventCount = dayEvents.length;
+                    const eventColor =
+                      eventCount > 0
+                        ? project?.color || (project?.projectId ? getColor(project.projectId) : undefined)
+                        : undefined;
                     const isSelected = selectedKey === key;
                     const isToday = todayKey === key;
                     const isFlashing = flashKey === key;
@@ -1620,29 +1619,7 @@ const CalendarOverviewCard: React.FC<CalendarOverviewCardProps> = ({
                         >
                           <div className="tile-date-number">{date.getDate()}</div>
 
-                          <div className="day-dots">
-                            {dayDots.slice(0, DOT_MAX_VISIBLE).map((color, idx) => (
-                              <svg
-                                key={`${key}-dot-${idx}`}
-                                width={DOT_SIZE}
-                                height={DOT_SIZE}
-                                viewBox="0 0 24 24"
-                                style={{
-                                  marginLeft: idx ? -DOT_OVERLAP_PX : 0,
-                                  filter: "drop-shadow(0 1px 1px rgba(0,0,0,.45))",
-                                  zIndex: 20 - idx,
-                                }}
-                                aria-hidden
-                              >
-                                <circle cx="12" cy="12" r="10" fill="rgba(0,0,0,0.65)" />
-                                <circle cx="12" cy="12" r={10 - DOT_STROKE} fill="none" stroke={color} strokeWidth={DOT_STROKE} />
-                                <path d="M12 7v5l3 2" stroke={color} strokeWidth={DOT_STROKE} fill="none" strokeLinecap="round" />
-                              </svg>
-                            ))}
-                            {dayDots.length > DOT_MAX_VISIBLE && (
-                              <span className="day-dot-more">+{dayDots.length - DOT_MAX_VISIBLE}</span>
-                            )}
-                          </div>
+                          <EventPill count={eventCount} color={eventColor} className="calendar-event-pill" />
 
                           {isHovered && dayEvents.length > 0 && (
                             <div className="tile-tooltip visible">

--- a/frontend/src/dashboard/project/components/Shared/EventPill.tsx
+++ b/frontend/src/dashboard/project/components/Shared/EventPill.tsx
@@ -1,0 +1,84 @@
+import type { FC } from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faClock } from "@fortawesome/free-solid-svg-icons";
+
+interface EventPillProps {
+  count?: number;
+  color?: string;
+  className?: string;
+}
+
+const DEFAULT_COLOR = "#FA3356";
+const DEFAULT_BACKGROUND = "rgba(250, 51, 86, 0.1)";
+
+function hexToRgb(color: string): { r: number; g: number; b: number } | null {
+  let value = color.trim();
+  if (!value) return null;
+  if (value.startsWith("#")) {
+    value = value.slice(1);
+  }
+  if (value.length === 3) {
+    value = value
+      .split("")
+      .map((ch) => ch + ch)
+      .join("");
+  }
+  if (value.length < 6) return null;
+  const r = parseInt(value.slice(0, 2), 16);
+  const g = parseInt(value.slice(2, 4), 16);
+  const b = parseInt(value.slice(4, 6), 16);
+  if (Number.isNaN(r) || Number.isNaN(g) || Number.isNaN(b)) return null;
+  return { r, g, b };
+}
+
+function toRgba(color?: string, alpha = 0.1): string {
+  if (!color) return DEFAULT_BACKGROUND;
+  const trimmed = color.trim();
+
+  const rgb = hexToRgb(trimmed);
+  if (rgb) {
+    const { r, g, b } = rgb;
+    return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+  }
+
+  const rgbMatch = trimmed.match(/^rgb\s*\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*\)$/i);
+  if (rgbMatch) {
+    const [, r, g, b] = rgbMatch;
+    return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+  }
+
+  const rgbaMatch = trimmed.match(/^rgba\s*\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*([\d.]+)\s*\)$/i);
+  if (rgbaMatch) {
+    const [, r, g, b] = rgbaMatch;
+    return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+  }
+
+  return DEFAULT_BACKGROUND;
+}
+
+const EventPill: FC<EventPillProps> = ({ count = 0, color, className }) => {
+  if (!count || count <= 0) {
+    return null;
+  }
+
+  const baseColor = color?.trim() || DEFAULT_COLOR;
+  const pillClassName = ["event-pill", className].filter(Boolean).join(" ");
+  const backgroundColor = toRgba(baseColor, 0.1);
+  const borderColor = baseColor;
+  const textColor = baseColor;
+  const label = `${count} event${count === 1 ? "" : "s"}`;
+
+  return (
+    <span
+      className={pillClassName}
+      style={{ backgroundColor, borderColor, color: textColor }}
+      aria-label={label}
+      title={label}
+    >
+      <FontAwesomeIcon icon={faClock} className="event-pill-icon" aria-hidden />
+      <span className="event-pill-count">{count}</span>
+    </span>
+  );
+};
+
+export default EventPill;

--- a/frontend/src/dashboard/project/components/Shared/calendar-overview-card.css
+++ b/frontend/src/dashboard/project/components/Shared/calendar-overview-card.css
@@ -522,15 +522,32 @@
   color: #ffffff;
 }
 
-.calendar-overview-card-wrapper .day-dots {
+.calendar-overview-card-wrapper .calendar-day.has-badge {
+  padding-right: 18px;
+}
+
+.calendar-overview-card-wrapper .event-pill {
   position: absolute;
-  left: 0;
-  right: 0;
+  right: 6px;
   bottom: 6px;
-  display: flex;
-  justify-content: center;
+  display: inline-flex;
   align-items: center;
   gap: 4px;
+  padding: 2px 6px;
+  border-radius: 999px;
+  border: 1px solid currentColor;
+  font-size: 0.7rem;
+  font-weight: 600;
+  line-height: 1;
+  pointer-events: none;
+}
+
+.calendar-overview-card-wrapper .event-pill-icon {
+  font-size: 0.65rem;
+}
+
+.calendar-overview-card-wrapper .event-pill-count {
+  line-height: 1;
 }
 
 
@@ -561,8 +578,9 @@
     min-height: 56px;
     padding: 6px 10px 12px;
   }
-  .calendar-overview-card-wrapper .day-dots {
+  .calendar-overview-card-wrapper .event-pill {
     bottom: 5px;
+    right: 6px;
   }
   .calendar-overview-card-wrapper .tile-date-number {
     font-size: 0.85rem;

--- a/frontend/src/dashboard/project/features/calendar/ProjectCalendar.tsx
+++ b/frontend/src/dashboard/project/features/calendar/ProjectCalendar.tsx
@@ -28,6 +28,7 @@ import {
   faClock,
   faTimes,
 } from "@fortawesome/free-solid-svg-icons";
+import EventPill from "../../components/Shared/EventPill";
 // Frontend no longer persists timeline events directly; backend handles persistence
 import { useBudget } from "@/dashboard/project/features/budget/context/BudgetContext";
 import { notify } from "@/shared/ui/ToastNotifications";
@@ -106,11 +107,6 @@ const UNIT_OPTIONS = [
   "SQFT",
   "KG",
 ] as const;
-
-const DOT_SIZE = 10;
-const DOT_STROKE = 2;
-const DOT_MAX_VISIBLE = 4;
-const DOT_OVERLAP_PX = 3;
 
 const MOBILE_QUERY = "(max-width: 640px)";
 const POPPER_GAP = 12;
@@ -269,6 +265,7 @@ const CalendarDayButton = React.forwardRef<HTMLButtonElement, CalendarDayButtonP
       isSelected ? "selected" : "",
       isFlashing ? "tile-highlight" : "",
       inRange ? "in-range" : "",
+      hasEvents ? "has-badge" : "",
     ]
       .filter(Boolean)
       .join(" ");
@@ -1523,7 +1520,11 @@ const ProjectCalendar: React.FC<ProjectCalendarProps> = ({
 
                   {week.map(({ date, key, inMonth }) => {
                     const dayEvents = eventsByDate[key] || [];
-                    const dayDots = dayEvents.map((e, idx) => project?.color || getColor(e.description || String(idx)));
+                    const eventCount = dayEvents.length;
+                    const eventColor =
+                      eventCount > 0
+                        ? project?.color || (project?.projectId ? getColor(project.projectId) : undefined)
+                        : undefined;
                     const isSelected = selectedKey === key;
                     const isToday = todayKey === key;
                     const isFlashing = flashKey === key;
@@ -1553,29 +1554,7 @@ const ProjectCalendar: React.FC<ProjectCalendarProps> = ({
                         >
                           <div className="tile-date-number">{date.getDate()}</div>
 
-                          <div className="day-dots">
-                            {dayDots.slice(0, DOT_MAX_VISIBLE).map((color, idx) => (
-                              <svg
-                                key={`${key}-dot-${idx}`}
-                                width={DOT_SIZE}
-                                height={DOT_SIZE}
-                                viewBox="0 0 24 24"
-                                style={{
-                                  marginLeft: idx ? -DOT_OVERLAP_PX : 0,
-                                  filter: "drop-shadow(0 1px 1px rgba(0,0,0,.45))",
-                                  zIndex: 20 - idx,
-                                }}
-                                aria-hidden
-                              >
-                                <circle cx="12" cy="12" r="10" fill="rgba(0,0,0,0.65)" />
-                                <circle cx="12" cy="12" r={10 - DOT_STROKE} fill="none" stroke={color} strokeWidth={DOT_STROKE} />
-                                <path d="M12 7v5l3 2" stroke={color} strokeWidth={DOT_STROKE} fill="none" strokeLinecap="round" />
-                              </svg>
-                            ))}
-                            {dayDots.length > DOT_MAX_VISIBLE && (
-                              <span className="day-dot-more">+{dayDots.length - DOT_MAX_VISIBLE}</span>
-                            )}
-                          </div>
+                          <EventPill count={eventCount} color={eventColor} className="calendar-event-pill" />
 
                           {isHovered && dayEvents.length > 0 && (
                             <div className="tile-tooltip visible">

--- a/frontend/src/dashboard/project/features/calendar/project-calendar.css
+++ b/frontend/src/dashboard/project/features/calendar/project-calendar.css
@@ -446,15 +446,32 @@
   color: #ffffff;
 }
 
-.project-calendar-wrapper .day-dots {
+.project-calendar-wrapper .calendar-day.has-badge {
+  padding-right: 18px;
+}
+
+.project-calendar-wrapper .event-pill {
   position: absolute;
-  left: 0;
-  right: 0;
+  right: 6px;
   bottom: 6px;
-  display: flex;
-  justify-content: center;
+  display: inline-flex;
   align-items: center;
   gap: 4px;
+  padding: 2px 6px;
+  border-radius: 999px;
+  border: 1px solid currentColor;
+  font-size: 0.7rem;
+  font-weight: 600;
+  line-height: 1;
+  pointer-events: none;
+}
+
+.project-calendar-wrapper .event-pill-icon {
+  font-size: 0.65rem;
+}
+
+.project-calendar-wrapper .event-pill-count {
+  line-height: 1;
 }
 
 
@@ -485,8 +502,9 @@
     min-height: 56px;
     padding: 6px 10px 12px;
   }
-  .project-calendar-wrapper .day-dots {
+  .project-calendar-wrapper .event-pill {
     bottom: 5px;
+    right: 6px;
   }
   .project-calendar-wrapper .tile-date-number {
     font-size: 0.85rem;


### PR DESCRIPTION
## Summary
- add a shared `EventPill` component to render the clock-count badge for calendar tiles
- update the project calendar views to use the new pill and flag tiles that contain events
- restyle calendar tiles to position the badge and adjust padding when the pill is present

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce6d6b1ba48324977ed3de65a82673