### PR TITLE
Tighten spacing for project quick actions

### DIFF
--- a/frontend/src/features/dashboard/styles/components/project-header.css
+++ b/frontend/src/features/dashboard/styles/components/project-header.css
@@ -64,7 +64,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin: 0 10px;
+  margin: 0;
 }
 
 .finish-line-header span {
@@ -128,6 +128,33 @@
   box-shadow: none;
 }
 
+.project-header .quick-action {
+  margin: 0;
+}
+
+.project-header .quick-action svg {
+  margin: 0;
+}
+
+.project-header:not(.new-project-header) .project-quick-actions {
+  display: flex;
+  align-items: center;
+  gap: clamp(6px, 1vw, 12px);
+  margin-left: clamp(8px, 1.5vw, 16px);
+}
+
+.project-header:not(.new-project-header)
+  .project-quick-actions
+  .quick-action {
+  margin: 0;
+}
+
+.project-header:not(.new-project-header)
+  .project-quick-actions
+  .project-quick-actions__avatars {
+  margin: 0;
+}
+
 /* Mobile adjustments */
 @media (max-width: 768px) {
   .back-icon {
@@ -173,6 +200,11 @@
 
   .project-header .right-side svg {
     width: 15px;
+  }
+
+  .project-header:not(.new-project-header) .project-quick-actions {
+    gap: clamp(4px, 1.2vw, 8px);
+    margin-left: 6px;
   }
 
   .project-header .single-project-title {

--- a/frontend/src/features/project/components/ProjectHeader.tsx
+++ b/frontend/src/features/project/components/ProjectHeader.tsx
@@ -961,58 +961,66 @@ const ProjectHeader: React.FC<ProjectHeaderProps> = ({
               )}
             </svg>
 
-            <AvatarStack members={teamMembers} onClick={openTeamModal} />
+            <div className="project-quick-actions">
+              <div className="quick-action">
+                <AvatarStack
+                  members={teamMembers}
+                  onClick={openTeamModal}
+                  className="project-quick-actions__avatars"
+                />
+              </div>
 
-            <div
-              className="finish-line-header interactive"
-              onClick={openFinishLineModal}
-              onKeyDown={(e) => handleKeyDown(e, openFinishLineModal)}
-              role="button"
-              tabIndex={0}
-              title="Production dates"
-              aria-label="Production dates"
-              style={{ cursor: "pointer" }}
-            >
-              <span>{rangeLabel}</span>
-            </div>
+              <div
+                className="finish-line-header interactive quick-action"
+                onClick={openFinishLineModal}
+                onKeyDown={(e) => handleKeyDown(e, openFinishLineModal)}
+                role="button"
+                tabIndex={0}
+                title="Production dates"
+                aria-label="Production dates"
+                style={{ cursor: "pointer" }}
+              >
+                <span>{rangeLabel}</span>
+              </div>
 
-            <div
-              onClick={openSettingsModal}
-              onKeyDown={(e) => handleKeyDown(e, openSettingsModal)}
-              role="button"
-              tabIndex={0}
-              title="Project settings"
-              aria-label="Project settings"
-              className="interactive"
-              style={{ cursor: "pointer", margin: "10px" }}
-            >
-              <Settings size={20} className="settings-icon" />
-            </div>
+              <div
+                onClick={openSettingsModal}
+                onKeyDown={(e) => handleKeyDown(e, openSettingsModal)}
+                role="button"
+                tabIndex={0}
+                title="Project settings"
+                aria-label="Project settings"
+                className="interactive quick-action"
+                style={{ cursor: "pointer" }}
+              >
+                <Settings size={20} className="settings-icon" />
+              </div>
 
-            <div
-              onClick={onOpenQuickLinks}
-              onKeyDown={(e) => handleKeyDown(e, onOpenQuickLinks)}
-              role="button"
-              tabIndex={0}
-              title="Quick links"
-              aria-label="Quick links"
-              className="interactive"
-              style={{ cursor: "pointer" }}
-            >
-              <Link2 size={20} />
-            </div>
+              <div
+                onClick={onOpenQuickLinks}
+                onKeyDown={(e) => handleKeyDown(e, onOpenQuickLinks)}
+                role="button"
+                tabIndex={0}
+                title="Quick links"
+                aria-label="Quick links"
+                className="interactive quick-action"
+                style={{ cursor: "pointer" }}
+              >
+                <Link2 size={20} />
+              </div>
 
-            <div
-              onClick={onOpenFiles}
-              onKeyDown={(e) => handleKeyDown(e, onOpenFiles)}
-              role="button"
-              tabIndex={0}
-              title="Open file manager"
-              aria-label="Open file manager"
-              className="interactive"
-              style={{ cursor: "pointer", margin: "10px" }}
-            >
-              <Folder size={20} />
+              <div
+                onClick={onOpenFiles}
+                onKeyDown={(e) => handleKeyDown(e, onOpenFiles)}
+                role="button"
+                tabIndex={0}
+                title="Open file manager"
+                aria-label="Open file manager"
+                className="interactive quick-action"
+                style={{ cursor: "pointer" }}
+              >
+                <Folder size={20} />
+              </div>
             </div>
 
             <Modal

--- a/frontend/src/shared/ui/AvatarStack.tsx
+++ b/frontend/src/shared/ui/AvatarStack.tsx
@@ -13,6 +13,7 @@ interface AvatarStackProps {
   members?: Member[];
   onClick?: () => void;
   size?: number; // avatar diameter in px (default 34)
+  className?: string;
 }
 
 const getMaxVisible = (): number => {
@@ -23,7 +24,7 @@ const getMaxVisible = (): number => {
   return 4;
 };
 
-const AvatarStack: React.FC<AvatarStackProps> = ({ members = [], onClick, size }) => {
+const AvatarStack: React.FC<AvatarStackProps> = ({ members = [], onClick, size, className }) => {
   const [maxVisible, setMaxVisible] = useState<number>(getMaxVisible());
 
   useEffect(() => {
@@ -38,9 +39,11 @@ const AvatarStack: React.FC<AvatarStackProps> = ({ members = [], onClick, size }
   const avatarSize = typeof size === 'number' && size > 8 ? size : 34;
   const overlap = Math.floor(avatarSize / 2);
 
+  const stackClassName = className ? `${styles.stack} ${className}` : styles.stack;
+
   return (
     <div
-      className={styles.stack}
+      className={stackClassName}
       aria-label="Project team members"
       onClick={onClick}
       role={onClick ? 'button' : undefined}


### PR DESCRIPTION
## Summary
- wrap the project header quick action controls in a shared container for easier spacing tweaks
- allow AvatarStack to accept a custom className so its margins can be overridden where needed
- reduce the desktop and mobile gaps for .project-header:not(.new-project-header) quick actions and align the avatar stack with the new spacing

## Testing
- npm run lint *(fails: Unexpected any. Specify a different type in BudgetProvider.test.tsx and TasksComponent.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68d35a1dca508324809732563ba70b04