### PR TITLE
Adjust overview layout grid and responsive calendar

### DIFF
--- a/frontend/src/dashboard/home/styles/components/calendar.css
+++ b/frontend/src/dashboard/home/styles/components/calendar.css
@@ -36,23 +36,38 @@
   max-height: none;
 }
 
-/* Budget + Calendar two-column layout */
-.budget-calendar-layout {
-  display: flex;
-  flex-direction: row !important;
-  gap: 5px;
+/* Budget + Calendar responsive grid layout */
+.dashboard-layout.budget-calendar-layout {
+  --budget-calendar-gap: 5px;
+  --calendar-min-width: 420px;
+  --calendar-max-width: 520px;
+  --budget-min-width: 360px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) clamp(var(--calendar-min-width), 30%, var(--calendar-max-width));
+  gap: var(--budget-calendar-gap);
+  align-items: stretch;
 }
 
 .budget-calendar-layout .budget-column {
-  flex: 0 0 calc(70% - 2.5px);
   display: flex;
   flex-direction: column;
-  gap: 5px;
+  gap: var(--budget-calendar-gap);
+  min-width: 0;
 }
 
 .budget-calendar-layout .calendar-column {
-  flex: 0 0 calc(30% - 2.5px);
   min-width: 0;
+  width: clamp(var(--calendar-min-width), 30%, var(--calendar-max-width));
+}
+
+@container (max-width: calc(var(--calendar-min-width) + var(--budget-min-width) + var(--budget-calendar-gap))) {
+  .budget-calendar-layout {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .budget-calendar-layout .calendar-column {
+    width: 100%;
+  }
 }
 
 /* Timeline + Location row layout */

--- a/frontend/src/dashboard/home/styles/components/page-layouts.css
+++ b/frontend/src/dashboard/home/styles/components/page-layouts.css
@@ -22,6 +22,7 @@
   height: 100%;
   flex: 1;
   min-height: 0;
+  container-type: inline-size;
 }
 
 /* Active project details wrapper sizing */

--- a/frontend/src/dashboard/project/components/Shared/calendar-overview-card.css
+++ b/frontend/src/dashboard/project/components/Shared/calendar-overview-card.css
@@ -17,7 +17,8 @@
   background: var(--bg2, #111213);
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04), 0 18px 48px rgba(0, 0, 0, 0.45);
   border-radius: 32px 32px 32px 32px;
-  
+  container-type: inline-size;
+
 }
 
 /* Override dashboard-item hover highlighting for calendar */
