### PR TITLE
Make invoice delete confirm modal compact

### DIFF
--- a/frontend/src/dashboard/project/features/budget/components/InvoicePreviewModal.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/InvoicePreviewModal.tsx
@@ -1761,9 +1761,9 @@ const InvoicePreviewModal: React.FC<InvoicePreviewModalProps> = ({
         onConfirm={performDeleteInvoices}
         message="Delete selected invoices?"
         className={{
-          base: styles.modalContent,
-          afterOpen: styles.modalContentAfterOpen,
-          beforeClose: styles.modalContentBeforeClose,
+          base: styles.confirmModalContent,
+          afterOpen: styles.confirmModalContentAfterOpen,
+          beforeClose: styles.confirmModalContentBeforeClose,
         }}
         overlayClassName={{
           base: styles.modalOverlay,

--- a/frontend/src/dashboard/project/features/budget/components/invoice-preview-modal.module.css
+++ b/frontend/src/dashboard/project/features/budget/components/invoice-preview-modal.module.css
@@ -42,6 +42,34 @@
   opacity: 0;
   transform: translateY(-20px);
 }
+
+.confirmModalContent {
+  background: #111111;
+  color: #ffffff;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 16px;
+  padding: 24px 28px;
+  width: min(90vw, 420px);
+  max-width: 420px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  text-align: center;
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.45);
+  opacity: 0;
+  transform: translateY(-16px) scale(0.98);
+  transition: opacity 0.25s ease, transform 0.25s ease;
+}
+
+.confirmModalContentAfterOpen {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+}
+
+.confirmModalContentBeforeClose {
+  opacity: 0;
+  transform: translateY(-16px) scale(0.98);
+}
 .modalHeader {
   display: flex;
   justify-content: space-between;

--- a/frontend/src/shared/ui/ConfirmModal.tsx
+++ b/frontend/src/shared/ui/ConfirmModal.tsx
@@ -50,8 +50,8 @@ const ConfirmModal: React.FC<ConfirmModalProps> = ({
       isOpen={isOpen}
       onRequestClose={onRequestClose}
       contentLabel="Confirmation"
-      className={className as string}
-      overlayClassName={overlayClassName as string}
+      className={className}
+      overlayClassName={overlayClassName}
       shouldCloseOnOverlayClick={false}
     >
       <div style={{ textAlign: 'center' }}>


### PR DESCRIPTION
## Summary
- add compact confirm-modal styles to the invoice preview module
- wire the delete confirmation dialog to use the tighter modal styles

## Testing
- npm run test -- src/shared/ui/ConfirmModal.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d202750100832487b78b74562e2556