### PR TITLE
Improve budget overview mobile layout

### DIFF
--- a/frontend/src/dashboard/home/styles/components/calendar.css
+++ b/frontend/src/dashboard/home/styles/components/calendar.css
@@ -55,6 +55,18 @@
   min-width: 0;
 }
 
+@media (max-width: var(--breakpoint-md)) {
+  .budget-calendar-layout {
+    flex-direction: column !important;
+  }
+
+  .budget-calendar-layout .budget-column,
+  .budget-calendar-layout .calendar-column {
+    flex: 1 1 100%;
+    width: 100%;
+  }
+}
+
 /* Timeline + Location row layout */
 .timeline-location-row {
   display: flex;

--- a/frontend/src/dashboard/home/styles/components/calendar.css
+++ b/frontend/src/dashboard/home/styles/components/calendar.css
@@ -58,11 +58,15 @@
 @media (max-width: var(--breakpoint-md)) {
   .budget-calendar-layout {
     flex-direction: column !important;
+    height: auto;
+    min-height: 0;
+    overflow: visible;
+    align-items: stretch;
   }
 
   .budget-calendar-layout .budget-column,
   .budget-calendar-layout .calendar-column {
-    flex: 1 1 100%;
+    flex: 1 1 auto;
     width: 100%;
   }
 }

--- a/frontend/src/dashboard/home/styles/components/dashboard-cards.css
+++ b/frontend/src/dashboard/home/styles/components/dashboard-cards.css
@@ -86,6 +86,78 @@
   width: 100%;
 }
 
