### PR TITLE
Adjust dashboard task cards spacing

### DIFF
--- a/frontend/src/dashboard/home/components/MobileTasksOverviewCard.module.css
+++ b/frontend/src/dashboard/home/components/MobileTasksOverviewCard.module.css
@@ -4,8 +4,8 @@
   justify-content: space-between;
   height: 100%;
   min-height: 0;
-  padding: 14px 16px;
-  gap: 12px;
+  padding: 13px 15px;
+  gap: 11px;
   color: rgba(255, 255, 255, 0.92);
   background:
     radial-gradient(120% 120% at 100% 0%, color-mix(in srgb, var(--brand, #fa3356) 12%, transparent) 0%, transparent 60%),
@@ -20,12 +20,12 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
+  gap: 7px;
 }
 
 .title {
   margin: 0;
-  font-size: 16px;
+  font-size: 15px;
   font-weight: 600;
   letter-spacing: -0.01em;
 }
@@ -34,7 +34,7 @@
   border: none;
   background: none;
   color: rgba(255, 255, 255, 0.75);
-  font-size: 12px;
+  font-size: 11px;
   font-weight: 600;
   text-decoration: none;
   padding: 4px 0;
@@ -52,7 +52,7 @@
 
 .statRow {
   display: flex;
-  gap: 8px;
+  gap: 7px;
 }
 
 .stat {
@@ -60,16 +60,16 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
-  gap: 4px;
-  padding: 10px 12px;
-  border-radius: 18px;
+  gap: 3px;
+  padding: 9px 11px;
+  border-radius: 16px;
   background: rgba(255, 255, 255, 0.05);
   border: 1px solid rgba(255, 255, 255, 0.08);
-  min-height: 64px;
+  min-height: 58px;
 }
 
 .statValue {
-  font-size: 18px;
+  font-size: 17px;
   font-weight: 600;
 }
 
@@ -97,24 +97,24 @@
 
 .status {
   margin: 0;
-  font-size: 13px;
+  font-size: 12px;
   color: rgba(255, 255, 255, 0.65);
-  line-height: 1.3;
+  line-height: 1.28;
 }
 
 @media (max-width: 480px) {
   .card {
-    padding: 12px 14px;
-    gap: 10px;
+    padding: 11px 13px;
+    gap: 9px;
   }
 
   .statRow {
-    gap: 6px;
+    gap: 5px;
   }
 
   .stat {
-    padding: 10px;
-    border-radius: 16px;
+    padding: 9px;
+    border-radius: 15px;
   }
 }
 

--- a/frontend/src/dashboard/home/components/TasksOverviewCard.module.css
+++ b/frontend/src/dashboard/home/components/TasksOverviewCard.module.css
@@ -6,13 +6,13 @@
   border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: 20px;
   overflow: hidden;
-  padding: 20px;
+  padding: 18px;
   box-sizing: border-box;
   flex-shrink: 0;
   position: relative;
   display: flex;
   flex-direction: column;
-  gap: var(--space-2, 16px);
+  gap: 14px;
   color: rgba(255, 255, 255, 0.95);
   isolation: isolate;
   background:
@@ -33,40 +33,40 @@
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  gap: var(--space-2, 16px);
+  gap: 14px;
 }
 
 .titleWrap {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 3px;
 }
 
 .title {
   margin: 0;
-  font-size: 18px;
+  font-size: 17px;
   font-weight: 600;
 }
 
 .subtitle {
   margin: 0;
-  font-size: 13px;
+  font-size: 12px;
   color: rgba(255, 255, 255, 0.65);
 }
 
 .actions {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
+  gap: 7px;
 }
 
 .iconButton {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 38px;
-  height: 38px;
-  border-radius: 14px;
+  width: 36px;
+  height: 36px;
+  border-radius: 13px;
   border: 1px solid rgba(255, 255, 255, 0.14);
   background: rgba(255, 255, 255, 0.05);
   color: rgba(255, 255, 255, 0.92);
@@ -100,19 +100,19 @@
 
 .statGrid {
   display: grid;
-  gap: var(--space-2, 16px);
+  gap: 14px;
   grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
 }
 
 .stat {
   display: flex;
   flex-direction: column;
-  gap: 6px;
-  padding: 14px 16px;
-  border-radius: 18px;
+  gap: 5px;
+  padding: 12px 14px;
+  border-radius: 16px;
   border: 1px solid rgba(255, 255, 255, 0.1);
   background: rgba(255, 255, 255, 0.04);
-  min-height: 82px;
+  min-height: 74px;
 }
 
 .statOk {
@@ -131,14 +131,14 @@
 }
 
 .statLabel {
-  font-size: 12px;
+  font-size: 11px;
   color: rgba(255, 255, 255, 0.7);
   letter-spacing: 0.02em;
   text-transform: uppercase;
 }
 
 .statValue {
-  font-size: 24px;
+  font-size: 22px;
   font-weight: 600;
   letter-spacing: -0.01em;
 }
@@ -146,17 +146,17 @@
 .groups {
   display: flex;
   flex-direction: column;
-  gap: var(--space-2, 16px);
+  gap: 14px;
 }
 
 .group {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 9px;
 }
 
 .groupLabel {
-  font-size: 12px;
+  font-size: 11px;
   color: rgba(255, 255, 255, 0.58);
   font-variant-numeric: tabular-nums;
   letter-spacing: 0.02em;
@@ -165,26 +165,26 @@
 .chips {
   display: flex;
   flex-wrap: wrap;
-  gap: 10px;
+  gap: 9px;
 }
 
 .chip {
   display: inline-flex;
   align-items: center;
-  gap: 10px;
-  padding: 9px 14px;
-  border-radius: 16px;
+  gap: 9px;
+  padding: 8px 13px;
+  border-radius: 15px;
   border: 1px solid rgba(255, 255, 255, 0.1);
   background: rgba(255, 255, 255, 0.05);
   color: rgba(255, 255, 255, 0.9);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
-  font-size: 13px;
+  font-size: 12px;
   line-height: 1.2;
 }
 
 .chipDot {
-  width: 10px;
-  height: 10px;
+  width: 9px;
+  height: 9px;
   border-radius: 50%;
   flex-shrink: 0;
   box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.35);
@@ -195,13 +195,13 @@
 }
 
 .chipMeta {
-  font-size: 12px;
+  font-size: 11px;
   color: rgba(255, 255, 255, 0.62);
 }
 
 .empty {
-  padding: 18px 0 6px;
-  font-size: 13px;
+  padding: 16px 0 6px;
+  font-size: 12px;
   color: rgba(255, 255, 255, 0.55);
 }
 


### PR DESCRIPTION
## Summary
- compress the desktop dashboard tasks overview card by tightening spacing, paddings, and typography while preserving its hierarchy
- align the mobile tasks overview card with the more compact layout so both variants share balanced proportions

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0bc76451c83248c260c091455cb81