### PR TITLE
style: give desktop project header card styling

### DIFF
--- a/frontend/src/dashboard/project/components/Shared/DesktopProjectHeader.tsx
+++ b/frontend/src/dashboard/project/components/Shared/DesktopProjectHeader.tsx
@@ -162,8 +162,7 @@ const DesktopProjectHeader = ({
             tabIndex={0}
             title="Project settings"
             aria-label="Project settings"
-            className="interactive"
-            style={{ cursor: "pointer", margin: "10px" }}
+            className="interactive icon-button"
           >
             <Settings size={20} className="settings-icon" />
           </div>
@@ -175,8 +174,7 @@ const DesktopProjectHeader = ({
             tabIndex={0}
             title="Quick links"
             aria-label="Quick links"
-            className="interactive"
-            style={{ cursor: "pointer" }}
+            className="interactive icon-button"
           >
             <Link2 size={20} />
           </div>
@@ -188,15 +186,14 @@ const DesktopProjectHeader = ({
             tabIndex={0}
             title="Open file manager"
             aria-label="Open file manager"
-            className="interactive"
-            style={{ cursor: "pointer", margin: "10px" }}
+            className="interactive icon-button"
           >
             <Folder size={20} />
           </div>
         </div>
 
         <div className="right-side">
-          <div className="project-nav-tabs" style={{ padding: "0 10px 10px" }}>
+          <div className="project-nav-tabs">
             <ProjectTabs
               tabs={navigation.tabs}
               activeIndex={navigation.activeIndex}

--- a/frontend/src/dashboard/project/components/Shared/project-header.css
+++ b/frontend/src/dashboard/project/components/Shared/project-header.css
@@ -104,3 +104,198 @@
 
 
 
+.project-header:not(.new-project-header) {
+  position: relative;
+  width: 100%;
+  padding: clamp(20px, 2.5vw, 32px);
+  margin-bottom: clamp(16px, 3vw, 40px);
+  background: var(--project-header-bg, var(--bg2, #111213));
+  border: 2px solid rgba(255, 255, 255, 0.1);
+  border-radius: 24px;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04), 0 18px 48px rgba(0, 0, 0, 0.45);
+  color: rgba(255, 255, 255, 0.95);
+  overflow: hidden;
+  isolation: isolate;
+}
+
+.project-header:not(.new-project-header)::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='128' height='128'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='.95' numOctaves='1' stitchTiles='stitch'/></filter><rect width='128' height='128' filter='url(%23n)' opacity='.08'/></svg>");
+  background-size: 240px 240px;
+  mix-blend-mode: soft-light;
+  opacity: 0.18;
+}
+
+.project-header:not(.new-project-header) > * {
+  position: relative;
+  z-index: 1;
+}
+
+.project-header:not(.new-project-header) .header-content {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: clamp(16px, 2vw, 32px);
+}
+
+.project-header:not(.new-project-header) .left-side,
+.project-header:not(.new-project-header) .right-side {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: clamp(14px, 2vw, 24px);
+}
+
+.project-header:not(.new-project-header) .left-side {
+  flex: 1 1 520px;
+  min-width: 0;
+}
+
+.project-header:not(.new-project-header) .project-identity {
+  display: flex;
+  align-items: center;
+  gap: clamp(12px, 1.5vw, 20px);
+  min-width: 0;
+}
+
+.project-header:not(.new-project-header) .project-text-group {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6px;
+  min-width: 0;
+  color: inherit;
+}
+
+.project-header:not(.new-project-header) .project-title-heading {
+  color: inherit;
+}
+
+.project-header:not(.new-project-header) .finish-line-header {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.04);
+  color: rgba(255, 255, 255, 0.78);
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.project-header:not(.new-project-header) .finish-line-header:hover,
+.project-header:not(.new-project-header) .finish-line-header:focus-visible {
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.88);
+  transform: translateY(-1px);
+}
+
+.project-header:not(.new-project-header) .finish-line-header span {
+  color: inherit;
+}
+
+.project-header:not(.new-project-header) .right-side {
+  flex: 1 1 320px;
+  justify-content: flex-end;
+  min-width: 0;
+}
+
+.project-header:not(.new-project-header) .project-nav-tabs {
+  flex: 1 1 100%;
+  width: 100%;
+  padding-top: clamp(12px, 1.5vw, 20px);
+}
+
+.project-header:not(.new-project-header) .project-nav-tabs .segmented-control {
+  width: 100%;
+  justify-content: flex-start;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+}
+
+.project-header:not(.new-project-header) .project-nav-tabs .segmented-control button {
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.project-header:not(.new-project-header) .project-nav-tabs .segmented-control button.active {
+  color: #ffffff;
+}
+
+.project-header:not(.new-project-header) .project-nav-tabs .tab-slider {
+  background: rgba(255, 255, 255, 0.18);
+}
+
+.project-header:not(.new-project-header) .icon-button {
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.04);
+  color: rgba(255, 255, 255, 0.88);
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.project-header:not(.new-project-header) .icon-button:hover,
+.project-header:not(.new-project-header) .icon-button:focus-visible {
+  background: rgba(255, 255, 255, 0.1);
+  color: #ffffff;
+  transform: translateY(-1px);
+}
+
+.project-header:not(.new-project-header) .project-logo-button {
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.95);
+}
+
+.project-header:not(.new-project-header) .project-logo-button:hover {
+  background: rgba(255, 255, 255, 0.14);
+}
+
+.project-header:not(.new-project-header) .project-logo-button:focus-visible {
+  outline-color: rgba(255, 255, 255, 0.45);
+}
+
+.project-header:not(.new-project-header) .project-logo-image {
+  border-radius: inherit;
+}
+
+.project-header:not(.new-project-header) .finish-line-header,
+.project-header:not(.new-project-header) .icon-button,
+.project-header:not(.new-project-header) .project-nav-tabs .segmented-control {
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
+}
+
+@media (max-width: 1200px) {
+  .project-header:not(.new-project-header) {
+    border-radius: 20px;
+    padding: clamp(18px, 3vw, 26px);
+  }
+
+  .project-header:not(.new-project-header) .right-side {
+    justify-content: flex-start;
+  }
+}
+
+@media (max-width: 1024px) {
+  .project-header:not(.new-project-header) .header-content {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .project-header:not(.new-project-header) .left-side,
+  .project-header:not(.new-project-header) .right-side {
+    flex: 1 1 100%;
+    justify-content: flex-start;
+  }
+
+  .project-header:not(.new-project-header) .project-nav-tabs {
+    padding-top: 16px;
+  }
+}
+


### PR DESCRIPTION
## Summary
- style the desktop project header container like the other dashboard cards with a bordered, grainy panel and refreshed spacing
- update the icon controls and navigation tabs to align with the new card layout while keeping the new project header unaffected

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0e25cc04083249d67614a9fc1be0a