### PR TITLE
Simplify project overview layout

### DIFF
--- a/frontend/src/dashboard/home/styles/components/calendar.css
+++ b/frontend/src/dashboard/home/styles/components/calendar.css
@@ -38,135 +38,108 @@
 
 /* Budget + Calendar two-column layout */
 .budget-calendar-layout {
-  --budget-calendar-gap: 12px;
-  min-height: 0;
-  --budget-calendar-min-calendar: 400px;
-  --budget-calendar-max-calendar: 520px;
-  --budget-calendar-stack-budget: 420px;
-
-  display: grid;
-  gap: var(--budget-calendar-gap);
-  grid-template-columns: minmax(0, 1fr)
-    clamp(
-      var(--budget-calendar-min-calendar),
-      30%,
-      var(--budget-calendar-max-calendar)
-    );
-  grid-template-areas: "budget calendar";
-  align-items: stretch;
-  container-type: inline-size;
-  container-name: budget-calendar;
-}
-
-.budget-calendar-layout--stacked {
-  grid-template-columns: minmax(0, 1fr);
-  grid-template-areas:
-    "budget"
-    "calendar";
-}
-
-.budget-calendar-layout--stacked .budget-column,
-.budget-calendar-layout--stacked .calendar-column {
+  display: flex;
+  flex-direction: row;
+  gap: 12px;
   width: 100%;
-  min-inline-size: 0;
-  gap: var(--budget-calendar-gap);
+  min-height: 0;
 }
 
-.budget-calendar-layout--stacked .calendar-column {
+.budget-calendar-layout .budget-column,
+.budget-calendar-layout .calendar-column {
   display: flex;
   flex-direction: column;
+  gap: 12px;
+  min-width: 0;
+  min-height: 0;
 }
 
 .budget-calendar-layout .budget-column {
-  grid-area: budget;
-  display: flex;
-  flex-direction: column;
-  gap: var(--budget-calendar-gap);
-  min-inline-size: 0;
+  flex: 3 1 0;
+  height: 100%;
 }
 
 .budget-calendar-layout .calendar-column {
-  grid-area: calendar;
-  display: flex;
-  flex-direction: column;
-  gap: var(--budget-calendar-gap);
-  min-inline-size: 0;
-  container-type: inline-size;
-  container-name: calendar-panel;
+  flex: 2 1 0;
+  height: 100%;
 }
 
-.budget-calendar-layout .budget-column > *,
+.budget-calendar-layout .budget-column > :first-child {
+  flex: 3 1 0;
+  min-height: 0;
+  width: 100%;
+}
+
+.budget-calendar-layout .budget-column > :last-child {
+  flex: 2 1 0;
+  min-height: 0;
+  width: 100%;
+}
+
 .budget-calendar-layout .calendar-column > * {
   width: 100%;
 }
 
-@container budget-calendar (max-width: calc(
-    var(--budget-calendar-min-calendar) +
-    var(--budget-calendar-stack-budget) +
-    var(--budget-calendar-gap)
-  )) {
-  .budget-calendar-layout {
-    grid-template-columns: minmax(0, 1fr);
-    grid-template-areas:
-      "budget"
-      "calendar";
-  }
+.budget-calendar-layout--stacked {
+  flex-direction: column;
+  gap: 20px;
 }
 
-@media (max-width: var(--breakpoint-sm)) {
+.budget-calendar-layout--stacked .budget-column,
+.budget-calendar-layout--stacked .calendar-column {
+  flex: 1 1 auto;
+  width: 100%;
+  height: auto;
+  gap: 20px;
+}
+
+.budget-calendar-layout--stacked .budget-column > :first-child,
+.budget-calendar-layout--stacked .budget-column > :last-child {
+  flex: 0 0 auto;
+}
+
+@media (max-width: var(--breakpoint-md)) {
   .budget-calendar-layout {
-    grid-template-columns: minmax(0, 1fr);
-    grid-template-areas:
-      "budget"
-      "calendar";
+    flex-direction: column;
     gap: 20px;
   }
 
   .budget-calendar-layout .budget-column,
   .budget-calendar-layout .calendar-column {
+    flex: 1 1 auto;
     width: 100%;
+    height: auto;
     gap: 20px;
   }
 
-  .budget-calendar-layout .budget-column > *,
-  .budget-calendar-layout .calendar-column > * {
-    width: 100%;
+  .budget-calendar-layout .budget-column > :first-child,
+  .budget-calendar-layout .budget-column > :last-child {
+    flex: 0 0 auto;
   }
 }
 
-/* Overview height distribution */
+/* Overview layout sizing */
 .overview-layout > .dashboard-layout {
-  min-height: 0;
+  width: 100%;
+}
+
+.overview-layout > .budget-calendar-layout {
   flex: 1 1 auto;
+  min-height: 0;
 }
 
-.overview-layout > .dashboard-layout.budget-calendar-layout {
-  flex: 1 1 80%;
-  min-height: clamp(240px, 34vh, 500px);
-  max-height: 500px; 
-}
-
-.overview-layout > .dashboard-layout.timeline-location-row {
-  flex: 1 1 20%;
-  min-height: clamp(200px, 28vh, 380px);
-}
-
-@media (max-height: 820px),
-       (max-width: var(--breakpoint-md)) {
-  .overview-layout > .dashboard-layout.budget-calendar-layout,
-  .overview-layout > .dashboard-layout.timeline-location-row {
-    flex: 1 1 auto;
-  }
+.overview-layout > .timeline-location-row {
+  margin-top: auto;
+  flex: 0 0 auto;
 }
 
 /* Timeline + Location row layout */
 .timeline-location-row {
-  padding-top: 12px;
   display: flex;
-  flex-direction: row !important;
+  flex-direction: row;
   gap: 12px;
   align-items: stretch;
-  min-height: clamp(220px, 28vh, 360px);
+  padding-top: 12px;
 }
 
 .timeline-location-row > * {

--- a/frontend/src/dashboard/home/styles/components/page-layouts.css
+++ b/frontend/src/dashboard/home/styles/components/page-layouts.css
@@ -22,7 +22,7 @@
   height: 100%;
   flex: 1;
   min-height: 0;
-
+  gap: 12px;
 }
 
 .budget-layout {


### PR DESCRIPTION
## Summary
- simplify the project overview budget/calendar layout to a basic flex arrangement with a 60/40 split and vertical card ratios
- let the timeline/tasks row sit at the bottom and add consistent spacing for the overview stack

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d31585d0bc8324af8965d6ed3de579