### PR TITLE
Improve project header schedule microcopy spacing

### DIFF
--- a/frontend/src/dashboard/project/components/Shared/mobile-project-header.module.css
+++ b/frontend/src/dashboard/project/components/Shared/mobile-project-header.module.css
@@ -161,9 +161,8 @@
 .dateText {
   font-size: 0.75rem;
   color: #f87171;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  line-height: 1.4;
+  white-space: normal;
 }
 
 .tabs {

--- a/frontend/src/dashboard/project/components/Shared/project-header.css
+++ b/frontend/src/dashboard/project/components/Shared/project-header.css
@@ -189,11 +189,17 @@
   align-items: center;
   gap: 6px;
 
+  padding: 6px 12px;
   border-radius: 10px;
 
   color: rgba(255, 255, 255, 0.65);
   cursor: pointer;
   transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+  line-height: 1.4;
+  white-space: normal;
+  max-width: 100%;
+  min-width: 0;
+  text-align: left;
 }
 
 .project-header:not(.new-project-header) .finish-line-header:hover,
@@ -205,6 +211,8 @@
 
 .project-header:not(.new-project-header) .finish-line-header span {
   color: inherit;
+  line-height: inherit;
+  white-space: inherit;
 }
 
 .project-header:not(.new-project-header) .project-nav-tabs {

--- a/frontend/src/dashboard/project/components/Shared/projectHeaderUtils.ts
+++ b/frontend/src/dashboard/project/components/Shared/projectHeaderUtils.ts
@@ -127,11 +127,11 @@ export function useRangeLabels(project: Project) {
 
   const rangeLabel = useMemo(() => {
     const totalPart = `${totalHours} hrs`;
-    if (!startDate || !endDate) return totalPart;
+    if (!startDate || !endDate) return `⏱ ${totalPart}`;
     const options: Intl.DateTimeFormatOptions = { month: "short", day: "numeric" };
     const startStr = startDate.toLocaleDateString(undefined, options);
     const endStr = endDate.toLocaleDateString(undefined, options);
-    return `${startStr} – ${endStr}  ⏱ ${totalPart}`;
+    return `${startStr} – ${endStr}  •  ⏱ ${totalPart}`;
   }, [startDate, endDate, totalHours]);
 
   const mobileRangeLabel = useMemo(() => {


### PR DESCRIPTION
## Summary
- add breathing room to the project header date/time microcopy with a bullet separator
- allow the schedule chip to wrap and improve readability on desktop and mobile headers

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d35ba60cd88324bb5901c47ff05993