### PR TITLE
Improve mobile budget overview layout

### DIFF
--- a/frontend/src/dashboard/home/styles/components/dashboard-cards.css
+++ b/frontend/src/dashboard/home/styles/components/dashboard-cards.css
@@ -86,6 +86,58 @@
   width: 100%;
 }
 
+.budget-overview-card {
+  gap: 16px;
+}
+
+.budget-overview-summary {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.budget-overview-header {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 12px;
+}
+
+.budget-overview-icon {
+  flex-shrink: 0;
+}
+
+.budget-overview-revision {
+  margin-left: 8px;
+  font-size: 0.9rem;
+  color: #666;
+}
+
+.budget-overview-spinner {
+  margin-top: 8px;
+}
+
+.budget-overview-amount {
+  margin-top: 8px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.budget-overview-invoice-icon {
+  font-size: 1.75rem;
+  cursor: pointer;
+  margin-left: 8px;
+}
+
+.budget-overview-date {
+  margin-top: 8px;
+}
+
+.budget-calendar-mobile-card {
+  width: 100%;
+}
+
 .chart-legend-container {
   display: flex;
   align-items: stretch;
@@ -171,14 +223,48 @@
     align-items: flex-start;
     min-height: 200px;
   }
+  .budget-overview-card {
+    flex-wrap: wrap;
+    gap: 12px;
+  }
+  .budget-overview-summary {
+    gap: 4px;
+  }
+  .budget-overview-header {
+    gap: 8px;
+  }
+  .budget-overview-revision {
+    margin-left: 6px;
+    font-size: 0.8rem;
+  }
+  .budget-overview-spinner {
+    margin-top: 6px;
+  }
+  .budget-overview-amount {
+    margin-top: 4px;
+  }
+  .budget-overview-invoice-icon {
+    margin-left: 4px;
+  }
+  .budget-overview-date {
+    margin-top: 4px;
+  }
+  .budget-calendar-mobile-card {
+    display: flex;
+  }
+  .budget-calendar-mobile-card > * {
+    flex: 1 1 auto;
+  }
   .budget-component-container {
     flex-direction: row;
     align-items: flex-start;
+    flex-wrap: wrap;
   }
   .chart-legend-container {
     flex-direction: column;
     align-items: center;
     margin-left: 0;
+    gap: 8px;
   }
   .budget-legend {
     flex-direction: row;
@@ -209,6 +295,10 @@
   .dashboard-item.notes span {
     display: block;
     white-space: pre-wrap;
+  }
+  .budget-chart {
+    width: min(140px, 45vw);
+    height: min(140px, 45vw);
   }
 }
 

--- a/frontend/src/dashboard/project/features/budget/components/BudgetOverviewCard.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetOverviewCard.tsx
@@ -114,30 +114,16 @@ const BudgetOverviewCard: React.FC<BudgetOverviewCardProps> = ({ projectId }) =>
 
   return (
     <div
-      className="dashboard-item budget budget-component-container"
+      className="dashboard-item budget budget-component-container budget-overview-card"
       onClick={isAdmin ? openBudgetPage : undefined}
       style={{ cursor: isAdmin ? "pointer" : "default", position: "relative" }}
     >
-      <div
-        style={{
-          display: "flex",
-          flexDirection: "column",
-          alignItems: "flex-start",
-        }}
-      >
-        <span
-          style={{
-            display: "inline-flex",
-            alignItems: "center",
-            justifyContent: "flex-start",
-          }}
-        >
-          <CircleDollarSign size={26} style={{ marginRight: "12px" }} />
+      <div className="budget-overview-summary">
+        <span className="budget-overview-header">
+          <CircleDollarSign size={26} className="budget-overview-icon" />
           Budget
           {budgetHeader?.clientRevisionId != null && (
-            <span style={{ marginLeft: "8px", fontSize: "0.9rem", color: "#666" }}>
-              {`Rev.${budgetHeader.clientRevisionId}`}
-            </span>
+            <span className="budget-overview-revision">{`Rev.${budgetHeader.clientRevisionId}`}</span>
           )}
         </span>
 
@@ -145,24 +131,17 @@ const BudgetOverviewCard: React.FC<BudgetOverviewCardProps> = ({ projectId }) =>
           <FontAwesomeIcon
             icon={faSpinner}
             spin
-            style={{ marginTop: "8px" }}
+            className="budget-overview-spinner"
             aria-label="Loading budget"
           />
         ) : (
           <>
-            <span
-              style={{
-                marginTop: "8px",
-                display: "inline-flex",
-                alignItems: "center",
-                gap: "8px",
-              }}
-            >
+            <span className="budget-overview-amount">
               {budgetHeader ? formatUSD(ballparkValue) : "Not available"}
               {budgetHeader && (
                 <FontAwesomeIcon
                   icon={faFileInvoiceDollar}
-                  style={{ fontSize: "1.75rem", cursor: "pointer", marginLeft: "8px" }}
+                  className="budget-overview-invoice-icon"
                   title="Invoice preview"
                   aria-label="Invoice preview"
                   role="button"
@@ -182,7 +161,7 @@ const BudgetOverviewCard: React.FC<BudgetOverviewCardProps> = ({ projectId }) =>
               )}
             </span>
 
-            <span style={{ marginTop: "8px" }}>
+            <span className="budget-overview-date">
               {(() => {
                 const createdAt = budgetHeader?.createdAt;
                 return createdAt ? new Date(createdAt as string | number | Date).toLocaleDateString() : "No date";

--- a/frontend/src/dashboard/project/project.tsx
+++ b/frontend/src/dashboard/project/project.tsx
@@ -23,6 +23,8 @@ import { useProjectPalette } from "@/dashboard/project/hooks/useProjectPalette";
 import { resolveProjectCoverUrl } from "@/dashboard/project/utils/theme";
 import { getProjectDashboardPath } from "@/shared/utils/projectUrl";
 
+const MOBILE_LAYOUT_WIDTH = 640;
+
 interface LocationState {
   flashDate?: string;
 }
@@ -44,6 +46,11 @@ const SingleProject: React.FC = () => {
   const [filesOpen, setFilesOpen] = useState<boolean>(false);
   const quickLinksRef = useRef<QuickLinksRef>(null);
   const { ws } = useSocket();
+
+  const [isMobileBudgetLayout, setIsMobileBudgetLayout] = useState(() => {
+    if (typeof window === "undefined") return false;
+    return window.innerWidth <= MOBILE_LAYOUT_WIDTH;
+  });
 
   const projectNameFromPath = useMemo(() => {
     const segments = location.pathname.split("/").filter(Boolean);
@@ -77,7 +84,6 @@ const SingleProject: React.FC = () => {
     navigate("/dashboard");
   }, [navigate]);
 
-
   const openCalendarPage = useCallback(() => {
     if (!activeProject) return;
     navigate(
@@ -103,6 +109,18 @@ const SingleProject: React.FC = () => {
     },
     [fetchProjectDetails]
   );
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const handleResize = () => {
+      setIsMobileBudgetLayout(window.innerWidth <= MOBILE_LAYOUT_WIDTH);
+    };
+    handleResize();
+    window.addEventListener("resize", handleResize);
+    return () => {
+      window.removeEventListener("resize", handleResize);
+    };
+  }, []);
 
   // Keep the active project in sync with the ID from the route.
   useEffect(() => {
@@ -181,6 +199,42 @@ const SingleProject: React.FC = () => {
     };
   }, [ws, activeProject?.projectId]);
 
+  const calendarOverviewCard = (
+    <CalendarOverviewCard
+      project={activeProject as {
+        projectId: string;
+        title?: string;
+        color?: string;
+        dateCreated?: string;
+        productionStart?: string;
+        finishline?: string;
+        timelineEvents?: Array<{
+          id: string;
+          eventId?: string;
+          date: string;
+          description?: string;
+          hours?: number | string;
+          budgetItemId?: string | null;
+          createdAt?: string;
+          payload?: Record<string, unknown>;
+        }>;
+        address?: string;
+        company?: string;
+        clientName?: string;
+        invoiceBrandName?: string;
+        invoiceBrandAddress?: string;
+        clientAddress?: string;
+        invoiceBrandPhone?: string;
+        clientPhone?: string;
+        clientEmail?: string;
+      }}
+      initialFlashDate={flashDate}
+      showEventList={false}
+      onWrapperClick={openCalendarPage}
+      onDateSelect={noop}
+    />
+  );
+
   // Render
   return (
     <ProjectPageLayout
@@ -227,44 +281,13 @@ const SingleProject: React.FC = () => {
               <div className="dashboard-layout budget-calendar-layout">
                 <div className="budget-column">
                   <BudgetOverviewCard projectId={activeProject?.projectId} />
+                  {isMobileBudgetLayout && (
+                    <div className="budget-calendar-mobile-card">{calendarOverviewCard}</div>
+                  )}
 
                   <GalleryComponent />
                 </div>
-                <div className="calendar-column">
-                  <CalendarOverviewCard
-                    project={activeProject as {
-                      projectId: string;
-                      title?: string;
-                      color?: string;
-                      dateCreated?: string;
-                      productionStart?: string;
-                      finishline?: string;
-                      timelineEvents?: Array<{
-                        id: string;
-                        eventId?: string;
-                        date: string;
-                        description?: string;
-                        hours?: number | string;
-                        budgetItemId?: string | null;
-                        createdAt?: string;
-                        payload?: Record<string, unknown>;
-                      }>;
-                      address?: string;
-                      company?: string;
-                      clientName?: string;
-                      invoiceBrandName?: string;
-                      invoiceBrandAddress?: string;
-                      clientAddress?: string;
-                      invoiceBrandPhone?: string;
-                      clientPhone?: string;
-                      clientEmail?: string;
-                    }}
-                    initialFlashDate={flashDate}
-                    showEventList={false}
-                    onWrapperClick={openCalendarPage}
-                    onDateSelect={noop}
-                  />
-                </div>
+                {!isMobileBudgetLayout && <div className="calendar-column">{calendarOverviewCard}</div>}
               </div>
 
               <Timeline


### PR DESCRIPTION
## Summary
- restructure the budget overview card markup to rely on utility classes so spacing can be tuned for narrow screens without changing the existing desktop typography
- tighten mobile-specific spacing and chart sizing in the dashboard card styles while leaving desktop styles intact
- detect the mobile viewport in the project dashboard so the calendar overview renders directly under the budget card on phones while retaining the two-column layout on larger screens

## Testing
- npm run lint *(emits existing warning in useFileTransfers.ts about a missing dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68cf60f7731c83248a92c83a8badfe68