### PR TITLE
feat: embed moodboard inside editor workspace

### DIFF
--- a/frontend/src/dashboard/home/styles/components/chat-panel.css
+++ b/frontend/src/dashboard/home/styles/components/chat-panel.css
@@ -68,7 +68,8 @@ body.chat-panel-docked {
   display: flex;
   flex-direction: column;
   flex: 1 1 auto;
-  min-height: 800px;
+  min-height: 0;
+  height: 100%;
 }
 
 @media (max-width: var(--breakpoint-sm)) {

--- a/frontend/src/dashboard/home/styles/components/editor-page.css
+++ b/frontend/src/dashboard/home/styles/components/editor-page.css
@@ -21,6 +21,18 @@
   overflow-y: auto;
 }
 
+.editor-mode-panel {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.editor-mode-layout {
+  flex: 1;
+  min-height: 0;
+}
+
 
 
 

--- a/frontend/src/dashboard/home/styles/components/editor-page.css
+++ b/frontend/src/dashboard/home/styles/components/editor-page.css
@@ -19,6 +19,7 @@
   display: flex;
   flex-direction: column;
   overflow-y: auto;
+  min-height: 0;
 }
 
 .editor-mode-panel {
@@ -29,6 +30,15 @@
 }
 
 .editor-mode-layout {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.editor-content-wrapper {
+  display: flex;
+  flex-direction: column;
   flex: 1;
   min-height: 0;
 }

--- a/frontend/src/dashboard/project/components/Shared/useProjectTabs.tsx
+++ b/frontend/src/dashboard/project/components/Shared/useProjectTabs.tsx
@@ -1,12 +1,6 @@
 import React from "react";
 import { useNavigate, useLocation } from "react-router-dom";
-import {
-  LayoutDashboard,
-  Coins,
-  Calendar as CalendarIcon,
-  StickyNote,
-  PenTool,
-} from "lucide-react";
+import { LayoutDashboard, Coins, Calendar as CalendarIcon, PenTool } from "lucide-react";
 import { useData } from "@/app/contexts/useData";
 import { getProjectDashboardPath } from "@/shared/utils/projectUrl";
 
@@ -39,7 +33,6 @@ export const useProjectTabs = (
 
   const showBudgetTab = isAdmin;
   const showCalendarTab = isAdmin || isDesigner;
-  const showMoodboardTab = isAdmin || isDesigner;
   const showEditorTab = isAdmin || isDesigner;
 
   const hasProject = Boolean(projectId);
@@ -71,18 +64,6 @@ export const useProjectTabs = (
             projectId,
             projectTitle ?? undefined,
             "/calendar"
-          )
-        : "/dashboard/projects",
-    [hasProject, projectId, projectTitle]
-  );
-
-  const moodboardPath = React.useMemo(
-    () =>
-      hasProject
-        ? getProjectDashboardPath(
-            projectId,
-            projectTitle ?? undefined,
-            "/moodboard"
           )
         : "/dashboard/projects",
     [hasProject, projectId, projectTitle]
@@ -128,14 +109,6 @@ export const useProjectTabs = (
           matches: (pathname: string) => pathname.startsWith(calendarPath),
         },
         {
-          key: "moodboard",
-          label: "Moodboard",
-          icon: <StickyNote size={16} />,
-          path: moodboardPath,
-          visible: showMoodboardTab,
-          matches: (pathname: string) => pathname.startsWith(moodboardPath),
-        },
-        {
           key: "editor",
           label: "Editor",
           icon: <PenTool size={16} />,
@@ -148,11 +121,9 @@ export const useProjectTabs = (
       basePath,
       budgetPath,
       calendarPath,
-      moodboardPath,
       editorPath,
       showBudgetTab,
       showCalendarTab,
-      showMoodboardTab,
       showEditorTab,
     ]
   );

--- a/frontend/src/dashboard/project/features/editor/components/UnifiedToolbar.tsx
+++ b/frontend/src/dashboard/project/features/editor/components/UnifiedToolbar.tsx
@@ -1,10 +1,46 @@
 /* eslint-disable */
 import React, { useState, useRef, useEffect, ChangeEvent } from 'react';
-import { Bold, Italic, Underline, Strikethrough, Code, Heading1, Heading2, Quote, List, ListOrdered, AlignLeft, AlignCenter, AlignRight, AlignJustify, Square, Circle, Pencil, Type, Image as ImageIcon, MousePointer, ClipboardCopy, ClipboardPaste, Trash2, Eraser, Eye, Save, Undo2, Redo2, Figma, Mic, FileText, Paintbrush, } from 'lucide-react';
+import {
+    Bold,
+    Italic,
+    Underline,
+    Strikethrough,
+    Code,
+    Heading1,
+    Heading2,
+    Quote,
+    List,
+    ListOrdered,
+    AlignLeft,
+    AlignCenter,
+    AlignRight,
+    AlignJustify,
+    Square,
+    Circle,
+    Pencil,
+    Type,
+    Image as ImageIcon,
+    MousePointer,
+    ClipboardCopy,
+    ClipboardPaste,
+    Trash2,
+    Eraser,
+    Eye,
+    Save,
+    Undo2,
+    Redo2,
+    Figma,
+    Mic,
+    FileText,
+    Paintbrush,
+    LayoutDashboard,
+} from 'lucide-react';
 import { LayoutOutlined as LayoutIcon } from '@ant-design/icons';
 import { motion } from 'framer-motion';
 import './UnifiedToolbar.css';
 import ColorPicker from '@/shared/ui/ColorPicker';
+
+type EditorMode = 'brief' | 'canvas' | 'moodboard';
 
 interface UnifiedToolbarProps {
     onBold?: () => void;
@@ -44,14 +80,14 @@ interface UnifiedToolbarProps {
     onSave?: () => void;
     onUndo?: () => void;
     onRedo?: () => void;
-    initialMode?: 'brief' | 'canvas';
-    onModeChange?: (mode: 'brief' | 'canvas') => void;
+    initialMode?: EditorMode;
+    onModeChange?: (mode: EditorMode) => void;
     theme?: 'dark' | 'light';
     orientation?: 'horizontal' | 'vertical';
 }
 
 const UnifiedToolbar: React.FC<UnifiedToolbarProps> = ({ onBold, onItalic, onUnderline, onStrikethrough, onCode, onParagraph, onHeading1, onHeading2, onQuote, onUnorderedList, onOrderedList, onFontChange, onFontSizeChange, onFontColorChange, onBgColorChange, onAlignLeft, onAlignCenter, onAlignRight, onAlignJustify, onAddRectangle, onAddCircle, onFreeDraw, onSelectTool, onAddText, onAddImage, onInsertLayout, onColorChange, onFigma, onVoice, onCopy, onPaste, onDelete, onClearCanvas, onPreview, onSave, onUndo, onRedo, initialMode = 'brief', onModeChange, theme = 'dark', orientation = 'horizontal', }) => {
-    const [mode, setMode] = useState<'brief' | 'canvas'>(initialMode);
+    const [mode, setMode] = useState<EditorMode>(initialMode);
     const [fontColor, setFontColor] = useState<string>('');
     const [bgColor, setBgColor] = useState<string>('');
     const [layoutOpen, setLayoutOpen] = useState(false);
@@ -116,15 +152,16 @@ const UnifiedToolbar: React.FC<UnifiedToolbarProps> = ({ onBold, onItalic, onUnd
                 break;
         }
     };
-    const handleModeChange = (newMode: 'brief' | 'canvas') => {
+    const handleModeChange = (newMode: EditorMode) => {
         setMode(newMode);
         if (onModeChange)
             onModeChange(newMode);
     };
-    
-    const modes = [
-        { key: 'brief' as const, label: 'Brief', icon: FileText },
-        { key: 'canvas' as const, label: 'Canvas', icon: Paintbrush },
+
+    const modes: { key: EditorMode; label: string; icon: React.ComponentType<{ size?: number }> }[] = [
+        { key: 'brief', label: 'Brief', icon: FileText },
+        { key: 'canvas', label: 'Canvas', icon: Paintbrush },
+        { key: 'moodboard', label: 'Moodboard', icon: LayoutDashboard },
     ];
     
     const tabRefs = useRef<Record<string, HTMLButtonElement | null>>({});
@@ -317,7 +354,7 @@ const UnifiedToolbar: React.FC<UnifiedToolbarProps> = ({ onBold, onItalic, onUnd
                 <button type="button" onClick={onPreview} title="Preview">
                     <Eye size={16} />
                 </button>
-                <button type="button" onClick={onSave} title="Save">
+                <button type="button" onClick={onSave} title="Save" disabled={mode === 'moodboard'}>
                     <Save size={16} />
                 </button>
                 <button type="button" onClick={onUndo} title="Undo">

--- a/frontend/src/dashboard/project/features/editor/pages/editorpage.tsx
+++ b/frontend/src/dashboard/project/features/editor/pages/editorpage.tsx
@@ -286,13 +286,17 @@ const EditorPage: React.FC = () => {
                 <AnimatePresence mode="wait">
                   {activeTab === "brief" && (
                     <motion.div
+                      className="editor-mode-panel"
                       key="brief"
                       initial={{ opacity: 0, x: -20 }}
                       animate={{ opacity: 1, x: 0 }}
                       exit={{ opacity: 0, x: 20 }}
                       transition={{ duration: 0.3 }}
                     >
-                      <div className="dashboard-layout" style={{ paddingBottom: "5px" }}>
+                      <div
+                        className="dashboard-layout editor-mode-layout"
+                        style={{ paddingBottom: "5px" }}
+                      >
                         {activeProject?.description ? (
                           <LexicalEditor
                             key={activeProject.projectId}
@@ -308,13 +312,17 @@ const EditorPage: React.FC = () => {
                   )}
                   {activeTab === "canvas" && (
                     <motion.div
+                      className="editor-mode-panel"
                       key="canvas"
                       initial={{ opacity: 0, x: 20 }}
                       animate={{ opacity: 1, x: 0 }}
                       exit={{ opacity: 0, x: -20 }}
                       transition={{ duration: 0.3 }}
                     >
-                      <div className="dashboard-layout" style={{ paddingBottom: "5px" }}>
+                      <div
+                        className="dashboard-layout editor-mode-layout"
+                        style={{ paddingBottom: "5px" }}
+                      >
                         <div style={{ maxWidth: "1920px", width: "100%" }}>
                           <div
                             className="editor-container"
@@ -328,13 +336,17 @@ const EditorPage: React.FC = () => {
                   )}
                   {activeTab === "moodboard" && (
                     <motion.div
+                      className="editor-mode-panel"
                       key="moodboard"
                       initial={{ opacity: 0, x: 20 }}
                       animate={{ opacity: 1, x: 0 }}
                       exit={{ opacity: 0, x: -20 }}
                       transition={{ duration: 0.3 }}
                     >
-                      <div className="dashboard-layout" style={{ paddingBottom: "5px", height: "100%" }}>
+                      <div
+                        className="dashboard-layout editor-mode-layout"
+                        style={{ paddingBottom: "5px" }}
+                      >
                         <MoodboardCanvas
                           projectId={activeProject?.projectId}
                           userId={userId ?? undefined}

--- a/frontend/src/dashboard/project/features/editor/pages/editorpage.tsx
+++ b/frontend/src/dashboard/project/features/editor/pages/editorpage.tsx
@@ -10,6 +10,7 @@ import FileManagerComponent from "@/dashboard/project/components/FileManager/Fil
 import PreviewDrawer from "@/dashboard/project/features/editor/components/PreviewDrawer";
 import UnifiedToolbar from "@/dashboard/project/features/editor/components/UnifiedToolbar";
 import LexicalEditor from "@/dashboard/project/features/editor/components/Brief/LexicalEditor";
+import MoodboardCanvas from "@/dashboard/project/features/moodboard/components/MoodboardCanvas";
 import { useData } from "@/app/contexts/useData";
 import { Project } from "@/app/contexts/DataProvider";
 import { useSocket } from "@/app/contexts/useSocket";
@@ -35,7 +36,7 @@ const EditorPage: React.FC = () => {
   const { ws } = useSocket();
 
   const [activeProject, setActiveProject] = useState<Project | null>(initialActiveProject);
-  const [activeTab, setActiveTab] = useState<"brief" | "canvas">("brief");
+  const [activeTab, setActiveTab] = useState<"brief" | "canvas" | "moodboard">("brief");
   const [previewOpen, setPreviewOpen] = useState(false);
   const [filesOpen, setFilesOpen] = useState(false);
   const [briefToolbarActions, setBriefToolbarActions] = useState<Record<string, unknown>>({});
@@ -183,7 +184,7 @@ const EditorPage: React.FC = () => {
   const handleSave = useCallback(() => {
     if (activeTab === "canvas") {
       designerRef.current?.handleSave();
-    } else {
+    } else if (activeTab === "brief") {
       void saveBrief();
     }
   }, [activeTab, saveBrief]);
@@ -242,7 +243,7 @@ const EditorPage: React.FC = () => {
           <UnifiedToolbar
             initialMode={activeTab}
             onModeChange={(mode) => {
-              if (mode === "canvas" && activeTab === "brief" && isBriefDirty) {
+              if (mode !== "brief" && activeTab === "brief" && isBriefDirty) {
                 const confirmLeave = window.confirm(
                   "You have unsaved changes, continue?"
                 );
@@ -322,6 +323,23 @@ const EditorPage: React.FC = () => {
                             <DesignerComponent ref={designerRef} />
                           </div>
                         </div>
+                      </div>
+                    </motion.div>
+                  )}
+                  {activeTab === "moodboard" && (
+                    <motion.div
+                      key="moodboard"
+                      initial={{ opacity: 0, x: 20 }}
+                      animate={{ opacity: 1, x: 0 }}
+                      exit={{ opacity: 0, x: -20 }}
+                      transition={{ duration: 0.3 }}
+                    >
+                      <div className="dashboard-layout" style={{ paddingBottom: "5px", height: "100%" }}>
+                        <MoodboardCanvas
+                          projectId={activeProject?.projectId}
+                          userId={userId ?? undefined}
+                          palette={projectPalette}
+                        />
                       </div>
                     </motion.div>
                   )}

--- a/frontend/src/dashboard/project/features/editor/pages/editorpage.tsx
+++ b/frontend/src/dashboard/project/features/editor/pages/editorpage.tsx
@@ -270,6 +270,7 @@ const EditorPage: React.FC = () => {
           <AnimatePresence mode="wait">
             <motion.div
               key={location.pathname}
+              className="editor-content-wrapper"
               initial={{ x: 100, opacity: 0 }}
               animate={{ x: 0, opacity: 1 }}
               exit={{ x: -100, opacity: 0 }}

--- a/frontend/src/dashboard/project/features/moodboard/moodboard.module.css
+++ b/frontend/src/dashboard/project/features/moodboard/moodboard.module.css
@@ -4,7 +4,7 @@
   gap: 1.5rem;
   padding: 1.5rem;
   flex: 1;
-  min-height: 100%;
+  min-height: 0;
   height: 100%;
   background: radial-gradient(circle at top, rgba(255, 255, 255, 0.02), transparent 55%),
     var(--moodboard-page-bg, #0f1014);

--- a/frontend/src/dashboard/project/features/moodboard/moodboard.module.css
+++ b/frontend/src/dashboard/project/features/moodboard/moodboard.module.css
@@ -3,6 +3,7 @@
   flex-direction: column;
   gap: 1.5rem;
   padding: 1.5rem;
+  flex: 1;
   min-height: 100%;
   height: 100%;
   background: radial-gradient(circle at top, rgba(255, 255, 255, 0.02), transparent 55%),


### PR DESCRIPTION
## Summary
- expose the moodboard canvas as a third tab within the editor experience
- extend the unified toolbar to support switching between Brief, Canvas, and Moodboard modes
- disable the save control when moodboard mode is active since the board autosaves locally

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d179565a6c8324ba2c998fa1dd8f68