### PR TITLE
Refactor file manager navigation and allow custom folders

### DIFF
--- a/frontend/src/dashboard/project/components/FileManager/FileManager.test.tsx
+++ b/frontend/src/dashboard/project/components/FileManager/FileManager.test.tsx
@@ -93,6 +93,7 @@ import FileManagerComponent from "./FileManager";
 // Mock NotificationContainer since it's just a wrapper
 vi.mock('@/shared/ui/ToastNotifications', () => ({
   NotificationContainer: () => null,
+  notify: vi.fn(),
 }));
 
 // Import mocked modules after mocks are defined

--- a/frontend/src/dashboard/project/components/FileManager/FileManager.tsx
+++ b/frontend/src/dashboard/project/components/FileManager/FileManager.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useCallback, useImperativeHandle } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useMemo } from "react";
 import Modal from "../../../../shared/ui/ModalWithStack";
 import ConfirmModal from "@/shared/ui/ConfirmModal";
 import { FileText, Download, Layout, Upload as UploadIcon, PenTool } from "lucide-react";
@@ -14,6 +14,8 @@ import { useFileMessenger } from "../Shared/hooks/useFileMessenger";
 import { useFileTransfers } from "../Shared/hooks/useFileTransfers";
 import type { Message } from "@/app/contexts/DataProvider";
 import type { FileManagerProps, FileManagerRef, FolderOption } from "./FileManagerTypes";
+import { apiFetch, API_BASE_URL } from "@/shared/utils/api";
+import { notify } from "@/shared/ui/ToastNotifications";
 
 export type { FileManagerProps, FileManagerRef, FileItem } from "./FileManagerTypes";
 
@@ -22,11 +24,33 @@ if (typeof document !== "undefined") {
 }
 
 const SYSTEM_FOLDERS: FolderOption[] = [
-  { key: "uploads", name: "User Files" },
   { key: "drawings", name: "Drawings" },
   { key: "invoices", name: "Documents" },
   { key: "downloads", name: "Downloads" },
 ];
