### PR TITLE
Handle quiet gallery file deletions

### DIFF
--- a/backend/projects/router.mjs
+++ b/backend/projects/router.mjs
@@ -120,6 +120,27 @@ const listAllKeys = async (bucket, prefix) => {
   return keys;
 };
 
+const resolveGallerySlug = async (projectId, slugOrId) => {
+  if (!projectId || !slugOrId) {
+    return { slug: null, galleryId: null };
+  }
+
+  try {
+    const res = await ddb.get({ TableName: GALLERIES_TABLE, Key: { galleryId: slugOrId } });
+    const item = res?.Item;
+    if (item && (!item.projectId || item.projectId === projectId)) {
+      return {
+        slug: item.slug || item.galleryId || slugOrId,
+        galleryId: item.galleryId || slugOrId,
+      };
+    }
+  } catch (err) {
+    console.warn('resolve_gallery_slug_failed', { projectId, slugOrId, err });
+  }
+
+  return { slug: slugOrId, galleryId: slugOrId };
+};
+
 const chunk = (arr, n = 1000) => {
   const out = [];
   for (let i = 0; i < arr.length; i += n) out.push(arr.slice(i, i + n));
@@ -879,11 +900,16 @@ const deleteGalleryFilesBySlug = async (e, C, { projectId, gallerySlug }) => {
     return json(400, C, { error: "projectId and gallerySlug required" });
   }
 
-  const prefix = `projects/${projectId}/gallery/${gallerySlug}/`;
+  const { slug: resolvedSlug, galleryId } = await resolveGallerySlug(projectId, gallerySlug);
+  if (!resolvedSlug) {
+    return json(404, C, { error: "Gallery not found", projectId, gallerySlug });
+  }
+
+  const prefix = `projects/${projectId}/gallery/${resolvedSlug}/`;
   try {
     const keys = await listAllKeys(FILE_BUCKET, prefix);
     if (!keys.length) {
-      return json(200, C, { ok: true, projectId, gallerySlug, deletedCount: 0, errors: [] });
+      return json(200, C, { ok: true, projectId, gallerySlug: resolvedSlug, galleryId, deletedCount: 0, errors: [] });
     }
 
     const batches = chunk(keys, 1000);
@@ -900,13 +926,21 @@ const deleteGalleryFilesBySlug = async (e, C, { projectId, gallerySlug }) => {
 
     return json(200, C, {
       ok: errors.length === 0,
-      projectId, gallerySlug,
+      projectId,
+      gallerySlug: resolvedSlug,
+      galleryId,
       deletedCount: keys.length,
       errors
     });
   } catch (err) {
-    console.error("delete_gallery_files_error", { projectId, gallerySlug, err });
-    return json(500, C, { error: "Failed to delete gallery files", detail: String(err?.message || err) });
+    console.error("delete_gallery_files_error", { projectId, gallerySlug: resolvedSlug, err });
+    return json(500, C, {
+      error: "Failed to delete gallery files",
+      detail: String(err?.message || err),
+      projectId,
+      gallerySlug: resolvedSlug,
+      galleryId,
+    });
   }
 };
 

--- a/frontend/src/shared/utils/api.ts
+++ b/frontend/src/shared/utils/api.ts
@@ -15,6 +15,7 @@ export interface ApiFetchOptions extends RequestInit {
   retryDelay?: number;          // ms
   skipRateLimit?: boolean;
   onNetworkError?: (error: Error) => void;
+  suppressErrorLog?: boolean;
 }
 
 type JsonRecord = Record<string, unknown>;
@@ -362,6 +363,7 @@ export async function apiFetch<T = unknown>(url: string, options: ApiFetchOption
     retryDelay = 500,
     skipRateLimit = false,
     onNetworkError,
+    suppressErrorLog = false,
     ...fetchOptions
   } = options;
 
@@ -396,14 +398,18 @@ export async function apiFetch<T = unknown>(url: string, options: ApiFetchOption
       const res = await fetch(url, { ...fetchOptions, headers });
 
       if (res.status === 503 && attempt < retryCount) {
-        console.warn('[apiFetch] 503 Service Unavailable — retrying after delay');
+        if (!suppressErrorLog) {
+          console.warn('[apiFetch] 503 Service Unavailable — retrying after delay');
+        }
         await new Promise((r) => setTimeout(r, retryDelay));
         continue;
       }
 
       if (!res.ok) {
         const text = await res.text().catch(() => '');
-        console.error(`[apiFetch] ❌ ${url} → ${res.status} ${res.statusText} — ${text}`);
+        if (!suppressErrorLog) {
+          console.error(`[apiFetch] ❌ ${url} → ${res.status} ${res.statusText} — ${text}`);
+        }
 
         if (res.status === 401 || res.status === 403) {
           logSecurityEvent('authentication_error', { url, status: res.status, statusText: res.statusText });
@@ -431,7 +437,9 @@ export async function apiFetch<T = unknown>(url: string, options: ApiFetchOption
         try {
           return JSON.parse(text) as T;
         } catch {
-              console.warn('[apiFetch] Non-JSON response, returning {}:', { url, text });
+          if (!suppressErrorLog) {
+            console.warn('[apiFetch] Non-JSON response, returning {}:', { url, text });
+          }
           return ({} as unknown) as T;
         }
       }
@@ -439,7 +447,9 @@ export async function apiFetch<T = unknown>(url: string, options: ApiFetchOption
       try {
         data = await res.json();
       } catch {
-        console.warn('[apiFetch] Failed to parse JSON, returning {}:', { url });
+        if (!suppressErrorLog) {
+          console.warn('[apiFetch] Failed to parse JSON, returning {}:', { url });
+        }
         return ({} as unknown) as T;
       }
       if (['POST', 'PUT', 'PATCH', 'DELETE'].includes((fetchOptions.method || '').toUpperCase())) {
@@ -452,7 +462,9 @@ export async function apiFetch<T = unknown>(url: string, options: ApiFetchOption
     } catch (err) {
       lastError = err;
       if (attempt < retryCount) {
-        console.warn('[apiFetch] Error, will retry:', (err as Error)?.message);
+        if (!suppressErrorLog) {
+          console.warn('[apiFetch] Error, will retry:', (err as Error)?.message);
+        }
         await new Promise((r) => setTimeout(r, retryDelay));
       }
     }
@@ -464,7 +476,9 @@ export async function apiFetch<T = unknown>(url: string, options: ApiFetchOption
     lastError = networkErr;
   }
 
-  console.error('[apiFetch] Final error:', lastError);
+  if (!suppressErrorLog) {
+    console.error('[apiFetch] Final error:', lastError);
+  }
   logSecurityEvent('api_request_failed', { url: new URL(url).pathname, error: (lastError as Error).message });
   throw lastError;
 }
@@ -767,6 +781,8 @@ export async function deleteGalleryFiles(projectId: string, galleryId?: string, 
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({}),
+    retryCount: 0,
+    suppressErrorLog: true,
     onNetworkError: (err: Error) => {
       try {
         console.error('[deleteGalleryFiles] Network error callback:', err);


### PR DESCRIPTION
## Summary
- add a helper that resolves gallery slugs from gallery IDs before issuing S3 cleanup so the delete-files endpoint accepts either identifier
- suppress apiFetch logging/retries for the fire-and-forget gallery file deletion request to avoid noisy console errors while still surfacing toast notifications
- return richer metadata from the gallery file deletion endpoint when nothing is removed or an error occurs

## Testing
- npm test -- src/dashboard/project/features/gallery/GalleryAdminEdit.test.tsx *(hangs in this environment, cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68d63aad497c83248fc6d47fb2dc5027