### PR TITLE
Restrict project thread resizing to vertical

### DIFF
--- a/frontend/src/dashboard/home/styles/components/chat-panel.css
+++ b/frontend/src/dashboard/home/styles/components/chat-panel.css
@@ -108,25 +108,34 @@ body.chat-panel-docked {
 
 .chat-panel-resizer {
   position: absolute;
-  width: 20px;
-  height: 20px;
-  right: 10px;
-  bottom: 10px;
-  cursor: nwse-resize;
-  opacity: 0.3;
+  width: 36px;
+  height: 18px;
+  left: 50%;
+  transform: translateX(-50%);
+  bottom: 6px;
+  cursor: ns-resize;
+  opacity: 0.4;
   transition: opacity 0.2s;
 }
 
 .chat-panel-resizer:hover {
-  opacity: 0.6;
+  opacity: 0.7;
 }
 
 .chat-panel-resizer::after {
   content: "";
   position: absolute;
-  inset: 0;
-  pointer-events: none;
-  background: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHdpZHRoPScyMCcgaGVpZ2h0PScyMCcgZmlsbD0nbm9uZScgc3Ryb2tlPSd3aGl0ZScgc3Ryb2tlLXdpZHRoPScyJz48bGluZSB4MT0nNCcgeTE9JzIwJyB4Mj0nMjAnIHkyPSc0Jy8+PGxpbmUgeDE9JzEwJyB5MT0nMjAnIHgyPScyMCcgeTI9JzEwJy8+PGxpbmUgeDE9JzE2JyB5MT0nMjAnIHgyPScyMCcgeTI9JzE2Jy8+PC9zdmc+") no-repeat center;
+  inset: 4px 6px;
+  border-radius: 999px;
+  background: linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0.45) 0%,
+    rgba(255, 255, 255, 0.45) 40%,
+    transparent 40%,
+    transparent 60%,
+    rgba(255, 255, 255, 0.45) 60%,
+    rgba(255, 255, 255, 0.45) 100%
+  );
 }
 
 

--- a/frontend/src/dashboard/home/styles/components/page-layouts.css
+++ b/frontend/src/dashboard/home/styles/components/page-layouts.css
@@ -35,11 +35,10 @@
   box-sizing: border-box;
 }
 
-/* Thread resizer between content and chat panel */
+/* Thread divider between content and chat panel */
 .thread-resizer {
   margin: 0 5px;
   width: 2px;
-  cursor: col-resize;
   background: rgba(255, 255, 255, 0.2);
   flex-shrink: 0;
 }

--- a/frontend/src/dashboard/project/components/Shared/ChatPanel.tsx
+++ b/frontend/src/dashboard/project/components/Shared/ChatPanel.tsx
@@ -250,20 +250,16 @@ const ChatPanel: React.FC<ChatPanelProps> = ({
   const onResize = (e: MouseEvent) => {
     if (!resizingRef.current || !panelRef.current) return;
     const rect = panelRef.current.getBoundingClientRect();
-    let newWidth = e.clientX - rect.left;
     let newHeight = e.clientY - rect.top;
 
-    const MIN_W = 360;
     const MIN_H = 280;
-    const maxWidth = window.innerWidth - rect.left;
     const maxHeight = window.innerHeight - rect.top;
 
-    newWidth = Math.min(maxWidth, Math.max(MIN_W, newWidth));
     newHeight = Math.min(maxHeight, Math.max(MIN_H, newHeight));
 
-    setSize({ width: newWidth, height: newHeight });
+    setSize((prev) => ({ ...prev, height: newHeight }));
     setPosition((pos) => ({
-      x: Math.max(0, Math.min(pos.x, window.innerWidth - newWidth)),
+      x: Math.max(0, Math.min(pos.x, window.innerWidth - rect.width)),
       y: Math.max(0, Math.min(pos.y, window.innerHeight - newHeight)),
     }));
   };

--- a/frontend/src/dashboard/project/components/Shared/ProjectPageLayout.tsx
+++ b/frontend/src/dashboard/project/components/Shared/ProjectPageLayout.tsx
@@ -47,7 +47,6 @@ const ProjectPageLayout: React.FC<ProjectPageLayoutProps> = ({
 }) => {
   const projectHeaderRef = React.useRef<HTMLDivElement | null>(null);
   const layoutRef = React.useRef<HTMLDivElement | null>(null);
-  const resizingRef = React.useRef<boolean>(false);
 
   const themeStyle = React.useMemo<React.CSSProperties | undefined>(() => {
     if (!theme) return undefined;
@@ -72,7 +71,7 @@ const ProjectPageLayout: React.FC<ProjectPageLayoutProps> = ({
 
   const safeProjectId = projectId ?? "";
 
-  const [threadWidth, setThreadWidth] = React.useState<number>(MIN_THREAD_WIDTH);
+  const threadWidth = MIN_THREAD_WIDTH;
   const [headerHeights, setHeaderHeights] = React.useState<{ global: number; project: number }>({
     global: 0,
     project: 0,
@@ -127,28 +126,6 @@ const ProjectPageLayout: React.FC<ProjectPageLayoutProps> = ({
     return () => window.removeEventListener("resize", handleResize);
   }, []);
 
-  // Handle drag-resize for the thread pane
-  React.useEffect(() => {
-    const handleMove = (e: MouseEvent) => {
-      if (!resizingRef.current || !layoutRef.current) return;
-      const rect = layoutRef.current.getBoundingClientRect();
-      let newWidth = rect.right - e.clientX;
-      newWidth = Math.min(MAX_THREAD_WIDTH, Math.max(MIN_THREAD_WIDTH, newWidth));
-      setThreadWidth(newWidth);
-    };
-
-    const stopResize = () => {
-      resizingRef.current = false;
-    };
-
-    window.addEventListener("mousemove", handleMove);
-    window.addEventListener("mouseup", stopResize);
-    return () => {
-      window.removeEventListener("mousemove", handleMove);
-      window.removeEventListener("mouseup", stopResize);
-    };
-  }, []);
-
   // Persist floatingThread state
   React.useEffect(() => {
     if (typeof window === "undefined") return;
@@ -180,11 +157,6 @@ const ProjectPageLayout: React.FC<ProjectPageLayoutProps> = ({
       window.removeEventListener("project-open-chat", handleOpenChat);
     };
   }, [setFloatingThread, setChatOpenSignal]);
-
-  const startResize = (e: React.MouseEvent<HTMLDivElement>) => {
-    e.preventDefault();
-    resizingRef.current = true;
-  };
 
   const viewportUnit = React.useMemo(() => {
     if (typeof window === "undefined") {
@@ -241,15 +213,7 @@ const ProjectPageLayout: React.FC<ProjectPageLayoutProps> = ({
 
         {!floatingThread && !isMobile && (
           <>
-            <div
-              className="thread-resizer"
-              role="separator"
-              aria-orientation="vertical"
-              aria-label="Resize chat panel"
-              onMouseDown={startResize}
-              // Make it keyboard focusable if you later add keyboard resizing
-              tabIndex={0}
-            />
+            <div className="thread-resizer" aria-hidden="true" />
 
             <div
               style={{


### PR DESCRIPTION
## Summary
- limit the floating project messages thread to vertical resizing by locking the resize handler to height updates and centering the handle
- remove the docked thread width drag logic so the right rail uses a fixed divider instead of a draggable resizer

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf6893b0108324bb8997ad20bf85ce