### PR TITLE
Refactor desktop project header layout

### DIFF
--- a/frontend/src/dashboard/project/components/Shared/DesktopProjectHeader.tsx
+++ b/frontend/src/dashboard/project/components/Shared/DesktopProjectHeader.tsx
@@ -57,142 +57,115 @@ const DesktopProjectHeader = ({
   getFileUrlForThumbnail,
 }: DesktopProjectHeaderProps) => {
   const thumbnailKey = project?.thumbnails?.[0] as string | undefined;
+  const projectTitle = project?.title || "Summary";
+  const progressPercentage = Number.isFinite(progressValue)
+    ? Math.min(Math.max(progressValue, 0), 100)
+    : 0;
+  const completeLabel = `${Math.round(progressPercentage)}% Complete`;
 
   return (
-    <div className="project-header">
-      <div className="header-content">
-        <div className="left-side">
-          <div className="project-logo-wrapper">
-            <Squircle
-              as="button"
-              type="button"
-              onClick={onOpenThumbnail}
-              title="Change Project Thumbnail"
-              aria-label="Change Project Thumbnail"
-              className="interactive project-logo-button"
-              radius={18}
-              smoothing={0.88}
-            >
-              {thumbnailKey ? (
-                <img
-                  src={getFileUrlForThumbnail(thumbnailKey)}
-                  alt="Project Thumbnail"
-                  className="project-logo-image"
-                />
-              ) : (
-                <span className="project-logo-initial">{projectInitial.toUpperCase()}</span>
-              )}
-            </Squircle>
-          </div>
-
-          <div className="single-project-title">
-            <h2 className="project-title-heading">{project?.title || "Summary"}</h2>
-          </div>
-
-          <svg
-            id="StatusSVG"
-            viewBox="0 0 400 400"
-            onClick={onOpenStatus}
-            onKeyDown={(event) => handleKeyDown(event, onOpenStatus)}
-            role="button"
-            tabIndex={0}
-            aria-label={`Status: ${displayStatus} Complete`}
-            className="interactive status-svg"
-            style={{ cursor: "pointer" }}
-          >
-            <title>{`Status: ${displayStatus} Complete`}</title>
-            <text
-              className="project-status"
-              transform={`translate(${progressValue !== 100 ? 75 : 56.58} 375.21)`}
-            >
-              <tspan x="22.5" y="-136">
-                {displayStatus}
-              </tspan>
-            </text>
-            {progressValue >= 0 && (
-              <ellipse
-                cx="200"
-                cy="200"
-                rx="160"
-                ry="160"
-                fill="none"
-                strokeWidth="15"
-                strokeDasharray={`${(progressValue / 100) * 1002}, 1004`}
-                style={{
-                  stroke: "var(--progress-accent, var(--accent-strong, #FA3356))",
-                }}
+    <header className="desktop-project-header">
+      <div className="desktop-project-header__inner">
+        <div className="desktop-project-header__top">
+          <div className="desktop-project-header__identity">
+            <div className="project-logo-wrapper">
+              <Squircle
+                as="button"
+                type="button"
+                onClick={onOpenThumbnail}
+                title="Change Project Thumbnail"
+                aria-label="Change Project Thumbnail"
+                className="interactive project-logo-button desktop-project-header__logo-button"
+                radius={18}
+                smoothing={0.88}
               >
-                {progressValue < 100 && (
-                  <animate
-                    attributeName="stroke-dasharray"
-                    from="0, 1004"
-                    to={`${(progressValue / 100) * 1002}, 1004`}
-                    dur="1s"
-                    begin="0s"
-                    fill="freeze"
+                {thumbnailKey ? (
+                  <img
+                    src={getFileUrlForThumbnail(thumbnailKey)}
+                    alt="Project Thumbnail"
+                    className="project-logo-image"
                   />
+                ) : (
+                  <span className="project-logo-initial">{projectInitial.toUpperCase()}</span>
                 )}
-              </ellipse>
-            )}
-          </svg>
+              </Squircle>
+            </div>
 
-          <AvatarStack members={teamMembers} onClick={onOpenTeam} />
+            <div className="desktop-project-header__identity-text">
+              <div className="desktop-project-header__title-row">
+                <h2 className="desktop-project-header__title">{projectTitle}</h2>
+                <button
+                  type="button"
+                  className="desktop-project-header__status-badge interactive"
+                  onClick={onOpenStatus}
+                  onKeyDown={(event) => handleKeyDown(event, onOpenStatus)}
+                  aria-label={`Update status (${displayStatus})`}
+                >
+                  {displayStatus}
+                </button>
+              </div>
 
-          <div
-            className="finish-line-header interactive"
-            onClick={onOpenFinishLine}
-            onKeyDown={(event) => handleKeyDown(event, onOpenFinishLine)}
-            role="button"
-            tabIndex={0}
-            title="Production dates"
-            aria-label="Production dates"
-            style={{ cursor: "pointer" }}
-          >
-            <span>{rangeLabel}</span>
+              <button
+                type="button"
+                className="desktop-project-header__range interactive"
+                onClick={onOpenFinishLine}
+                onKeyDown={(event) => handleKeyDown(event, onOpenFinishLine)}
+                aria-label="Edit production dates"
+              >
+                {rangeLabel}
+              </button>
+            </div>
           </div>
 
-          <div
-            onClick={onOpenSettings}
-            onKeyDown={(event) => handleKeyDown(event, onOpenSettings)}
-            role="button"
-            tabIndex={0}
-            title="Project settings"
-            aria-label="Project settings"
-            className="interactive"
-            style={{ cursor: "pointer", margin: "10px" }}
-          >
-            <Settings size={20} className="settings-icon" />
-          </div>
+          <div className="desktop-project-header__meta">
+            <div className="desktop-project-header__progress" aria-live="polite">
+              <div className="desktop-project-header__progress-bar" aria-hidden="true">
+                <div
+                  className="desktop-project-header__progress-fill"
+                  style={{ width: `${progressPercentage}%` }}
+                />
+              </div>
+              <span className="desktop-project-header__progress-label">{completeLabel}</span>
+            </div>
 
-          <div
-            onClick={onOpenQuickLinks}
-            onKeyDown={(event) => handleKeyDown(event, onOpenQuickLinks)}
-            role="button"
-            tabIndex={0}
-            title="Quick links"
-            aria-label="Quick links"
-            className="interactive"
-            style={{ cursor: "pointer" }}
-          >
-            <Link2 size={20} />
-          </div>
+            <div className="desktop-project-header__team">
+              <AvatarStack members={teamMembers} onClick={onOpenTeam} />
+            </div>
 
-          <div
-            onClick={onOpenFiles}
-            onKeyDown={(event) => handleKeyDown(event, onOpenFiles)}
-            role="button"
-            tabIndex={0}
-            title="Open file manager"
-            aria-label="Open file manager"
-            className="interactive"
-            style={{ cursor: "pointer", margin: "10px" }}
-          >
-            <Folder size={20} />
+            <div className="desktop-project-header__icon-buttons">
+              <button
+                type="button"
+                className="desktop-project-header__icon-button interactive"
+                onClick={onOpenSettings}
+                onKeyDown={(event) => handleKeyDown(event, onOpenSettings)}
+                aria-label="Project settings"
+              >
+                <Settings size={18} />
+              </button>
+              <button
+                type="button"
+                className="desktop-project-header__icon-button interactive"
+                onClick={onOpenQuickLinks}
+                onKeyDown={(event) => handleKeyDown(event, onOpenQuickLinks)}
+                aria-label="Quick links"
+              >
+                <Link2 size={18} />
+              </button>
+              <button
+                type="button"
+                className="desktop-project-header__icon-button interactive"
+                onClick={onOpenFiles}
+                onKeyDown={(event) => handleKeyDown(event, onOpenFiles)}
+                aria-label="Open file manager"
+              >
+                <Folder size={18} />
+              </button>
+            </div>
           </div>
         </div>
 
-        <div className="right-side">
-          <div className="project-nav-tabs" style={{ padding: "0 10px 10px" }}>
+        <nav className="desktop-project-header__nav" aria-label="Project navigation">
+          <div className="project-nav-tabs">
             <ProjectTabs
               tabs={navigation.tabs}
               activeIndex={navigation.activeIndex}
@@ -201,9 +174,9 @@ const DesktopProjectHeader = ({
               confirmNavigate={navigation.confirmNavigate}
             />
           </div>
-        </div>
+        </nav>
       </div>
-    </div>
+    </header>
   );
 };
 

--- a/frontend/src/dashboard/project/components/Shared/project-header.css
+++ b/frontend/src/dashboard/project/components/Shared/project-header.css
@@ -1,53 +1,90 @@
-.single-project-title .project-title-heading {
-  font-size: clamp(1.5rem, 2vw + 1rem, 2.5rem);
-  font-weight: 600;
-  margin: 0;
-  line-height: 1.1;
-  word-break: break-word;
+.desktop-project-header {
+  width: 100%;
+  background-color: #0c0c0c;
+  color: #fff;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
 }
 
-.project-logo {
-  width: clamp(32px, 3vw, 36px);
-  height: clamp(32px, 3vw, 36px);
-  border-radius: 50%;
-  object-fit: cover;
-  transition: width 0.2s, height 0.2s;
-  padding: 0px;
-  box-sizing: border-box;
+.desktop-project-header__inner {
+  display: flex;
+  flex-direction: column;
+}
+
+.desktop-project-header__top {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 32px;
+  padding: 32px;
+}
+
+.desktop-project-header__identity {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  min-width: 0;
+}
+
+.desktop-project-header__identity-text {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-width: 0;
+}
+
+.desktop-project-header__title-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.desktop-project-header__title {
+  font-size: 24px;
+  font-weight: 700;
+  margin: 0;
+  color: #fff;
+  line-height: 1.1;
+  word-break: break-word;
 }
 
 .project-logo-wrapper {
   display: flex;
   align-items: center;
-  margin: 2px 6px;
-  
 }
 
 .project-logo-button {
   --shape-radius: 18px;
   --shape-smoothing: 0.88;
-  width: clamp(36px, 4vw, 44px);
-  aspect-ratio: 1 / 1;
+  width: 56px;
+  height: 56px;
   border: none;
   padding: 0;
-  background: rgba(15, 23, 42, 0.06);
-  color: var(--text-strong, #111827);
+  background: rgba(255, 255, 255, 0.06);
+  color: #fff;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   font-weight: 600;
-  font-size: clamp(1rem, 1.5vw + 0.2rem, 1.4rem);
+  font-size: 1.4rem;
   cursor: pointer;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.4);
+  border-radius: 16px;
   transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+.desktop-project-header__logo-button {
+  border: 1px solid rgba(255, 255, 255, 0.08);
 }
 
 .project-logo-button:hover {
   transform: scale(1.02);
-  background: rgba(15, 23, 42, 0.1);
+  background: rgba(255, 255, 255, 0.12);
 }
 
 .project-logo-button:focus-visible {
-  outline: 2px solid rgba(15, 23, 42, 0.35);
+  outline: 2px solid rgba(255, 255, 255, 0.35);
   outline-offset: 2px;
 }
 
@@ -55,52 +92,183 @@
   width: 100%;
   height: 100%;
   object-fit: cover;
-  display: block;
+  border-radius: 12px;
 }
 
 .project-logo-initial {
   line-height: 1;
 }
 
-.status-svg {
-  width: clamp(40px, 5vw, 60px) !important;
-  height: clamp(40px, 5vw, 60px) !important;
-  min-width: 40px !important;
-  min-height: 40px !important;
-  max-width: 60px !important;
-  max-height: 60px !important;
-  transition: width 0.2s, height 0.2s;
-  vertical-align: middle;
+.desktop-project-header__status-badge {
+  padding: 8px 18px;
+  border-radius: 9999px;
+  border: none;
+  background: #fa3356;
+  color: #fff;
+  font-weight: 600;
+  font-size: 0.9rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
 }
 
+.desktop-project-header__status-badge:hover {
+  background: #ff4d6c;
+}
 
-@media (max-width: 600px) {
-  .status-svg {
-    width: clamp(32px, 10vw, 44px) !important;
-    height: clamp(32px, 10vw, 44px) !important;
-    min-width: 32px !important;
-    min-height: 32px !important;
-    max-width: 44px !important;
-    max-height: 44px !important;
+.desktop-project-header__status-badge:focus-visible {
+  outline: 2px solid rgba(250, 51, 86, 0.4);
+  outline-offset: 2px;
+}
+
+.desktop-project-header__range {
+  align-self: flex-start;
+  padding: 6px 14px;
+  border-radius: 9999px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.75);
+  font-size: 0.95rem;
+}
+
+.desktop-project-header__range:hover {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.desktop-project-header__range:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.35);
+  outline-offset: 2px;
+}
+
+.desktop-project-header__meta {
+  display: flex;
+  align-items: center;
+  gap: 32px;
+  flex-wrap: wrap;
+}
+
+.desktop-project-header__progress {
+  width: 200px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.desktop-project-header__progress-bar {
+  position: relative;
+  height: 8px;
+  width: 100%;
+  background: rgba(255, 255, 255, 0.12);
+  border-radius: 9999px;
+  overflow: hidden;
+}
+
+.desktop-project-header__progress-fill {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  background: linear-gradient(90deg, #fa3356, #ff6a7f);
+  border-radius: inherit;
+  transition: width 0.3s ease;
+}
+
+.desktop-project-header__progress-label {
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.desktop-project-header__team {
+  display: flex;
+  align-items: center;
+}
+
+.desktop-project-header__icon-buttons {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.desktop-project-header__icon-button {
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.08);
+  color: #fff;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background-color 0.2s ease, transform 0.2s ease;
+}
+
+.desktop-project-header__icon-button:hover {
+  background: rgba(255, 255, 255, 0.16);
+  transform: translateY(-1px);
+}
+
+.desktop-project-header__icon-button:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.35);
+  outline-offset: 2px;
+}
+
+.desktop-project-header__nav {
+  padding: 16px 32px 24px;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.desktop-project-header__nav .project-nav-tabs {
+  width: 100%;
+}
+
+.desktop-project-header__nav .segmented-control {
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 9999px;
+}
+
+.desktop-project-header__nav .segmented-control button {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.desktop-project-header__nav .segmented-control button.active {
+  color: #fff;
+}
+
+.desktop-project-header__nav .segmented-control.with-slider .tab-slider {
+  background-color: #fa3356;
+  border-radius: 9999px;
+  box-shadow: 0 6px 16px rgba(250, 51, 86, 0.35);
+}
+
+.desktop-project-header__nav .segmented-control svg {
+  color: inherit;
+}
+
+@media (max-width: 960px) {
+  .desktop-project-header__top {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .desktop-project-header__meta {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .desktop-project-header__progress {
+    width: 100%;
   }
 }
 
 @media (max-width: 600px) {
-  .project-logo {
-    width: clamp(40px, 15vw, 44px);
-    height: clamp(40px, 15vw, 44px);
+  .desktop-project-header__top {
+    padding: 24px;
+    gap: 24px;
+  }
+
+  .desktop-project-header__nav {
+    padding: 12px 24px 20px;
   }
 }
-
-@media (max-width: 600px) {
-  .single-project-title .project-title-heading {
-    font-size: clamp(1.1rem, 5vw, 1.7rem);
-  }
-}
-
-
-
-
-
-
-


### PR DESCRIPTION
## Summary
- rebuild the desktop project header component structure to follow the updated dark desktop layout while preserving existing interactions
- add refreshed styling for the header, progress bar, navigation tabs, and utility buttons to match the new design

## Testing
- npm run lint -- src/dashboard/project/components/Shared/DesktopProjectHeader.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d0d0c605d083248e14caddc16ee756