### PR TITLE
Center project tabs and restyle desktop project header

### DIFF
--- a/frontend/src/dashboard/project/components/Shared/DesktopProjectHeader.tsx
+++ b/frontend/src/dashboard/project/components/Shared/DesktopProjectHeader.tsx
@@ -152,7 +152,21 @@ const DesktopProjectHeader = ({
               </ellipse>
             )}
           </svg>
+        </div>
 
+        <div className="project-nav-center">
+          <div className="project-nav-tabs">
+            <ProjectTabs
+              tabs={navigation.tabs}
+              activeIndex={navigation.activeIndex}
+              getFromIndex={navigation.getFromIndex}
+              storageKey={navigation.storageKey}
+              confirmNavigate={navigation.confirmNavigate}
+            />
+          </div>
+        </div>
+
+        <div className="right-side">
           <AvatarStack members={teamMembers} onClick={onOpenTeam} />
 
           <div
@@ -189,18 +203,6 @@ const DesktopProjectHeader = ({
             className="interactive icon-button"
           >
             <Folder size={20} />
-          </div>
-        </div>
-
-        <div className="right-side">
-          <div className="project-nav-tabs">
-            <ProjectTabs
-              tabs={navigation.tabs}
-              activeIndex={navigation.activeIndex}
-              getFromIndex={navigation.getFromIndex}
-              storageKey={navigation.storageKey}
-              confirmNavigate={navigation.confirmNavigate}
-            />
           </div>
         </div>
       </div>

--- a/frontend/src/dashboard/project/components/Shared/ProjectTabs.tsx
+++ b/frontend/src/dashboard/project/components/Shared/ProjectTabs.tsx
@@ -93,7 +93,6 @@ const ProjectTabs = ({
             className={isActive ? "active" : ""}
             aria-pressed={isActive}
           >
-            {tab.icon}
             <span>{tab.label}</span>
           </button>
         );

--- a/frontend/src/dashboard/project/components/Shared/project-header.css
+++ b/frontend/src/dashboard/project/components/Shared/project-header.css
@@ -202,7 +202,7 @@
 .project-header:not(.new-project-header) .project-nav-center {
   justify-self: center;
   width: 100%;
-  max-width: 640px;
+  max-width: 560px;
   display: flex;
   justify-content: center;
 }
@@ -223,37 +223,61 @@
 .project-header:not(.new-project-header) .project-nav-tabs .segmented-control {
   width: auto;
   justify-content: center;
-  padding: 4px;
-  gap: 2px;
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid rgba(255, 255, 255, 0.16);
-  border-radius: 999px;
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04), 0 10px 24px rgba(0, 0, 0, 0.25);
+  flex-wrap: wrap;
+  padding: 0;
+  gap: clamp(6px, 1vw, 12px);
+  background: transparent;
+  border: none;
+  border-radius: 0;
+  overflow: visible;
+  box-shadow: none;
 }
 
 .project-header:not(.new-project-header) .project-nav-tabs .segmented-control button {
-  padding: 8px 16px;
+  padding: 6px 14px;
   font-weight: 600;
-  font-size: 0.9rem;
-  letter-spacing: 0.005em;
-  color: rgba(255, 255, 255, 0.76);
+  font-size: clamp(0.78rem, 0.2vw + 0.74rem, 0.88rem);
+  letter-spacing: 0.01em;
+  color: rgba(255, 255, 255, 0.78);
   border-radius: 999px;
-  transition: color 0.2s ease;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: rgba(255, 255, 255, 0.06);
+  box-shadow: 0 4px 12px rgba(5, 10, 28, 0.2);
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease,
+    box-shadow 0.2s ease, transform 0.2s ease;
 }
 
-.project-header:not(.new-project-header) .project-nav-tabs .segmented-control button:hover,
-.project-header:not(.new-project-header) .project-nav-tabs .segmented-control button:focus-visible {
+.project-header:not(.new-project-header) .project-nav-tabs .segmented-control button:hover {
+  background: rgba(255, 255, 255, 0.12);
+  border-color: rgba(255, 255, 255, 0.22);
   color: rgba(255, 255, 255, 0.92);
+  transform: translateY(-1px);
+}
+
+.project-header:not(.new-project-header) .project-nav-tabs .segmented-control button:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.5);
+  outline-offset: 2px;
+}
+
+.project-header:not(.new-project-header)
+  .project-nav-tabs
+  .segmented-control
+  button:focus-visible:not(.active) {
+  background: rgba(255, 255, 255, 0.12);
+  border-color: rgba(255, 255, 255, 0.22);
+  color: rgba(255, 255, 255, 0.92);
+  transform: translateY(-1px);
 }
 
 .project-header:not(.new-project-header) .project-nav-tabs .segmented-control button.active {
+  background: rgba(255, 255, 255, 0.98);
+  border-color: transparent;
   color: #111213;
+  box-shadow: 0 8px 20px rgba(5, 10, 28, 0.32);
 }
 
-.project-header:not(.new-project-header) .project-nav-tabs .tab-slider {
-  background: #ffffff;
-  border-radius: 999px;
-  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.28);
+.project-header:not(.new-project-header) .project-nav-tabs .segmented-control .tab-slider {
+  display: none;
 }
 
 .project-header:not(.new-project-header) .icon-button {

--- a/frontend/src/dashboard/project/components/Shared/project-header.css
+++ b/frontend/src/dashboard/project/components/Shared/project-header.css
@@ -223,18 +223,19 @@
 .project-header:not(.new-project-header) .project-nav-tabs .segmented-control {
   width: auto;
   justify-content: center;
-  padding: 6px;
-  gap: 4px;
-  background: rgba(255, 255, 255, 0.06);
-  border: 1px solid rgba(255, 255, 255, 0.18);
+  padding: 4px;
+  gap: 2px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.16);
   border-radius: 999px;
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04), 0 12px 32px rgba(0, 0, 0, 0.28);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04), 0 10px 24px rgba(0, 0, 0, 0.25);
 }
 
 .project-header:not(.new-project-header) .project-nav-tabs .segmented-control button {
-  padding: 10px 22px;
+  padding: 8px 16px;
   font-weight: 600;
-  letter-spacing: 0.01em;
+  font-size: 0.9rem;
+  letter-spacing: 0.005em;
   color: rgba(255, 255, 255, 0.76);
   border-radius: 999px;
   transition: color 0.2s ease;
@@ -252,7 +253,7 @@
 .project-header:not(.new-project-header) .project-nav-tabs .tab-slider {
   background: #ffffff;
   border-radius: 999px;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.32);
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.28);
 }
 
 .project-header:not(.new-project-header) .icon-button {

--- a/frontend/src/dashboard/project/components/Shared/project-header.css
+++ b/frontend/src/dashboard/project/components/Shared/project-header.css
@@ -137,10 +137,9 @@
 }
 
 .project-header:not(.new-project-header) .header-content {
-  display: flex;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
   align-items: center;
-  justify-content: space-between;
-  flex-wrap: wrap;
   gap: clamp(16px, 2vw, 32px);
 }
 
