### PR TITLE
Adjust timeline and location layout sizing

### DIFF
--- a/frontend/src/dashboard/home/styles/components/calendar.css
+++ b/frontend/src/dashboard/home/styles/components/calendar.css
@@ -138,15 +138,24 @@
   display: flex;
   flex-direction: row !important;
   gap: 12px;
+  align-items: stretch;
+  flex-wrap: wrap;
 }
 
-.timeline-location-row > * {
-  flex: 1;
+.timeline-location-row .location-wrapper {
+  flex: 1 1 35%;
+  max-width: 40%;
+  min-width: min(320px, 40%);
+}
+
+.timeline-location-row .tasks-wrapper {
+  flex: 1 1 65%;
+  min-width: min(360px, 70%);
 }
 
 /* Location card and map container */
 .dashboard-layout .dashboard-item.location {
-  height: 400px;
+  height: clamp(260px, 36vh, 340px);
   padding: 0;
   overflow: hidden;
   border-radius: 20px;
@@ -166,6 +175,23 @@
   height: 100%;
   overflow: hidden;
   min-width: 0;
+}
+
+@media (max-width: 1100px) {
+  .timeline-location-row {
+    flex-direction: column !important;
+  }
+
+  .timeline-location-row .location-wrapper,
+  .timeline-location-row .tasks-wrapper {
+    max-width: 100%;
+    min-width: 0;
+    flex-basis: 100%;
+  }
+
+  .dashboard-layout .dashboard-item.location {
+    height: clamp(240px, 45vh, 320px);
+  }
 }
 
 .location-wrapper .column-5 {

--- a/frontend/src/dashboard/project/components/Shared/projectHeaderUtils.ts
+++ b/frontend/src/dashboard/project/components/Shared/projectHeaderUtils.ts
@@ -131,7 +131,7 @@ export function useRangeLabels(project: Project) {
     const options: Intl.DateTimeFormatOptions = { month: "short", day: "numeric" };
     const startStr = startDate.toLocaleDateString(undefined, options);
     const endStr = endDate.toLocaleDateString(undefined, options);
-    return `${startStr} – ${endStr}  ⏱ ${totalPart}`;
+    return `${startStr} – ${endStr} ⏱ ${totalPart}`;
   }, [startDate, endDate, totalHours]);
 
   const mobileRangeLabel = useMemo(() => {

--- a/frontend/src/dashboard/project/project.tsx
+++ b/frontend/src/dashboard/project/project.tsx
@@ -6,7 +6,6 @@ import BudgetOverviewCard from "@/dashboard/project/features/budget/components/B
 import GalleryComponent from "@/dashboard/project/components/Gallery/GalleryComponent";
 
 import ProjectPageLayout from "@/dashboard/project/components/Shared/ProjectPageLayout";
-import Timeline from "@/dashboard/project/components/Timeline/Timeline";
 import CalendarOverviewCard from "@/dashboard/project/components/Shared/CalendarOverviewCard";
 import QuickLinksComponent from "@/dashboard/project/components/Shared/QuickLinksComponent";
 import type { QuickLinksRef } from "@/dashboard/project/components/Shared/QuickLinksComponent";


### PR DESCRIPTION
## Summary
- rebalance the timeline/location row so the location panel uses roughly 35% width and the tasks panel fills the remaining space while keeping the row shorter
- add responsive stacking rules to prevent the row from overlapping other dashboard content on smaller breakpoints
- clean up lint issues by removing an unused import and replacing irregular whitespace in the project header utilities

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1dc4049dc8324966f34b7119d55c7