### PR TITLE
Restyle project header date metadata

### DIFF
--- a/frontend/src/dashboard/project/components/Shared/DesktopProjectHeader.tsx
+++ b/frontend/src/dashboard/project/components/Shared/DesktopProjectHeader.tsx
@@ -10,6 +10,8 @@ import type { Project } from "@/app/contexts/DataProvider";
 import ProjectTabs from "./ProjectTabs";
 import type { TeamMember } from "./types";
 import type { ProjectTabItem } from "./useProjectTabs";
+import RangeMeta from "./RangeMeta";
+import type { RangeDisplayMeta } from "./projectHeaderTypes";
 
 interface NavigationProps {
   tabs: ProjectTabItem[];
@@ -25,6 +27,7 @@ interface DesktopProjectHeaderProps {
   displayStatus: string;
   progressValue: number;
   rangeLabel: string;
+  rangeMeta: RangeDisplayMeta | null;
   handleKeyDown: (event: KeyboardEvent, action: () => void) => void;
   onOpenStatus: () => void;
   onOpenFinishLine: () => void;
@@ -44,6 +47,7 @@ const DesktopProjectHeader = ({
   displayStatus,
   progressValue,
   rangeLabel,
+  rangeMeta,
   handleKeyDown,
   onOpenStatus,
   onOpenFinishLine,
@@ -113,7 +117,7 @@ const DesktopProjectHeader = ({
                 aria-label="Production dates"
                 style={{ cursor: "pointer" }}
               >
-                <span>{rangeLabel}</span>
+                {rangeMeta ? <RangeMeta meta={rangeMeta} /> : <span>{rangeLabel}</span>}
               </div>
             </div>
           </div>

--- a/frontend/src/dashboard/project/components/Shared/MobileProjectHeader.tsx
+++ b/frontend/src/dashboard/project/components/Shared/MobileProjectHeader.tsx
@@ -18,6 +18,8 @@ import type { ProjectTabItem } from "./useProjectTabs";
 import styles from "./mobile-project-header.module.css";
 import Squircle from "@/shared/ui/Squircle";
 import { useNavigate } from "react-router-dom";
+import RangeMeta from "./RangeMeta";
+import type { RangeDisplayMeta } from "./projectHeaderTypes";
 
 interface MobileProjectHeaderProps {
   projectName?: string;
@@ -26,6 +28,7 @@ interface MobileProjectHeaderProps {
   statusLabel: string;
   progressValue: number;
   rangeLabel?: string;
+  rangeMeta?: RangeDisplayMeta | null;
   teamMembers: TeamMember[];
   onOpenQuickLinks: () => void;
   onOpenFiles: () => void;
@@ -47,6 +50,7 @@ const MobileProjectHeader: React.FC<MobileProjectHeaderProps> = ({
   statusLabel,
   progressValue,
   rangeLabel,
+  rangeMeta,
   teamMembers,
   onOpenQuickLinks,
   onOpenFiles,
@@ -145,7 +149,7 @@ const MobileProjectHeader: React.FC<MobileProjectHeaderProps> = ({
               </button>
             </div>
 
-            {rangeLabel ? (
+            {rangeMeta || rangeLabel ? (
               <button
                 type="button"
                 onClick={onOpenFinishLine}
@@ -159,7 +163,11 @@ const MobileProjectHeader: React.FC<MobileProjectHeaderProps> = ({
                 }}
                 aria-label="Edit project schedule"
               >
-                <div className={styles.dateText}>{rangeLabel}</div>
+                {rangeMeta ? (
+                  <RangeMeta meta={rangeMeta} className={styles.dateText} />
+                ) : (
+                  <div className={styles.dateText}>{rangeLabel}</div>
+                )}
               </button>
             ) : null}
           </div>

--- a/frontend/src/dashboard/project/components/Shared/ProjectHeader.tsx
+++ b/frontend/src/dashboard/project/components/Shared/ProjectHeader.tsx
@@ -28,6 +28,7 @@ const ProjectHeader: React.FC<ProjectHeaderProps> = (props) => {
     displayStatus,
     progressValue,
     rangeLabel,
+    rangeMeta,
     mobileRangeLabel,
     handleKeyDown,
     navigation,
@@ -58,6 +59,7 @@ const ProjectHeader: React.FC<ProjectHeaderProps> = (props) => {
           statusLabel={displayStatus}
           progressValue={progressValue}
           rangeLabel={mobileRangeLabel || undefined}
+          rangeMeta={rangeMeta}
           teamMembers={teamModal.members}
           onOpenQuickLinks={props.onOpenQuickLinks}
           onOpenFiles={props.onOpenFiles}
@@ -77,6 +79,7 @@ const ProjectHeader: React.FC<ProjectHeaderProps> = (props) => {
           displayStatus={displayStatus}
           progressValue={progressValue}
           rangeLabel={rangeLabel}
+          rangeMeta={rangeMeta}
           handleKeyDown={handleKeyDown}
           onOpenStatus={editStatusModal.open}
           onOpenFinishLine={finishLineModal.open}

--- a/frontend/src/dashboard/project/components/Shared/RangeMeta.tsx
+++ b/frontend/src/dashboard/project/components/Shared/RangeMeta.tsx
@@ -1,0 +1,45 @@
+import type { FC } from "react";
+
+import type { RangeDisplayMeta } from "./projectHeaderTypes";
+
+interface RangeMetaProps {
+  meta: RangeDisplayMeta | null;
+  className?: string;
+}
+
+const RangeMeta: FC<RangeMetaProps> = ({ meta, className }) => {
+  if (!meta) return null;
+
+  const { start, end, duration, accessibleLabel, label } = meta;
+  const hasDate = Boolean(start || end);
+  const combinedClassName = ["meta", className].filter(Boolean).join(" ");
+
+  return (
+    <span className={combinedClassName} role="text" aria-label={accessibleLabel || label}>
+      {start ? (
+        <time dateTime={start.dateTime}>{start.label}</time>
+      ) : null}
+      {start && end ? (
+        <span className="range-separator" aria-hidden="true">
+          –
+        </span>
+      ) : null}
+      {end ? (
+        <time dateTime={end.dateTime}>{end.label}</time>
+      ) : null}
+      {hasDate ? (
+        <span className="dot" aria-hidden="true">
+          ·
+        </span>
+      ) : null}
+      <span className="duration">
+        <span className="clock" aria-hidden="true">
+          ⏱
+        </span>
+        <span>{duration.label}</span>
+      </span>
+    </span>
+  );
+};
+
+export default RangeMeta;

--- a/frontend/src/dashboard/project/components/Shared/mobile-project-header.module.css
+++ b/frontend/src/dashboard/project/components/Shared/mobile-project-header.module.css
@@ -164,6 +164,34 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  display: inline-flex;
+  align-items: center;
+  font-variant-numeric: tabular-nums;
+  gap: 0;
+  --project-date-range-gap: 0.65ch;
+  --project-date-dot-gap: 1.5ch;
+  --project-date-duration-gap: 2.1ch;
+  --project-date-icon-gap: 0.7ch;
+}
+
+.dateText :global(.range-separator) {
+  margin: 0 var(--project-date-range-gap, 0.65ch);
+}
+
+.dateText :global(.dot) {
+  margin: 0 var(--project-date-dot-gap, 1.5ch);
+}
+
+.dateText :global(.duration) {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--project-date-icon-gap, 0.7ch);
+  margin-left: var(--project-date-duration-gap, 2.1ch);
+}
+
+.dateText :global(.clock) {
+  font-size: 0.85em;
+  line-height: 1;
 }
 
 .tabs {

--- a/frontend/src/dashboard/project/components/Shared/project-header.css
+++ b/frontend/src/dashboard/project/components/Shared/project-header.css
@@ -118,6 +118,10 @@
   isolation: isolate;
   margin-top: 12px;
   margin-bottom: 12px;
+  --project-date-range-gap: 0.75ch;
+  --project-date-dot-gap: 1.75ch;
+  --project-date-duration-gap: 2.25ch;
+  --project-date-icon-gap: 0.75ch;
 }
 
 .project-header:not(.new-project-header)::after {
@@ -187,7 +191,7 @@
 .project-header:not(.new-project-header) .finish-line-header {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  gap: 0;
 
   border-radius: 10px;
 
@@ -205,6 +209,41 @@
 
 .project-header:not(.new-project-header) .finish-line-header span {
   color: inherit;
+}
+
+.project-header:not(.new-project-header) .finish-line-header .meta {
+  display: inline-flex;
+  align-items: center;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  gap: 0;
+}
+
+.project-header:not(.new-project-header) .finish-line-header .meta time {
+  color: inherit;
+}
+
+.project-header:not(.new-project-header) .finish-line-header .meta .range-separator {
+  margin: 0 var(--project-date-range-gap, 0.75ch);
+  color: inherit;
+}
+
+.project-header:not(.new-project-header) .finish-line-header .meta .dot {
+  margin: 0 var(--project-date-dot-gap, 1.75ch);
+  color: inherit;
+}
+
+.project-header:not(.new-project-header) .finish-line-header .meta .duration {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--project-date-icon-gap, 0.75ch);
+  margin-left: var(--project-date-duration-gap, 2.25ch);
+  color: inherit;
+}
+
+.project-header:not(.new-project-header) .finish-line-header .meta .clock {
+  font-size: 0.9em;
+  line-height: 1;
 }
 
 .project-header:not(.new-project-header) .project-nav-tabs {

--- a/frontend/src/dashboard/project/components/Shared/projectHeaderState/useLocalProjectState.ts
+++ b/frontend/src/dashboard/project/components/Shared/projectHeaderState/useLocalProjectState.ts
@@ -45,7 +45,7 @@ export function useLocalProjectState(activeProject: Project | null) {
     [localProject?.status]
   );
 
-  const { rangeLabel, mobileRangeLabel } = useRangeLabels(localProject);
+  const { rangeLabel, mobileRangeLabel, rangeMeta } = useRangeLabels(localProject);
 
   const resolvedProjectId = (localProject?.projectId as string | undefined) || projectId;
 
@@ -55,6 +55,7 @@ export function useLocalProjectState(activeProject: Project | null) {
     projectInitial,
     displayStatus,
     rangeLabel,
+    rangeMeta,
     mobileRangeLabel,
     resolvedProjectId,
   };

--- a/frontend/src/dashboard/project/components/Shared/projectHeaderTypes.ts
+++ b/frontend/src/dashboard/project/components/Shared/projectHeaderTypes.ts
@@ -13,6 +13,23 @@ import type { Area } from "react-easy-crop";
 import type { TeamMember } from "./types";
 import type { ProjectTabItem } from "./useProjectTabs";
 
+export interface RangeDisplayMeta {
+  label: string;
+  accessibleLabel: string;
+  duration: {
+    label: string;
+    accessibleLabel: string;
+  };
+  start?: {
+    label: string;
+    dateTime: string;
+  };
+  end?: {
+    label: string;
+    dateTime: string;
+  };
+}
+
 export interface ProjectHeaderProps {
   title?: string;
   parseStatusToNumber: (status: string | number | undefined) => number;
@@ -146,6 +163,7 @@ export interface ProjectHeaderState {
   displayStatus: string;
   progressValue: number;
   rangeLabel: string;
+  rangeMeta: RangeDisplayMeta | null;
   mobileRangeLabel: string;
   handleKeyDown: (event: KeyboardEvent, action: () => void) => void;
   navigation: NavigationState;

--- a/frontend/src/dashboard/project/components/Shared/projectHeaderUtils.ts
+++ b/frontend/src/dashboard/project/components/Shared/projectHeaderUtils.ts
@@ -5,7 +5,14 @@ import { getProjectDashboardPath } from "@/shared/utils/projectUrl";
 import { fileUrlsToKeys } from "@/shared/utils/api";
 
 import type { Project } from "@/app/contexts/DataProvider";
-import type { ProjectHeaderProps } from "./projectHeaderTypes";
+import type { ProjectHeaderProps, RangeDisplayMeta } from "./projectHeaderTypes";
+
+function formatISODateOnly(date: Date): string {
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, "0");
+  const day = `${date.getDate()}`.padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
 
 export function toString(value: unknown): string {
   return typeof value === "string" ? value : "";
@@ -125,20 +132,61 @@ export function useRangeLabels(project: Project) {
     [project?.timelineEvents]
   );
 
-  const rangeLabel = useMemo(() => {
-    const totalPart = `${totalHours} hrs`;
-    if (!startDate || !endDate) return totalPart;
+  const rangeMeta = useMemo<RangeDisplayMeta>(() => {
+    const hoursLabel = `${totalHours}h`;
+    const durationAccessible = `${totalHours} ${totalHours === 1 ? "hour" : "hours"}`;
+    const duration = {
+      label: hoursLabel,
+      accessibleLabel: durationAccessible,
+    };
+
     const options: Intl.DateTimeFormatOptions = { month: "short", day: "numeric" };
-    const startStr = startDate.toLocaleDateString(undefined, options);
-    const endStr = endDate.toLocaleDateString(undefined, options);
-    return `${startStr} – ${endStr}  ⏱ ${totalPart}`;
-  }, [startDate, endDate, totalHours]);
 
-  const mobileRangeLabel = useMemo(() => {
-    return rangeLabel;
-  }, [rangeLabel]);
+    const startInfo = startDate
+      ? {
+          label: startDate.toLocaleDateString(undefined, options),
+          dateTime: formatISODateOnly(startDate),
+        }
+      : undefined;
 
-  return { rangeLabel, mobileRangeLabel, totalHours };
+    const endInfo = endDate
+      ? {
+          label: endDate.toLocaleDateString(undefined, options),
+          dateTime: formatISODateOnly(endDate),
+        }
+      : undefined;
+
+    const hasStart = Boolean(startInfo);
+    const hasEnd = Boolean(endInfo);
+
+    const datePart = hasStart && hasEnd
+      ? `${startInfo!.label} – ${endInfo!.label}`
+      : (startInfo || endInfo)?.label;
+
+    const label = datePart ? `${datePart} · ${hoursLabel}` : hoursLabel;
+
+    const accessibleDatePart = hasStart && hasEnd
+      ? `${startInfo!.label} – ${endInfo!.label}`
+      : (startInfo || endInfo)?.label;
+
+    const accessibleLabel = [accessibleDatePart, durationAccessible]
+      .filter(Boolean)
+      .join(", ");
+
+    return {
+      label,
+      accessibleLabel: accessibleLabel || durationAccessible,
+      duration,
+      start: startInfo,
+      end: endInfo,
+    };
+  }, [endDate, startDate, totalHours]);
+
+  const rangeLabel = rangeMeta.label;
+
+  const mobileRangeLabel = rangeMeta.label;
+
+  return { rangeLabel, mobileRangeLabel, totalHours, rangeMeta };
 }
 
 export function deriveProjectInitialState(props: ProjectHeaderProps) {

--- a/frontend/src/dashboard/project/components/Shared/useProjectHeaderState.ts
+++ b/frontend/src/dashboard/project/components/Shared/useProjectHeaderState.ts
@@ -92,6 +92,7 @@ export function useProjectHeaderState(props: ProjectHeaderProps): ProjectHeaderS
     projectInitial,
     displayStatus,
     rangeLabel,
+    rangeMeta,
     mobileRangeLabel,
     resolvedProjectId,
   } = useLocalProjectState(activeProject);
@@ -478,6 +479,7 @@ export function useProjectHeaderState(props: ProjectHeaderProps): ProjectHeaderS
     displayStatus,
     progressValue,
     rangeLabel,
+    rangeMeta,
     mobileRangeLabel,
     handleKeyDown,
     navigation,


### PR DESCRIPTION
## Summary
- add a reusable `RangeMeta` renderer that formats the project schedule with `<time>` elements, en-dash ranges, and duration chips
- compute structured range metadata in the header utilities and thread it through state so both desktop and mobile headers render the new markup
- update header styles to support the inline-flex meta layout with configurable spacing variables and refined mobile styling

## Testing
- `npm run typecheck` *(fails: Cannot find module 'recharts' for BudgetDonut.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68d354c316288324ab4c6db02162e6f2