@@ -365,8 +366,8 @@
 
 @media (max-height: 750px) {
   .calendar-overview-card-wrapper .calendar-day {
-    min-height: clamp(30px, 7vh, 50px);
-    padding-bottom: clamp(2px, 0.5vh, 3px);
+    padding: clamp(6px, 1.5vh, 10px) clamp(10px, 2.5vh, 16px)
+      clamp(8px, 1.5vh, 12px);
   }
   .calendar-overview-card-wrapper .tile-date-number {
     font-size: clamp(0.5rem, 1vh, 0.7rem);
@@ -483,13 +484,18 @@
   display: flex;
   flex-direction: column;
   align-items: stretch;
+  aspect-ratio: 1 / 1;
+  min-width: 0;
+  width: 100%;
   z-index: 2;
 }
 
 .calendar-overview-card-wrapper .calendar-day {
   position: relative;
-  min-height: 54px;
-  padding: 12px 18px 12px;
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  padding: 12px 18px 16px;
   border-radius: 50px;
   border: none;
   background: none;
@@ -543,12 +549,108 @@
   gap: 4px;
 }
 
+@container (max-width: 560px) {
+  .calendar-overview-card-wrapper .month-widget {
+    gap: 10px;
+  }
+
+  .calendar-overview-card-wrapper .month-widget-header {
+    gap: 10px;
+  }
+
+  .calendar-overview-card-wrapper .month-title {
+    font-size: 0.95rem;
+  }
+
+  .calendar-overview-card-wrapper .month-nav-btn {
+    padding: 4px 8px;
+  }
+
+  .calendar-overview-card-wrapper .calendar-weekdays {
+    gap: 3px;
+    font-size: 0.65rem;
+  }
+
+  .calendar-overview-card-wrapper .calendar-weeks {
+    gap: 3px;
+  }
+
+  .calendar-overview-card-wrapper .calendar-week {
+    gap: 3px;
+    padding-bottom: 10px;
+  }
+
+  .calendar-overview-card-wrapper .calendar-day {
+    padding: 10px 14px 14px;
+  }
+
+  .calendar-overview-card-wrapper .day-dots {
+    bottom: 5px;
+    gap: 3px;
+  }
+
+  .calendar-overview-card-wrapper .tile-date-number {
+    font-size: 0.9rem;
+  }
+}
+
+@container (max-width: 480px) {
+  .calendar-overview-card-wrapper .month-widget {
+    gap: 8px;
+  }
+
+  .calendar-overview-card-wrapper .month-widget-header {
+    gap: 8px;
+  }
+
+  .calendar-overview-card-wrapper .month-title {
+    font-size: 0.9rem;
+  }
+
+  .calendar-overview-card-wrapper .month-nav-btn {
+    padding: 4px 6px;
+  }
+
+  .calendar-overview-card-wrapper .calendar-weekdays {
+    gap: 2px;
+    font-size: 0.6rem;
+  }
+
+  .calendar-overview-card-wrapper .calendar-weeks {
+    gap: 2px;
+  }
+
+  .calendar-overview-card-wrapper .calendar-week {
+    gap: 2px;
+    padding-bottom: 8px;
+  }
+
+  .calendar-overview-card-wrapper .calendar-day {
+    padding: 8px 10px 12px;
+  }
+
+  .calendar-overview-card-wrapper .day-dots {
+    bottom: 4px;
+    gap: 2px;
+  }
+
+  .calendar-overview-card-wrapper .tile-date-number {
+    font-size: 0.85rem;
+  }
+
+  .calendar-overview-card-wrapper .calendar-week-track {
+    top: 10px;
+    bottom: 10px;
+  }
+}
+
 
 .calendar-overview-card-wrapper .calendar-week-track {
   position: absolute;
-  height: 60px;
+  top: 12px;
+  bottom: 12px;
+  height: auto;
   border-radius: 4px;
-  bottom: 9px;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
   border-radius: 30px;
   pointer-events: none;
@@ -563,20 +665,7 @@
 
 @media (max-width: 768px) {
   .calendar-overview-card-wrapper .calendar-content {
-    padding: 12px 2px;
-  }
-  .calendar-overview-card-wrapper .calendar-week {
-    padding-bottom: 12px;
-  }
-  .calendar-overview-card-wrapper .calendar-day {
-    min-height: 56px;
-    padding: 6px 10px 12px;
-  }
-  .calendar-overview-card-wrapper .day-dots {
-    bottom: 5px;
-  }
-  .calendar-overview-card-wrapper .tile-date-number {
-    font-size: 0.85rem;
+    padding: 16px 2px;
   }
 }
 

--- a/frontend/src/dashboard/project/project.tsx
+++ b/frontend/src/dashboard/project/project.tsx
@@ -23,8 +23,6 @@ import { useProjectPalette } from "@/dashboard/project/hooks/useProjectPalette";
 import { resolveProjectCoverUrl } from "@/dashboard/project/utils/theme";
 import { getProjectDashboardPath } from "@/shared/utils/projectUrl";
 
-const MOBILE_LAYOUT_WIDTH = 640;
-
 interface LocationState {
   flashDate?: string;
 }
@@ -46,11 +44,6 @@ const SingleProject: React.FC = () => {
   const [filesOpen, setFilesOpen] = useState<boolean>(false);
   const quickLinksRef = useRef<QuickLinksRef>(null);
   const { ws } = useSocket();
-
-  const [isMobileBudgetLayout, setIsMobileBudgetLayout] = useState(() => {
-    if (typeof window === "undefined") return false;
-    return window.innerWidth <= MOBILE_LAYOUT_WIDTH;
-  });
 
   const projectNameFromPath = useMemo(() => {
     const segments = location.pathname.split("/").filter(Boolean);
@@ -109,18 +102,6 @@ const SingleProject: React.FC = () => {
     },
     [fetchProjectDetails]
   );
-
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    const handleResize = () => {
-      setIsMobileBudgetLayout(window.innerWidth <= MOBILE_LAYOUT_WIDTH);
-    };
-    handleResize();
-    window.addEventListener("resize", handleResize);
-    return () => {
-      window.removeEventListener("resize", handleResize);
-    };
-  }, []);
 
   // Keep the active project in sync with the ID from the route.
   useEffect(() => {
@@ -281,13 +262,9 @@ const SingleProject: React.FC = () => {
               <div className="dashboard-layout budget-calendar-layout">
                 <div className="budget-column">
                   <BudgetOverviewCard projectId={activeProject?.projectId} />
-                  {isMobileBudgetLayout && (
-                    <div className="budget-calendar-mobile-card">{calendarOverviewCard}</div>
-                  )}
-
                   <GalleryComponent />
                 </div>
-                {!isMobileBudgetLayout && <div className="calendar-column">{calendarOverviewCard}</div>}
+                <div className="calendar-column">{calendarOverviewCard}</div>
               </div>
 
               <Timeline


### PR DESCRIPTION
## Summary
- convert the overview budget/calendar row to a responsive CSS grid with clamp-based calendar sizing and container-query stacking
- remove the mobile-only calendar duplication in the project page so the grid stacks budget then calendar on narrow containers
- enforce square calendar tiles and add calendar container queries to tune gaps, fonts, and track sizing at smaller widths

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0a7ee8c708324a0411795253aa601