### PR TITLE
Prevent moodboard project refetch loop after failures

### DIFF
--- a/frontend/src/app/contexts/ProjectsContextValue.ts
+++ b/frontend/src/app/contexts/ProjectsContextValue.ts
@@ -13,7 +13,7 @@ export interface ProjectsValue {
   setActiveProject: React.Dispatch<React.SetStateAction<Project | null>>;
   selectedProjects: string[];
   setSelectedProjects: React.Dispatch<React.SetStateAction<string[]>>;
-  fetchProjectDetails: (projectId: string) => Promise<void>;
+  fetchProjectDetails: (projectId: string) => Promise<boolean>;
   fetchProjects: (retryCount?: number) => Promise<void>;
   fetchUserProfile: () => Promise<void>;
   fetchRecentActivity: (limit?: number) => Promise<

--- a/frontend/src/app/contexts/ProjectsProvider.tsx
+++ b/frontend/src/app/contexts/ProjectsProvider.tsx
@@ -278,9 +278,10 @@ export const ProjectsProvider: React.FC<PropsWithChildren> = ({ children }) => {
     async (projectId) => {
       if (!projects || !Array.isArray(projects)) {
         console.error("Projects data is not available yet.");
-        return;
+        return false;
       }
       let project = projects.find((p) => p.projectId === projectId);
+      let fetchFailed = false;
 
       // Attempt to hydrate from localStorage when important fields are missing
       if (projectNeedsDetailHydration(project)) {
@@ -341,6 +342,7 @@ export const ProjectsProvider: React.FC<PropsWithChildren> = ({ children }) => {
             });
           }
         } catch (err) {
+          fetchFailed = true;
           console.error("Error fetching project details", err);
         }
       } else if (!Array.isArray(project.timelineEvents)) {
@@ -379,10 +381,14 @@ export const ProjectsProvider: React.FC<PropsWithChildren> = ({ children }) => {
         } catch {
           /* ignore */
         }
-      } else {
-        console.error(`Project with projectId: ${projectId} not found`);
-        setActiveProject(null);
+        return true;
       }
+
+      console.error(`Project with projectId: ${projectId} not found`);
+      if (!fetchFailed) {
+        setActiveProject((prev) => (prev?.projectId === projectId ? null : prev));
+      }
+      return false;
     },
     [projects, addIdsToEvents]
   );

--- a/frontend/src/dashboard/project/features/moodboard/pages/MoodboardPage.tsx
+++ b/frontend/src/dashboard/project/features/moodboard/pages/MoodboardPage.tsx
@@ -10,6 +10,16 @@ import type { Project } from "@/app/contexts/DataProvider";
 import { useProjectPalette } from "@/dashboard/project/hooks/useProjectPalette";
 import { resolveProjectCoverUrl } from "@/dashboard/project/utils/theme";
 
+type DetailFetchStatus = "idle" | "loading" | "success" | "error";
+
+const projectNeedsDetailHydration = (project?: Project | null): boolean =>
+  Boolean(
+    project &&
+      (project.description === undefined ||
+        project.customFolders === undefined ||
+        !Array.isArray(project.team))
+  );
+
 const MoodboardPage: React.FC = () => {
   const { projectId } = useParams<{ projectId: string }>();
   const navigate = useNavigate();
@@ -23,6 +33,40 @@ const MoodboardPage: React.FC = () => {
   } = useData();
 
   const [activeProject, setActiveProject] = useState<Project | null>(initialProject ?? null);
+  const [detailFetchStatusById, setDetailFetchStatusById] = useState<Record<string, DetailFetchStatus>>({});
+
+  const requestProjectDetails = useCallback(
+    async (id: string | undefined | null) => {
+      if (!id) return;
+
+      let shouldFetch = false;
+      setDetailFetchStatusById((prev) => {
+        const current = prev[id];
+        if (current === "loading" || current === "success" || current === "error") {
+          return prev;
+        }
+        shouldFetch = true;
+        return { ...prev, [id]: "loading" };
+      });
+
+      if (!shouldFetch) return;
+
+      try {
+        const success = await fetchProjectDetails(id);
+        setDetailFetchStatusById((prev) => {
+          const nextStatus: DetailFetchStatus = success ? "success" : "error";
+          if (prev[id] === nextStatus) return prev;
+          return { ...prev, [id]: nextStatus };
+        });
+      } catch {
+        setDetailFetchStatusById((prev) => {
+          if (prev[id] === "error") return prev;
+          return { ...prev, [id]: "error" };
+        });
+      }
+    },
+    [fetchProjectDetails]
+  );
 
   const coverImage = useMemo(() => resolveProjectCoverUrl(activeProject), [activeProject]);
   const projectPalette = useProjectPalette(coverImage, {
@@ -35,10 +79,42 @@ const MoodboardPage: React.FC = () => {
 
   useEffect(() => {
     if (!projectId) return;
-    if (!initialProject || initialProject.projectId !== projectId) {
-      void fetchProjectDetails(projectId);
+
+    const matchingProject =
+      (initialProject && initialProject.projectId === projectId ? initialProject : null) ??
+      (activeProject && activeProject.projectId === projectId ? activeProject : null);
+
+    if (matchingProject && !projectNeedsDetailHydration(matchingProject)) {
+      setDetailFetchStatusById((prev) => {
+        if (prev[projectId] === "success") return prev;
+        return { ...prev, [projectId]: "success" };
+      });
+      return;
     }
-  }, [projectId, initialProject, fetchProjectDetails]);
+
+    if (detailFetchStatusById[projectId] === "error") {
+      return;
+    }
+
+    void requestProjectDetails(projectId);
+  }, [
+    projectId,
+    initialProject,
+    activeProject,
+    detailFetchStatusById,
+    requestProjectDetails,
+  ]);
+
+  useEffect(() => {
+    if (!activeProject?.projectId) return;
+    if (projectNeedsDetailHydration(activeProject)) return;
+
+    const targetId = activeProject.projectId;
+    setDetailFetchStatusById((prev) => {
+      if (prev[targetId] === "success") return prev;
+      return { ...prev, [targetId]: "success" };
+    });
+  }, [activeProject]);
 
   useEffect(() => {
     if (!projectId) return;
@@ -61,9 +137,12 @@ const MoodboardPage: React.FC = () => {
   ]);
 
   useEffect(() => {
-    if (!activeProject?.projectId) return;
-    void fetchProjectDetails(activeProject.projectId);
-  }, [activeProject?.projectId, fetchProjectDetails]);
+    const targetId = activeProject?.projectId;
+    if (!targetId) return;
+    if (targetId === projectId) return;
+
+    void requestProjectDetails(targetId);
+  }, [activeProject?.projectId, projectId, requestProjectDetails]);
 
   const parseStatusToNumber = useCallback((status: string | number | undefined | null) => {
     if (status === undefined || status === null) return 0;


### PR DESCRIPTION
## Summary
- update `ProjectsProvider.fetchProjectDetails` to return a success flag and keep the previous active project when detail fetches fail
- track detail fetch status per project on the moodboard page so we only hydrate missing data once and stop retrying after an error
- align the projects context typing with the new boolean return value

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d09d50168c8324b14270608d15c813