+.budget-overview-card {
+  gap: 16px;
+  align-items: stretch;
+}
+
+.budget-overview-header {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.budget-title-row {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.budget-title-icon {
+  color: currentColor;
+}
+
+.budget-title-text {
+  font-size: clamp(1.2rem, 3vw, 1.75rem);
+  font-weight: 600;
+}
+
+.budget-revision {
+  font-size: 0.9rem;
+  color: #9ca3af;
+}
+
+.budget-spinner {
+  margin-top: 4px;
+}
+
+.budget-summary {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+.budget-amount {
+  font-size: clamp(1.5rem, 4vw, 3rem);
+  font-weight: 700;
+}
+
+.budget-invoice-icon {
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+
+.budget-updated {
+  font-size: clamp(0.85rem, 2vw, 1.1rem);
+  color: #9ca3af;
+}
+
+.budget-loading-chart {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-left: auto;
+  min-height: 160px;
+  flex: 0 0 auto;
+}
+
+.budget-chart-wrapper {
+  margin-left: 10px;
+}
+
 .chart-legend-container {
   display: flex;
   align-items: stretch;
@@ -166,23 +238,41 @@
 /* Mobile adjustments for dashboard cards */
 @media (max-width: var(--breakpoint-sm)) {
   .dashboard-item.budget {
-    padding: 15px;
-    flex-direction: row;
-    align-items: flex-start;
-    min-height: 200px;
-  }
-  .budget-component-container {
-    flex-direction: row;
-    align-items: flex-start;
-  }
-  .chart-legend-container {
+    padding: 12px 16px;
     flex-direction: column;
-    align-items: center;
+    align-items: stretch;
+    min-height: auto;
+    gap: 12px;
+  }
+  .budget-overview-card {
+    flex-direction: column;
+    gap: 12px;
+  }
+  .budget-overview-header {
+    gap: 6px;
+  }
+  .budget-summary {
+    flex-wrap: wrap;
+    align-items: flex-end;
+    gap: 6px;
+  }
+  .budget-amount {
+    font-size: clamp(1.25rem, 6vw, 2rem);
+  }
+  .budget-chart-wrapper,
+  .budget-loading-chart,
+  .chart-legend-container {
     margin-left: 0;
+    justify-content: center;
+  }
+  .budget-chart {
+    width: min(220px, 65vw);
+    height: min(220px, 65vw);
   }
   .budget-legend {
     flex-direction: row;
     flex-wrap: wrap;
+    justify-content: center;
     margin: 8px 0 0;
   }
   .budget-legend-item {
@@ -190,7 +280,6 @@
     font-size: 0.7rem;
     line-height: 0.9;
   }
-  .dashboard-item.budget span,
   .dashboard-item.view-gallery span {
     font-size: 18px;
   }

--- a/frontend/src/dashboard/home/styles/components/dashboard-cards.css
+++ b/frontend/src/dashboard/home/styles/components/dashboard-cards.css
@@ -110,13 +110,12 @@
 }
 
 .budget-title-text {
-  font-size: clamp(1.2rem, 3vw, 1.75rem);
-  font-weight: 600;
+  font-size: clamp(1rem, 3vw, 1.75rem);
 }
 
 .budget-revision {
   font-size: 0.9rem;
-  color: #9ca3af;
+  color: #666666;
 }
 
 .budget-spinner {
@@ -132,7 +131,6 @@
 
 .budget-amount {
   font-size: clamp(1.5rem, 4vw, 3rem);
-  font-weight: 700;
 }
 
 .budget-invoice-icon {
@@ -141,8 +139,8 @@
 }
 
 .budget-updated {
-  font-size: clamp(0.85rem, 2vw, 1.1rem);
-  color: #9ca3af;
+  font-size: clamp(1rem, 2vw, 1.5rem);
+  color: #fa3356;
 }
 
 .budget-loading-chart {

--- a/frontend/src/dashboard/home/styles/components/dashboard-cards.css
+++ b/frontend/src/dashboard/home/styles/components/dashboard-cards.css
@@ -251,13 +251,29 @@
   .budget-overview-header {
     gap: 6px;
   }
+  .budget-title-row {
+    gap: 8px;
+  }
+  .budget-title-icon {
+    width: 22px;
+    height: 22px;
+  }
+  .budget-title-text {
+    font-size: clamp(1rem, 4.5vw, 1.2rem);
+  }
+  .budget-revision {
+    font-size: 0.75rem;
+  }
   .budget-summary {
     flex-wrap: wrap;
     align-items: flex-end;
     gap: 6px;
   }
   .budget-amount {
-    font-size: clamp(1.25rem, 6vw, 2rem);
+    font-size: clamp(1.1rem, 5.5vw, 1.6rem);
+  }
+  .budget-updated {
+    font-size: clamp(0.7rem, 3vw, 0.85rem);
   }
   .budget-chart-wrapper,
   .budget-loading-chart,

--- a/frontend/src/dashboard/project/components/Shared/CalendarOverviewCard.tsx
+++ b/frontend/src/dashboard/project/components/Shared/CalendarOverviewCard.tsx
@@ -154,8 +154,6 @@ function getDateKey(date?: Date | null): string | null {
   return `${y}-${m}-${d}`;
 }
 
-const fmt = (date: Date): string => getDateKey(date) || "";
-
 function formatDateLabel(date: Date): string {
   return date.toLocaleDateString(undefined, {
     weekday: "long",
@@ -1374,7 +1372,7 @@ const CalendarOverviewCard: React.FC<CalendarOverviewCardProps> = ({
   const handleDayOpen = useCallback(
     (
       anchor: HTMLButtonElement,
-      { date, dayKey, inMonth }: { date: Date; dayKey: string; inMonth: boolean }
+      { date, dayKey }: { date: Date; dayKey: string; inMonth: boolean }
     ) => {
       if (!dayKey) return;
 

--- a/frontend/src/dashboard/project/components/Shared/calendar-overview-card.css
+++ b/frontend/src/dashboard/project/components/Shared/calendar-overview-card.css
@@ -16,7 +16,14 @@
   background: var(--bg2, #111213);
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04), 0 18px 48px rgba(0, 0, 0, 0.45);
   border-radius: 32px 32px 32px 32px;
-  
+
+}
+
+@media (max-width: var(--breakpoint-md)) {
+  .calendar-overview-card-wrapper {
+    height: auto;
+    max-height: none;
+  }
 }
 
 /* Override dashboard-item hover highlighting for calendar */

--- a/frontend/src/dashboard/project/features/budget/components/BudgetOverviewCard.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetOverviewCard.tsx
@@ -114,98 +114,75 @@ const BudgetOverviewCard: React.FC<BudgetOverviewCardProps> = ({ projectId }) =>
 
   return (
     <div
-      className="dashboard-item budget budget-component-container"
+      className="dashboard-item budget"
       onClick={isAdmin ? openBudgetPage : undefined}
       style={{ cursor: isAdmin ? "pointer" : "default", position: "relative" }}
     >
-      <div
-        style={{
-          display: "flex",
-          flexDirection: "column",
-          alignItems: "flex-start",
-        }}
-      >
-        <span
-          style={{
-            display: "inline-flex",
-            alignItems: "center",
-            justifyContent: "flex-start",
-          }}
-        >
-          <CircleDollarSign size={26} style={{ marginRight: "12px" }} />
-          Budget
-          {budgetHeader?.clientRevisionId != null && (
-            <span style={{ marginLeft: "8px", fontSize: "0.9rem", color: "#666" }}>
-              {`Rev.${budgetHeader.clientRevisionId}`}
-            </span>
-          )}
-        </span>
+      <div className="budget-overview-card budget-component-container">
+        <div className="budget-overview-header">
+          <div className="budget-title-row">
+            <CircleDollarSign className="budget-title-icon" size={26} />
+            <span className="budget-title-text">Budget</span>
+            {budgetHeader?.clientRevisionId != null && (
+              <span className="budget-revision">{`Rev.${budgetHeader.clientRevisionId}`}</span>
+            )}
+          </div>
 
-        {loading ? (
-          <FontAwesomeIcon
-            icon={faSpinner}
-            spin
-            style={{ marginTop: "8px" }}
-            aria-label="Loading budget"
-          />
-        ) : (
-          <>
-            <span
-              style={{
-                marginTop: "8px",
-                display: "inline-flex",
-                alignItems: "center",
-                gap: "8px",
-              }}
-            >
-              {budgetHeader ? formatUSD(ballparkValue) : "Not available"}
-              {budgetHeader && (
-                <FontAwesomeIcon
-                  icon={faFileInvoiceDollar}
-                  style={{ fontSize: "1.75rem", cursor: "pointer", marginLeft: "8px" }}
-                  title="Invoice preview"
-                  aria-label="Invoice preview"
-                  role="button"
-                  tabIndex={0}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    openInvoicePreview();
-                  }}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter" || e.key === " ") {
-                      e.preventDefault();
+          {loading ? (
+            <FontAwesomeIcon
+              icon={faSpinner}
+              spin
+              className="budget-spinner"
+              aria-label="Loading budget"
+            />
+          ) : (
+            <>
+              <div className="budget-summary">
+                <span className="budget-amount">
+                  {budgetHeader ? formatUSD(ballparkValue) : "Not available"}
+                </span>
+                {budgetHeader && (
+                  <FontAwesomeIcon
+                    icon={faFileInvoiceDollar}
+                    className="budget-invoice-icon"
+                    title="Invoice preview"
+                    aria-label="Invoice preview"
+                    role="button"
+                    tabIndex={0}
+                    onClick={(e) => {
                       e.stopPropagation();
                       openInvoicePreview();
-                    }
-                  }}
-                />
-              )}
-            </span>
+                    }}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        openInvoicePreview();
+                      }
+                    }}
+                  />
+                )}
+              </div>
 
-            <span style={{ marginTop: "8px" }}>
-              {(() => {
-                const createdAt = budgetHeader?.createdAt;
-                return createdAt ? new Date(createdAt as string | number | Date).toLocaleDateString() : "No date";
-              })()}
-            </span>
-          </>
-        )}
-      </div>
-
-      {loading ? (
-        <div
-          style={{
-            marginTop: "16px",
-            display: "flex",
-            justifyContent: "center",
-          }}
-        >
-          <FontAwesomeIcon icon={faSpinner} spin aria-label="Loading chart" />
+              <span className="budget-updated">
+                {(() => {
+                  const createdAt = budgetHeader?.createdAt;
+                  return createdAt
+                    ? new Date(createdAt as string | number | Date).toLocaleDateString()
+                    : "No date";
+                })()}
+              </span>
+            </>
+          )}
         </div>
-      ) : (
-        budgetHeader && (
-          <>
-            <div className="chart-legend-container">
+
+        {loading ? (
+          <div className="budget-loading-chart">
+            <FontAwesomeIcon icon={faSpinner} spin aria-label="Loading chart" />
+          </div>
+        ) : (
+          budgetHeader && (
+            <div className="chart-legend-container budget-chart-wrapper">
               <div className="budget-chart">
                 <VisxPieChart
                   data={pieDataSorted}
@@ -216,9 +193,9 @@ const BudgetOverviewCard: React.FC<BudgetOverviewCardProps> = ({ projectId }) =>
                 />
               </div>
             </div>
-          </>
-        )
-      )}
+          )
+        )}
+      </div>
 
       <ClientInvoicePreviewModal
         isOpen={isInvoicePreviewOpen}

--- a/frontend/src/dashboard/project/project.tsx
+++ b/frontend/src/dashboard/project/project.tsx
@@ -260,43 +260,81 @@ const SingleProject: React.FC = () => {
                 <div className="budget-column">
                   <BudgetOverviewCard projectId={activeProject?.projectId} />
 
+                  {isMobileViewport ? (
+                    <CalendarOverviewCard
+                      project={activeProject as {
+                        projectId: string;
+                        title?: string;
+                        color?: string;
+                        dateCreated?: string;
+                        productionStart?: string;
+                        finishline?: string;
+                        timelineEvents?: Array<{
+                          id: string;
+                          eventId?: string;
+                          date: string;
+                          description?: string;
+                          hours?: number | string;
+                          budgetItemId?: string | null;
+                          createdAt?: string;
+                          payload?: Record<string, unknown>;
+                        }>;
+                        address?: string;
+                        company?: string;
+                        clientName?: string;
+                        invoiceBrandName?: string;
+                        invoiceBrandAddress?: string;
+                        clientAddress?: string;
+                        invoiceBrandPhone?: string;
+                        clientPhone?: string;
+                        clientEmail?: string;
+                      }}
+                      initialFlashDate={flashDate}
+                      showEventList={false}
+                      onWrapperClick={openCalendarPage}
+                      onDateSelect={noop}
+                    />
+                  ) : null}
+
                   <GalleryComponent />
                 </div>
-                <div className="calendar-column">
-                  <CalendarOverviewCard
-                    project={activeProject as {
-                      projectId: string;
-                      title?: string;
-                      color?: string;
-                      dateCreated?: string;
-                      productionStart?: string;
-                      finishline?: string;
-                      timelineEvents?: Array<{
-                        id: string;
-                        eventId?: string;
-                        date: string;
-                        description?: string;
-                        hours?: number | string;
-                        budgetItemId?: string | null;
-                        createdAt?: string;
-                        payload?: Record<string, unknown>;
-                      }>;
-                      address?: string;
-                      company?: string;
-                      clientName?: string;
-                      invoiceBrandName?: string;
-                      invoiceBrandAddress?: string;
-                      clientAddress?: string;
-                      invoiceBrandPhone?: string;
-                      clientPhone?: string;
-                      clientEmail?: string;
-                    }}
-                    initialFlashDate={flashDate}
-                    showEventList={false}
-                    onWrapperClick={openCalendarPage}
-                    onDateSelect={noop}
-                  />
-                </div>
+                {!isMobileViewport && (
+                  <div className="calendar-column">
+                    <CalendarOverviewCard
+                      project={activeProject as {
+                        projectId: string;
+                        title?: string;
+                        color?: string;
+                        dateCreated?: string;
+                        productionStart?: string;
+                        finishline?: string;
+                        timelineEvents?: Array<{
+                          id: string;
+                          eventId?: string;
+                          date: string;
+                          description?: string;
+                          hours?: number | string;
+                          budgetItemId?: string | null;
+                          createdAt?: string;
+                          payload?: Record<string, unknown>;
+                        }>;
+                        address?: string;
+                        company?: string;
+                        clientName?: string;
+                        invoiceBrandName?: string;
+                        invoiceBrandAddress?: string;
+                        clientAddress?: string;
+                        invoiceBrandPhone?: string;
+                        clientPhone?: string;
+                        clientEmail?: string;
+                      }}
+                      initialFlashDate={flashDate}
+                      showEventList={false}
+                      onWrapperClick={openCalendarPage}
+                      onDateSelect={noop}
+                    />
+                  </div>
+                )}
               </div>
 
               {!isMobileViewport && (

--- a/frontend/src/dashboard/project/project.tsx
+++ b/frontend/src/dashboard/project/project.tsx
@@ -1,4 +1,10 @@
-import React, { useState, useEffect, useRef, useCallback, useMemo } from "react";
+import React, {
+  useState,
+  useEffect,
+  useRef,
+  useCallback,
+  useMemo,
+} from "react";
 import ProjectHeader from "@/dashboard/project/components/Shared/ProjectHeader";
 
 import BudgetOverviewCard from "@/dashboard/project/features/budget/components/BudgetOverviewCard";
@@ -27,6 +33,31 @@ interface LocationState {
   flashDate?: string;
 }
 
+const MOBILE_VIEW_QUERY = "(max-width: 768px)";
+
+function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(() => {
+    if (typeof window === "undefined" || !window.matchMedia) {
+      return false;
+    }
+    return window.matchMedia(query).matches;
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return;
+
+    const matcher = window.matchMedia(query);
+    const handler = (event: MediaQueryListEvent) => setMatches(event.matches);
+
+    setMatches(matcher.matches);
+    matcher.addEventListener("change", handler);
+
+    return () => matcher.removeEventListener("change", handler);
+  }, [query]);
+
+  return matches;
+}
+
 const SingleProject: React.FC = () => {
   const {
     activeProject,
@@ -44,6 +75,7 @@ const SingleProject: React.FC = () => {
   const [filesOpen, setFilesOpen] = useState<boolean>(false);
   const quickLinksRef = useRef<QuickLinksRef>(null);
   const { ws } = useSocket();
+  const isMobileViewport = useMediaQuery(MOBILE_VIEW_QUERY);
 
   const projectNameFromPath = useMemo(() => {
     const segments = location.pathname.split("/").filter(Boolean);
@@ -267,11 +299,13 @@ const SingleProject: React.FC = () => {
                 </div>
               </div>
 
-              <Timeline
-                activeProject={activeProject as Project & { status: string; milestoneTitles?: string[] }}
-                parseStatusToNumber={parseStatusToNumber}
-                onActiveProjectChange={handleActiveProjectChange}
-              />
+              {!isMobileViewport && (
+                <Timeline
+                  activeProject={activeProject as Project & { status: string; milestoneTitles?: string[] }}
+                  parseStatusToNumber={parseStatusToNumber}
+                  onActiveProjectChange={handleActiveProjectChange}
+                />
+              )}
 
               <div className="dashboard-layout timeline-location-row">
                 <div className="location-wrapper">


### PR DESCRIPTION
## Summary
- restructure the budget overview card markup to support compact header content and responsive chart placement
- refresh the shared dashboard card styles for budget details and ensure the calendar card stacks beneath on small screens
- clean up unused calendar helpers to satisfy linting after the layout updates

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf4f6223b08324a17be5ceee330b88