### PR TITLE
Refine project dashboard layout responsiveness

### DIFF
--- a/frontend/src/dashboard/home/styles/components/calendar.css
+++ b/frontend/src/dashboard/home/styles/components/calendar.css
@@ -1,5 +1,25 @@
 /* Calendar and Combo Layouts */
 
+:root {
+  --hdr: 84px;
+  --gap: 16px;
+  --row2: clamp(300px, 36svh, 540px);
+  --row3: clamp(260px, calc(100svh - var(--hdr) - var(--gap) - var(--row2)), 1fr);
+}
+
+@media (max-height: 820px) {
+  :root {
+    --row2: clamp(280px, 30svh, 420px);
+  }
+}
+
+@media (min-height: 1000px) {
+  :root {
+    --row2: clamp(360px, 32svh, 560px);
+    --row3: minmax(340px, 1fr);
+  }
+}
+
 /* Calendar page: stack calendar and timeline vertically */
 .calendar-layout {
   display: flex;
@@ -36,153 +56,129 @@
   max-height: none;
 }
 
-/* Budget + Calendar two-column layout */
-.budget-calendar-layout {
-  --budget-calendar-gap: 12px;
-  min-height: 0;
-  --budget-calendar-min-calendar: 400px;
-  --budget-calendar-max-calendar: 520px;
-  --budget-calendar-stack-budget: 420px;
-
+/* Project dashboard grid */
+.project-dashboard-layout {
   display: grid;
-  gap: var(--budget-calendar-gap);
-  grid-template-columns: minmax(0, 1fr)
-    clamp(
-      var(--budget-calendar-min-calendar),
-      30%,
-      var(--budget-calendar-max-calendar)
-    );
-  grid-template-areas: "budget calendar";
-  align-items: stretch;
-  container-type: inline-size;
-  container-name: budget-calendar;
-}
-
-.budget-calendar-layout--stacked {
-  grid-template-columns: minmax(0, 1fr);
-  grid-template-areas:
-    "budget"
-    "calendar";
-}
-
-.budget-calendar-layout--stacked .budget-column,
-.budget-calendar-layout--stacked .calendar-column {
+  grid-template-columns: 1fr 380px;
+  grid-template-rows: var(--row2) var(--row3);
+  gap: var(--gap);
   width: 100%;
-  min-inline-size: 0;
-  gap: var(--budget-calendar-gap);
+  min-height: calc(100svh - var(--hdr));
 }
 
-.budget-calendar-layout--stacked .calendar-column {
+@media (max-width: 1100px) {
+  .project-dashboard-layout {
+    grid-template-columns: 1fr;
+    grid-template-rows: var(--row2) auto auto;
+  }
+}
+
+.project-dashboard-layout > .dashboard-budget {
+  grid-row: 1;
+  min-height: 0;
   display: flex;
   flex-direction: column;
+  gap: var(--gap);
 }
 
-.budget-calendar-layout .budget-column {
-  grid-area: budget;
+.project-dashboard-layout .dashboard-galleries {
+  min-height: 0;
+}
+
+.project-dashboard-layout > .dashboard-calendarChat {
+  grid-row: 1 / span 2;
+  min-height: 0;
   display: flex;
   flex-direction: column;
-  gap: var(--budget-calendar-gap);
-  min-inline-size: 0;
+  gap: var(--gap);
 }
 
-.budget-calendar-layout .calendar-column {
-  grid-area: calendar;
-  display: flex;
-  flex-direction: column;
-  gap: var(--budget-calendar-gap);
-  min-inline-size: 0;
-  container-type: inline-size;
-  container-name: calendar-panel;
+.project-dashboard-layout > .dashboard-timelineRow {
+  grid-row: 2;
+  min-height: 0;
+  display: grid;
+  grid-template-columns: minmax(300px, 1fr) minmax(420px, 560px);
+  grid-auto-rows: 1fr;
+  gap: var(--gap);
+  min-block-size: var(--row3);
 }
 
-.budget-calendar-layout .budget-column > *,
-.budget-calendar-layout .calendar-column > * {
-  width: 100%;
-}
+@media (max-width: 1100px) {
+  .project-dashboard-layout > .dashboard-calendarChat {
+    grid-row: 2;
+  }
 
-@container budget-calendar (max-width: calc(
-    var(--budget-calendar-min-calendar) +
-    var(--budget-calendar-stack-budget) +
-    var(--budget-calendar-gap)
-  )) {
-  .budget-calendar-layout {
+  .project-dashboard-layout > .dashboard-timelineRow {
+    grid-row: 3;
     grid-template-columns: minmax(0, 1fr);
-    grid-template-areas:
-      "budget"
-      "calendar";
   }
 }
 
-@media (max-width: var(--breakpoint-sm)) {
-  .budget-calendar-layout {
-    grid-template-columns: minmax(0, 1fr);
-    grid-template-areas:
-      "budget"
-      "calendar";
-    gap: 20px;
-  }
-
-  .budget-calendar-layout .budget-column,
-  .budget-calendar-layout .calendar-column {
-    width: 100%;
-    gap: 20px;
-  }
-
-  .budget-calendar-layout .budget-column > *,
-  .budget-calendar-layout .calendar-column > * {
-    width: 100%;
-  }
+.dashboard-budgetCard .card {
+  max-height: var(--row2);
 }
 
-/* Overview height distribution */
-.overview-layout > .dashboard-layout {
+.dashboard-budgetCard .card__body {
+  overflow: visible;
+}
+
+.dashboard-galleries .card__body {
+  min-height: 180px;
+  max-height: calc(var(--row3) - 16px);
+  overflow: auto;
+}
+
+.dashboard-map {
+  block-size: 100%;
+}
+
+.budget-donut {
+  inline-size: clamp(220px, 28vw, 360px);
+  aspect-ratio: 1;
+  margin: 0 auto;
+}
+
+.dashboard-calendarChat,
+.dashboard-calendarChat .card,
+.chatList {
+  min-height: 0;
+}
+
+.chatList {
+  overflow: auto;
+}
+
+.dashboard-calendar .card__body {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.project-dashboard-layout .card__body {
+  scrollbar-width: thin;
+}
+
+.overview-layout > .project-dashboard-layout {
   min-height: 0;
   flex: 1 1 auto;
 }
 
-.overview-layout > .dashboard-layout.budget-calendar-layout {
-  flex: 1 1 70%;
-  min-height: clamp(240px, 34vh, 500px);
-}
-
-.overview-layout > .dashboard-layout.timeline-location-row {
-  flex: 1 1 30%;
-  min-height: clamp(200px, 28vh, 380px);
-}
-
-@media (max-height: 820px),
-       (max-width: var(--breakpoint-md)) {
-  .overview-layout > .dashboard-layout.budget-calendar-layout,
-  .overview-layout > .dashboard-layout.timeline-location-row {
-    flex: 1 1 auto;
-  }
-}
-
-/* Timeline + Location row layout */
-.timeline-location-row {
-  padding-top: 12px;
-  display: flex;
-  flex-direction: row !important;
-  gap: 12px;
-  align-items: stretch;
-  min-height: clamp(220px, 28vh, 360px);
-}
-
-.timeline-location-row > * {
-  flex: 1 1 0;
-  min-width: 0;
-  min-height: 0;
-}
-
 /* Location card and map container */
-.dashboard-layout .dashboard-item.location {
-  height: 400px;
+.dashboard-map .card__body {
   padding: 0;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
   overflow: hidden;
-  border-radius: 20px;
 }
 
-.dashboard-layout #map {
+.dashboard-map .column-5 {
+  flex: 1 1 auto;
+  min-height: 0;
+  position: relative;
+}
+
+.dashboard-map #map {
   width: 100%;
   height: 100%;
   margin: 0;
@@ -190,18 +186,27 @@
   overflow: hidden;
 }
 
-.location-wrapper,
-.tasks-wrapper {
-  width: 100%;
-  height: 100%;
-  overflow: hidden;
-  min-width: 0;
+.dashboard-tasks .card__body {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow: auto;
+}
+
+.dashboard-tasks .tasks-component,
+.dashboard-tasks .tasks-card {
+  display: flex;
+  flex-direction: column;
   min-height: 0;
 }
 
-.location-wrapper .column-5 {
-  height: 100%;
+.dashboard-tasks .tasks-card {
+  flex: 1 1 auto;
   overflow: hidden;
+}
+
+.dashboard-tasks .tasks-table-wrapper {
+  flex: 1 1 auto;
 }
 
 .leaflet-container {

--- a/frontend/src/dashboard/home/styles/components/dashboard-cards.css
+++ b/frontend/src/dashboard/home/styles/components/dashboard-cards.css
@@ -1,7 +1,6 @@
 /* Dashboard Cards and Budget Overview */
 
 .dashboard-item {
-  
   padding: 18px;
   border-radius: 20px;
   display: flex;
@@ -11,6 +10,25 @@
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04), 0 18px 48px rgba(0, 0, 0, 0.45);
   border-radius: 32px 32px 32px 32px;
   border: 2px solid rgba(255, 255, 255, 0.10);
+}
+
+.card {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: stretch;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.card__header {
+  flex: 0 0 auto;
+}
+
+.card__body {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: auto;
 }
 
 .dashboard-item:hover {
@@ -81,9 +99,8 @@
 .budget-component-container {
   cursor: pointer;
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
   align-items: stretch;
-  justify-content: flex-start;
   gap: clamp(12px, 2vw, 24px);
   width: 100%;
   container-type: inline-size;
@@ -98,9 +115,8 @@
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  flex: 1 1 0%;
-  max-width: 50%;
-  min-width: 0;
+  width: 100%;
+  gap: 8px;
 }
 
 .budget-overview-header {

--- a/frontend/src/dashboard/project/components/Gallery/GalleryComponent.tsx
+++ b/frontend/src/dashboard/project/components/Gallery/GalleryComponent.tsx
@@ -796,8 +796,8 @@ const GalleryComponent: React.FC = () => {
     <Fragment>
       {saving && <div style={{ color: "#FA3356", marginBottom: "10px" }}>Saving...</div>}
 
-      <div
-        className={`dashboard-item view-gallery ${styles.galleryTrigger}`}
+      <section
+        className={`card dashboard-item view-gallery dashboard-galleries ${styles.galleryTrigger}`}
         onClick={handleTriggerClick}
         role="button"
         tabIndex={0}
@@ -808,50 +808,54 @@ const GalleryComponent: React.FC = () => {
           }
         }}
       >
-        <div className={styles.topRow}>
-          <GalleryVerticalEnd size={26} className={styles.triggerIcon} />
-          <span>Galleries</span>
-        </div>
+        <header className="card__header">
+          <div className={styles.topRow}>
+            <GalleryVerticalEnd size={26} className={styles.triggerIcon} />
+            <span>Galleries</span>
+          </div>
+        </header>
 
-        {combinedGalleries.length > 0 && (
-          <div
-            className={`${styles.thumbnailRow} ${styles.galleryCover}`}
-            onClick={(e) => {
-              e.stopPropagation();
-              openModal();
-            }}
-            role="button"
-            tabIndex={0}
-            aria-label="Edit galleries"
-            onKeyDown={(e) => {
-              if (e.key === "Enter" || e.key === " ") {
-                e.preventDefault();
+        <div className="card__body">
+          {combinedGalleries.length > 0 && (
+            <div
+              className={`${styles.thumbnailRow} ${styles.galleryCover}`}
+              onClick={(e) => {
                 e.stopPropagation();
                 openModal();
-              }
-            }}
-          >
-            {combinedGalleries.map((galleryItem, idx) => {
-              const previewUrl = getPreviewUrl(galleryItem);
-              return previewUrl ? (
-                <img
-                  src={previewUrl ? getFileUrl(previewUrl) : ''}
-                  alt=""
-                  className={styles.previewThumbnail}
-                  key={galleryItem.slug || idx}
-                />
-              ) : (
-                <div
-                  className={`${styles.previewThumbnail} ${styles.previewPlaceholder}`}
-                  key={galleryItem.slug || idx}
-                >
-                  <GalleryVerticalEnd size={32} />
-                </div>
-              );
-            })}
-          </div>
-        )}
-      </div>
+              }}
+              role="button"
+              tabIndex={0}
+              aria-label="Edit galleries"
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  openModal();
+                }
+              }}
+            >
+              {combinedGalleries.map((galleryItem, idx) => {
+                const previewUrl = getPreviewUrl(galleryItem);
+                return previewUrl ? (
+                  <img
+                    src={previewUrl ? getFileUrl(previewUrl) : ''}
+                    alt=""
+                    className={styles.previewThumbnail}
+                    key={galleryItem.slug || idx}
+                  />
+                ) : (
+                  <div
+                    className={`${styles.previewThumbnail} ${styles.previewPlaceholder}`}
+                    key={galleryItem.slug || idx}
+                  >
+                    <GalleryVerticalEnd size={32} />
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </section>
 
       <Modal
         isOpen={isModalOpen}

--- a/frontend/src/dashboard/project/components/Shared/calendar-overview-card.css
+++ b/frontend/src/dashboard/project/components/Shared/calendar-overview-card.css
@@ -1,44 +1,15 @@
-/* Wrapper mimicking the dashboard item style */
+/* Wrapper uses outer card styling */
 .calendar-overview-card-wrapper {
   display: flex;
   flex-direction: column;
   width: 100%;
   box-sizing: border-box;
-  border: 2px solid rgba(255, 255, 255, 0.10);
-
   color: white;
-
-  border-radius: 20px;
   flex: 1 1 auto;
-  height: 100%;
-  max-height: 100%;
-  min-height: clamp(260px, 36vh, 520px);
+  min-height: 0;
   overflow: hidden;
-  background: var(--bg2, #111213);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04), 0 18px 48px rgba(0, 0, 0, 0.45);
-  border-radius: 32px 32px 32px 32px;
-  
 }
 
-/* Override dashboard-item hover highlighting for calendar */
-.dashboard-item.calendar-overview-card-wrapper {
-  padding: 0;
-    background: var(--bg2, #111213);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04), 0 18px 48px rgba(0, 0, 0, 0.45);
-  border-radius: 32px 32px 32px 32px;
-  border: 2px solid rgba(255, 255, 255, 0.10);
-  cursor: default;
-  transition: background-color 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
-}
-
-.calendar-overview-card-wrapper.calendar-card-hover {
-  background-color: rgba(255, 255, 255, 0.05);
-  border-color: rgba(255, 255, 255, 0.18);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08), 0 22px 54px rgba(0, 0, 0, 0.5);
-  cursor: pointer;
-}
-
-/* React Calendar overrides */
 .calendar-overview-card-wrapper .calendar-content {
   flex: 1 1 auto;
   overflow-y: auto;

--- a/frontend/src/dashboard/project/features/budget/components/BudgetOverviewCard.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetOverviewCard.tsx
@@ -231,8 +231,8 @@ const BudgetOverviewCard: React.FC<BudgetOverviewCardProps> = ({ projectId }) =>
 
 
   return (
-    <div
-      className="dashboard-item budget budget-component-container budget-overview-card"
+    <section
+      className="card dashboard-item budget budget-component-container budget-overview-card"
       onClick={isAdmin ? openBudgetPage : undefined}
       style={{
         cursor: isAdmin ? "pointer" : "default",
@@ -241,74 +241,78 @@ const BudgetOverviewCard: React.FC<BudgetOverviewCardProps> = ({ projectId }) =>
         zIndex: 2,
       }}
     >
-      <div className="budget-overview-summary">
-        <span className="budget-overview-header">
-          <CircleDollarSign size={26} className="budget-overview-icon" />
-          Budget
-          {budgetHeader?.clientRevisionId != null && (
-            <span className="budget-overview-revision">{`Rev.${budgetHeader.clientRevisionId}`}</span>
-          )}
-        </span>
+      <header className="card__header">
+        <div className="budget-overview-summary">
+          <span className="budget-overview-header">
+            <CircleDollarSign size={26} className="budget-overview-icon" />
+            Budget
+            {budgetHeader?.clientRevisionId != null && (
+              <span className="budget-overview-revision">{`Rev.${budgetHeader.clientRevisionId}`}</span>
+            )}
+          </span>
 
-        {loading ? (
-          <FontAwesomeIcon
-            icon={faSpinner}
-            spin
-            className="budget-overview-spinner"
-            aria-label="Loading budget"
-          />
-        ) : (
-          <>
-            <span className="budget-overview-amount">
-              {budgetHeader ? formatUSD(ballparkValue) : "Not available"}
-              {budgetHeader && (
-                <FontAwesomeIcon
-                  icon={faFileInvoiceDollar}
-                  className="budget-overview-invoice-icon"
-                  title="Invoice preview"
-                  aria-label="Invoice preview"
-                  role="button"
-                  tabIndex={0}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    openInvoicePreview();
-                  }}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter" || e.key === " ") {
-                      e.preventDefault();
+          {loading ? (
+            <FontAwesomeIcon
+              icon={faSpinner}
+              spin
+              className="budget-overview-spinner"
+              aria-label="Loading budget"
+            />
+          ) : (
+            <>
+              <span className="budget-overview-amount">
+                {budgetHeader ? formatUSD(ballparkValue) : "Not available"}
+                {budgetHeader && (
+                  <FontAwesomeIcon
+                    icon={faFileInvoiceDollar}
+                    className="budget-overview-invoice-icon"
+                    title="Invoice preview"
+                    aria-label="Invoice preview"
+                    role="button"
+                    tabIndex={0}
+                    onClick={(e) => {
                       e.stopPropagation();
                       openInvoicePreview();
-                    }
-                  }}
-                />
-              )}
-            </span>
+                    }}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        openInvoicePreview();
+                      }
+                    }}
+                  />
+                )}
+              </span>
 
-            <span className="budget-overview-date">
-              {(() => {
-                const createdAt = budgetHeader?.createdAt;
-                return createdAt ? new Date(createdAt as string | number | Date).toLocaleDateString() : "No date";
-              })()}
-            </span>
-          </>
-        )}
-      </div>
-
-      {loading ? (
-        <div
-          style={{
-            marginTop: "16px",
-            display: "flex",
-            justifyContent: "center",
-          }}
-        >
-          <FontAwesomeIcon icon={faSpinner} spin aria-label="Loading chart" />
+              <span className="budget-overview-date">
+                {(() => {
+                  const createdAt = budgetHeader?.createdAt;
+                  return createdAt
+                    ? new Date(createdAt as string | number | Date).toLocaleDateString()
+                    : "No date";
+                })()}
+              </span>
+            </>
+          )}
         </div>
-      ) : (
-        budgetHeader && (
-          <>
+      </header>
+
+      <div className="card__body">
+        {loading ? (
+          <div
+            style={{
+              marginTop: "16px",
+              display: "flex",
+              justifyContent: "center",
+            }}
+          >
+            <FontAwesomeIcon icon={faSpinner} spin aria-label="Loading chart" />
+          </div>
+        ) : (
+          budgetHeader && (
             <div className="chart-legend-container">
-              <div className="budget-chart">
+              <div className="budget-chart budget-donut">
                 <BudgetDonut
                   data={chartState.slices}
                   total={chartState.total}
@@ -318,9 +322,9 @@ const BudgetOverviewCard: React.FC<BudgetOverviewCardProps> = ({ projectId }) =>
                 />
               </div>
             </div>
-          </>
-        )
-      )}
+          )
+        )}
+      </div>
 
       <ClientInvoicePreviewModal
         isOpen={isInvoicePreviewOpen}
@@ -328,7 +332,7 @@ const BudgetOverviewCard: React.FC<BudgetOverviewCardProps> = ({ projectId }) =>
         revision={invoiceRevision}
         project={activeProject}
       />
-    </div>
+    </section>
   );
 };
 

--- a/frontend/src/dashboard/project/project.tsx
+++ b/frontend/src/dashboard/project/project.tsx
@@ -22,8 +22,6 @@ import { useProjectPalette } from "@/dashboard/project/hooks/useProjectPalette";
 import { resolveProjectCoverUrl } from "@/dashboard/project/utils/theme";
 import { getProjectDashboardPath } from "@/shared/utils/projectUrl";
 
-const MOBILE_LAYOUT_WIDTH = 640;
-
 interface LocationState {
   flashDate?: string;
 }
@@ -45,11 +43,6 @@ const SingleProject: React.FC = () => {
   const [filesOpen, setFilesOpen] = useState<boolean>(false);
   const quickLinksRef = useRef<QuickLinksRef>(null);
   const { ws } = useSocket();
-
-  const [isMobileBudgetLayout, setIsMobileBudgetLayout] = useState(() => {
-    if (typeof window === "undefined") return false;
-    return window.innerWidth <= MOBILE_LAYOUT_WIDTH;
-  });
 
   const projectNameFromPath = useMemo(() => {
     const segments = location.pathname.split("/").filter(Boolean);
@@ -108,18 +101,6 @@ const SingleProject: React.FC = () => {
     },
     [fetchProjectDetails]
   );
-
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    const handleResize = () => {
-      setIsMobileBudgetLayout(window.innerWidth <= MOBILE_LAYOUT_WIDTH);
-    };
-    handleResize();
-    window.addEventListener("resize", handleResize);
-    return () => {
-      window.removeEventListener("resize", handleResize);
-    };
-  }, []);
 
   // Keep the active project in sync with the ID from the route.
   useEffect(() => {
@@ -277,41 +258,49 @@ const SingleProject: React.FC = () => {
               />
             )}
 
-              <div
-                className={`dashboard-layout budget-calendar-layout${
-                  isMobileBudgetLayout ? " budget-calendar-layout--stacked" : ""
-                }`}
-              >
-                <div className="budget-column">
-                  <BudgetOverviewCard projectId={activeProject?.projectId} />
-                  {isMobileBudgetLayout && (
-                    <div className="budget-calendar-mobile-card">{calendarOverviewCard}</div>
-                  )}
-
-                  <GalleryComponent />
+              <div className="dashboard-layout project-dashboard-layout">
+                <div className="dashboard-budget">
+                  <div className="dashboard-budgetCard">
+                    <BudgetOverviewCard projectId={activeProject?.projectId} />
+                  </div>
+                  <div className="dashboard-galleries">
+                    <GalleryComponent />
+                  </div>
                 </div>
-                {!isMobileBudgetLayout && <div className="calendar-column">{calendarOverviewCard}</div>}
-              </div>
 
-              {/* <Timeline
-                activeProject={activeProject as Project & { status: string; milestoneTitles?: string[] }}
-                parseStatusToNumber={parseStatusToNumber}
-                onActiveProjectChange={handleActiveProjectChange}
-              /> */}
-
-              <div className="dashboard-layout timeline-location-row">
-                <div className="location-wrapper">
-                  <LocationComponent
-                    activeProject={activeProject}
-                    onActiveProjectChange={handleActiveProjectChange}
-                  />
+                <div className="dashboard-calendarChat">
+                  <section className="card dashboard-calendar">
+                    <header className="card__header">
+                      <span>Calendar</span>
+                    </header>
+                    <div className="card__body">{calendarOverviewCard}</div>
+                  </section>
                 </div>
-                <div className="tasks-wrapper">
-                  <TasksComponent
-                    projectId={activeProject?.projectId}
-                    userId={userId}
-                    team={activeProject?.team}
-                  />
+
+                <div className="dashboard-timelineRow">
+                  <section className="card dashboard-map">
+                    <header className="card__header">
+                      <span>Project Location</span>
+                    </header>
+                    <div className="card__body">
+                      <LocationComponent
+                        activeProject={activeProject}
+                        onActiveProjectChange={handleActiveProjectChange}
+                      />
+                    </div>
+                  </section>
+                  <section className="card dashboard-tasks">
+                    <header className="card__header">
+                      <span>Tasks</span>
+                    </header>
+                    <div className="card__body">
+                      <TasksComponent
+                        projectId={activeProject?.projectId}
+                        userId={userId}
+                        team={activeProject?.team}
+                      />
+                    </div>
+                  </section>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- reworked the project dashboard container to use safe viewport grid tokens so the budget row stays bounded and the timeline row expands on taller screens
- introduced shared card scaffolding and updated the budget overview, gallery, calendar, map, and tasks panels so only their bodies scroll while headers stay pinned
- cleaned up supporting styles for the calendar card and map/tasks wrappers to keep inner content visible on shorter laptops without double scrollbars

## Testing
- npm run lint *(fails: missing @eslint/js in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3032bb170832494076897815d6f90