@@ -149,12 +148,12 @@
   display: flex;
   align-items: center;
   flex-wrap: wrap;
-  gap:16px;
+  gap: clamp(12px, 1.4vw, 20px);
 }
 
 .project-header:not(.new-project-header) .left-side {
-  flex: 1 1 520px;
   min-width: 0;
+  gap: clamp(16px, 1.8vw, 28px);
 }
 
 .project-header:not(.new-project-header) .project-identity {
@@ -200,35 +199,60 @@
   color: inherit;
 }
 
+.project-header:not(.new-project-header) .project-nav-center {
+  justify-self: center;
+  width: 100%;
+  max-width: 640px;
+  display: flex;
+  justify-content: center;
+}
+
 .project-header:not(.new-project-header) .right-side {
-  flex: 1 1 320px;
   justify-content: flex-end;
+  justify-self: end;
   min-width: 0;
 }
 
 .project-header:not(.new-project-header) .project-nav-tabs {
-  flex: 1 1 100%;
-  width: 100%;
-  padding-top: clamp(12px, 1.5vw, 20px);
+  width: auto;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 .project-header:not(.new-project-header) .project-nav-tabs .segmented-control {
-  width: 100%;
-  justify-content: flex-start;
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid rgba(255, 255, 255, 0.14);
+  width: auto;
+  justify-content: center;
+  padding: 6px;
+  gap: 4px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 999px;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04), 0 12px 32px rgba(0, 0, 0, 0.28);
 }
 
 .project-header:not(.new-project-header) .project-nav-tabs .segmented-control button {
-  color: rgba(255, 255, 255, 0.75);
+  padding: 10px 22px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  color: rgba(255, 255, 255, 0.76);
+  border-radius: 999px;
+  transition: color 0.2s ease;
+}
+
+.project-header:not(.new-project-header) .project-nav-tabs .segmented-control button:hover,
+.project-header:not(.new-project-header) .project-nav-tabs .segmented-control button:focus-visible {
+  color: rgba(255, 255, 255, 0.92);
 }
 
 .project-header:not(.new-project-header) .project-nav-tabs .segmented-control button.active {
-  color: #ffffff;
+  color: #111213;
 }
 
 .project-header:not(.new-project-header) .project-nav-tabs .tab-slider {
-  background: rgba(255, 255, 255, 0.18);
+  background: #ffffff;
+  border-radius: 999px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.32);
 }
 
 .project-header:not(.new-project-header) .icon-button {
@@ -236,18 +260,22 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 8px;
-  border-radius: 12px;
-  background: rgba(255, 255, 255, 0.04);
-  color: rgba(255, 255, 255, 0.88);
-  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+  width: 44px;
+  height: 44px;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: rgba(12, 12, 12, 0.72);
+  color: rgba(255, 255, 255, 0.92);
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease, border-color 0.2s ease;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.35);
 }
 
 .project-header:not(.new-project-header) .icon-button:hover,
 .project-header:not(.new-project-header) .icon-button:focus-visible {
-  background: rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.16);
+  border-color: rgba(255, 255, 255, 0.38);
   color: #ffffff;
