### PR TITLE
Update gallery trigger interactions and styling

### DIFF
--- a/frontend/src/dashboard/project/components/Gallery/GalleryComponent.tsx
+++ b/frontend/src/dashboard/project/components/Gallery/GalleryComponent.tsx
@@ -19,7 +19,6 @@ const GalleryComponent: React.FC = () => {
     saving,
     combinedGalleries,
     handleTriggerClick,
-    openModal,
     isConfirmingDelete,
     setIsConfirmingDelete,
     setDeleteIndex,
@@ -33,7 +32,6 @@ const GalleryComponent: React.FC = () => {
       <GalleryTrigger
         galleries={combinedGalleries}
         onTriggerClick={handleTriggerClick}
-        onOpenModal={openModal}
       />
 
       <GalleryModal controller={controller} />

--- a/frontend/src/dashboard/project/components/Gallery/GalleryTrigger.tsx
+++ b/frontend/src/dashboard/project/components/Gallery/GalleryTrigger.tsx
@@ -9,14 +9,9 @@ import { getFileUrl } from "../../../../shared/utils/api";
 interface GalleryTriggerProps {
   galleries: Gallery[];
   onTriggerClick: () => void;
-  onOpenModal: () => void;
 }
 
-const GalleryTrigger: React.FC<GalleryTriggerProps> = ({
-  galleries,
-  onTriggerClick,
-  onOpenModal,
-}) => {
+const GalleryTrigger: React.FC<GalleryTriggerProps> = ({ galleries, onTriggerClick }) => {
   const hasGalleries = galleries.length > 0;
   const visibleCount = Math.min(3, galleries.length);
   const visibleGalleries = galleries.slice(0, visibleCount);
@@ -42,16 +37,16 @@ const GalleryTrigger: React.FC<GalleryTriggerProps> = ({
           <span>Galleries</span>
           {hasGalleries && (
             <span className={styles.galleryCount}>
-              {galleries.length} {galleries.length === 1 ? "item" : "items"}
+              {galleries.length} {galleries.length === 1 ? "gallery" : "galleries"}
             </span>
           )}
         </div>
         {hasGalleries ? (
           <p className={styles.galleryHelperText}>
-            Peek at the latest uploads or jump into the full gallery.
+            Open the gallery drawer to review uploads, curate covers, or share links.
           </p>
         ) : (
-          <p className={styles.galleryHelperText}>Create your first gallery to showcase work.</p>
+          <p className={styles.galleryHelperText}>Create your first gallery to curate and deliver work.</p>
         )}
       </div>
 
@@ -80,18 +75,6 @@ const GalleryTrigger: React.FC<GalleryTriggerProps> = ({
                 <div className={`${styles.thumbnailTile} ${styles.moreTile}`}>+{hiddenCount}</div>
               )}
             </div>
-            {hasGalleries && (
-              <button
-                type="button"
-                className={styles.viewAllButton}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onOpenModal();
-                }}
-              >
-                View all galleries
-              </button>
-            )}
           </div>
         ) : (
           <div className={styles.emptyState}>No galleries yet</div>

--- a/frontend/src/dashboard/project/components/Gallery/gallery-component.module.css
+++ b/frontend/src/dashboard/project/components/Gallery/gallery-component.module.css
@@ -46,16 +46,16 @@
 .galleryCount {
   margin-left: 8px;
   font-size: 0.85rem;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.55);
+  letter-spacing: 0.02em;
+  text-transform: none;
+  color: rgba(255, 255, 255, 0.7);
 }
 
 .galleryHelperText {
   margin-top: 6px;
-  font-size: 0.78rem;
+  font-size: 0.8rem;
   line-height: 1.35;
-  color: rgba(255, 255, 255, 0.55);
+  color: rgba(255, 255, 255, 0.6);
 }
 
 .carouselSection {
@@ -91,7 +91,7 @@
 }
 
 .thumbnailTile {
-  flex: 0 1 clamp(110px, 24vw, 150px);
+  flex: 0 1 clamp(110px, 22vw, 148px);
   aspect-ratio: 4 / 3;
   border-radius: 14px;
   border: 2px solid rgba(255, 255, 255, 0.25);
@@ -134,26 +134,6 @@
   color: #FA3356;
 }
 
-.viewAllButton {
-  align-self: flex-end;
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid rgba(255, 255, 255, 0.18);
-  border-radius: 999px;
-  padding: 6px 14px;
-  font-size: 0.72rem;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: #ffffff;
-  cursor: pointer;
-  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
-}
-
-.viewAllButton:hover {
-  background: rgba(250, 51, 86, 0.15);
-  border-color: #FA3356;
-  transform: translateY(-1px);
-}
-
 .emptyState {
   font-size: 0.82rem;
   opacity: 0.7;
@@ -161,6 +141,12 @@
   border-radius: 12px;
   padding: 10px 14px;
   text-align: center;
+}
+
+@media (max-width: 1024px) {
+  .thumbnailTile {
+    flex-basis: clamp(95px, 26vw, 132px);
+  }
 }
 
 @media (max-width: 768px) {
@@ -189,8 +175,20 @@
     justify-content: flex-start;
   }
 
-  .viewAllButton {
-    align-self: flex-start;
+  .thumbnailTile {
+    flex-basis: clamp(82px, 42vw, 120px);
+  }
+}
+
+@media (max-width: 520px) {
+  .thumbnailTile {
+    flex-basis: clamp(70px, 48vw, 108px);
+    border-radius: 12px;
+  }
+
+  .thumbnailPlaceholder svg {
+    width: 22px;
+    height: 22px;
   }
 }
 

--- a/frontend/src/dashboard/project/components/Gallery/hooks/useGalleryController.ts
+++ b/frontend/src/dashboard/project/components/Gallery/hooks/useGalleryController.ts
@@ -23,7 +23,6 @@ const useGalleryController = (): GalleryController => {
     recentlyCreated,
     loadGalleries,
     activeProjectId,
-    activeProjectTitle,
     updateProjectFields,
     isAdmin,
     isBuilder,
@@ -306,19 +305,17 @@ const useGalleryController = (): GalleryController => {
   const legacyCount = legacyGalleries.length;
   const hasGalleries = combinedGalleries.length > 0;
 
-  const handleTriggerClick = async () => {
-    if (combinedGalleries.length > 0) {
-      const lastGallery = combinedGalleries[combinedGalleries.length - 1];
-      const slug = lastGallery.slug || slugify(lastGallery.name || "");
-      if (!activeProjectId) {
-        console.warn("Cannot navigate to gallery without an active project ID");
-        return;
-      }
-      await fetchProjects(1);
-      navigate(`/gallery/${activeProjectId}/${slug}`);
-    } else {
+  const handleTriggerClick = () => {
+    if (!combinedGalleries.length) {
       openModal();
+      return;
     }
+
+    if (!activeProjectId) {
+      console.warn("Cannot open gallery list without an active project ID");
+    }
+
+    openModal();
   };
 
   const handleGalleryNavigate = async (galleryItem: Gallery, slug: string) => {


### PR DESCRIPTION
## Summary
- open the gallery list modal when the dashboard gallery tile is clicked
- refresh the gallery trigger copy and remove the redundant "view all" button
- tune responsive thumbnail sizing so previews shrink on smaller screens

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d65781e0f88324ab809e521ea317f3