### PR TITLE
Point gallery cleanup API to legacy Lambda

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,6 +1,8 @@
 VITE_APP_ENV=development
 # Replace with your newsletter subscription endpoint
 VITE_NEWSLETTER_SUBSCRIBE_URL=https://api.yoursite.com/newsletter
+# Legacy gallery cleanup Lambda (required for deleting S3 assets when removing a gallery)
+VITE_DELETE_GALLERY_FUNCTION_URL=https://o01t8q8mjk.execute-api.us-west-1.amazonaws.com/default/deleteGalleryFiles
 # Optional override. If unset, app & proxy default to 35.165.113.63:1234
 # Optional override. If unset, app & proxy default to 35.165.113.63:1234
 # VITE_YJS_WS_URL=ws://35.165.113.63:1234

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -41,6 +41,10 @@ Auth: AWS Cognito with role claims injected at token issuance
 
 Storage: Amazon S3 for files and assets
 
+## Environment configuration
+
+- `VITE_DELETE_GALLERY_FUNCTION_URL` – Points to the legacy Lambda used to remove gallery assets from S3 when a gallery is deleted. For the development stack this should be set to `https://o01t8q8mjk.execute-api.us-west-1.amazonaws.com/default/deleteGalleryFiles`.
+
 🚀 Roadmap
 
 Multi-user calendar sharing and task scheduling

--- a/frontend/src/shared/utils/api.ts
+++ b/frontend/src/shared/utils/api.ts
@@ -236,7 +236,8 @@ const BASE_ENDPOINTS = {
     EDIT_MESSAGE_URL: 'https://uzcx04lrr9.execute-api.us-west-2.amazonaws.com/messages',
     GALLERY_UPLOAD_URL: 'https://bevnkraeqa.execute-api.us-west-2.amazonaws.com/projects/galleries/upload',
     CREATE_GALLERY_FUNCTION_URL: 'https://bevnkraeqa.execute-api.us-west-2.amazonaws.com/projects/galleries',
-    DELETE_GALLERY_FUNCTION_URL: 'https://bevnkraeqa.execute-api.us-west-2.amazonaws.com/projects/galleries',
+    DELETE_GALLERY_FUNCTION_URL:
+      'https://o01t8q8mjk.execute-api.us-west-1.amazonaws.com/default/deleteGalleryFiles',
     GALLERIES_API_URL: 'https://bevnkraeqa.execute-api.us-west-2.amazonaws.com/projects/galleries',
     POST_PROJECTS_URL: 'https://bevnkraeqa.execute-api.us-west-2.amazonaws.com/projects',
     POST_PROJECT_TO_USER_URL: 'https://gy8dq7w0a3.execute-api.us-west-2.amazonaws.com/postProjectToUserId',


### PR DESCRIPTION
## Summary
- point the DELETE_GALLERY_FUNCTION_URL default at the legacy gallery cleanup Lambda used to purge S3 assets
- document the required VITE_DELETE_GALLERY_FUNCTION_URL in the sample env file and README so deployments pick up the correct endpoint

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d35da1dccc832490475dd76e7127dd