### PR TITLE
Use project ID routing on gallery page

### DIFF
--- a/frontend/src/app/routes.tsx
+++ b/frontend/src/app/routes.tsx
@@ -150,8 +150,8 @@ const ActualRoutes: React.FC<ActualRoutesProps> = ({ location }) => {
           } 
         />
         
-        <Route 
-          path="/gallery/:projectSlug/:gallerySlug" 
+        <Route
+          path="/gallery/:projectId/:gallerySlug"
           element={
             <motion.div
               initial="initial"

--- a/frontend/src/dashboard/project/components/Gallery/hooks/useGalleryController.ts
+++ b/frontend/src/dashboard/project/components/Gallery/hooks/useGalleryController.ts
@@ -318,8 +318,12 @@ const useGalleryController = (): GalleryController => {
     if (combinedGalleries.length > 0) {
       const lastGallery = combinedGalleries[combinedGalleries.length - 1];
       const slug = lastGallery.slug || slugify(lastGallery.name || "");
+      if (!activeProjectId) {
+        console.warn("Cannot navigate to gallery without an active project ID");
+        return;
+      }
       await fetchProjects(1);
-      navigate(`/gallery/${slugify(activeProjectTitle || "")}/${slug}`);
+      navigate(`/gallery/${activeProjectId}/${slug}`);
     } else {
       openModal();
     }
@@ -337,8 +341,12 @@ const useGalleryController = (): GalleryController => {
       return;
     }
 
+    if (!activeProjectId) {
+      console.warn("Cannot navigate to gallery without an active project ID");
+      return;
+    }
     await fetchProjects(1);
-    navigate(`/gallery/${slugify(activeProjectTitle || "")}/${slug}`);
+    navigate(`/gallery/${activeProjectId}/${slug}`);
   };
 
   const isEditing = editingIndex !== null;

--- a/frontend/src/dashboard/project/features/gallery/GalleryPage.extra.test.tsx
+++ b/frontend/src/dashboard/project/features/gallery/GalleryPage.extra.test.tsx
@@ -139,7 +139,7 @@ describe('GalleryPage', () => {
     fetchGalleriesMock.mockResolvedValue([
       { projectId: '1', name: 'client 001', slug: 'client-001', updatedSvgUrl: '/test.svg', imageUrls: ['img1.png'] },
     ]);
-    useParamsMock.mockReturnValue({ projectSlug: 'project-1', gallerySlug: 'client-001' });
+    useParamsMock.mockReturnValue({ projectId: 'project-1', gallerySlug: 'client-001' });
     useNavigateMock.mockReturnValue(vi.fn());
   });
 
@@ -167,7 +167,7 @@ describe('GalleryPage', () => {
     render(<GalleryPage projectId="1" />);
     const backButton = await screen.findByRole('button', { name: /back to dashboard/i });
     await userEvent.click(backButton);
-    expect(navigateMock).toHaveBeenCalledWith('/dashboard');
+    expect(navigateMock).toHaveBeenCalledWith('/dashboard/projects/1');
   });
 
   it('renders gallery page with link navigation', async () => {
@@ -176,7 +176,7 @@ describe('GalleryPage', () => {
     fetchGalleriesMock.mockResolvedValue([
       { projectId: 'project-1', name: 'link-gallery', slug: 'link', link: '/other' },
     ]);
-    useParamsMock.mockReturnValue({ projectSlug: 'project-2', gallerySlug: 'link' });
+    useParamsMock.mockReturnValue({ projectId: 'project-2', gallerySlug: 'link' });
     render(<GalleryPage projectId="1" />);
     await waitFor(() => expect(navigateMock).toHaveBeenCalledWith('/other'));
   });
@@ -196,7 +196,7 @@ describe('GalleryPage', () => {
     fetchGalleriesMock.mockResolvedValue([
       { projectId: 'project-1', name: 'secret', slug: 'secret', passwordHash: 'abc', passwordEnabled: true },
     ]);
-    useParamsMock.mockReturnValue({ projectSlug: 'project-3', gallerySlug: 'secret' });
+    useParamsMock.mockReturnValue({ projectId: 'project-3', gallerySlug: 'secret' });
     render(<GalleryPage projectId="1" />);
     const input = await screen.findByTestId('password-input');
     expect(input).toBeInTheDocument();
@@ -223,7 +223,7 @@ describe('GalleryPage', () => {
     fetchGalleriesMock.mockResolvedValue([
       { projectId: 'project-1', slug: 'pdf', updatedPdfUrl: '/dummy.pdf', imageUrls: ['img1.png'] },
     ]);
-    useParamsMock.mockReturnValue({ projectSlug: 'project-4', gallerySlug: 'pdf' });
+    useParamsMock.mockReturnValue({ projectId: 'project-4', gallerySlug: 'pdf' });
     const { default: GalleryPagePdf } = await import('./GalleryPage');
     render(<GalleryPagePdf />);
     expect(pdfjs.getDocument).toHaveBeenCalled();
@@ -247,7 +247,7 @@ describe('GalleryPage', () => {
     fetchGalleriesMock.mockResolvedValue([
       { projectId: 'project-1', slug: 'pdf', updatedPdfUrl: '/dummy.pdf' },
     ]);
-    useParamsMock.mockReturnValue({ projectSlug: 'project-5', gallerySlug: 'pdf' });
+    useParamsMock.mockReturnValue({ projectId: 'project-5', gallerySlug: 'pdf' });
     const { default: GalleryPagePdf } = await import('./GalleryPage');
     render(<GalleryPagePdf />);
     const container = await screen.findByTestId('svg-container');

--- a/frontend/src/dashboard/project/features/gallery/GalleryPage.tsx
+++ b/frontend/src/dashboard/project/features/gallery/GalleryPage.tsx
@@ -13,7 +13,7 @@ import ReactModal from "react-modal";
 import { sha256 } from "@/shared/utils/hash";
 import useModalStack from "@/shared/utils/useModalStack";
 import { useData } from "@/app/contexts/useData";
-import { slugify, findProjectBySlug } from "@/shared/utils/slug";
+import { slugify } from "@/shared/utils/slug";
 import { fetchGalleries, fileUrlsToKeys, getFileUrl } from "@/shared/utils/api";
 import Preloader from "@/shared/ui/Preloader";
 import * as pdfjsLibLocal from "pdfjs-dist/legacy/build/pdf";
@@ -127,30 +127,33 @@ const renderScale = 2; // scale used when rendering pages in Lambda
    ============================ */
 
 const GalleryPage: FC<GalleryPageProps> = ({ projectId: propProjectId }) => {
-  const { gallerySlug, projectSlug } = useParams<{
+  const { gallerySlug, projectId: projectIdParam } = useParams<{
     gallerySlug: string;
-    projectSlug: string;
+    projectId: string;
   }>();
   const navigate = useNavigate();
 
   const { projects } = useData() as { projects?: Project[] };
 
-  const projectObj = useMemo(
-    () => (projects ? (findProjectBySlug(projects, projectSlug) as Project | undefined) : undefined),
-    [projects, projectSlug]
-  );
-
-  const projectId = propProjectId || projectObj?.projectId;
+  const projectId = propProjectId || projectIdParam;
 
   if (import.meta.env.DEV) {
     console.log("Loaded projects in GalleryPage:", projects);
-    console.log("Project slug:", projectSlug);
+    console.log("Project route ID:", projectIdParam);
     console.log("Resolved project ID:", projectId);
   }
 
   if (typeof document !== "undefined") {
     ReactModal.setAppElement("#root");
   }
+
+  const handleBack = useCallback(() => {
+    if (projectId) {
+      navigate(`/dashboard/projects/${encodeURIComponent(projectId)}`);
+    } else {
+      navigate("/dashboard");
+    }
+  }, [navigate, projectId]);
 
   const [apiGalleries, setApiGalleries] = useState<Gallery[] | null>(null);
   const [loadingGalleries, setLoadingGalleries] = useState<boolean>(!!projectId);
@@ -580,7 +583,7 @@ const GalleryPage: FC<GalleryPageProps> = ({ projectId: propProjectId }) => {
           onToggleLayout={() => setUseMasonryLayout((v) => !v)}
           downloadUrl={normalizedOriginalUrl || ""}
           isPdf={isPdf}
-          onBack={() => navigate("/dashboard")}
+          onBack={handleBack}
         />
 
         {useMasonryLayout ? (

--- a/frontend/src/shared/ui/LayoutPdfButtons.tsx
+++ b/frontend/src/shared/ui/LayoutPdfButtons.tsx
@@ -23,23 +23,23 @@ const LayoutPdfButtons: React.FC<LayoutPdfButtonsProps> = ({
   backLabel = 'Back to dashboard',
 }) => (
   <div className={`${styles.container} ${className}`.trim()}>
-    <div className={styles.layoutToggle}>
-      <button
-        type="button"
-        onClick={onToggleLayout}
-        className={styles.actionButton}
-      >
-        <LayoutGrid size={16} />
-        <span>{useMasonryLayout ? 'Grid Layout' : 'Masonry Layout'}</span>
+    {onBack && (
+      <button type="button" onClick={onBack} className={styles.actionButton}>
+        <ArrowLeft size={16} />
+        <span>{backLabel}</span>
       </button>
-    </div>
+    )}
     <div className={styles.actionGroup}>
-      {onBack && (
-        <button type="button" onClick={onBack} className={styles.actionButton}>
-          <ArrowLeft size={16} />
-          <span>{backLabel}</span>
+      <div className={styles.layoutToggle}>
+        <button
+          type="button"
+          onClick={onToggleLayout}
+          className={styles.actionButton}
+        >
+          <LayoutGrid size={16} />
+          <span>{useMasonryLayout ? 'Grid Layout' : 'Masonry Layout'}</span>
         </button>
-      )}
+      </div>
       {downloadUrl && (
         <a href={getFileUrl(downloadUrl)} download className={styles.actionButton}>
           <FileDown size={16} />

--- a/frontend/src/shared/ui/layout-pdf-buttons.module.css
+++ b/frontend/src/shared/ui/layout-pdf-buttons.module.css
@@ -11,7 +11,7 @@
 
 .layoutToggle {
   display: flex;
-  flex: 1 1 auto;
+  flex: none;
 }
 
 .actionGroup {


### PR DESCRIPTION
## Summary
- swap the gallery route to accept a `projectId` parameter and update the gallery controller to navigate with it
- move the back button to the left of the layout/download controls and keep the Masonry toggle grouped with the download link
- wire the gallery page back button to the active project dashboard and refresh tests for the new URLs

## Testing
- npm test -- src/dashboard/project/features/gallery/GalleryPage.extra.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d642db19388324a84ffc2f9f6327dd