### PR TITLE
Rearrange project header layout

### DIFF
--- a/frontend/src/dashboard/project/components/Shared/DesktopProjectHeader.tsx
+++ b/frontend/src/dashboard/project/components/Shared/DesktopProjectHeader.tsx
@@ -189,6 +189,18 @@ const DesktopProjectHeader = ({
             >
               <Folder size={20} />
             </div>
+
+            <div
+              onClick={onOpenTeam}
+              onKeyDown={(event) => handleKeyDown(event, onOpenTeam)}
+              role="button"
+              tabIndex={0}
+              title="View project team"
+              aria-label="View project team"
+              className="interactive project-team-stack"
+            >
+              <AvatarStack members={teamMembers} />
+            </div>
           </div>
         </div>
 
@@ -202,8 +214,6 @@ const DesktopProjectHeader = ({
               confirmNavigate={navigation.confirmNavigate}
             />
           </div>
-
-          <AvatarStack members={teamMembers} onClick={onOpenTeam} />
         </div>
       </div>
     </div>

--- a/frontend/src/dashboard/project/components/Shared/DesktopProjectHeader.tsx
+++ b/frontend/src/dashboard/project/components/Shared/DesktopProjectHeader.tsx
@@ -87,8 +87,20 @@ const DesktopProjectHeader = ({
             </div>
 
             <div className="project-text-group">
-              <div className="single-project-title">
+              <div className="single-project-title project-title-row">
                 <h2 className="project-title-heading">{project?.title || "Summary"}</h2>
+
+                <div
+                  onClick={onOpenSettings}
+                  onKeyDown={(event) => handleKeyDown(event, onOpenSettings)}
+                  role="button"
+                  tabIndex={0}
+                  title="Project settings"
+                  aria-label="Project settings"
+                  className="interactive icon-button project-settings-button"
+                >
+                  <Settings size={18} className="settings-icon" />
+                </div>
               </div>
 
               <div
@@ -106,55 +118,81 @@ const DesktopProjectHeader = ({
             </div>
           </div>
 
-          <svg
-            id="StatusSVG"
-            viewBox="0 0 400 400"
-            onClick={onOpenStatus}
-            onKeyDown={(event) => handleKeyDown(event, onOpenStatus)}
-            role="button"
-            tabIndex={0}
-            aria-label={`Status: ${displayStatus} Complete`}
-            className="interactive status-svg"
-            style={{ cursor: "pointer" }}
-          >
-            <title>{`Status: ${displayStatus} Complete`}</title>
-            <text
-              className="project-status"
-              transform={`translate(${progressValue !== 100 ? 75 : 56.58} 375.21)`}
+          <div className="project-quick-actions">
+            <svg
+              id="StatusSVG"
+              viewBox="0 0 400 400"
+              onClick={onOpenStatus}
+              onKeyDown={(event) => handleKeyDown(event, onOpenStatus)}
+              role="button"
+              tabIndex={0}
+              aria-label={`Status: ${displayStatus} Complete`}
+              className="interactive status-svg"
+              style={{ cursor: "pointer" }}
             >
-              <tspan x="22.5" y="-136">
-                {displayStatus}
-              </tspan>
-            </text>
-            {progressValue >= 0 && (
-              <ellipse
-                cx="200"
-                cy="200"
-                rx="160"
-                ry="160"
-                fill="none"
-                strokeWidth="15"
-                strokeDasharray={`${(progressValue / 100) * 1002}, 1004`}
-                style={{
-                  stroke: "var(--progress-accent, var(--accent-strong, #FA3356))",
-                }}
+              <title>{`Status: ${displayStatus} Complete`}</title>
+              <text
+                className="project-status"
+                transform={`translate(${progressValue !== 100 ? 75 : 56.58} 375.21)`}
               >
-                {progressValue < 100 && (
-                  <animate
-                    attributeName="stroke-dasharray"
-                    from="0, 1004"
-                    to={`${(progressValue / 100) * 1002}, 1004`}
-                    dur="1s"
-                    begin="0s"
-                    fill="freeze"
-                  />
-                )}
-              </ellipse>
-            )}
-          </svg>
+                <tspan x="22.5" y="-136">
+                  {displayStatus}
+                </tspan>
+              </text>
+              {progressValue >= 0 && (
+                <ellipse
+                  cx="200"
+                  cy="200"
+                  rx="160"
+                  ry="160"
+                  fill="none"
+                  strokeWidth="15"
+                  strokeDasharray={`${(progressValue / 100) * 1002}, 1004`}
+                  style={{
+                    stroke: "var(--progress-accent, var(--accent-strong, #FA3356))",
+                  }}
+                >
+                  {progressValue < 100 && (
+                    <animate
+                      attributeName="stroke-dasharray"
+                      from="0, 1004"
+                      to={`${(progressValue / 100) * 1002}, 1004`}
+                      dur="1s"
+                      begin="0s"
+                      fill="freeze"
+                    />
+                  )}
+                </ellipse>
+              )}
+            </svg>
+
+            <div
+              onClick={onOpenQuickLinks}
+              onKeyDown={(event) => handleKeyDown(event, onOpenQuickLinks)}
+              role="button"
+              tabIndex={0}
+              title="Quick links"
+              aria-label="Quick links"
+              className="interactive icon-button"
+            >
+              <Link2 size={20} />
+            </div>
+
+            <div
+              onClick={onOpenFiles}
+              onKeyDown={(event) => handleKeyDown(event, onOpenFiles)}
+              role="button"
+              tabIndex={0}
+              title="Open file manager"
+              aria-label="Open file manager"
+              className="interactive icon-button"
+            >
+              <Folder size={20} />
+            </div>
+          </div>
         </div>
 
-        <div className="project-nav-center">
+        <div className="right-side">
           <div className="project-nav-tabs">
             <ProjectTabs
               tabs={navigation.tabs}
@@ -164,46 +202,8 @@ const DesktopProjectHeader = ({
               confirmNavigate={navigation.confirmNavigate}
             />
           </div>
-        </div>
 
-        <div className="right-side">
           <AvatarStack members={teamMembers} onClick={onOpenTeam} />
-
-          <div
-            onClick={onOpenSettings}
-            onKeyDown={(event) => handleKeyDown(event, onOpenSettings)}
-            role="button"
-            tabIndex={0}
-            title="Project settings"
-            aria-label="Project settings"
-            className="interactive icon-button"
-          >
-            <Settings size={20} className="settings-icon" />
-          </div>
-
-          <div
-            onClick={onOpenQuickLinks}
-            onKeyDown={(event) => handleKeyDown(event, onOpenQuickLinks)}
-            role="button"
-            tabIndex={0}
-            title="Quick links"
-            aria-label="Quick links"
-            className="interactive icon-button"
-          >
-            <Link2 size={20} />
-          </div>
-
-          <div
-            onClick={onOpenFiles}
-            onKeyDown={(event) => handleKeyDown(event, onOpenFiles)}
-            role="button"
-            tabIndex={0}
-            title="Open file manager"
-            aria-label="Open file manager"
-            className="interactive icon-button"
-          >
-            <Folder size={20} />
-          </div>
         </div>
       </div>
     </div>

--- a/frontend/src/dashboard/project/components/Shared/project-header.css
+++ b/frontend/src/dashboard/project/components/Shared/project-header.css
@@ -136,9 +136,10 @@
   z-index: 1;
 }
 
+
 .project-header:not(.new-project-header) .header-content {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+  grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
   gap: clamp(16px, 2vw, 32px);
 }
@@ -152,6 +153,14 @@
 }
 
 .project-header:not(.new-project-header) .left-side {
+  min-width: 0;
+  gap: clamp(16px, 1.8vw, 28px);
+  justify-content: flex-start;
+}
+
+.project-header:not(.new-project-header) .right-side {
+  justify-content: flex-end;
+  justify-self: end;
   min-width: 0;
   gap: clamp(16px, 1.8vw, 28px);
 }
@@ -199,30 +208,17 @@
   color: inherit;
 }
 
-.project-header:not(.new-project-header) .project-nav-center {
-  justify-self: center;
+.project-header:not(.new-project-header) .project-nav-tabs {
   width: 100%;
   max-width: 560px;
   display: flex;
-  justify-content: center;
-}
-
-.project-header:not(.new-project-header) .right-side {
   justify-content: flex-end;
-  justify-self: end;
-  min-width: 0;
-}
-
-.project-header:not(.new-project-header) .project-nav-tabs {
-  width: auto;
-  display: flex;
-  justify-content: center;
   align-items: center;
 }
 
 .project-header:not(.new-project-header) .project-nav-tabs .segmented-control {
   width: auto;
-  justify-content: center;
+  justify-content: flex-end;
   flex-wrap: wrap;
   padding: 0;
   gap: clamp(6px, 1vw, 12px);
@@ -324,6 +320,37 @@
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
 }
 
+.project-header:not(.new-project-header) .project-title-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.project-header:not(.new-project-header) .project-settings-button {
+  width: 36px;
+  height: 36px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.18);
+}
+
+.project-header:not(.new-project-header) .project-settings-button:hover,
+.project-header:not(.new-project-header) .project-settings-button:focus-visible {
+  background: rgba(255, 255, 255, 0.16);
+  border-color: rgba(255, 255, 255, 0.32);
+}
+
+.project-header:not(.new-project-header) .project-quick-actions {
+  display: flex;
+  align-items: center;
+  gap: clamp(12px, 1.4vw, 20px);
+}
+
+.project-header:not(.new-project-header) .project-quick-actions .icon-button {
+  width: 40px;
+  height: 40px;
+}
+
 @media (max-width: 1200px) {
   .project-header:not(.new-project-header) {
     border-radius: 20px;
@@ -332,14 +359,6 @@
 
   .project-header:not(.new-project-header) .header-content {
     grid-template-columns: minmax(0, 1fr) auto;
-  }
-
-  .project-header:not(.new-project-header) .project-nav-center {
-    justify-self: center;
-  }
-
-  .project-header:not(.new-project-header) .right-side {
-    justify-self: end;
   }
 }
 
@@ -355,17 +374,15 @@
     justify-content: flex-start;
   }
 
-  .project-header:not(.new-project-header) .project-nav-center {
-    justify-self: stretch;
-  }
-
   .project-header:not(.new-project-header) .project-nav-tabs {
     width: 100%;
     padding-top: 16px;
+    justify-content: flex-start;
   }
 
   .project-header:not(.new-project-header) .project-nav-tabs .segmented-control {
     width: 100%;
+    justify-content: flex-start;
   }
 }
 

--- a/frontend/src/dashboard/project/components/Shared/project-header.css
+++ b/frontend/src/dashboard/project/components/Shared/project-header.css
@@ -351,6 +351,26 @@
   height: 40px;
 }
 
+.project-header:not(.new-project-header) .project-team-stack {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 40px;
+  padding: 4px 6px;
+  border-radius: 14px;
+  cursor: pointer;
+  transition: background 0.2s ease, outline 0.2s ease;
+}
+
+.project-header:not(.new-project-header) .project-team-stack:hover {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.project-header:not(.new-project-header) .project-team-stack:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.35);
+  outline-offset: 2px;
+}
+
 @media (max-width: 1200px) {
   .project-header:not(.new-project-header) {
     border-radius: 20px;


### PR DESCRIPTION
## Summary
- group the project status, quick links, and file manager actions together on the left side of the project header
- move the settings shortcut beside the project title and shift the project navigation pills to the right with updated styling hooks

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1c6aca8d08324beb79c41679bc013