### PR TITLE
Adjust project messages layout sizing

### DIFF
--- a/frontend/src/dashboard/features/messages/ProjectMessagesThread.tsx
+++ b/frontend/src/dashboard/features/messages/ProjectMessagesThread.tsx
@@ -1023,9 +1023,9 @@ const ProjectMessagesThread: React.FC<ProjectMessagesThreadProps> = ({
             style={{
               flexGrow: 1,
               overflowY: "auto",
-              padding: "10px",
+              padding: "8px",
               borderRadius: "5px",
-              marginBottom: "10px",
+              marginBottom: "8px",
               display: "flex",
               flexDirection: "column",
               justifyContent:

--- a/frontend/src/dashboard/features/messages/project-messages-thread.css
+++ b/frontend/src/dashboard/features/messages/project-messages-thread.css
@@ -1,9 +1,9 @@
 .chat-messages {
   flex-grow: 1;
   overflow-y: auto;
-  padding: 10px;
+  padding: 8px;
   border-radius: 5px;
-  margin-bottom: 10px;
+  margin-bottom: 8px;
   display: flex;
   flex-direction: column;
 }
@@ -19,7 +19,7 @@
 }
 
 .message-row {
-  margin-bottom: 12px;
+  margin-bottom: 10px;
   display: flex;
   align-items: flex-end;
 }
@@ -33,11 +33,11 @@
 }
 
 .avatar {
-  width: 32px;
-  height: 32px;
+  width: 28px;
+  height: 28px;
   border-radius: 50%;
   object-fit: cover;
-  margin-right: 10px;
+  margin-right: 8px;
 }
 
 .avatar-wrapper {
@@ -48,15 +48,15 @@
 
 
 .avatar.avatar-right {
-  margin-left: 10px;
+  margin-left: 8px;
   margin-right: 0;
 }
 
 .message-bubble {
   position: relative;
-  max-width: 65%;
-  min-width: 220px;
-  padding: 8px 16px;
+  max-width: 60%;
+  min-width: 180px;
+  padding: 8px 12px;
   border-radius: 15px;
   color: #fff;
   word-wrap: break-word;
@@ -70,7 +70,7 @@
 }
 
 .message-sender {
-  font-size: 12px;
+  font-size: 11px;
   opacity: 0.7;
   margin-bottom: 5px;
 }
@@ -140,11 +140,11 @@
 
 .message-input-container {
   display: flex;
-  gap: 10px;
+  gap: 8px;
   align-items: center;
   margin-top: 10px;
   border-radius: 10px;
-  padding: 10px;
+  padding: 8px;
   position: relative;
   background-color: #1c1c1c;
 }
@@ -152,7 +152,7 @@
 .message-input-inner {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 6px;
   position: relative;
   flex: 1;
 }
@@ -169,7 +169,7 @@
   left: 0;
   display: flex;
   gap: 6px;
-  padding: 6px 8px;
+  padding: 5px 8px;
   border-radius: 999px;
   background: #333;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
@@ -185,7 +185,7 @@
   color: #fff;
   cursor: pointer;
   font-size: 12px;
-  padding: 4px 10px;
+  padding: 4px 8px;
   border-radius: 999px;
   transition: background-color 0.2s ease;
 }
@@ -198,7 +198,7 @@
 
 .message-input {
   flex-grow: 1;
-  padding: 10px;
+  padding: 8px;
   border-radius: 6px;
   border: 1px solid #444;
   background: #262626;
@@ -214,7 +214,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 6px;
+  padding: 5px;
   border-radius: 6px;
   transition: background-color 0.2s ease;
 }
@@ -252,7 +252,7 @@
   background: none;
   border: none;
   cursor: pointer;
-  font-size: 18px;
+  font-size: 16px;
   line-height: 1;
   padding: 4px;
   border-radius: 4px;
@@ -268,7 +268,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 10px 15px;
+  padding: 8px 12px;
   background: #FA3356;
   border: none;
   border-radius: 6px;
@@ -284,16 +284,16 @@
 
 @media (max-width: 767px) {
   .message-input-container {
-    gap: 8px;
-    padding: 8px;
+    gap: 6px;
+    padding: 6px;
   }
 
   .message-icon-button {
-    padding: 4px;
+    padding: 3px;
   }
 
   .send-button {
-    padding: 8px 12px;
+    padding: 7px 10px;
   }
 }
 

--- a/frontend/src/dashboard/home/styles/components/chat-panel.css
+++ b/frontend/src/dashboard/home/styles/components/chat-panel.css
@@ -1,14 +1,14 @@
 /* Chat Panel Styles (docked and floating) */
 
 body.chat-panel-docked {
-  padding-right: var(--chat-panel-width, 350px);
+  padding-right: var(--chat-panel-width, 320px);
 }
 
 .chat-panel {
   position: fixed;
   top: var(--chat-panel-top, 50px);
   height: calc(100% - var(--chat-panel-top, 50px));
-  width: 350px;
+  width: 320px;
   background: rgba(0, 0, 0, 0.8);
   display: flex;
   flex-direction: column;
@@ -35,9 +35,9 @@ body.chat-panel-docked {
   height: 400px;
   border-radius: 32px;
   box-shadow: 0 0 10px rgba(0,0,0,0.3);
-  
+
   transition: height 0.3s ease;
-  min-width: 300px;
+  min-width: 280px;
   min-height: 280px;
 }
 

--- a/frontend/src/dashboard/home/styles/components/messages-files.css
+++ b/frontend/src/dashboard/home/styles/components/messages-files.css
@@ -35,19 +35,20 @@
 
 /* Project messages panel */
 .project-messages {
-  flex: 3;
+  flex: 2.25;
   min-height: 0;
   display: flex;
   flex-direction: column;
-  padding-right: 5px;
-  
+  padding-right: 4px;
+  max-width: min(420px, 100%);
+
   border-radius: 32px;
-  padding: 16px;
+  padding: 12px;
   background: rgba(255, 255, 255, 0.02);
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.05);
   backdrop-filter: blur(8px);
   position: sticky;
-    background: var(--bg2, #111213);
+  background: var(--bg2, #111213);
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04), 0 18px 48px rgba(0, 0, 0, 0.45);
   border-radius: 32px 32px 32px 32px;
   border: 2px solid rgba(255, 255, 255, 0.10);
@@ -62,7 +63,7 @@
 }
 
 .project-messages.floating {
-  min-width: 350px;
+  min-width: 320px;
 }
 
 .project-messages .messages-inner {
@@ -70,12 +71,19 @@
   overflow-y: auto;
 }
 
+@media (max-width: 1024px) {
+  .project-messages {
+    flex: 1 1 100%;
+    max-width: none;
+  }
+}
+
 /* Thread header and title */
 .project-thread-title {
   color: #fff;
   margin: 0 0 10px 0;
   padding: 0;
-  font-size: min(1.5rem, 3vw);
+  font-size: clamp(1.1rem, 2.4vw, 1.35rem);
 }
 
 .thread-panel-header {
@@ -110,7 +118,7 @@
 /* Mobile font sizes */
 @media (max-width: 576px) {
   .project-thread-title {
-    font-size: 20px;
+    font-size: 19px;
   }
   .files-shared-style {
     font-size: 20px;

--- a/frontend/src/dashboard/project/components/Shared/ChatPanel.tsx
+++ b/frontend/src/dashboard/project/components/Shared/ChatPanel.tsx
@@ -47,14 +47,14 @@ const ChatPanel: React.FC<ChatPanelProps> = ({
   );
 
   const [size, setSize] = useState<Size>(() => {
-    if (typeof window === "undefined") return { width: 360, height: 400 };
+    if (typeof window === "undefined") return { width: 320, height: 400 };
     try {
       const stored = localStorage.getItem("chatPanelSize");
       if (stored) return JSON.parse(stored) as Size;
     } catch {
       /* ignore */
     }
-    return { width: 360, height: 400 };
+    return { width: 320, height: 400 };
   });
 
   const [position, setPosition] = useState<Pos>(() => {
@@ -65,7 +65,7 @@ const ChatPanel: React.FC<ChatPanelProps> = ({
     } catch {
       /* ignore */
     }
-    const panelWidth = 360;
+    const panelWidth = 320;
     const panelHeight = 400;
     return {
       x: window.innerWidth - panelWidth - 32,
@@ -158,7 +158,7 @@ const ChatPanel: React.FC<ChatPanelProps> = ({
     if (typeof document === "undefined") return;
     const body = document.body;
     if (open && !floating) {
-      const width = panelRef.current?.offsetWidth ?? 350;
+      const width = panelRef.current?.offsetWidth ?? 320;
       body.classList.add("chat-panel-docked");
       body.style.setProperty("--chat-panel-width", `${width}px`);
     } else {
@@ -288,7 +288,7 @@ const ChatPanel: React.FC<ChatPanelProps> = ({
         right: "auto",
         width: size.width,
         height: size.height,
-        minWidth: 300,
+        minWidth: 280,
         minHeight: open ? 280 : headerHeight,
       }
     : { ["--chat-panel-top"]: `${headerOffset}px`, height: dockedHeight ? `${dockedHeight}px` : undefined };


### PR DESCRIPTION
## Summary
- reduce the chat panel's default width and floating minimums to shrink the project messages area
- tighten layout tokens for the project messages column and header so the panel stays narrower across breakpoints
- scale message bubbles, avatars, and composer controls to match the compact layout and update inline spacing

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0c18f32148324bb5bf149c390941f