### PR TITLE
feat: allow closing and reopening project chat on desktop

### DIFF
--- a/frontend/src/dashboard/features/messages/ProjectMessagesThread.tsx
+++ b/frontend/src/dashboard/features/messages/ProjectMessagesThread.tsx
@@ -119,6 +119,7 @@ type ProjectMessagesThreadProps = {
   setFloating: (fn: (v: boolean) => boolean | boolean) => void;
   startDrag: (e: React.MouseEvent<HTMLDivElement>) => void;
   headerOffset?: number;
+  onCloseChat?: () => void;
 };
 
 /* =============================================================================
@@ -252,6 +253,7 @@ const ProjectMessagesThread: React.FC<ProjectMessagesThreadProps> = ({
   setFloating,
   startDrag,
   headerOffset = 0,
+  onCloseChat,
 }) => {
   const {
     activeProject,
@@ -1011,6 +1013,16 @@ const ProjectMessagesThread: React.FC<ProjectMessagesThreadProps> = ({
                 title={floating ? "Dock" : "Float"}
               >
                 {floating ? <Dock size={16} /> : <Move size={16} />}
+              </button>
+            )}
+            {!isMobile && (
+              <button
+                className="icon-btn"
+                onClick={() => onCloseChat?.()}
+                aria-label="Close chat"
+                title="Close chat"
+              >
+                <FontAwesomeIcon icon={faTimes} />
               </button>
             )}
           </div>

--- a/frontend/src/dashboard/project/components/Shared/ChatPanel.tsx
+++ b/frontend/src/dashboard/project/components/Shared/ChatPanel.tsx
@@ -13,6 +13,7 @@ type ChatPanelProps = {
   onFloatingChange?: (floating: boolean) => void;
   initialOpen?: boolean;
   openSignal?: number;
+  onCloseChat?: () => void;
 };
 
 type Size = { width: number; height: number };
@@ -28,6 +29,7 @@ const ChatPanel: React.FC<ChatPanelProps> = ({
   onFloatingChange,
   initialOpen,
   openSignal = 0,
+  onCloseChat,
 }) => {
   const isNarrowScreen =
     typeof window !== "undefined" ? window.innerWidth < 768 : false;
@@ -315,6 +317,7 @@ const ChatPanel: React.FC<ChatPanelProps> = ({
         floating={floating}
         setFloating={handleSetFloating}
         startDrag={startDrag}
+        onCloseChat={onCloseChat}
       />
       {floating && !isMobile && (
         <div className="chat-panel-resizer" onMouseDown={startResize} />

--- a/frontend/src/dashboard/project/components/Shared/DesktopProjectHeader.tsx
+++ b/frontend/src/dashboard/project/components/Shared/DesktopProjectHeader.tsx
@@ -1,6 +1,6 @@
 import type { KeyboardEvent } from "react";
 
-import { Folder, Link2, Settings } from "lucide-react";
+import { Folder, Link2, MessageCircle, Settings } from "lucide-react";
 
 import AvatarStack from "@/shared/ui/AvatarStack";
 import Squircle from "@/shared/ui/Squircle";
@@ -36,6 +36,8 @@ interface DesktopProjectHeaderProps {
   teamMembers: TeamMember[];
   navigation: NavigationProps;
   getFileUrlForThumbnail: (thumbnail: string) => string;
+  onOpenChat?: () => void;
+  isChatHidden?: boolean;
 }
 
 const DesktopProjectHeader = ({
@@ -55,6 +57,8 @@ const DesktopProjectHeader = ({
   teamMembers,
   navigation,
   getFileUrlForThumbnail,
+  onOpenChat,
+  isChatHidden,
 }: DesktopProjectHeaderProps) => {
   const thumbnailKey = project?.thumbnails?.[0] as string | undefined;
 
@@ -201,6 +205,23 @@ const DesktopProjectHeader = ({
             >
               <AvatarStack members={teamMembers} />
             </div>
+
+            <button
+              type="button"
+              onClick={() => {
+                if (onOpenChat) {
+                  onOpenChat();
+                } else if (typeof window !== "undefined") {
+                  window.dispatchEvent(new CustomEvent("project-open-chat"));
+                }
+              }}
+              className="interactive icon-button"
+              aria-label={isChatHidden ? "Open project chat" : "Show project chat"}
+              title={isChatHidden ? "Open project chat" : "Show project chat"}
+              aria-pressed={!isChatHidden}
+            >
+              <MessageCircle size={20} />
+            </button>
           </div>
         </div>
 

--- a/frontend/src/dashboard/project/components/Shared/ProjectHeader.tsx
+++ b/frontend/src/dashboard/project/components/Shared/ProjectHeader.tsx
@@ -66,6 +66,7 @@ const ProjectHeader: React.FC<ProjectHeaderProps> = (props) => {
           onOpenFinishLine={finishLineModal.open}
           onOpenStatus={editStatusModal.open}
           onOpenThumbnail={() => thumbnailModal.open()}
+          onOpenChat={props.onOpenChat}
           tabs={navigation.tabs}
           activeTabKey={navigation.activeTabKey}
           onSelectTab={(tab) => navigation.confirmNavigate(tab.path)}
@@ -94,6 +95,8 @@ const ProjectHeader: React.FC<ProjectHeaderProps> = (props) => {
             confirmNavigate: navigation.confirmNavigate,
           }}
           getFileUrlForThumbnail={getFileUrlForThumbnail}
+          onOpenChat={props.onOpenChat}
+          isChatHidden={props.isChatHidden}
         />
       )}
 

--- a/frontend/src/dashboard/project/components/Shared/ProjectPageLayout.tsx
+++ b/frontend/src/dashboard/project/components/Shared/ProjectPageLayout.tsx
@@ -16,11 +16,12 @@ type ProjectPageLayoutProps = {
 type ProjectMessagesThreadProps = {
   projectId: string;
   open: boolean;
-  setOpen: (open: boolean) => void;
+  setOpen: (open: boolean | ((prev: boolean) => boolean)) => void;
   floating: boolean;
-  setFloating: (floating: boolean) => void;
-  startDrag: () => void;
+  setFloating: (floating: boolean | ((prev: boolean) => boolean)) => void;
+  startDrag: (event: React.MouseEvent<HTMLDivElement>) => void;
   headerOffset: number;
+  onCloseChat?: () => void;
 };
 
 type ChatPanelProps = {
@@ -28,6 +29,7 @@ type ChatPanelProps = {
   initialFloating?: boolean;
   onFloatingChange?: (floating: boolean) => void;
   openSignal?: number;
+  onCloseChat?: () => void;
 };
 
 // (If your imported components already export types, remove these lines)
@@ -94,6 +96,15 @@ const ProjectPageLayout: React.FC<ProjectPageLayoutProps> = ({
     }
   });
   const [chatOpenSignal, setChatOpenSignal] = React.useState<number>(0);
+  const [isChatHidden, setIsChatHidden] = React.useState<boolean>(() => {
+    if (typeof window === "undefined") return false;
+    try {
+      const stored = localStorage.getItem("chatPanelHidden");
+      return stored === "true";
+    } catch {
+      return false;
+    }
+  });
 
   const [isNavCollapsed, setIsNavCollapsed] = useNavCollapsed("project");
 
@@ -137,11 +148,21 @@ const ProjectPageLayout: React.FC<ProjectPageLayoutProps> = ({
   }, [floatingThread]);
 
   React.useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      localStorage.setItem("chatPanelHidden", isChatHidden ? "true" : "false");
+    } catch {
+      /* ignore write errors */
+    }
+  }, [isChatHidden]);
+
+  React.useEffect(() => {
     if (typeof window === "undefined") {
       return;
     }
 
     const handleOpenChat = () => {
+      setIsChatHidden(false);
       setFloatingThread((prev) => {
         if (!prev) {
           return true;
@@ -157,6 +178,15 @@ const ProjectPageLayout: React.FC<ProjectPageLayoutProps> = ({
       window.removeEventListener("project-open-chat", handleOpenChat);
     };
   }, [setFloatingThread, setChatOpenSignal]);
+
+  const handleHideChat = React.useCallback(() => {
+    setIsChatHidden(true);
+  }, []);
+
+  const handleShowChat = React.useCallback(() => {
+    setIsChatHidden(false);
+    setChatOpenSignal((prev) => prev + 1);
+  }, []);
 
   const viewportUnit = React.useMemo(() => {
     if (typeof window === "undefined") {
@@ -188,7 +218,12 @@ const ProjectPageLayout: React.FC<ProjectPageLayoutProps> = ({
         ref={projectHeaderRef}
         style={{ position: "sticky", top: 0, zIndex: 5, backgroundColor: "#0c0c0c" }}
       >
-        {header}
+        {React.isValidElement(header)
+          ? React.cloneElement(header, {
+              onOpenChat: handleShowChat,
+              isChatHidden,
+            })
+          : header}
       </div>
 
       <div
@@ -211,9 +246,9 @@ const ProjectPageLayout: React.FC<ProjectPageLayoutProps> = ({
           {children}
         </div>
 
-        {!floatingThread && !isMobile && (
+        {!isChatHidden && !floatingThread && !isMobile && (
           <>
-            
+
 
             <div
               style={{
@@ -229,23 +264,29 @@ const ProjectPageLayout: React.FC<ProjectPageLayoutProps> = ({
               <_ProjectMessagesThread
                 projectId={safeProjectId}
                 open
-                setOpen={() => {}}
+                setOpen={(value) => {
+                  void value;
+                }}
                 floating={false}
                 setFloating={setFloatingThread}
-                startDrag={() => {}}
+                startDrag={(event) => {
+                  void event;
+                }}
                 headerOffset={headerHeights.global + headerHeights.project}
+                onCloseChat={handleHideChat}
               />
             </div>
           </>
         )}
       </div>
 
-      {floatingThread && (
+      {floatingThread && !isChatHidden && (
         <_ChatPanel
           projectId={safeProjectId}
           initialFloating
           onFloatingChange={setFloatingThread}
           openSignal={chatOpenSignal}
+          onCloseChat={handleHideChat}
         />
       )}
     </div>

--- a/frontend/src/dashboard/project/components/Shared/projectHeaderTypes.ts
+++ b/frontend/src/dashboard/project/components/Shared/projectHeaderTypes.ts
@@ -23,6 +23,8 @@ export interface ProjectHeaderProps {
   onActiveProjectChange?: (project: Project) => void;
   onOpenFiles: () => void;
   onOpenQuickLinks: () => void;
+  onOpenChat?: () => void;
+  isChatHidden?: boolean;
 }
 
 export interface NavigationState {


### PR DESCRIPTION
## Summary
- add a desktop-only close control to the project chat thread
- persist a hidden state so the chat can be restored via the project header chat icon
- surface the existing chat icon in the desktop header for quick access

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d35581716883249d205a8eb3c5446e