### PR TITLE
Improve popover positioning and mobile close control

### DIFF
--- a/frontend/src/components/ui/popover.css
+++ b/frontend/src/components/ui/popover.css
@@ -4,14 +4,40 @@
 }
 
 .ui-popover-content {
-  position: absolute;
-  top: calc(100% + 0.25rem);
-  right: 0;
+  position: fixed;
   min-width: 8rem;
   background: #1a1a1a;
   border: 1px solid rgba(255, 255, 255, 0.12);
   border-radius: 0.75rem;
-  padding: 0.5rem;
+  padding: 0.75rem;
   box-shadow: 0 12px 24px rgba(0, 0, 0, 0.35);
-  z-index: 50;
+  z-index: 60;
+  max-width: calc(100vw - 24px);
+}
+
+.ui-popover-close {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 9999px;
+  width: 28px;
+  height: 28px;
+  color: #ffffff;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.ui-popover-close:hover,
+.ui-popover-close:focus-visible {
+  background: rgba(255, 255, 255, 0.16);
+  outline: none;
+}
+
+.ui-popover-close span {
+  font-size: 1.25rem;
+  line-height: 1;
 }

--- a/frontend/src/components/ui/popover.tsx
+++ b/frontend/src/components/ui/popover.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { createPortal } from "react-dom";
 import { cn } from "./utils";
 import "./popover.css";
 
@@ -143,9 +144,26 @@ interface PopoverContentProps
 
 export const PopoverContent = React.forwardRef<HTMLDivElement, PopoverContentProps>(
   ({ className, style, align = "end", children, ...props }, forwardedRef) => {
-    const { open, contentRef } = usePopoverContext();
+    const { open, contentRef, triggerRef, setOpen } = usePopoverContext();
+    const [position, setPosition] = React.useState<
+      | null
+      | {
+          top: number;
+          left: number;
+          placement: "top" | "bottom";
+        }
+    >(null);
+    const [isMobile, setIsMobile] = React.useState(false);
 
-    if (!open) return null;
+    React.useEffect(() => {
+      if (typeof window === "undefined") return undefined;
+
+      const mq = window.matchMedia("(max-width: 640px)");
+      const handleChange = () => setIsMobile(mq.matches);
+      handleChange();
+      mq.addEventListener("change", handleChange);
+      return () => mq.removeEventListener("change", handleChange);
+    }, []);
 
     const refCallback = (node: HTMLDivElement | null) => {
       contentRef.current = node;
@@ -157,24 +175,114 @@ export const PopoverContent = React.forwardRef<HTMLDivElement, PopoverContentPro
       }
     };
 
-    const alignStyle: React.CSSProperties =
-      align === "start"
-        ? { left: 0, right: "auto" }
-        : align === "center"
-        ? { left: "50%", transform: "translateX(-50%)" }
-        : { right: 0 };
+    React.useLayoutEffect(() => {
+      if (typeof window === "undefined") return;
 
-    return (
+      if (!open) {
+        setPosition(null);
+        return;
+      }
+
+      const spacing = 8;
+      const viewportPadding = 12;
+
+      const updatePosition = () => {
+        if (!triggerRef.current || !contentRef.current) return;
+
+        const triggerRect = triggerRef.current.getBoundingClientRect();
+
+        // Temporarily reset inline styles to measure natural size
+        contentRef.current.style.left = "0px";
+        contentRef.current.style.top = "0px";
+        contentRef.current.style.transform = "none";
+
+        const contentRect = contentRef.current.getBoundingClientRect();
+        const viewportWidth = window.innerWidth;
+        const viewportHeight = window.innerHeight;
+
+        let left: number;
+        switch (align) {
+          case "start":
+            left = triggerRect.left;
+            break;
+          case "center":
+            left = triggerRect.left + triggerRect.width / 2 - contentRect.width / 2;
+            break;
+          case "end":
+          default:
+            left = triggerRect.right - contentRect.width;
+        }
+
+        const maxLeft = viewportWidth - contentRect.width - viewportPadding;
+        if (contentRect.width >= viewportWidth - viewportPadding * 2) {
+          left = viewportPadding;
+        } else {
+          left = Math.min(Math.max(left, viewportPadding), maxLeft);
+        }
+
+        let top = triggerRect.bottom + spacing;
+        let placement: "top" | "bottom" = "bottom";
+
+        if (top + contentRect.height > viewportHeight - viewportPadding) {
+          const aboveTop = triggerRect.top - spacing - contentRect.height;
+
+          if (aboveTop >= viewportPadding) {
+            top = aboveTop;
+            placement = "top";
+          } else {
+            // Clamp within viewport when neither direction fits perfectly
+            const maxTop = viewportHeight - viewportPadding - contentRect.height;
+            top = Math.max(viewportPadding, Math.min(top, maxTop));
+          }
+        }
+
+        setPosition({ top, left, placement });
+      };
+
+      updatePosition();
+
+      window.addEventListener("resize", updatePosition);
+      window.addEventListener("scroll", updatePosition, true);
+
+      return () => {
+        window.removeEventListener("resize", updatePosition);
+        window.removeEventListener("scroll", updatePosition, true);
+      };
+    }, [align, open, triggerRef, contentRef]);
+
+    if (!open) return null;
+
+    const shouldShowMobileClose = isMobile && align === "center";
+
+    const content = (
       <div
         ref={refCallback}
         className={cn("ui-popover-content", className)}
-        style={{ ...alignStyle, ...style }}
+        style={{
+          top: position?.top,
+          left: position?.left,
+          visibility: position ? "visible" : "hidden",
+          ...style,
+        }}
         role="menu"
+        data-placement={position?.placement}
         {...props}
       >
+        {shouldShowMobileClose ? (
+          <button
+            type="button"
+            className="ui-popover-close"
+            onClick={() => setOpen(false)}
+            aria-label="Close menu"
+          >
+            <span aria-hidden="true">×</span>
+          </button>
+        ) : null}
         {children}
       </div>
     );
+
+    return createPortal(content, document.body);
   }
 );
 


### PR DESCRIPTION
## Summary
- render popovers through a portal and recompute their viewport-safe position with top/bottom flipping
- clamp popover width within the viewport and provide a mobile close affordance for centered menus
- update popover styles to support fixed positioning and the new close control

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0db62f7208324a063361d9496f282