### PR TITLE
Adjust project timeline row and gallery layout

### DIFF
--- a/frontend/src/dashboard/home/styles/components/calendar.css
+++ b/frontend/src/dashboard/home/styles/components/calendar.css
@@ -137,16 +137,34 @@
 .timeline-location-row {
   display: flex;
   flex-direction: row !important;
+  align-items: stretch;
   gap: 18px;
+  min-height: 0;
+  flex-wrap: nowrap;
 }
 
 .timeline-location-row > * {
-  flex: 1;
+  flex: 1 1 0;
+  min-width: 0;
+  display: flex;
+}
+
+.timeline-location-row .location-wrapper {
+  flex: 1 1 38%;
+  min-width: clamp(260px, 36vw, 420px);
+  min-height: clamp(260px, 32vh, 340px);
+}
+
+.timeline-location-row .tasks-wrapper {
+  flex: 1 1 62%;
+  min-width: clamp(320px, 48vw, 660px);
+  min-height: clamp(280px, 40vh, 420px);
 }
 
 /* Location card and map container */
 .dashboard-layout .dashboard-item.location {
-  height: 400px;
+  height: 100%;
+  min-height: inherit;
   padding: 0;
   overflow: hidden;
   border-radius: 20px;
@@ -166,6 +184,36 @@
   height: 100%;
   overflow: hidden;
   min-width: 0;
+}
+
+.location-wrapper .column-5,
+.tasks-wrapper .tasks-component {
+  height: 100%;
+}
+
+@media (max-width: var(--breakpoint-xl)) {
+  .timeline-location-row {
+    flex-wrap: wrap;
+  }
+
+  .timeline-location-row .location-wrapper,
+  .timeline-location-row .tasks-wrapper {
+    flex: 1 1 100%;
+    min-width: 0;
+    min-height: clamp(260px, 50vh, 380px);
+  }
+}
+
+@media (max-width: var(--breakpoint-md)) {
+  .timeline-location-row {
+    flex-direction: column !important;
+    gap: 14px;
+  }
+
+  .timeline-location-row .location-wrapper,
+  .timeline-location-row .tasks-wrapper {
+    min-height: clamp(240px, 55vh, 360px);
+  }
 }
 
 .location-wrapper .column-5 {

--- a/frontend/src/dashboard/home/styles/components/dashboard-cards.css
+++ b/frontend/src/dashboard/home/styles/components/dashboard-cards.css
@@ -48,10 +48,14 @@
 }
 
 .dashboard-item.view-gallery {
-  
+
   flex-direction: column;
   align-items: flex-start;
   justify-content: flex-start;
+  aspect-ratio: 1 / 1;
+  width: 100%;
+  min-height: 0;
+  gap: clamp(10px, 2vw, 18px);
 }
 
 .dashboard-item.view-gallery span {

--- a/frontend/src/dashboard/project/components/Gallery/gallery-component.module.css
+++ b/frontend/src/dashboard/project/components/Gallery/gallery-component.module.css
@@ -2,10 +2,13 @@
   cursor: pointer;
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
+  align-items: stretch;
   justify-content: flex-start;
   width: 100%;
-  flex: .6;
+  height: 100%;
+  min-height: 0;
+  flex: 1 1 auto;
+  gap: 12px;
   transition: transform 0.2s ease;
 }
 
@@ -439,20 +442,19 @@
 
 /* Rectangular thumbnail used for gallery previews outside the modal */
 .previewThumbnail {
-  max-height: 100px;
-  max-width: 150px;
-  width: auto;
-  height: auto;
+  width: 100%;
+  height: 100%;
+  aspect-ratio: 1;
   border-radius: 8px;
-  object-fit: contain;
+  object-fit: cover;
   border: 2px solid white;
-  padding: 5px;
+  padding: 4px;
   box-sizing: border-box;
 }
 
 .previewPlaceholder {
-  width: 150px;
-  height: 100px;
+  width: 100%;
+  aspect-ratio: 1;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -465,12 +467,11 @@
 }
 
 .thumbnailRow {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(72px, 1fr));
   gap: 8px;
-  margin-top: 8px;
-  margin-left: auto;
-  justify-content: flex-end;
+  margin-top: auto;
+  width: 100%;
 }
 
 .galleryCover {

--- a/frontend/src/dashboard/project/components/Shared/projectHeaderUtils.ts
+++ b/frontend/src/dashboard/project/components/Shared/projectHeaderUtils.ts
@@ -131,7 +131,7 @@ export function useRangeLabels(project: Project) {
     const options: Intl.DateTimeFormatOptions = { month: "short", day: "numeric" };
     const startStr = startDate.toLocaleDateString(undefined, options);
     const endStr = endDate.toLocaleDateString(undefined, options);
-    return `${startStr} – ${endStr}  ⏱ ${totalPart}`;
+    return `${startStr} – ${endStr} ⏱ ${totalPart}`;
   }, [startDate, endDate, totalHours]);
 
   const mobileRangeLabel = useMemo(() => {

--- a/frontend/src/dashboard/project/project.tsx
+++ b/frontend/src/dashboard/project/project.tsx
@@ -6,7 +6,6 @@ import BudgetOverviewCard from "@/dashboard/project/features/budget/components/B
 import GalleryComponent from "@/dashboard/project/components/Gallery/GalleryComponent";
 
 import ProjectPageLayout from "@/dashboard/project/components/Shared/ProjectPageLayout";
-import Timeline from "@/dashboard/project/components/Timeline/Timeline";
 import CalendarOverviewCard from "@/dashboard/project/components/Shared/CalendarOverviewCard";
 import QuickLinksComponent from "@/dashboard/project/components/Shared/QuickLinksComponent";
 import type { QuickLinksRef } from "@/dashboard/project/components/Shared/QuickLinksComponent";


### PR DESCRIPTION
## Summary
- resize the project timeline/location row so the task panel drives 60–70% of the width, trims map height, and stacks cleanly on narrow screens
- make the dashboard gallery card square and lay out preview thumbnails in a responsive grid to match the new aspect ratio
- resolve minor lint complaints uncovered while running checks

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1d49d7c34832497a45f8aead3f88c