### PR TITLE
Ensure FileManager custom folders persist after reload

### DIFF
--- a/frontend/src/dashboard/project/components/FileManager/FileManager.test.tsx
+++ b/frontend/src/dashboard/project/components/FileManager/FileManager.test.tsx
@@ -4,6 +4,8 @@ import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 import { vi, test, expect, beforeEach } from "vitest";
 
+type Mock = ReturnType<typeof vi.fn>;
+
 // -- Types ---------------------------------------------------------------------
 interface MockS3Item {
   key: string;
@@ -24,6 +26,7 @@ interface MockDataValue {
   activeProject: MockProject;
   user: MockUser;
   isAdmin: boolean;
+  setActiveProject: Mock;
 }
 vi.mock("lucide-react", () => ({
   Folder: () => null,
@@ -77,6 +80,7 @@ vi.mock("@/shared/utils/api", () => {
     ZIP_FILES_URL: "zip",
     DELETE_PROJECT_MESSAGE_URL: "delMsg",
     GET_PROJECT_MESSAGES_URL: "getMsgs",
+    EDIT_PROJECT_URL: "editProject",
     EDIT_MESSAGE_URL: "editMsg",
     getFileUrl: buildUrl,
     normalizeFileUrl: (u: string) => buildUrl(u),
@@ -99,10 +103,9 @@ vi.mock('@/shared/ui/ToastNotifications', () => ({
 // Import mocked modules after mocks are defined
 import { NotificationContainer } from '@/shared/ui/ToastNotifications';
 
-type Mock = ReturnType<typeof vi.fn>;
-
 let useDataMock: Mock;
 let apiFetchMock: Mock;
+let setActiveProjectMock: Mock;
 
 // -- Setup ----------------------------------------------------------------------
 beforeEach(async () => {
@@ -113,6 +116,7 @@ beforeEach(async () => {
   apiFetchMock = apiModule.apiFetch as Mock;
 
   useDataMock.mockReset();
+  setActiveProjectMock = vi.fn();
   useDataMock.mockReturnValue({
     activeProject: {
       projectId: '1',
@@ -124,6 +128,7 @@ beforeEach(async () => {
     },
     user: { userId: 'u1', role: 'admin' },
     isAdmin: true,
+    setActiveProject: setActiveProjectMock,
   } as MockDataValue);
 
   apiFetchMock.mockReset();
@@ -200,6 +205,41 @@ test("sorts files by selected option including kind", async () => {
       "file3.txt",
     ]);
   });
+});
+
+test("creating a new folder persists it to the active project", async () => {
+  const promptSpy = vi.spyOn(window, "prompt").mockReturnValue("Custom Folder");
+
+  try {
+    render(
+      <>
+        <NotificationContainer />
+        <FileManagerComponent folder="invoices" />
+      </>
+    );
+
+    await userEvent.click(screen.getByText("Invoices"));
+
+    const createButton = await screen.findByText("New Folder");
+    await userEvent.click(createButton);
+
+    await waitFor(() => {
+      expect(setActiveProjectMock).toHaveBeenCalled();
+    });
+
+    const updater = setActiveProjectMock.mock.calls[0][0] as (prev: unknown) => unknown;
+    const previous = { projectId: "1", customFolders: [] };
+    const updated = updater(previous) as { customFolders?: unknown; [key: string]: unknown };
+
+    expect(updated).toMatchObject({
+      customFolders: expect.arrayContaining([
+        { key: "custom-folder", name: "Custom Folder" },
+      ]),
+      "custom-folder": [],
+    });
+  } finally {
+    promptSpy.mockRestore();
+  }
 });
 
 test("filters files by kind", async () => {

--- a/frontend/src/dashboard/project/components/FileManager/FileManager.test.tsx
+++ b/frontend/src/dashboard/project/components/FileManager/FileManager.test.tsx
@@ -242,6 +242,29 @@ test("creating a new folder persists it to the active project", async () => {
   }
 });
 
+test("creating a new folder displays it immediately in the UI", async () => {
+  const promptSpy = vi.spyOn(window, "prompt").mockReturnValue("Instant Folder");
+
+  try {
+    render(
+      <>
+        <NotificationContainer />
+        <FileManagerComponent folder="invoices" />
+      </>
+    );
+
+    await userEvent.click(screen.getByText("Invoices"));
+
+    const createButton = await screen.findByText("New Folder");
+    await userEvent.click(createButton);
+
+    const folderButton = await screen.findByRole("button", { name: "Instant Folder" });
+    expect(folderButton).toBeInTheDocument();
+  } finally {
+    promptSpy.mockRestore();
+  }
+});
+
 test("filters files by kind", async () => {
   render(
     <>

--- a/frontend/src/dashboard/project/components/FileManager/FileManager.tsx
+++ b/frontend/src/dashboard/project/components/FileManager/FileManager.tsx
@@ -81,6 +81,7 @@ const FileManagerComponent = forwardRef<FileManagerRef, FileManagerProps>(
   ) => {
     const {
       activeProject,
+      setActiveProject,
       user,
       isAdmin,
       isBuilder,
@@ -224,6 +225,16 @@ const FileManagerComponent = forwardRef<FileManagerRef, FileManagerProps>(
       );
 
       addCustomFolder(newFolder);
+      setActiveProject((prevProject) => {
+        if (!prevProject || prevProject.projectId !== projectId) return prevProject;
+        const record = prevProject as Record<string, unknown>;
+        const existingFiles = Array.isArray(record[newFolder.key]) ? (record[newFolder.key] as unknown[]) : [];
+        return {
+          ...prevProject,
+          customFolders: updatedCustomFolders,
+          [newFolder.key]: existingFiles,
+        };
+      });
       setFolderKey(newFolder.key);
       setSelectedFiles([]);
       setSelectedItems(new Set());
@@ -252,6 +263,7 @@ const FileManagerComponent = forwardRef<FileManagerRef, FileManagerProps>(
       setSelectedFiles,
       setSelectedItems,
       setIsSelectMode,
+      setActiveProject,
     ]);
 
     const openFilesModal = useCallback(async () => {

--- a/frontend/src/dashboard/project/components/FileManager/FileManager.tsx
+++ b/frontend/src/dashboard/project/components/FileManager/FileManager.tsx
@@ -150,7 +150,7 @@ const FileManagerComponent = forwardRef<FileManagerRef, FileManagerProps>(
       handleTouchEnd,
       sortOptionsList,
       customFolders,
-      addCustomFolder,
+      syncCustomFolders,
     } = state;
 
     const { removeReferences } = useFileMessenger({
@@ -224,7 +224,7 @@ const FileManagerComponent = forwardRef<FileManagerRef, FileManagerProps>(
         new Map<string, FolderOption>([...customFolders, newFolder].map((folder) => [folder.key, folder])).values()
       );
 
-      addCustomFolder(newFolder);
+      syncCustomFolders(updatedCustomFolders);
       setActiveProject((prevProject) => {
         if (!prevProject || prevProject.projectId !== projectId) return prevProject;
         const record = prevProject as Record<string, unknown>;
@@ -256,7 +256,7 @@ const FileManagerComponent = forwardRef<FileManagerRef, FileManagerProps>(
       }
     }, [
       activeProject?.projectId,
-      addCustomFolder,
+      syncCustomFolders,
       customFolders,
       folderDisplayList,
       setFolderKey,

--- a/frontend/src/dashboard/project/components/Shared/hooks/useFileManagerState.ts
+++ b/frontend/src/dashboard/project/components/Shared/hooks/useFileManagerState.ts
@@ -322,6 +322,32 @@ export const useFileManagerState = ({
     [setLocalActiveProject]
   );
 
+  const syncCustomFolders = useCallback(
+    (folders: FolderOption[]) => {
+      const uniqueFolders = Array.from(new Map(folders.map((folder) => [folder.key, folder])).values());
+
+      setCustomFolders(uniqueFolders);
+
+      setLocalActiveProject((prevProject: Project) => {
+        const baseProject = (prevProject ?? {}) as Project;
+        const nextProject: Project = {
+          ...baseProject,
+          customFolders: uniqueFolders,
+        } as Project;
+
+        uniqueFolders.forEach((folder) => {
+          const previousValue = (baseProject as Record<string, unknown>)[folder.key];
+          (nextProject as Record<string, unknown>)[folder.key] = Array.isArray(previousValue)
+            ? (previousValue as unknown[])
+            : [];
+        });
+
+        return nextProject;
+      });
+    },
+    [setLocalActiveProject]
+  );
+
   return {
     fileInputRef,
     scrollerRef,
@@ -379,6 +405,7 @@ export const useFileManagerState = ({
     sortOptionsList: SORT_OPTIONS,
     customFolders,
     addCustomFolder,
+    syncCustomFolders,
   };
 };
 


### PR DESCRIPTION
## Summary
- sync newly created FileManager folders into the active project context so they persist after reloads
- extend FileManager tests to cover the persistence path and update supporting mocks

## Testing
- npm test -- FileManager

------
https://chatgpt.com/codex/tasks/task_e_68cf61f30a688324828528fe3e98fa64