### PR TITLE
Add dashboard back link and width limits to gallery page

### DIFF
--- a/frontend/src/dashboard/project/features/gallery/GalleryPage.extra.test.tsx
+++ b/frontend/src/dashboard/project/features/gallery/GalleryPage.extra.test.tsx
@@ -161,6 +161,15 @@ describe('GalleryPage', () => {
     expect(screen.getByText('Grid Layout')).toBeInTheDocument();
   });
 
+  it('navigates back to dashboard when clicking back button', async () => {
+    const navigateMock = vi.fn();
+    useNavigateMock.mockReturnValue(navigateMock);
+    render(<GalleryPage projectId="1" />);
+    const backButton = await screen.findByRole('button', { name: /back to dashboard/i });
+    await userEvent.click(backButton);
+    expect(navigateMock).toHaveBeenCalledWith('/dashboard');
+  });
+
   it('renders gallery page with link navigation', async () => {
     const navigateMock = vi.fn();
     useNavigateMock.mockReturnValue(navigateMock);

--- a/frontend/src/dashboard/project/features/gallery/GalleryPage.tsx
+++ b/frontend/src/dashboard/project/features/gallery/GalleryPage.tsx
@@ -574,23 +574,25 @@ const GalleryPage: FC<GalleryPageProps> = ({ projectId: propProjectId }) => {
       {(loading || loadingGalleries) && <Preloader />}
       {error && <p className="text-danger mt-3">{error}</p>}
 
-      <LayoutPdfButtons
-        useMasonryLayout={useMasonryLayout}
-        onToggleLayout={() => setUseMasonryLayout((v) => !v)}
-        downloadUrl={normalizedOriginalUrl || ""}
-        isPdf={isPdf}
-      />
-
-      {useMasonryLayout ? (
-        <GalleryMasonry
-          imageUrls={imageUrls}
-          onImageClick={(i: number) => {
-            setCurrentIndex(i);
-            setIsModalOpen(true);
-          }}
+      <div className={styles.galleryContainer}>
+        <LayoutPdfButtons
+          useMasonryLayout={useMasonryLayout}
+          onToggleLayout={() => setUseMasonryLayout((v) => !v)}
+          downloadUrl={normalizedOriginalUrl || ""}
+          isPdf={isPdf}
+          onBack={() => navigate("/dashboard")}
         />
-      ) : isPdf ? (
-        <div data-testid="svg-container" className={styles.pdfContainer}>
+
+        {useMasonryLayout ? (
+          <GalleryMasonry
+            imageUrls={imageUrls}
+            onImageClick={(i: number) => {
+              setCurrentIndex(i);
+              setIsModalOpen(true);
+            }}
+          />
+        ) : isPdf ? (
+          <div data-testid="svg-container" className={styles.pdfContainer}>
           {totalPages > 0 && pagesLoaded < totalPages && (
             <div className={styles.loadingOverlay} data-testid="pdf-loading">
               <div className={styles.dotSpinner}>
@@ -669,6 +671,7 @@ const GalleryPage: FC<GalleryPageProps> = ({ projectId: propProjectId }) => {
           dangerouslySetInnerHTML={{ __html: svgContent }}
         />
       )}
+      </div>
 
       <ReactModal
         isOpen={isModalOpen}

--- a/frontend/src/dashboard/project/features/gallery/gallery-page.module.css
+++ b/frontend/src/dashboard/project/features/gallery/gallery-page.module.css
@@ -53,6 +53,17 @@
   margin-top: 75px;
 }
 
+.galleryContainer {
+  max-width: 1920px;
+  margin: 0 auto;
+  width: 100%;
+  padding: 0 24px 40px;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
 @media (max-width: 768px) {
   .passwordWrapper {
     height: calc(100vh - 45px);
@@ -60,6 +71,10 @@
   }
   .galleryPage {
     margin-top: 45px;
+  }
+  .galleryContainer {
+    padding: 0 16px 32px;
+    gap: 16px;
   }
 }
 

--- a/frontend/src/shared/ui/LayoutPdfButtons.tsx
+++ b/frontend/src/shared/ui/LayoutPdfButtons.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { LayoutGrid, FileDown } from 'lucide-react';
+import { LayoutGrid, FileDown, ArrowLeft } from 'lucide-react';
 import styles from './layout-pdf-buttons.module.css';
 import { getFileUrl } from '../utils/api';
 
@@ -9,6 +9,8 @@ interface LayoutPdfButtonsProps {
   downloadUrl?: string;
   isPdf?: boolean;
   className?: string;
+  onBack?: () => void;
+  backLabel?: string;
 }
 
 const LayoutPdfButtons: React.FC<LayoutPdfButtonsProps> = ({
@@ -17,22 +19,34 @@ const LayoutPdfButtons: React.FC<LayoutPdfButtonsProps> = ({
   downloadUrl = '',
   isPdf = true,
   className = '',
+  onBack,
+  backLabel = 'Back to dashboard',
 }) => (
   <div className={`${styles.container} ${className}`.trim()}>
-    <button
-      type="button"
-      onClick={onToggleLayout}
-      className={styles.actionButton}
-    >
-      <LayoutGrid size={16} />
-      <span>{useMasonryLayout ? 'Grid Layout' : 'Masonry Layout'}</span>
-    </button>
-    {downloadUrl && (
-      <a href={getFileUrl(downloadUrl)} download className={styles.actionButton}>
-        <FileDown size={16} />
-        <span>{isPdf ? 'Download PDF' : 'Download SVG'}</span>
-      </a>
-    )}
+    <div className={styles.layoutToggle}>
+      <button
+        type="button"
+        onClick={onToggleLayout}
+        className={styles.actionButton}
+      >
+        <LayoutGrid size={16} />
+        <span>{useMasonryLayout ? 'Grid Layout' : 'Masonry Layout'}</span>
+      </button>
+    </div>
+    <div className={styles.actionGroup}>
+      {onBack && (
+        <button type="button" onClick={onBack} className={styles.actionButton}>
+          <ArrowLeft size={16} />
+          <span>{backLabel}</span>
+        </button>
+      )}
+      {downloadUrl && (
+        <a href={getFileUrl(downloadUrl)} download className={styles.actionButton}>
+          <FileDown size={16} />
+          <span>{isPdf ? 'Download PDF' : 'Download SVG'}</span>
+        </a>
+      )}
+    </div>
   </div>
 );
 

--- a/frontend/src/shared/ui/layout-pdf-buttons.module.css
+++ b/frontend/src/shared/ui/layout-pdf-buttons.module.css
@@ -1,9 +1,25 @@
 
+
 .container {
   display: flex;
+  justify-content: flex-start;
+  align-items: center;
   gap: 8px;
-  justify-content: flex-end;
   padding: 8px;
+  flex-wrap: wrap;
+}
+
+.layoutToggle {
+  display: flex;
+  flex: 1 1 auto;
+}
+
+.actionGroup {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-left: auto;
 }
 
 .actionButton {


### PR DESCRIPTION
## Summary
- add an optional back-to-dashboard button to the gallery action bar alongside the download control
- constrain gallery content to a centered container capped at 1920px wide and adjust action bar layout styles
- expand gallery page tests to verify the new back navigation behaviour

## Testing
- npm run test -- frontend/src/dashboard/project/features/gallery/GalleryPage.extra.test.tsx *(fails: vitest not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d638ba0dbc83248972b01fbb8fb2d9