+
+const ROOT_FOLDER: FolderOption = { key: "uploads", name: "Project Files" };
+
+const sanitizeFolderKey = (name: string, existingKeys: Set<string>): string => {
+  const fallback = "folder";
+  const cleaned = name
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9\-\s_]+/g, "")
+    .replace(/[\s_]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+  const base = cleaned || fallback;
+  let candidate = base;
+  let counter = 2;
+
+  while (existingKeys.has(candidate)) {
+    candidate = `${base}-${counter}`;
+    counter += 1;
+  }
+
+  return candidate;
+};
 
 const getFolderIcon = (key: string, size = 24) => {
   switch (key) {
@@ -124,6 +148,8 @@ const FileManagerComponent = forwardRef<FileManagerRef, FileManagerProps>(
       handleTouchMove,
       handleTouchEnd,
       sortOptionsList,
+      customFolders,
+      addCustomFolder,
     } = state;
 
     const { removeReferences } = useFileMessenger({
@@ -134,6 +160,22 @@ const FileManagerComponent = forwardRef<FileManagerRef, FileManagerProps>(
       user,
       ws,
     });
+
+    const folderDisplayList = useMemo(() => {
+      const seen = new Set<string>();
+      return [...SYSTEM_FOLDERS, ...customFolders].filter((folder) => {
+        if (seen.has(folder.key)) return false;
+        seen.add(folder.key);
+        return true;
+      });
+    }, [customFolders]);
+
+    const activeFolderName = useMemo(() => {
+      if (folderKey === ROOT_FOLDER.key) return ROOT_FOLDER.name;
+      return folderDisplayList.find((folder) => folder.key === folderKey)?.name || folderKey;
+    }, [folderDisplayList, folderKey]);
+
+    const canCreateFolder = canUpload;
 
     const {
       loadFiles,
@@ -161,6 +203,56 @@ const FileManagerComponent = forwardRef<FileManagerRef, FileManagerProps>(
       projectMessages: projectMessages as Record<string, Message[]>,
       canDelete,
     });
+
+    const handleCreateFolder = useCallback(async () => {
+      if (typeof window === "undefined") return;
+      const projectId = (activeProject?.projectId as string | undefined) ?? undefined;
+      if (!projectId) {
+        notify("error", "You need an active project to create folders.");
+        return;
+      }
+
+      const inputName = window.prompt("New folder name", "");
+      const trimmed = inputName?.trim();
+      if (!trimmed) return;
+
+      const existingKeys = new Set<string>([ROOT_FOLDER.key, ...folderDisplayList.map((folder) => folder.key)]);
+      const folderKeyValue = sanitizeFolderKey(trimmed, existingKeys);
+      const newFolder: FolderOption = { key: folderKeyValue, name: trimmed };
+      const updatedCustomFolders = Array.from(
+        new Map<string, FolderOption>([...customFolders, newFolder].map((folder) => [folder.key, folder])).values()
+      );
+
+      addCustomFolder(newFolder);
+      setFolderKey(newFolder.key);
+      setSelectedFiles([]);
+      setSelectedItems(new Set());
+      setIsSelectMode(false);
+
+      try {
+        await apiFetch(`${API_BASE_URL}/editProject?projectId=${projectId}`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            customFolders: updatedCustomFolders,
+            [newFolder.key]: [],
+          }),
+        });
+        notify("success", `Folder "${newFolder.name}" created.`);
+      } catch (error) {
+        console.error("Error creating folder", error);
+        notify("error", "Unable to create folder. Please try again.");
+      }
+    }, [
+      activeProject?.projectId,
+      addCustomFolder,
+      customFolders,
+      folderDisplayList,
+      setFolderKey,
+      setSelectedFiles,
+      setSelectedItems,
+      setIsSelectMode,
+    ]);
 
     const openFilesModal = useCallback(async () => {
       setFilesModalOpen(true);
@@ -208,8 +300,7 @@ const FileManagerComponent = forwardRef<FileManagerRef, FileManagerProps>(
         >
           <FileManagerToolbar
             folderKey={folderKey}
-            systemFolders={SYSTEM_FOLDERS}
-            onFolderChange={setFolderKey}
+            activeFolderName={activeFolderName}
             searchTerm={searchTerm}
             onSearchChange={setSearchTerm}
             filterOption={filterOption}
@@ -222,6 +313,8 @@ const FileManagerComponent = forwardRef<FileManagerRef, FileManagerProps>(
             layoutIcon={layoutIconToUse}
             onClose={closeFilesModal}
             renderFolderIcon={getFolderIcon}
+            onCreateFolder={handleCreateFolder}
+            canCreateFolder={canCreateFolder}
           />
 
           <FileManagerContent
@@ -244,6 +337,10 @@ const FileManagerComponent = forwardRef<FileManagerRef, FileManagerProps>(
             onDeleteSingle={handleDeleteSingle}
             canDelete={canDelete}
             folderKey={folderKey}
+            folders={folderDisplayList}
+            onFolderOpen={setFolderKey}
+            onBackToRoot={() => setFolderKey(ROOT_FOLDER.key)}
+            renderFolderIcon={getFolderIcon}
           />
 
           <FileManagerFooter

--- a/frontend/src/dashboard/project/components/FileManager/FileManagerContent.tsx
+++ b/frontend/src/dashboard/project/components/FileManager/FileManagerContent.tsx
@@ -2,7 +2,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCheck, faDownload, faTrash } from "@fortawesome/free-solid-svg-icons";
 import { Upload } from "lucide-react";
 import Spinner from "../../../../shared/ui/Spinner";
-import type { FileItem, ViewMode } from "./FileManagerTypes";
+import type { FileItem, FolderOption, ViewMode } from "./FileManagerTypes";
 import {
   getFilePreviewIcon,
   getThumbnailUrl,
@@ -31,6 +31,10 @@ interface FileManagerContentProps {
   onDeleteSingle: (url: string) => void;
   canDelete: boolean;
   folderKey: string;
+  folders: FolderOption[];
+  onFolderOpen: (key: string) => void;
+  onBackToRoot: () => void;
+  renderFolderIcon: (key: string, size?: number) => React.ReactNode;
 }
 
 const renderPreview = (file: FileItem, folderKey: string) => {
@@ -74,6 +78,10 @@ export const FileManagerContent = ({
   onDeleteSingle,
   canDelete,
   folderKey,
+  folders,
+  onFolderOpen,
+  onBackToRoot,
+  renderFolderIcon,
 }: FileManagerContentProps) => {
   return (
     <div
@@ -84,6 +92,34 @@ export const FileManagerContent = ({
       onDrop={onDrop}
     >
       {isDragging && <div className={styles.dragOverlay}>Drop files to upload</div>}
+
+      <div className={styles.folderSection}>
+        <div className={styles.folderSectionHeader}>
+          <h3>Folders</h3>
+          {folderKey !== "uploads" && (
+            <button className={styles.secondaryButton} onClick={onBackToRoot} type="button">
+              Back to Project Files
+            </button>
+          )}
+        </div>
+        {folders.length === 0 ? (
+          <div className={styles.emptyFoldersMessage}>No additional folders yet.</div>
+        ) : (
+          <div className={styles.folderGrid}>
+            {folders.map((folder) => (
+              <button
+                type="button"
+                key={folder.key}
+                className={`${styles.folderTile} ${folderKey === folder.key ? styles.activeFolderTile : ""}`}
+                onClick={() => onFolderOpen(folder.key)}
+              >
+                <span className={styles.folderIcon}>{renderFolderIcon(folder.key, 24)}</span>
+                <span className={styles.folderLabel}>{folder.name}</span>
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
 
       {isLoading && (
         <div className={styles.loadingOverlay}>

--- a/frontend/src/dashboard/project/components/FileManager/FileManagerToolbar.tsx
+++ b/frontend/src/dashboard/project/components/FileManager/FileManagerToolbar.tsx
@@ -1,14 +1,13 @@
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faXmark } from "@fortawesome/free-solid-svg-icons";
+import { faFolderPlus, faXmark } from "@fortawesome/free-solid-svg-icons";
 import type { IconDefinition } from "@fortawesome/fontawesome-svg-core";
 import Dropdown from "./Dropdown";
-import type { FilterValue, FolderOption, SortOption } from "./FileManagerTypes";
+import type { FilterValue, SortOption } from "./FileManagerTypes";
 import styles from "./file-manager.module.css";
 
 interface FileManagerToolbarProps {
   folderKey: string;
-  systemFolders: FolderOption[];
-  onFolderChange: (key: string) => void;
+  activeFolderName: string;
   searchTerm: string;
   onSearchChange: (value: string) => void;
   filterOption: FilterValue;
@@ -21,12 +20,13 @@ interface FileManagerToolbarProps {
   layoutIcon: IconDefinition;
   onClose: () => void;
   renderFolderIcon: (key: string, size?: number) => React.ReactNode;
+  onCreateFolder: () => void;
+  canCreateFolder: boolean;
 }
 
 export const FileManagerToolbar = ({
   folderKey,
-  systemFolders,
-  onFolderChange,
+  activeFolderName,
   searchTerm,
   onSearchChange,
   filterOption,
@@ -39,22 +39,28 @@ export const FileManagerToolbar = ({
   layoutIcon,
   onClose,
   renderFolderIcon,
+  onCreateFolder,
+  canCreateFolder,
 }: FileManagerToolbarProps) => {
   return (
     <div className={styles.modalHeader}>
-      <div className={styles.folderTabs}>
-        {systemFolders.map((folder) => (
-          <button
-            key={folder.key}
-            className={`${styles.tabButton} ${folderKey === folder.key ? styles.activeTab : ""}`}
-            onClick={() => onFolderChange(folder.key)}
-          >
-            {renderFolderIcon(folder.key, 16)} {folder.name}
-          </button>
-        ))}
+      <div className={styles.modalTitle}>
+        <div className={styles.titleText}>
+          {renderFolderIcon("uploads", 18)}
+          <h2>Project Files</h2>
+        </div>
+        {folderKey !== "uploads" && (
+          <span className={styles.activeFolderBadge}>{activeFolderName}</span>
+        )}
       </div>
 
       <div className={styles.actions}>
+        {canCreateFolder && (
+          <button className={styles.primaryButton} onClick={onCreateFolder} type="button">
+            <FontAwesomeIcon icon={faFolderPlus} />
+            <span className={styles.buttonLabel}>New Folder</span>
+          </button>
+        )}
         <input
           type="text"
           placeholder="Search"

--- a/frontend/src/dashboard/project/components/FileManager/file-manager.module.css
+++ b/frontend/src/dashboard/project/components/FileManager/file-manager.module.css
@@ -130,18 +130,43 @@
 .modalHeader {
   display: flex;
   justify-content: space-between;
-  align-items: center;
+  align-items: flex-start;
   width: 100%;
   padding: 0 1rem;
   margin-bottom: 0.5rem;
   font-family: system-ui, -apple-system, sans-serif;
+  flex-wrap: wrap;
+  gap: 1rem;
 }
 
 .modalTitle {
   display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.titleText {
+  display: flex;
   align-items: center;
-  gap: 8px;
-  font-size: 1rem;
+  gap: 10px;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.titleText h2 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.activeFolderBadge {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.12);
+  font-size: 0.85rem;
+  color: #ffffff;
+  width: fit-content;
 }
 
 .modalContentInner {
@@ -282,6 +307,125 @@
 .iconButton:hover {
   transform: scale(1.03);
   background-color: rgba(255, 255, 255, 0.1);
+}
+
+.primaryButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: #fa3356;
+  color: #fff;
+  border: none;
+  padding: 6px 12px;
+  border-radius: 999px;
+  cursor: pointer;
+  font-weight: 600;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.primaryButton:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 16px rgba(250, 51, 86, 0.35);
+}
+
+.buttonLabel {
+  display: none;
+}
+
+@media (min-width: 640px) {
+  .buttonLabel {
+    display: inline;
+  }
+}
+
+.folderSection {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 24px;
+}
+
+.folderSectionHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.folderSectionHeader h3 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.secondaryButton {
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 999px;
+  color: white;
+  padding: 6px 12px;
+  cursor: pointer;
+  font-size: 0.85rem;
+  transition: background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.secondaryButton:hover {
+  background: rgba(255, 255, 255, 0.1);
+  border-color: rgba(255, 255, 255, 0.4);
+}
+
+.folderGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 16px;
+}
+
+.folderTile {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 16px 12px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid transparent;
+  color: white;
+  gap: 10px;
+  cursor: pointer;
+  transition: transform 0.2s ease, background 0.2s ease, border-color 0.2s ease;
+  min-height: 120px;
+}
+
+.folderTile:hover {
+  transform: translateY(-2px);
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.activeFolderTile {
+  border-color: rgba(250, 51, 86, 0.8);
+  box-shadow: 0 0 0 1px rgba(250, 51, 86, 0.4);
+}
+
+.folderIcon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 48px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.folderLabel {
+  font-size: 0.9rem;
+  font-weight: 500;
+  text-align: center;
+}
+
+.emptyFoldersMessage {
+  color: rgba(255, 255, 255, 0.65);
+  font-size: 0.9rem;
+  font-style: italic;
 }
 
 .hiddenInput {
@@ -451,29 +595,11 @@
   z-index: 2;
 }
 
-.folderTabs {
-  display: flex;
-  gap: 8px;
-  margin-bottom: 10px;
-}
-
-.tabButton {
-  background: transparent;
-  border: none;
-  color: white;
-  padding: 6px 10px;
-  border-radius: 6px;
-  cursor: pointer;
-}
-
-.activeTab {
-  background: rgba(255, 255, 255, 0.1);
-}
-
 .actions {
   display: flex;
   align-items: center;
   gap: 8px;
+  flex-wrap: wrap;
 }
 
 .searchInput {

--- a/frontend/src/dashboard/project/components/Shared/hooks/useFileManagerState.ts
+++ b/frontend/src/dashboard/project/components/Shared/hooks/useFileManagerState.ts
@@ -11,6 +11,7 @@ import type {
   FileItem,
   FileManagerProps,
   FilterValue,
+  FolderOption,
   Project,
   SortOption,
   ViewMode,
@@ -20,6 +21,29 @@ interface UseFileManagerStateParams
   extends Pick<FileManagerProps, "folder" | "displayName" | "isOpen" | "onRequestClose"> {
   activeProject?: Project;
 }
+
+const parseCustomFolders = (value: unknown): FolderOption[] => {
+  if (!Array.isArray(value)) return [];
+
+  return value
+    .map((folder) => {
+      if (!folder) return null;
+      if (typeof folder === "string") {
+        return { key: folder, name: folder } satisfies FolderOption;
+      }
+      if (typeof folder === "object" && "key" in folder) {
+        const key = String((folder as { key: unknown }).key || "").trim();
+        if (!key) return null;
+        const name =
+          typeof (folder as { name?: unknown }).name === "string"
+            ? ((folder as { name?: string }).name || key)
+            : key;
+        return { key, name } satisfies FolderOption;
+      }
+      return null;
+    })
+    .filter((folder): folder is FolderOption => Boolean(folder?.key));
+};
 
 const SORT_OPTIONS: Array<{ value: SortOption; label: string }> = [
   { value: "name-asc", label: "Name (A-Z)" },
@@ -59,9 +83,16 @@ export const useFileManagerState = ({
   const [sortOption, setSortOption] = useState<SortOption>("name-asc");
   const [filterOption, setFilterOption] = useState<FilterValue>("all");
   const [localActiveProject, setLocalActiveProject] = useState<Project>(activeProject || {});
+  const [customFolders, setCustomFolders] = useState<FolderOption[]>(
+    () => parseCustomFolders((activeProject as { customFolders?: unknown })?.customFolders)
+  );
 
   const renderedName = useMemo(
-    () => displayName || folderKey.charAt(0).toUpperCase() + folderKey.slice(1),
+    () => {
+      if (displayName) return displayName;
+      if (folderKey === "uploads") return "Project Files";
+      return folderKey.charAt(0).toUpperCase() + folderKey.slice(1);
+    },
     [displayName, folderKey]
   );
 
@@ -72,6 +103,10 @@ export const useFileManagerState = ({
   useEffect(() => {
     setLocalActiveProject(activeProject || {});
   }, [activeProject]);
+
+  useEffect(() => {
+    setCustomFolders(parseCustomFolders((localActiveProject as { customFolders?: unknown })?.customFolders));
+  }, [localActiveProject]);
 
   useEffect(() => {
     if (typeof isOpen === "boolean") {
@@ -263,6 +298,30 @@ export const useFileManagerState = ({
 
   const layoutIconToUse = viewMode === "grid" ? faList : faThLarge;
 
+  const addCustomFolder = useCallback(
+    (folder: FolderOption) => {
+      setCustomFolders((prev) => {
+        if (prev.some((existing) => existing.key === folder.key)) {
+          return prev;
+        }
+        return [...prev, folder];
+      });
+
+      setLocalActiveProject((prevProject: Project) => {
+        const currentFolders = parseCustomFolders((prevProject as { customFolders?: unknown })?.customFolders);
+        if (currentFolders.some((existing) => existing.key === folder.key)) {
+          return prevProject;
+        }
+        return {
+          ...prevProject,
+          customFolders: [...currentFolders, folder],
+          [folder.key]: (prevProject as Record<string, unknown>)[folder.key] ?? [],
+        } as Project;
+      });
+    },
+    [setLocalActiveProject]
+  );
+
   return {
     fileInputRef,
     scrollerRef,
@@ -318,6 +377,8 @@ export const useFileManagerState = ({
     handleTouchEnd,
     setFilesModalOpenDirect: setFilesModalOpen,
     sortOptionsList: SORT_OPTIONS,
+    customFolders,
+    addCustomFolder,
   };
 };
 


### PR DESCRIPTION
## Summary
- update the file manager modal header to a "Project Files" title with toolbar actions
- render system and custom folder icons inside the content area with back navigation
- enable creating and persisting custom folders via the existing project edit endpoint

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cf4f04df688324ac177bdb3a4e6a8f