-  transform: translateY(-1px);
+  transform: translateY(-2px);
 }
 
 .project-header:not(.new-project-header) .project-logo-button {
@@ -267,9 +295,7 @@
   border-radius: inherit;
 }
 
-.project-header:not(.new-project-header) .finish-line-header,
-.project-header:not(.new-project-header) .icon-button,
-.project-header:not(.new-project-header) .project-nav-tabs .segmented-control {
+.project-header:not(.new-project-header) .finish-line-header {
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
 }
 
@@ -279,25 +305,42 @@
     padding: clamp(18px, 3vw, 26px);
   }
 
+  .project-header:not(.new-project-header) .header-content {
+    grid-template-columns: minmax(0, 1fr) auto;
+  }
+
+  .project-header:not(.new-project-header) .project-nav-center {
+    justify-self: center;
+  }
+
   .project-header:not(.new-project-header) .right-side {
-    justify-content: flex-start;
+    justify-self: end;
   }
 }
 
 @media (max-width: 1024px) {
   .project-header:not(.new-project-header) .header-content {
-    flex-direction: column;
-    align-items: stretch;
+    grid-template-columns: 1fr;
+    justify-items: stretch;
+    row-gap: clamp(14px, 3vw, 24px);
   }
 
   .project-header:not(.new-project-header) .left-side,
   .project-header:not(.new-project-header) .right-side {
-    flex: 1 1 100%;
     justify-content: flex-start;
   }
 
+  .project-header:not(.new-project-header) .project-nav-center {
+    justify-self: stretch;
+  }
+
   .project-header:not(.new-project-header) .project-nav-tabs {
+    width: 100%;
     padding-top: 16px;
+  }
+
+  .project-header:not(.new-project-header) .project-nav-tabs .segmented-control {
+    width: 100%;
   }
 }
 

