### PR TITLE
feat: allow creating custom folders in file manager

### DIFF
--- a/frontend/src/dashboard/project/components/FileManager/FileManager.test.tsx
+++ b/frontend/src/dashboard/project/components/FileManager/FileManager.test.tsx
@@ -85,23 +85,34 @@ vi.mock("@/shared/utils/api", () => {
     apiFetch: vi.fn(() =>
       Promise.resolve({ ok: true, json: vi.fn().mockResolvedValue([]) })
     ),
+    updateProjectFields: vi.fn(() => Promise.resolve({})),
   };
 });
 // -- Imports that use the mocks -------------------------------------------------
 import FileManagerComponent from "./FileManager";
 
+const toastMocks = vi.hoisted(() => ({
+  notify: vi.fn(),
+  notifyLoading: vi.fn(),
+  updateNotification: vi.fn(),
+}));
+
 // Mock NotificationContainer since it's just a wrapper
-vi.mock('@/shared/ui/ToastNotifications', () => ({
+vi.mock("@/shared/ui/ToastNotifications", () => ({
   NotificationContainer: () => null,
+  notify: toastMocks.notify,
+  notifyLoading: toastMocks.notifyLoading,
+  updateNotification: toastMocks.updateNotification,
 }));
 
 // Import mocked modules after mocks are defined
-import { NotificationContainer } from '@/shared/ui/ToastNotifications';
+import { NotificationContainer } from "@/shared/ui/ToastNotifications";
 
 type Mock = ReturnType<typeof vi.fn>;
 
 let useDataMock: Mock;
 let apiFetchMock: Mock;
+let updateProjectFieldsMock: Mock;
 
 // -- Setup ----------------------------------------------------------------------
 beforeEach(async () => {
@@ -110,6 +121,7 @@ beforeEach(async () => {
 
   const apiModule = await import('@/shared/utils/api');
   apiFetchMock = apiModule.apiFetch as Mock;
+  updateProjectFieldsMock = apiModule.updateProjectFields as Mock;
 
   useDataMock.mockReset();
   useDataMock.mockReturnValue({
@@ -127,6 +139,11 @@ beforeEach(async () => {
 
   apiFetchMock.mockReset();
   apiFetchMock.mockResolvedValue({ ok: true, json: vi.fn().mockResolvedValue([]) });
+  updateProjectFieldsMock.mockReset();
+  updateProjectFieldsMock.mockResolvedValue({});
+  toastMocks.notify.mockReset();
+  toastMocks.notifyLoading.mockReset();
+  toastMocks.updateNotification.mockReset();
 });
 
 // -- Tests ----------------------------------------------------------------------
@@ -199,6 +216,39 @@ test("sorts files by selected option including kind", async () => {
       "file3.txt",
     ]);
   });
+});
+
+test("allows creating a custom folder", async () => {
+  const user = userEvent.setup();
+  const promptSpy = vi.spyOn(window, "prompt").mockReturnValue("Specs");
+
+  try {
+    render(
+      <>
+        <NotificationContainer />
+        <FileManagerComponent folder="invoices" />
+      </>
+    );
+
+    await user.click(screen.getByText("Invoices"));
+
+    const createButton = await screen.findByLabelText("Create folder");
+    await user.click(createButton);
+
+    await waitFor(() => {
+      expect(updateProjectFieldsMock).toHaveBeenCalled();
+    });
+
+    expect(updateProjectFieldsMock).toHaveBeenCalledWith("1", {
+      fileManagerFolders: expect.arrayContaining([
+        expect.objectContaining({ key: "specs", name: "Specs" }),
+      ]),
+    });
+
+    expect(screen.getByRole("button", { name: /Specs/ })).toBeInTheDocument();
+  } finally {
+    promptSpy.mockRestore();
+  }
 });
 
 test("filters files by kind", async () => {

--- a/frontend/src/dashboard/project/components/FileManager/FileManager.tsx
+++ b/frontend/src/dashboard/project/components/FileManager/FileManager.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useCallback, useImperativeHandle } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useMemo } from "react";
 import Modal from "../../../../shared/ui/ModalWithStack";
 import ConfirmModal from "@/shared/ui/ConfirmModal";
 import { FileText, Download, Layout, Upload as UploadIcon, PenTool } from "lucide-react";
@@ -14,6 +14,8 @@ import { useFileMessenger } from "../Shared/hooks/useFileMessenger";
 import { useFileTransfers } from "../Shared/hooks/useFileTransfers";
 import type { Message } from "@/app/contexts/DataProvider";
 import type { FileManagerProps, FileManagerRef, FolderOption } from "./FileManagerTypes";
+import { notify } from "@/shared/ui/ToastNotifications";
+import { updateProjectFields } from "@/shared/utils/api";
 
 export type { FileManagerProps, FileManagerRef, FileItem } from "./FileManagerTypes";
 
@@ -112,6 +114,8 @@ const FileManagerComponent = forwardRef<FileManagerRef, FileManagerProps>(
       setFilterOption,
       filterOptionsList,
       displayedFiles,
+      customFolders,
+      setCustomFolders,
       handleSelectionChange,
       handleSelectAll,
       isSelected,
@@ -125,6 +129,15 @@ const FileManagerComponent = forwardRef<FileManagerRef, FileManagerProps>(
       handleTouchEnd,
       sortOptionsList,
     } = state;
+
+    const folderOptions = useMemo(() => {
+      const seen = new Set<string>();
+      return [...SYSTEM_FOLDERS, ...customFolders].filter((option) => {
+        if (!option?.key || seen.has(option.key)) return false;
+        seen.add(option.key);
+        return true;
+      });
+    }, [customFolders]);
 
     const { removeReferences } = useFileMessenger({
       activeProject: activeProject || {},
@@ -161,6 +174,87 @@ const FileManagerComponent = forwardRef<FileManagerRef, FileManagerProps>(
       projectMessages: projectMessages as Record<string, Message[]>,
       canDelete,
     });
+
+    const handleCreateFolder = useCallback(async () => {
+      if (!canUpload) {
+        notify("error", "You do not have permission to create folders.");
+        return;
+      }
+
+      if (typeof window === "undefined") return;
+
+      const rawName = window.prompt("New folder name");
+      if (rawName == null) return;
+
+      const normalizedName = rawName.replace(/\s+/g, " ").trim();
+      if (!normalizedName) {
+        notify("warning", "Folder name cannot be empty.");
+        return;
+      }
+
+      if (
+        folderOptions.some((folderOption) => folderOption.name.toLowerCase() === normalizedName.toLowerCase())
+      ) {
+        notify("warning", "A folder with that name already exists.");
+        return;
+      }
+
+      const baseSlug = normalizedName
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-+|-+$/g, "");
+      const fallbackSlug = baseSlug || normalizedName.toLowerCase().replace(/\s+/g, "-") || "folder";
+
+      const existingKeys = new Set(folderOptions.map((option) => option.key));
+      let candidateKey = fallbackSlug;
+      let suffix = 1;
+      while (!candidateKey || existingKeys.has(candidateKey)) {
+        candidateKey = `${fallbackSlug || "folder"}-${suffix}`;
+        suffix += 1;
+      }
+
+      const newFolder: FolderOption = { key: candidateKey, name: normalizedName };
+      const previousFolders = customFolders;
+      const previousKey = folderKey;
+
+      const projectId = activeProject?.projectId as string | undefined;
+      if (!projectId) {
+        notify("error", "Select a project before creating folders.");
+        return;
+      }
+
+      const updatedCustomFolders = [...previousFolders, newFolder];
+
+      setCustomFolders(updatedCustomFolders);
+      setFolderKey(candidateKey);
+      setLocalActiveProject((prev) => ({
+        ...(prev || {}),
+        fileManagerFolders: updatedCustomFolders,
+      }));
+
+      try {
+        await updateProjectFields(projectId, { fileManagerFolders: updatedCustomFolders });
+        notify("success", `Created folder "${normalizedName}".`);
+      } catch (error) {
+        console.error("Failed to persist new folder", error);
+        notify("error", "We couldn't save the new folder. Please try again.");
+        setCustomFolders(previousFolders);
+        setLocalActiveProject((prev) => ({
+          ...(prev || {}),
+          fileManagerFolders: previousFolders,
+        }));
+        setFolderKey(previousKey);
+      }
+    }, [
+      activeProject?.projectId,
+      canUpload,
+      customFolders,
+      folderKey,
+      folderOptions,
+      setCustomFolders,
+      setFolderKey,
+      setLocalActiveProject,
+    ]);
 
     const openFilesModal = useCallback(async () => {
       setFilesModalOpen(true);
@@ -208,7 +302,7 @@ const FileManagerComponent = forwardRef<FileManagerRef, FileManagerProps>(
         >
           <FileManagerToolbar
             folderKey={folderKey}
-            systemFolders={SYSTEM_FOLDERS}
+            folders={folderOptions}
             onFolderChange={setFolderKey}
             searchTerm={searchTerm}
             onSearchChange={setSearchTerm}
@@ -222,6 +316,8 @@ const FileManagerComponent = forwardRef<FileManagerRef, FileManagerProps>(
             layoutIcon={layoutIconToUse}
             onClose={closeFilesModal}
             renderFolderIcon={getFolderIcon}
+            canCreateFolders={canUpload}
+            onCreateFolder={handleCreateFolder}
           />
 
           <FileManagerContent

--- a/frontend/src/dashboard/project/components/FileManager/FileManagerToolbar.tsx
+++ b/frontend/src/dashboard/project/components/FileManager/FileManagerToolbar.tsx
@@ -1,5 +1,5 @@
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faXmark } from "@fortawesome/free-solid-svg-icons";
+import { faFolderPlus, faXmark } from "@fortawesome/free-solid-svg-icons";
 import type { IconDefinition } from "@fortawesome/fontawesome-svg-core";
 import Dropdown from "./Dropdown";
 import type { FilterValue, FolderOption, SortOption } from "./FileManagerTypes";
@@ -7,7 +7,7 @@ import styles from "./file-manager.module.css";
 
 interface FileManagerToolbarProps {
   folderKey: string;
-  systemFolders: FolderOption[];
+  folders: FolderOption[];
   onFolderChange: (key: string) => void;
   searchTerm: string;
   onSearchChange: (value: string) => void;
@@ -21,11 +21,13 @@ interface FileManagerToolbarProps {
   layoutIcon: IconDefinition;
   onClose: () => void;
   renderFolderIcon: (key: string, size?: number) => React.ReactNode;
+  canCreateFolders?: boolean;
+  onCreateFolder?: () => void;
 }
 
 export const FileManagerToolbar = ({
   folderKey,
-  systemFolders,
+  folders,
   onFolderChange,
   searchTerm,
   onSearchChange,
@@ -39,11 +41,13 @@ export const FileManagerToolbar = ({
   layoutIcon,
   onClose,
   renderFolderIcon,
+  canCreateFolders = false,
+  onCreateFolder,
 }: FileManagerToolbarProps) => {
   return (
     <div className={styles.modalHeader}>
       <div className={styles.folderTabs}>
-        {systemFolders.map((folder) => (
+        {folders.map((folder) => (
           <button
             key={folder.key}
             className={`${styles.tabButton} ${folderKey === folder.key ? styles.activeTab : ""}`}
@@ -69,6 +73,16 @@ export const FileManagerToolbar = ({
           onChange={onFilterChange}
         />
         <Dropdown label="Sort files" options={sortOptions} value={sortOption} onChange={onSortChange} />
+        {canCreateFolders && (
+          <button
+            type="button"
+            className={styles.iconButton}
+            onClick={onCreateFolder}
+            aria-label="Create folder"
+          >
+            <FontAwesomeIcon icon={faFolderPlus} />
+          </button>
+        )}
         <button className={styles.iconButton} onClick={onToggleView} aria-label="Toggle view">
           <FontAwesomeIcon icon={layoutIcon} />
         </button>

--- a/frontend/src/dashboard/project/components/Shared/hooks/useFileManagerState.ts
+++ b/frontend/src/dashboard/project/components/Shared/hooks/useFileManagerState.ts
@@ -15,6 +15,7 @@ import type {
   SortOption,
   ViewMode,
 } from "../../FileManager/FileManagerTypes";
+import type { FolderOption } from "../../FileManager/FileManagerTypes";
 
 interface UseFileManagerStateParams
   extends Pick<FileManagerProps, "folder" | "displayName" | "isOpen" | "onRequestClose"> {
@@ -29,6 +30,23 @@ const SORT_OPTIONS: Array<{ value: SortOption; label: string }> = [
   { value: "kind-asc", label: "Type (A-Z)" },
   { value: "kind-desc", label: "Type (Z-A)" },
 ];
+
+const sanitizeFolderOptions = (value: unknown): FolderOption[] => {
+  if (!Array.isArray(value)) return [];
+  const seen = new Set<string>();
+  const normalized: FolderOption[] = [];
+
+  (value as Array<Record<string, unknown>>).forEach((item) => {
+    const key = typeof item?.key === "string" ? item.key.trim() : "";
+    const name = typeof item?.name === "string" ? item.name.trim() : "";
+
+    if (!key || !name || seen.has(key)) return;
+    seen.add(key);
+    normalized.push({ key, name });
+  });
+
+  return normalized;
+};
 
 export const useFileManagerState = ({
   folder = "uploads",
@@ -59,6 +77,9 @@ export const useFileManagerState = ({
   const [sortOption, setSortOption] = useState<SortOption>("name-asc");
   const [filterOption, setFilterOption] = useState<FilterValue>("all");
   const [localActiveProject, setLocalActiveProject] = useState<Project>(activeProject || {});
+  const [customFolders, setCustomFolders] = useState<FolderOption[]>(() =>
+    sanitizeFolderOptions((activeProject as Record<string, unknown> | undefined)?.fileManagerFolders)
+  );
 
   const renderedName = useMemo(
     () => displayName || folderKey.charAt(0).toUpperCase() + folderKey.slice(1),
@@ -72,6 +93,12 @@ export const useFileManagerState = ({
   useEffect(() => {
     setLocalActiveProject(activeProject || {});
   }, [activeProject]);
+
+  useEffect(() => {
+    setCustomFolders(
+      sanitizeFolderOptions((activeProject as Record<string, unknown> | undefined)?.fileManagerFolders)
+    );
+  }, [activeProject?.fileManagerFolders]);
 
   useEffect(() => {
     if (typeof isOpen === "boolean") {
@@ -303,6 +330,8 @@ export const useFileManagerState = ({
     filterOptionsList,
     displayedFiles,
     sortFiles,
+    customFolders,
+    setCustomFolders,
     handleSelectionChange,
     handleSelectAll,
     isSelected,


### PR DESCRIPTION
## Summary
- add a "Create folder" action to the file manager toolbar and expose custom folder options from state
- persist newly created folders to the active project and surface them throughout the manager UI
- expand file manager tests to cover folder creation behaviour

## Testing
- npm test -- FileManager.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cf490529a483248c798b8ffde4ade8