### PR TITLE
Simplify project overview layout

### DIFF
--- a/frontend/src/dashboard/home/styles/components/calendar.css
+++ b/frontend/src/dashboard/home/styles/components/calendar.css
@@ -36,164 +36,18 @@
   max-height: none;
 }
 
-/* Budget + Calendar two-column layout */
-.budget-calendar-layout {
-  --budget-calendar-gap: 12px;
-  min-height: 0;
-  --budget-calendar-min-calendar: 400px;
-  --budget-calendar-max-calendar: 520px;
-  --budget-calendar-stack-budget: 420px;
-
-  display: grid;
-  gap: var(--budget-calendar-gap);
-  grid-template-columns: minmax(0, 1fr)
-    clamp(
-      var(--budget-calendar-min-calendar),
-      30%,
-      var(--budget-calendar-max-calendar)
-    );
-  grid-template-areas: "budget calendar";
-  align-items: stretch;
-  container-type: inline-size;
-  container-name: budget-calendar;
-}
-
-.budget-calendar-layout--stacked {
-  grid-template-columns: minmax(0, 1fr);
-  grid-template-areas:
-    "budget"
-    "calendar";
-}
-
-.budget-calendar-layout--stacked .budget-column,
-.budget-calendar-layout--stacked .calendar-column {
-  width: 100%;
-  min-inline-size: 0;
-  gap: var(--budget-calendar-gap);
-}
-
-.budget-calendar-layout--stacked .calendar-column {
-  display: flex;
-  flex-direction: column;
-}
-
-.budget-calendar-layout .budget-column {
-  grid-area: budget;
-  display: flex;
-  flex-direction: column;
-  gap: var(--budget-calendar-gap);
-  min-inline-size: 0;
-}
-
-.budget-calendar-layout .calendar-column {
-  grid-area: calendar;
-  display: flex;
-  flex-direction: column;
-  gap: var(--budget-calendar-gap);
-  min-inline-size: 0;
-  container-type: inline-size;
-  container-name: calendar-panel;
-}
-
-.budget-calendar-layout .budget-column > *,
-.budget-calendar-layout .calendar-column > * {
-  width: 100%;
-}
-
-@container budget-calendar (max-width: calc(
-    var(--budget-calendar-min-calendar) +
-    var(--budget-calendar-stack-budget) +
-    var(--budget-calendar-gap)
-  )) {
-  .budget-calendar-layout {
-    grid-template-columns: minmax(0, 1fr);
-    grid-template-areas:
-      "budget"
-      "calendar";
-  }
-}
-
-@media (max-width: var(--breakpoint-sm)) {
-  .budget-calendar-layout {
-    grid-template-columns: minmax(0, 1fr);
-    grid-template-areas:
-      "budget"
-      "calendar";
-    gap: 20px;
-  }
-
-  .budget-calendar-layout .budget-column,
-  .budget-calendar-layout .calendar-column {
-    width: 100%;
-    gap: 20px;
-  }
-
-  .budget-calendar-layout .budget-column > *,
-  .budget-calendar-layout .calendar-column > * {
-    width: 100%;
-  }
-}
-
-/* Overview height distribution */
-.overview-layout > .dashboard-layout {
-  min-height: 0;
-  flex: 1 1 auto;
-}
-
-.overview-layout > .dashboard-layout.budget-calendar-layout {
-  flex: 1 1 80%;
-  min-height: clamp(240px, 34vh, 500px);
-  max-height: 500px; 
-}
-
-.overview-layout > .dashboard-layout.timeline-location-row {
-  flex: 1 1 20%;
-  min-height: clamp(200px, 28vh, 380px);
-}
-
-/* Timeline + Location row layout */
-.timeline-location-row {
-  padding-top: 12px;
-  display: flex;
-  flex-direction: row !important;
-  gap: 12px;
-  align-items: stretch;
-  min-height: clamp(220px, 28vh, 360px);
-}
-
-.timeline-location-row > * {
-  flex: 1 1 0;
-  min-width: 0;
-  min-height: 0;
-}
-
-/* Location card and map container */
-.dashboard-layout .dashboard-item.location {
-  height: 400px;
+.overview-footer-location .dashboard-item {
+  min-height: 340px;
   padding: 0;
   overflow: hidden;
   border-radius: 20px;
 }
 
-.dashboard-layout #map {
+.overview-footer-location #map {
   width: 100%;
   height: 100%;
   margin: 0;
   padding: 0;
-  overflow: hidden;
-}
-
-.location-wrapper,
-.tasks-wrapper {
-  width: 100%;
-  height: 100%;
-  overflow: hidden;
-  min-width: 0;
-  min-height: 0;
-}
-
-.location-wrapper .column-5 {
-  height: 100%;
   overflow: hidden;
 }
 

--- a/frontend/src/dashboard/home/styles/components/page-layouts.css
+++ b/frontend/src/dashboard/home/styles/components/page-layouts.css
@@ -14,6 +14,7 @@
   overflow: hidden;      /* prevent extra scrollbars */
 }
 
