### PR TITLE
feat: make dashboard project kpis interactive

### DIFF
--- a/frontend/src/dashboard/home/components/AllProjects.tsx
+++ b/frontend/src/dashboard/home/components/AllProjects.tsx
@@ -696,7 +696,9 @@ const AllProjects: React.FC = () => {
           <span className={mobileStyles.dot} />
           <motion.button
             type="button"
-            className={mobileStyles.chip}
+            className={`${mobileStyles.chip} ${
+              showPendingOnly ? mobileStyles.chipActive : ''
+            }`}
             aria-pressed={showPendingOnly}
             whileHover={
               reduceMotion ? undefined : { scale: MICRO_WOBBLE_SCALE }

--- a/frontend/src/dashboard/home/components/AllProjects.tsx
+++ b/frontend/src/dashboard/home/components/AllProjects.tsx
@@ -15,6 +15,7 @@ import AvatarStack from '../../../shared/ui/AvatarStack';
 import { ProjectsFilterMenu } from './ProjectsFilterMenu';
 import { useProjectFilters } from './hooks/useProjectFilters';
 import {
+  parseProjectStatusToNumber,
   useProjectKpis,
   type ProjectLike,
 } from '@/dashboard/home/hooks/useProjectKpis';
@@ -103,6 +104,7 @@ const AllProjects: React.FC = () => {
     return stored === 'grid' || stored === 'list' ? stored : 'list';
   });
   const [menuOpenId, setMenuOpenId] = useState<string | null>(null);
+  const [showPendingOnly, setShowPendingOnly] = useState(false);
   const menuRefs = useRef<Record<string, HTMLDivElement | null>>({});
 
   useEffect(() => {
@@ -137,6 +139,7 @@ const AllProjects: React.FC = () => {
     statusTriggerLabel,
     statusDropdown,
     showStatusDropdown,
+    setStatusFilter,
     sortOptions,
     sortTriggerLabel,
     sortDropdown,
@@ -155,7 +158,32 @@ const AllProjects: React.FC = () => {
     [filteredProjectsWithMeta],
   );
 
+  const displayedProjects = useMemo(
+    () =>
+      showPendingOnly
+        ? filteredProjects.filter(
+            (project) => parseProjectStatusToNumber(project.status) < 100,
+          )
+        : filteredProjects,
+    [filteredProjects, showPendingOnly],
+  );
+
   const kpis = useProjectKpis(projects as ProjectLike[]);
+
+  const nextDueProject = useMemo(() => {
+    const today = new Date();
+    return (projects as Project[])
+      .filter((project) => {
+        if (!project.finishline) return false;
+        const deadline = new Date(project.finishline);
+        return !Number.isNaN(deadline.getTime()) && deadline > today;
+      })
+      .sort((a, b) => {
+        const aDate = new Date(a.finishline || 0).getTime();
+        const bDate = new Date(b.finishline || 0).getTime();
+        return aDate - bDate;
+      })[0] ?? null;
+  }, [projects]);
 
   const handleThumbnailError = useCallback((projectId: string) => {
     setImageErrors((prev) => {
@@ -266,7 +294,32 @@ const AllProjects: React.FC = () => {
     return d.toLocaleString(undefined, { month: 'short', day: 'numeric' });
   };
 
-  const isSingleProject = filteredProjects.length === 1;
+  useEffect(() => {
+    if (!filteredProjects.length) {
+      setShowPendingOnly(false);
+    }
+  }, [filteredProjects.length]);
+
+  const handleShowAllProjectsChip = useCallback(() => {
+    setScope('all');
+    setQuery('');
+    setStatusFilter('');
+    setShowPendingOnly(false);
+  }, [setQuery, setScope, setStatusFilter]);
+
+  const handleTogglePendingChip = useCallback(() => {
+    setScope('all');
+    setQuery('');
+    setStatusFilter('');
+    setShowPendingOnly((prev) => !prev);
+  }, [setQuery, setScope, setStatusFilter]);
+
+  const handleOpenNextProject = useCallback(() => {
+    if (!nextDueProject) return;
+    onSelectProject(nextDueProject);
+  }, [nextDueProject, onSelectProject]);
+
+  const isSingleProject = displayedProjects.length === 1;
 
   const renderProjectThumbnail = useCallback(
     (project: Project, variant: 'grid' | 'list') => {
@@ -378,6 +431,22 @@ const AllProjects: React.FC = () => {
         </p>
       </div>
     );
+  } else if (showPendingOnly && displayedProjects.length === 0) {
+    content = (
+      <div
+        style={{
+          display: 'flex',
+          flex: 1,
+          alignItems: 'center',
+          justifyContent: 'center',
+          width: '100%',
+        }}
+      >
+        <p style={{ fontSize: '14px', color: '#aaa', textAlign: 'center' }}>
+          No pending projects
+        </p>
+      </div>
+    );
   } else if (viewMode === 'grid') {
     content = (
       <div
@@ -385,7 +454,7 @@ const AllProjects: React.FC = () => {
           isSingleProject ? 'single-item' : ''
         }`}
       >
-        {filteredProjects.map((project: Project) => (
+        {displayedProjects.map((project: Project) => (
           <div
             key={project.projectId}
             className={`project-container-welcome ${
@@ -451,7 +520,7 @@ const AllProjects: React.FC = () => {
 
     content = (
       <ul className="projects-list">
-        {filteredProjects.map((project: Project) => {
+        {displayedProjects.map((project: Project) => {
           const statusText = formatStatus(String(project.status || ''));
           const team = normalizeTeam(project.team);
           const progress = Number(statusText.replace('%', ''));
@@ -610,7 +679,8 @@ const AllProjects: React.FC = () => {
         </div>
 
         <div className={mobileStyles.kpis}>
-          <motion.span
+          <motion.button
+            type="button"
             className={mobileStyles.chip}
             whileHover={
               reduceMotion ? undefined : { scale: MICRO_WOBBLE_SCALE }
@@ -619,12 +689,15 @@ const AllProjects: React.FC = () => {
               reduceMotion ? undefined : { scale: MICRO_WOBBLE_SCALE }
             }
             transition={reduceMotion ? undefined : SPRING_FAST}
+            onClick={handleShowAllProjectsChip}
           >
             {kpis.totalProjects} Projects
-          </motion.span>
+          </motion.button>
           <span className={mobileStyles.dot} />
-          <motion.span
+          <motion.button
+            type="button"
             className={mobileStyles.chip}
+            aria-pressed={showPendingOnly}
             whileHover={
               reduceMotion ? undefined : { scale: MICRO_WOBBLE_SCALE }
             }
@@ -632,12 +705,14 @@ const AllProjects: React.FC = () => {
               reduceMotion ? undefined : { scale: MICRO_WOBBLE_SCALE }
             }
             transition={reduceMotion ? undefined : SPRING_FAST}
+            onClick={handleTogglePendingChip}
           >
             {kpis.pendingProjects} Pending
-          </motion.span>
+          </motion.button>
           <span className={mobileStyles.dot} />
-          <motion.span
-            className={mobileStyles.chip}
+          <motion.button
+            type="button"
+            className={`${mobileStyles.chip} ${mobileStyles.chipNext}`}
             whileHover={
               reduceMotion ? undefined : { scale: MICRO_WOBBLE_SCALE }
             }
@@ -645,11 +720,13 @@ const AllProjects: React.FC = () => {
               reduceMotion ? undefined : { scale: MICRO_WOBBLE_SCALE }
             }
             transition={reduceMotion ? undefined : SPRING_FAST}
+            onClick={handleOpenNextProject}
+            disabled={!nextDueProject}
           >
             {kpis.nextProject
               ? `Next: ${kpis.nextProject.title} ${kpis.nextProject.date}`
               : 'No upcoming projects'}
-          </motion.span>
+          </motion.button>
         </div>
       </header>
       <div className="projects-scrollable">{content}</div>

--- a/frontend/src/dashboard/home/components/ProjectsPanelDesktop.tsx
+++ b/frontend/src/dashboard/home/components/ProjectsPanelDesktop.tsx
@@ -202,7 +202,9 @@ const ProjectsPanelDesktop: React.FC<ProjectsPanelDesktopProps> = ({ onOpenProje
           <span className={mobileStyles.dot} />
           <motion.button
             type="button"
-            className={mobileStyles.chip}
+            className={`${mobileStyles.chip} ${
+              showPendingOnly ? mobileStyles.chipActive : ""
+            }`}
             aria-pressed={showPendingOnly}
             whileHover={reduceMotion ? undefined : { scale: MICRO_WOBBLE_SCALE }}
             whileFocus={reduceMotion ? undefined : { scale: MICRO_WOBBLE_SCALE }}

--- a/frontend/src/dashboard/home/components/ProjectsPanelDesktop.tsx
+++ b/frontend/src/dashboard/home/components/ProjectsPanelDesktop.tsx
@@ -5,8 +5,13 @@ import { useNavigate } from "react-router-dom";
 
 import { useData } from "@/app/contexts/useData";
 import type { UserLite } from "@/app/contexts/DataProvider";
-import { useProjectKpis, type ProjectLike } from "@/dashboard/home/hooks/useProjectKpis";
+import {
+  parseProjectStatusToNumber,
+  useProjectKpis,
+  type ProjectLike,
+} from "@/dashboard/home/hooks/useProjectKpis";
 import { MICRO_WOBBLE_SCALE, SPRING_FAST } from "@/shared/ui/motionTokens";
+import { getProjectDashboardPath } from "@/shared/utils/projectUrl";
 
 import desktopStyles from "./ProjectsPanelDesktop.module.css";
 import mobileStyles from "@/dashboard/home/components/projects-panel.module.css";
@@ -36,6 +41,7 @@ const ProjectsPanelDesktop: React.FC<ProjectsPanelDesktopProps> = ({ onOpenProje
   const navigate = useNavigate();
 
   const [imgError, setImgError] = useState<Record<string, boolean>>({});
+  const [showPendingOnly, setShowPendingOnly] = useState(false);
 
   useEffect(() => {
     if (!isLoading && projects.length === 0 && !projectsError) {
@@ -54,11 +60,20 @@ const ProjectsPanelDesktop: React.FC<ProjectsPanelDesktopProps> = ({ onOpenProje
     (projectId: string) => {
       if (onOpenProject) {
         onOpenProject(projectId);
-      } else {
-        navigate("/dashboard/projects");
+        return;
       }
+
+      const project = (projects as ProjectLike[]).find(
+        (entry) => entry.projectId === projectId
+      );
+      if (project) {
+        navigate(getProjectDashboardPath(projectId, project.title));
+        return;
+      }
+
+      navigate("/dashboard/projects");
     },
-    [onOpenProject, navigate]
+    [onOpenProject, navigate, projects]
   );
 
   const {
@@ -74,6 +89,7 @@ const ProjectsPanelDesktop: React.FC<ProjectsPanelDesktopProps> = ({ onOpenProje
     statusTriggerLabel,
     statusDropdown,
     showStatusDropdown,
+    setStatusFilter,
     sortOptions,
     sortTriggerLabel,
     sortDropdown,
@@ -84,6 +100,49 @@ const ProjectsPanelDesktop: React.FC<ProjectsPanelDesktopProps> = ({ onOpenProje
   });
 
   const kpis = useProjectKpis(projects as ProjectLike[]);
+
+  const nextDueProject = useMemo(() => {
+    const today = new Date();
+    return (projects as ProjectLike[])
+      .filter((project) => {
+        if (!project.finishline) return false;
+        const deadline = new Date(project.finishline);
+        return !Number.isNaN(deadline.getTime()) && deadline > today;
+      })
+      .sort((a, b) => {
+        const aDate = new Date(a.finishline || 0).getTime();
+        const bDate = new Date(b.finishline || 0).getTime();
+        return aDate - bDate;
+      })[0] ?? null;
+  }, [projects]);
+
+  const filteredProjectsToDisplay = useMemo(() => {
+    if (!showPendingOnly) return filteredProjects;
+
+    return (filteredProjects as ProjectWithMeta[]).filter((project) =>
+      parseProjectStatusToNumber(project.status) < 100
+    );
+  }, [filteredProjects, showPendingOnly]);
+
+  const handleNavigateToAllProjects = useCallback(() => {
+    setShowPendingOnly(false);
+    setScope("all");
+    setQuery("");
+    setStatusFilter("");
+    navigate("/dashboard/projects");
+  }, [navigate, setQuery, setScope, setStatusFilter]);
+
+  const handleTogglePendingFilter = useCallback(() => {
+    setScope("all");
+    setQuery("");
+    setStatusFilter("");
+    setShowPendingOnly((prev) => !prev);
+  }, [setQuery, setScope, setStatusFilter]);
+
+  const handleOpenNextProject = useCallback(() => {
+    if (!nextDueProject?.projectId) return;
+    handleOpen(nextDueProject.projectId);
+  }, [handleOpen, nextDueProject]);
 
   const usersById = useMemo(() => {
     const map = new Map<string, UserLite>();
@@ -130,40 +189,48 @@ const ProjectsPanelDesktop: React.FC<ProjectsPanelDesktopProps> = ({ onOpenProje
         />
 
         <div className={mobileStyles.kpis}>
-          <motion.span
+          <motion.button
+            type="button"
             className={mobileStyles.chip}
             whileHover={reduceMotion ? undefined : { scale: MICRO_WOBBLE_SCALE }}
             whileFocus={reduceMotion ? undefined : { scale: MICRO_WOBBLE_SCALE }}
             transition={reduceMotion ? undefined : SPRING_FAST}
+            onClick={handleNavigateToAllProjects}
           >
             {kpis.totalProjects} Projects
-          </motion.span>
+          </motion.button>
           <span className={mobileStyles.dot} />
-          <motion.span
+          <motion.button
+            type="button"
             className={mobileStyles.chip}
+            aria-pressed={showPendingOnly}
             whileHover={reduceMotion ? undefined : { scale: MICRO_WOBBLE_SCALE }}
             whileFocus={reduceMotion ? undefined : { scale: MICRO_WOBBLE_SCALE }}
             transition={reduceMotion ? undefined : SPRING_FAST}
+            onClick={handleTogglePendingFilter}
           >
             {kpis.pendingProjects} Pending
-          </motion.span>
+          </motion.button>
           <span className={mobileStyles.dot} />
-          <motion.span
-            className={mobileStyles.chip}
+          <motion.button
+            type="button"
+            className={`${mobileStyles.chip} ${mobileStyles.chipNext}`}
             whileHover={reduceMotion ? undefined : { scale: MICRO_WOBBLE_SCALE }}
             whileFocus={reduceMotion ? undefined : { scale: MICRO_WOBBLE_SCALE }}
             transition={reduceMotion ? undefined : SPRING_FAST}
+            onClick={handleOpenNextProject}
+            disabled={!nextDueProject}
           >
             {kpis.nextProject
               ? `Next: ${kpis.nextProject.title} ${kpis.nextProject.date}`
               : "No upcoming projects"}
-          </motion.span>
+          </motion.button>
         </div>
       </header>
 
       <div className={desktopStyles.content}>
         <ProjectsTable
-          projects={filteredProjects as ProjectWithMeta[]}
+          projects={filteredProjectsToDisplay as ProjectWithMeta[]}
           isLoading={isLoading}
           projectsError={projectsError}
           onOpenProject={handleOpen}

--- a/frontend/src/dashboard/home/components/hooks/useProjectFilters.ts
+++ b/frontend/src/dashboard/home/components/hooks/useProjectFilters.ts
@@ -38,6 +38,7 @@ type UseProjectFiltersResult = {
   query: string;
   setQuery: (value: string) => void;
   statusFilter: string;
+  setStatusFilter: (value: string) => void;
   statusOptions: DropdownOption<string>[];
   statusTriggerLabel: string;
   statusDropdown: DropdownHelpers<string>;
@@ -234,6 +235,7 @@ export const useProjectFilters = ({
     query,
     setQuery,
     statusFilter,
+    setStatusFilter,
     statusOptions,
     statusTriggerLabel,
     statusDropdown,

--- a/frontend/src/dashboard/home/components/projects-panel.module.css
+++ b/frontend/src/dashboard/home/components/projects-panel.module.css
@@ -184,10 +184,22 @@
   white-space: nowrap;
   max-width: 100%;
   transition: background-color .2s ease;
+  cursor: pointer;
 }
 
 .chip:hover {
   background: rgba(255, 255, 255, .03);
+}
+
+.chipActive {
+  background: rgba(255, 255, 255, .08);
+  border-color: rgba(255, 255, 255, .24);
+  color: rgba(255, 255, 255, .95);
+}
+
+.chip:disabled,
+.chip[aria-pressed="true"]:disabled {
+  cursor: not-allowed;
 }
 
 .chipNoWrap {

--- a/frontend/src/dashboard/home/hooks/useProjectKpis.ts
+++ b/frontend/src/dashboard/home/hooks/useProjectKpis.ts
@@ -28,6 +28,13 @@ interface KPIs {
   nextProject: { title: string; date: string } | null;
 }
 
+export const parseProjectStatusToNumber = (status: unknown): number => {
+  if (status === undefined || status === null) return 0;
+  const str = typeof status === "string" ? status : String(status);
+  const num = parseFloat(str.replace("%", ""));
+  return Number.isNaN(num) ? 0 : num;
+};
+
 /**
  * Derive dashboard KPIs from a list of projects.
  * - total number of projects
@@ -36,16 +43,9 @@ interface KPIs {
  */
 export function useProjectKpis(projects: ProjectLike[]): KPIs {
   return useMemo(() => {
-    const parseStatusToNumber = (status: unknown): number => {
-      if (status === undefined || status === null) return 0;
-      const str = typeof status === "string" ? status : String(status);
-      const num = parseFloat(str.replace("%", ""));
-      return Number.isNaN(num) ? 0 : num;
-    };
-
     const totalProjects = projects.length;
     const completed = projects.filter(
-      (p) => parseStatusToNumber(p.status) >= 100
+      (p) => parseProjectStatusToNumber(p.status) >= 100
     ).length;
     const pendingProjects = totalProjects - completed;
 


### PR DESCRIPTION
## Summary
- make the Projects overview KPIs clickable so they can open the full projects view, toggle pending projects, and jump to the next deadline
- mirror the KPI interactions in the All Projects view, including a pending-only toggle and handling empty pending states
- expose helpers needed for the KPI interactions by exporting the status parsing utility and surfacing the status filter setter

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0b779a63c8324bc99fb169b2c5e72