### PR TITLE
Sanitize budget line item updates before API calls

### DIFF
--- a/frontend/src/dashboard/project/features/budget/components/BudgetEventManager.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetEventManager.tsx
@@ -64,6 +64,30 @@ interface BudgetEventHandlers {
   getNextElementId: (category: string) => string;
 }
 
+const IMMUTABLE_FIELD_NAMES = new Set([
+  "projectid",
+  "budgetid",
+  "budgetitemid",
+]);
+
+const IMMUTABLE_FIELD_ALIASES = new Set(["pk", "sk"]);
+
+const GSI_KEY_PATTERN = /^gsi\d*(pk|sk)$/i;
+
+const sanitizeMutableBudgetFields = (payload: Record<string, unknown>): Record<string, unknown> =>
+  Object.entries(payload).reduce<Record<string, unknown>>((acc, [key, value]) => {
+    const normalizedKey = key.toLowerCase();
+    if (
+      IMMUTABLE_FIELD_NAMES.has(normalizedKey) ||
+      IMMUTABLE_FIELD_ALIASES.has(normalizedKey) ||
+      GSI_KEY_PATTERN.test(normalizedKey)
+    ) {
+      return acc;
+    }
+    acc[key] = value;
+    return acc;
+  }, {});
+
 const BudgetEventManager: React.FC<BudgetEventManagerProps> = ({
   activeProject,
   eventsByLineItem,
@@ -334,12 +358,19 @@ const BudgetEventManager: React.FC<BudgetEventManagerProps> = ({
     }
     stateManager.pushHistory();
     try {
+      const sanitized = sanitizeMutableBudgetFields(data);
       const normalized = {
-        ...data,
-        areaGroup: data.areaGroup ? String(data.areaGroup).trim().toUpperCase() : '',
-        invoiceGroup: data.invoiceGroup ? String(data.invoiceGroup).trim().toUpperCase() : '',
-        description: data.description ? String(data.description).trim().toUpperCase() : '',
-      };
+        ...sanitized,
+        areaGroup: sanitized["areaGroup"]
+          ? String(sanitized["areaGroup"]).trim().toUpperCase()
+          : '',
+        invoiceGroup: sanitized["invoiceGroup"]
+          ? String(sanitized["invoiceGroup"]).trim().toUpperCase()
+          : '',
+        description: sanitized["description"]
+          ? String(sanitized["description"]).trim().toUpperCase()
+          : '',
+      } as Partial<BudgetItem>;
       const updatedItem = await updateBudgetItem(
         activeProject.projectId,
         String(data.budgetItemId),
@@ -369,13 +400,18 @@ const BudgetEventManager: React.FC<BudgetEventManagerProps> = ({
     }
     stateManager.pushHistory();
     try {
+      const sanitized = sanitizeMutableBudgetFields(data);
       const normalized = {
-        ...data,
-        areaGroup: data.areaGroup ? String(data.areaGroup).trim().toUpperCase() : '',
-        invoiceGroup: data.invoiceGroup
-          ? String(data.invoiceGroup).trim().toUpperCase()
+        ...sanitized,
+        areaGroup: sanitized["areaGroup"]
+          ? String(sanitized["areaGroup"]).trim().toUpperCase()
           : '',
-        description: data.description ? String(data.description).trim().toUpperCase() : '',
+        invoiceGroup: sanitized["invoiceGroup"]
+          ? String(sanitized["invoiceGroup"]).trim().toUpperCase()
+          : '',
+        description: sanitized["description"]
+          ? String(sanitized["description"]).trim().toUpperCase()
+          : '',
       };
       const budgetId = String(budgetHeader?.budgetId || "");
       const revision = Number(budgetHeader?.revision ?? 1);

--- a/frontend/src/dashboard/project/features/budget/components/CreateLineItemModal.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/CreateLineItemModal.tsx
@@ -121,6 +121,29 @@ const TOOLTIP_TEXT: Partial<Record<keyof ItemForm, string>> = {
     "Markup will auto-adjust to keep Final Cost unchanged when you override costs. You can then modify Markup as needed.",
 };
 
+const IMMUTABLE_FORM_FIELD_NAMES = new Set(["projectid", "budgetid"]);
+const IMMUTABLE_FORM_FIELD_ALIASES = new Set(["pk", "sk"]);
+const FORM_GSI_KEY_PATTERN = /^gsi\d*(pk|sk)$/i;
+
+const shouldStripImmutableField = (key: string): boolean => {
+  const normalizedKey = key.toLowerCase();
+  if (normalizedKey === "budgetitemid") return false;
+  if (IMMUTABLE_FORM_FIELD_NAMES.has(normalizedKey)) return true;
+  if (IMMUTABLE_FORM_FIELD_ALIASES.has(normalizedKey)) return true;
+  return FORM_GSI_KEY_PATTERN.test(normalizedKey);
+};
+
+const sanitizeFormPayload = (payload: ItemForm): ItemForm => {
+  const sanitized = Object.entries(payload).reduce<Record<string, unknown>>((acc, [key, value]) => {
+    if (!shouldStripImmutableField(key)) {
+      acc[key] = value;
+    }
+    return acc;
+  }, {});
+
+  return sanitized as ItemForm;
+};
+
 const fields: FieldDef[] = [
   { name: "category", label: "Category", type: "select", options: CATEGORY_OPTIONS },
   { name: "elementKey", label: "Element Key" },
@@ -410,7 +433,8 @@ const CreateLineItemModal: React.FC<CreateLineItemModalProps> = ({
     data.revision = revision;
 
     if (onSubmit) {
-      return await onSubmit(data, isAutoSave);
+      const payload = sanitizeFormPayload(data);
+      return await onSubmit(payload, isAutoSave);
     }
     return null;
   };


### PR DESCRIPTION
## Summary
- strip immutable key fields from budget item payloads before invoking create/update APIs
- sanitize form submissions so modal edits do not forward Dynamo key fields back to the server

## Testing
- npm run typecheck *(fails: existing type export and dependency errors in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_e_68d1bcb5ad7883248a2c51c01bf06f83