+
 .budget-layout,
 .overview-layout {
   display: flex;
@@ -22,20 +23,91 @@
   height: 100%;
   flex: 1;
   min-height: 0;
-
 }
 
 .budget-layout {
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  flex: 1;
-  min-height: 0;
   padding: 12px 12px 0;
       background: var(--project-header-bg, var(--bg2, #111213));
     border: 2px solid rgba(255, 255, 255, 0.1);
     border-radius: 20px;
+}
+
+.overview-layout {
+  gap: 12px;
+}
+
+.overview-main {
+  display: grid;
+  grid-template-columns: 3fr 2fr;
+  gap: 12px;
+  flex: 1;
+  min-height: 0;
+}
+
+.overview-column {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-height: 0;
+}
+
+.overview-column-primary {
+  display: grid;
+  grid-template-rows: 3fr 2fr;
+  gap: 12px;
+  min-height: 0;
+}
+
+.overview-card {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.overview-card > * {
+  flex: 1;
+  min-height: 0;
+}
+
+.overview-column-secondary {
+  min-height: 0;
+}
+
+.overview-column-secondary > * {
+  flex: 1;
+  min-height: 0;
+}
+
+.overview-footer {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-height: 0;
+  margin-top: auto;
+}
+
+.overview-footer-location,
+.overview-footer-tasks {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.overview-footer-location > *,
+.overview-footer-tasks > * {
+  flex: 1;
+  min-height: 0;
+}
+
+@media (max-width: 960px) {
+  .overview-main {
+    grid-template-columns: 1fr;
+  }
+
+  .overview-column-primary {
+    display: flex;
+    flex-direction: column;
+  }
 }
 
 

--- a/frontend/src/dashboard/project/project.tsx
+++ b/frontend/src/dashboard/project/project.tsx
@@ -22,8 +22,6 @@ import { useProjectPalette } from "@/dashboard/project/hooks/useProjectPalette";
 import { resolveProjectCoverUrl } from "@/dashboard/project/utils/theme";
 import { getProjectDashboardPath } from "@/shared/utils/projectUrl";
 
-const MOBILE_LAYOUT_WIDTH = 640;
-
 interface LocationState {
   flashDate?: string;
 }
@@ -45,11 +43,6 @@ const SingleProject: React.FC = () => {
   const [filesOpen, setFilesOpen] = useState<boolean>(false);
   const quickLinksRef = useRef<QuickLinksRef>(null);
   const { ws } = useSocket();
-
-  const [isMobileBudgetLayout, setIsMobileBudgetLayout] = useState(() => {
-    if (typeof window === "undefined") return false;
-    return window.innerWidth <= MOBILE_LAYOUT_WIDTH;
-  });
 
   const projectNameFromPath = useMemo(() => {
     const segments = location.pathname.split("/").filter(Boolean);
@@ -108,18 +101,6 @@ const SingleProject: React.FC = () => {
     },
     [fetchProjectDetails]
   );
-
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    const handleResize = () => {
-      setIsMobileBudgetLayout(window.innerWidth <= MOBILE_LAYOUT_WIDTH);
-    };
-    handleResize();
-    window.addEventListener("resize", handleResize);
-    return () => {
-      window.removeEventListener("resize", handleResize);
-    };
-  }, []);
 
   // Keep the active project in sync with the ID from the route.
   useEffect(() => {
@@ -277,36 +258,28 @@ const SingleProject: React.FC = () => {
               />
             )}
 
-              <div
-                className={`dashboard-layout budget-calendar-layout${
-                  isMobileBudgetLayout ? " budget-calendar-layout--stacked" : ""
-                }`}
-              >
-                <div className="budget-column">
-                  <BudgetOverviewCard projectId={activeProject?.projectId} />
-                  {isMobileBudgetLayout && (
-                    <div className="budget-calendar-mobile-card">{calendarOverviewCard}</div>
-                  )}
-
-                  <GalleryComponent />
+              <div className="overview-main">
+                <div className="overview-column overview-column-primary">
+                  <div className="overview-card overview-card-budget">
+                    <BudgetOverviewCard projectId={activeProject?.projectId} />
+                  </div>
+                  <div className="overview-card overview-card-gallery">
+                    <GalleryComponent />
+                  </div>
                 </div>
-                {!isMobileBudgetLayout && <div className="calendar-column">{calendarOverviewCard}</div>}
+                <div className="overview-column overview-column-secondary">
+                  {calendarOverviewCard}
+                </div>
               </div>
 
-              {/* <Timeline
-                activeProject={activeProject as Project & { status: string; milestoneTitles?: string[] }}
-                parseStatusToNumber={parseStatusToNumber}
-                onActiveProjectChange={handleActiveProjectChange}
-              /> */}
-
-              <div className="dashboard-layout timeline-location-row">
-                <div className="location-wrapper">
+              <div className="overview-footer">
+                <div className="overview-footer-location">
                   <LocationComponent
                     activeProject={activeProject}
                     onActiveProjectChange={handleActiveProjectChange}
                   />
                 </div>
-                <div className="tasks-wrapper">
+                <div className="overview-footer-tasks">
                   <TasksComponent
                     projectId={activeProject?.projectId}
                     userId={userId}


### PR DESCRIPTION
## Summary
- refactor the project overview markup to use a simple two-column grid with a footer tasks section
- replace the old layout styles with straightforward grid and flex rules that enforce 60/40 splits for columns and cards
- update the location map styling to match the new footer container

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d33a8402b8832483717992f6c66cce