--- a/frontend/src/dashboard/project/components/Shared/useProjectTabs.tsx
+++ b/frontend/src/dashboard/project/components/Shared/useProjectTabs.tsx
@@ -1,13 +1,11 @@
 import React from "react";
 import { useNavigate, useLocation } from "react-router-dom";
-import { LayoutDashboard, Coins, Calendar as CalendarIcon, PenTool } from "lucide-react";
 import { useData } from "@/app/contexts/useData";
 import { getProjectDashboardPath } from "@/shared/utils/projectUrl";
 
 export type ProjectTabItem = {
   key: string;
   label: string;
-  icon: React.ReactNode;
   path: string;
   matches: (pathname: string) => boolean;
 };
@@ -81,52 +79,61 @@ export const useProjectTabs = (
     [hasProject, projectId, projectTitle]
   );
 
-  const tabs = React.useMemo(
-    () =>
-      [
-        {
-          key: "overview",
-          label: "Overview",
-          icon: <LayoutDashboard size={16} />,
-          path: basePath,
-          visible: true,
-          matches: (pathname: string) => pathname === basePath,
-        },
-        {
-          key: "budget",
-          label: "Budget",
-          icon: <Coins size={16} />,
-          path: budgetPath,
-          visible: showBudgetTab,
-          matches: (pathname: string) => pathname.startsWith(budgetPath),
-        },
-        {
-          key: "calendar",
-          label: "Calendar",
-          icon: <CalendarIcon size={16} />,
-          path: calendarPath,
-          visible: showCalendarTab,
-          matches: (pathname: string) => pathname.startsWith(calendarPath),
-        },
-        {
-          key: "editor",
-          label: "Editor",
-          icon: <PenTool size={16} />,
-          path: editorPath,
-          visible: showEditorTab,
-          matches: (pathname: string) => pathname.startsWith(editorPath),
-        },
-      ].filter((tab) => tab.visible),
-    [
-      basePath,
-      budgetPath,
-      calendarPath,
-      editorPath,
-      showBudgetTab,
-      showCalendarTab,
-      showEditorTab,
-    ]
-  );
+  const tabs = React.useMemo<ProjectTabItem[]>(() => {
+    const tabDefinitions = [
+      {
+        key: "overview",
+        label: "Overview",
+        path: basePath,
+        matches: (pathname: string) => pathname === basePath,
+        visible: true,
+      },
+      {
+        key: "budget",
+        label: "Budget",
+        path: budgetPath,
+        matches: (pathname: string) => pathname.startsWith(budgetPath),
+        visible: showBudgetTab,
+      },
+      {
+        key: "calendar",
+        label: "Calendar",
+        path: calendarPath,
+        matches: (pathname: string) => pathname.startsWith(calendarPath),
+        visible: showCalendarTab,
+      },
+      {
+        key: "editor",
+        label: "Editor",
+        path: editorPath,
+        matches: (pathname: string) => pathname.startsWith(editorPath),
+        visible: showEditorTab,
+      },
+    ];
+
+    return tabDefinitions.reduce<ProjectTabItem[]>((acc, tab) => {
+      if (!tab.visible) {
+        return acc;
+      }
+
+      acc.push({
+        key: tab.key,
+        label: tab.label,
+        path: tab.path,
+        matches: tab.matches,
+      });
+
+      return acc;
+    }, []);
+  }, [
+    basePath,
+    budgetPath,
+    calendarPath,
+    editorPath,
+    showBudgetTab,
+    showCalendarTab,
+    showEditorTab,
+  ]);
 
   const storageKey = React.useMemo(
     () => `project-tabs-prev:${projectId || "unknown"}`,


### PR DESCRIPTION
## Summary
- refactor the desktop project header markup to separate left content, centered navigation, and right-side actions
- restyle the project tabs and action buttons to match the new pill layout with centered segmented control
- update responsive rules so the centered navigation collapses cleanly on smaller viewports

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d188c0d7748324abcea76e460af6fa