### PR TITLE
feat: guard invoice preview close and enhance notes styling

### DIFF
--- a/frontend/src/dashboard/project/features/budget/components/InvoicePreviewModal.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/InvoicePreviewModal.tsx
@@ -7,6 +7,7 @@ import React, {
   useState,
   useCallback,
 } from "react";
+import { createPortal } from "react-dom";
 import Modal from "@/shared/ui/ModalWithStack";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
@@ -1707,34 +1708,37 @@ const InvoicePreviewModal: React.FC<InvoicePreviewModalProps> = ({
         </div>
       </Modal>
 
-      {showUnsavedPrompt && (
-        <div
-          className={styles.unsavedOverlay}
-          role="dialog"
-          aria-modal="true"
-          aria-label="Unsaved invoice changes"
-        >
-          <div className={styles.unsavedDialog}>
-            <p>This invoice has unsaved changes. Leave Anyway?</p>
-            <div className={styles.unsavedActions}>
-              <button
-                type="button"
-                className={styles.unsavedButton}
-                onClick={handleStayOpen}
-              >
-                Stay
-              </button>
-              <button
-                type="button"
-                className={`${styles.unsavedButton} ${styles.unsavedButtonPrimary}`}
-                onClick={handleConfirmLeave}
-              >
-                Leave Anyway
-              </button>
+      {showUnsavedPrompt &&
+        typeof document !== "undefined" &&
+        createPortal(
+          <div
+            className={styles.unsavedOverlay}
+            role="dialog"
+            aria-modal="true"
+            aria-label="Unsaved invoice changes"
+          >
+            <div className={styles.unsavedDialog}>
+              <p>This invoice has unsaved changes. Leave Anyway?</p>
+              <div className={styles.unsavedActions}>
+                <button
+                  type="button"
+                  className={styles.unsavedButton}
+                  onClick={handleStayOpen}
+                >
+                  Stay
+                </button>
+                <button
+                  type="button"
+                  className={`${styles.unsavedButton} ${styles.unsavedButtonPrimary}`}
+                  onClick={handleConfirmLeave}
+                >
+                  Leave Anyway
+                </button>
+              </div>
             </div>
-          </div>
-        </div>
-      )}
+          </div>,
+          document.body
+        )}
 
       <ConfirmModal
         isOpen={isConfirmingDelete}

--- a/frontend/src/dashboard/project/features/budget/components/InvoicePreviewModal.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/InvoicePreviewModal.tsx
@@ -116,6 +116,8 @@ const groupFields: Array<{ label: string; value: GroupField }> = [
   { label: "Category", value: "category" },
 ];
 
+const DEFAULT_NOTES_HTML = "<p>Notes...</p>";
+
 // ---------- Component ----------
 const InvoicePreviewModal: React.FC<InvoicePreviewModalProps> = ({
   isOpen,
@@ -167,7 +169,7 @@ const InvoicePreviewModal: React.FC<InvoicePreviewModalProps> = ({
   const [customerSummary, setCustomerSummary] = useState("Customer");
   const [invoiceSummary, setInvoiceSummary] = useState("Invoice Details");
   const [paymentSummary, setPaymentSummary] = useState("Payment");
-  const [notes, setNotes] = useState("Notes...");
+  const [notes, setNotes] = useState(DEFAULT_NOTES_HTML);
   const [depositReceived, setDepositReceived] = useState<number>(0);
   const [totalDue, setTotalDue] = useState<number>(0);
 
@@ -180,6 +182,8 @@ const InvoicePreviewModal: React.FC<InvoicePreviewModalProps> = ({
 
   // delete confirm
   const [isConfirmingDelete, setIsConfirmingDelete] = useState(false);
+
+  const [showUnsavedPrompt, setShowUnsavedPrompt] = useState(false);
 
   // logo file input
   const fileInputRef = useRef<HTMLInputElement | null>(null);
@@ -198,6 +202,23 @@ const InvoicePreviewModal: React.FC<InvoicePreviewModalProps> = ({
     };
     reader.readAsDataURL(file);
   };
+
+  const handleAttemptClose = useCallback(() => {
+    if (isDirty || invoiceDirty) {
+      setShowUnsavedPrompt(true);
+      return;
+    }
+    onRequestClose();
+  }, [isDirty, invoiceDirty, onRequestClose]);
+
+  const handleConfirmLeave = useCallback(() => {
+    setShowUnsavedPrompt(false);
+    onRequestClose();
+  }, [onRequestClose]);
+
+  const handleStayOpen = useCallback(() => {
+    setShowUnsavedPrompt(false);
+  }, []);
 
   const handleLogoDrop: React.DragEventHandler<HTMLDivElement> = (e) => {
     e.preventDefault();
@@ -323,7 +344,7 @@ const InvoicePreviewModal: React.FC<InvoicePreviewModalProps> = ({
       }
 
       const notesEl = q(".notes");
-      if (notesEl) setNotes(notesEl.textContent || "");
+      if (notesEl) setNotes(notesEl.innerHTML || "");
 
       // Try to infer grouping field from headers
       const parsedGroups = Array.from(
@@ -392,7 +413,7 @@ const InvoicePreviewModal: React.FC<InvoicePreviewModalProps> = ({
     setCustomerSummary(project?.clientName || "Customer");
     setInvoiceSummary("Invoice Details");
     setPaymentSummary("Payment");
-    setNotes("Notes...");
+    setNotes(DEFAULT_NOTES_HTML);
     setDepositReceived(0);
     setInvoiceDirty(false);
 
@@ -547,6 +568,12 @@ const InvoicePreviewModal: React.FC<InvoicePreviewModalProps> = ({
     setSelectedPages(pages.map((_, i) => i));
     setCurrentPage(0);
   }, [pages]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setShowUnsavedPrompt(false);
+    }
+  }, [isOpen]);
 
   // ---------- Build / Export / Save ----------
   const buildInvoiceHtml = (): string => {
@@ -800,7 +827,7 @@ const InvoicePreviewModal: React.FC<InvoicePreviewModalProps> = ({
     <Fragment>
       <Modal
         isOpen={isOpen}
-        onRequestClose={onRequestClose}
+        onRequestClose={handleAttemptClose}
         contentLabel="Invoice Preview"
         closeTimeoutMS={300}
         className={{
@@ -816,7 +843,7 @@ const InvoicePreviewModal: React.FC<InvoicePreviewModalProps> = ({
       >
         <div className={styles.modalHeader}>
           <div className={styles.modalTitle}>Invoice Preview</div>
-          <button className={styles.iconButton} onClick={onRequestClose} aria-label="Close">
+          <button className={styles.iconButton} onClick={handleAttemptClose} aria-label="Close">
             <FontAwesomeIcon icon={faXmark} />
           </button>
         </div>
@@ -1359,12 +1386,11 @@ const InvoicePreviewModal: React.FC<InvoicePreviewModalProps> = ({
                         contentEditable
                         suppressContentEditableWarning
                         onBlur={(e) => {
-                          setNotes(e.currentTarget.textContent || "");
+                          setNotes(e.currentTarget.innerHTML || "");
                           setInvoiceDirty(true);
                         }}
-                      >
-                        {notes}
-                      </div>
+                        dangerouslySetInnerHTML={{ __html: notes }}
+                      />
 
                       <div className="footer" contentEditable suppressContentEditableWarning>
                         {project?.company || "Company Name"}
@@ -1656,17 +1682,16 @@ const InvoicePreviewModal: React.FC<InvoicePreviewModalProps> = ({
                             </div>
                           </div>
 
-                          <div
-                            className="notes"
-                            contentEditable
-                            suppressContentEditableWarning
-                            onBlur={(e) => {
-                              setNotes(e.currentTarget.textContent || "");
-                              setInvoiceDirty(true);
-                            }}
-                          >
-                            {notes}
-                          </div>
+                            <div
+                              className="notes"
+                              contentEditable
+                              suppressContentEditableWarning
+                              onBlur={(e) => {
+                                setNotes(e.currentTarget.innerHTML || "");
+                                setInvoiceDirty(true);
+                              }}
+                              dangerouslySetInnerHTML={{ __html: notes }}
+                            />
 
                           <div className="footer" contentEditable suppressContentEditableWarning>
                             {project?.company || "Company Name"}
@@ -1681,6 +1706,35 @@ const InvoicePreviewModal: React.FC<InvoicePreviewModalProps> = ({
           )}
         </div>
       </Modal>
+
+      {showUnsavedPrompt && (
+        <div
+          className={styles.unsavedOverlay}
+          role="dialog"
+          aria-modal="true"
+          aria-label="Unsaved invoice changes"
+        >
+          <div className={styles.unsavedDialog}>
+            <p>This invoice has unsaved changes. Leave Anyway?</p>
+            <div className={styles.unsavedActions}>
+              <button
+                type="button"
+                className={styles.unsavedButton}
+                onClick={handleStayOpen}
+              >
+                Stay
+              </button>
+              <button
+                type="button"
+                className={`${styles.unsavedButton} ${styles.unsavedButtonPrimary}`}
+                onClick={handleConfirmLeave}
+              >
+                Leave Anyway
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
 
       <ConfirmModal
         isOpen={isConfirmingDelete}

--- a/frontend/src/dashboard/project/features/budget/components/invoice-preview-modal.module.css
+++ b/frontend/src/dashboard/project/features/budget/components/invoice-preview-modal.module.css
@@ -256,6 +256,17 @@
 
 .notes {
   margin-top: 20px;
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+.notes p {
+  margin: 0 0 0.5rem;
+  padding: 6px 0;
+}
+
+.notes p:last-child {
+  margin-bottom: 0;
 }
 
 .footer {
@@ -300,6 +311,67 @@
 .savedMsg {
   margin-top: 6px;
   color: #4caf50;
+}
+
+.unsavedOverlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.85);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1100;
+  padding: 20px;
+}
+
+.unsavedDialog {
+  background: #121212;
+  color: #ffffff;
+  padding: 24px;
+  border-radius: 12px;
+  text-align: center;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.45);
+  max-width: 360px;
+  width: min(100%, 360px);
+}
+
+.unsavedDialog p {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.unsavedActions {
+  margin-top: 20px;
+  display: flex;
+  justify-content: center;
+  gap: 12px;
+}
+
+.unsavedButton {
+  background: #1a1a1a;
+  border: 1px solid #555;
+  color: #ffffff;
+  padding: 8px 16px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.unsavedButton:hover {
+  background: #222;
+}
+
+.unsavedButtonPrimary {
+  background: #fa3356;
+  border-color: #fa3356;
+}
+
+.unsavedButtonPrimary:hover {
+  background: #ff4b6c;
+  border-color: #ff4b6c;
 }
 
 @media (max-width: 768px) {

--- a/frontend/src/dashboard/project/features/budget/components/invoice-preview-modal.module.css
+++ b/frontend/src/dashboard/project/features/budget/components/invoice-preview-modal.module.css
@@ -323,7 +323,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 1100;
+  z-index: 2000;
   padding: 20px;
 }
 


### PR DESCRIPTION
## Summary
- prevent closing the invoice preview modal when header or invoice edits are unsaved and show a centered confirmation prompt
- persist notes content as HTML so user formatting is retained in previews, exports, and saved invoices
- tweak invoice notes styling with a smaller font and padded paragraphs for improved readability

## Testing
- npm run lint *(fails: pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d1fc6d5e888324bd57783abab99c57