### PR TITLE
Improve task modals on mobile

### DIFF
--- a/frontend/src/dashboard/project/components/Tasks/TasksComponent.tsx
+++ b/frontend/src/dashboard/project/components/Tasks/TasksComponent.tsx
@@ -36,6 +36,7 @@ import {
 } from "@/shared/utils/api";
 import { useBudget } from "@/dashboard/project/features/budget/context/BudgetContext";
 import "./task-table.css";
+import "./tasks-modal.css";
 
 /* =========================
    Types
@@ -123,6 +124,28 @@ const TasksComponent: React.FC<TasksComponentProps> = ({
   const [isCommentModalOpen, setIsCommentModalOpen] = useState(false);
   const [commentTask, setCommentTask] = useState<Task | null>(null);
   const [commentText, setCommentText] = useState("");
+  const [isMobileViewport, setIsMobileViewport] = useState<boolean>(() => {
+    if (typeof window === "undefined") return false;
+    return window.matchMedia("(max-width: 640px)").matches;
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const mediaQuery = window.matchMedia("(max-width: 640px)");
+    const handleChange = (event: MediaQueryListEvent) => {
+      setIsMobileViewport(event.matches);
+    };
+
+    setIsMobileViewport(mediaQuery.matches);
+
+    if (typeof mediaQuery.addEventListener === "function") {
+      mediaQuery.addEventListener("change", handleChange);
+      return () => mediaQuery.removeEventListener("change", handleChange);
+    }
+
+    mediaQuery.addListener(handleChange);
+    return () => mediaQuery.removeListener(handleChange);
+  }, []);
 
   const [assignForm] = Form.useForm();
   const [assignLocationSearch, setAssignLocationSearch] = useState("");
@@ -601,6 +624,15 @@ const TasksComponent: React.FC<TasksComponentProps> = ({
     },
   ];
 
+  const modalRootClassName = isMobileViewport
+    ? "tasks-modal tasks-modal-mobile"
+    : "tasks-modal";
+  const modalCloseIcon = (
+    <span aria-hidden="true" className="tasks-modal-close-icon">
+      ×
+    </span>
+  );
+
   /* Render */
   return (
     <ConfigProvider theme={{ algorithm: theme.darkAlgorithm }}>
@@ -759,8 +791,13 @@ const TasksComponent: React.FC<TasksComponentProps> = ({
             open={isTaskModalOpen}
             onOk={saveTask}
             onCancel={() => setIsTaskModalOpen(false)}
-            centered
+            centered={!isMobileViewport}
+            maskClosable={isMobileViewport}
+            rootClassName={modalRootClassName}
+            closeIcon={modalCloseIcon}
             okButtonProps={{ style: { background: "#FA3356", borderColor: "#FA3356" } }}
+            okText={editingTask ? "Save Task" : "Add Task"}
+            cancelText="Cancel"
             forceRender
           >
             <Form layout="vertical" form={editForm} preserve={false}>
@@ -904,8 +941,13 @@ const TasksComponent: React.FC<TasksComponentProps> = ({
             open={isCommentModalOpen}
             onOk={saveComment}
             onCancel={() => setIsCommentModalOpen(false)}
-            centered
+            centered={!isMobileViewport}
+            maskClosable={isMobileViewport}
+            rootClassName={modalRootClassName}
+            closeIcon={modalCloseIcon}
             okButtonProps={{ style: { background: "#FA3356", borderColor: "#FA3356" } }}
+            okText="Save Comment"
+            cancelText="Cancel"
           >
             <Input.TextArea
               value={commentText}

--- a/frontend/src/dashboard/project/components/Tasks/tasks-modal.css
+++ b/frontend/src/dashboard/project/components/Tasks/tasks-modal.css
@@ -1,0 +1,74 @@
+.tasks-modal .ant-modal {
+  width: min(560px, calc(100vw - 48px));
+}
+
+.tasks-modal .ant-modal-content {
+  border-radius: 20px;
+}
+
+.tasks-modal .ant-modal-header {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.tasks-modal .ant-modal-footer {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.tasks-modal-mobile .ant-modal {
+  top: 20px !important;
+  margin: 0 auto;
+  width: calc(100vw - 32px);
+  max-width: 480px;
+  padding-bottom: 0;
+}
+
+.tasks-modal-mobile .ant-modal-content {
+  border-radius: 18px;
+}
+
+.tasks-modal-mobile .ant-modal-header,
+.tasks-modal-mobile .ant-modal-body,
+.tasks-modal-mobile .ant-modal-footer {
+  padding-left: 16px;
+  padding-right: 16px;
+}
+
+.tasks-modal-mobile .ant-modal-header {
+  padding-top: 16px;
+  padding-bottom: 12px;
+}
+
+.tasks-modal-mobile .ant-modal-body {
+  padding-top: 4px;
+  padding-bottom: 12px;
+}
+
+.tasks-modal-mobile .ant-modal-footer {
+  padding-top: 12px;
+  padding-bottom: 16px;
+  display: grid;
+  gap: 8px;
+}
+
+.tasks-modal-mobile .ant-modal-footer > .ant-btn {
+  width: 100%;
+}
+
+.tasks-modal-mobile .ant-modal-close {
+  top: 12px;
+  right: 12px;
+}
+
+.tasks-modal-close-icon {
+  font-size: 1.25rem;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+@media (max-width: 640px) {
+  .tasks-modal .ant-modal {
+    width: calc(100vw - 32px);
+  }
+}


### PR DESCRIPTION
## Summary
- detect mobile viewports in the task dashboard and adjust modal behaviour accordingly
- allow mask taps to close task modals, provide larger close affordance, and tune copy for action buttons
- add mobile-specific modal styling so dialogs fit within the viewport and stack footer buttons

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0d4b25d608324876ed32d15b7adfe