### PR TITLE
Improve budget revision handling and client revision sync

### DIFF
--- a/frontend/src/dashboard/project/features/budget/components/BudgetOverviewCard.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetOverviewCard.tsx
@@ -154,13 +154,47 @@ const BudgetOverviewCard: React.FC<BudgetOverviewCardProps> = ({ projectId }) =>
       if (!parsed || typeof parsed !== "object") return;
 
       const action = (parsed as { action?: unknown }).action;
-      if (typeof action !== "string" || !RELEVANT_WS_ACTIONS.has(action)) return;
+      if (typeof action !== "string") return;
+
+      if (action === "clientRevisionUpdated") {
+        const targetProject = (parsed as { projectId?: unknown }).projectId;
+        if (
+          resolvedProjectKey &&
+          targetProject &&
+          String(targetProject) !== resolvedProjectKey
+        ) {
+          return;
+        }
+        scheduleUpdate();
+        return;
+      }
+
+      if (!RELEVANT_WS_ACTIONS.has(action)) return;
 
       const targetProject = (parsed as { projectId?: unknown }).projectId;
       if (
         resolvedProjectKey &&
         targetProject &&
         String(targetProject) !== resolvedProjectKey
+      ) {
+        return;
+      }
+
+      const parseRevision = (value: unknown): number | null => {
+        if (typeof value === "number" && !Number.isNaN(value)) return value;
+        if (typeof value === "string") {
+          const numeric = Number(value);
+          return Number.isNaN(numeric) ? null : numeric;
+        }
+        return null;
+      };
+
+      const messageRevision = parseRevision((parsed as { revision?: unknown }).revision);
+      const currentRevision = parseRevision((budgetHeader as { revision?: unknown })?.revision);
+      if (
+        messageRevision != null &&
+        currentRevision != null &&
+        Number(messageRevision) !== Number(currentRevision)
       ) {
         return;
       }
@@ -172,7 +206,12 @@ const BudgetOverviewCard: React.FC<BudgetOverviewCardProps> = ({ projectId }) =>
     return () => {
       ws.removeEventListener("message", handleMessage);
     };
-  }, [ws, scheduleUpdate, resolvedProjectKey]);
+  }, [
+    ws,
+    scheduleUpdate,
+    resolvedProjectKey,
+    budgetHeader,
+  ]);
 
   const formatDatumValue = useCallback(
     (slice: BudgetDonutSlice) => {

--- a/frontend/src/dashboard/project/features/budget/context/BudgetContext.ts
+++ b/frontend/src/dashboard/project/features/budget/context/BudgetContext.ts
@@ -11,7 +11,9 @@ interface BudgetContextValue {
     header: BudgetHeaderShape | ((prev: BudgetHeaderShape) => BudgetHeaderShape)
   ) => void;
   setBudgetItems: (items: BudgetLineShape[]) => void;
-  refresh: () => Promise<{ header: BudgetHeaderShape; items: BudgetLineShape[] } | null>;
+  refresh: (
+    preferredRevision?: number | null,
+  ) => Promise<{ header: BudgetHeaderShape; items: BudgetLineShape[] } | null>;
   loading: boolean;
 
   // Memoized selectors
@@ -22,6 +24,9 @@ interface BudgetContextValue {
 
   // WebSocket operations
   wsOps: BudgetWebSocketOperations;
+
+  // Revision tracking helpers
+  setManualRevision: (manual: boolean) => void;
 }
 
 export const BudgetContext = createContext<BudgetContextValue | undefined>(undefined);

--- a/frontend/src/dashboard/project/features/budget/context/BudgetProvider.test.tsx
+++ b/frontend/src/dashboard/project/features/budget/context/BudgetProvider.test.tsx
@@ -33,6 +33,7 @@ vi.mock("./useBudget", () => ({
     setBudgetItems: vi.fn(),
     refresh: vi.fn(),
     loading: false,
+    setManualRevision: vi.fn(),
   }),
 }));
 
@@ -69,7 +70,14 @@ vi.mock("./BudgetContext", async (importOriginal) => {
       getPie: () => [{ label: "Group A", value: 1200 }],
       getRows: () => [],
       getLocks: () => [],
-      wsOps: { emitBudgetUpdate: vi.fn() },
+      setManualRevision: vi.fn(),
+      wsOps: {
+        emitBudgetUpdate: vi.fn(),
+        emitLineLock: vi.fn(),
+        emitLineUnlock: vi.fn(),
+        emitTimelineUpdate: vi.fn(),
+        emitClientRevisionUpdate: vi.fn(),
+      },
     }),
   };
 });

--- a/frontend/src/dashboard/project/features/budget/context/BudgetProvider.tsx
+++ b/frontend/src/dashboard/project/features/budget/context/BudgetProvider.tsx
@@ -1,4 +1,10 @@
-import React, { PropsWithChildren, useEffect, useMemo, useRef, useCallback } from "react";
+import React, {
+  PropsWithChildren,
+  useEffect,
+  useMemo,
+  useRef,
+  useCallback,
+} from "react";
 import useBudgetData from "@/dashboard/project/features/budget/context/useBudget";
 import { useSocket } from "@/app/contexts/useSocket";
 import { useData } from "@/app/contexts/useData";
@@ -11,16 +17,34 @@ interface ProviderProps extends PropsWithChildren {
 }
 
 export const BudgetProvider: React.FC<ProviderProps> = ({ projectId, children }) => {
-  const { budgetHeader, budgetItems, setBudgetHeader, setBudgetItems, refresh, loading } = useBudgetData(projectId);
+  const {
+    budgetHeader,
+    budgetItems,
+    setBudgetHeader,
+    setBudgetItems,
+    refresh,
+    loading,
+  } = useBudgetData(projectId);
   const { ws } = useSocket();
   const { user, userId } = useData();
-  
+
   const refreshRef = useRef(refresh);
   const lockedLinesRef = useRef<string[]>([]);
+  const activeRevisionRef = useRef<number | null>(null);
+  const manualRevisionRef = useRef(false);
   
   useEffect(() => {
     refreshRef.current = refresh;
   }, [refresh]);
+
+  useEffect(() => {
+    const revision = Number((budgetHeader as Record<string, unknown>)?.revision ?? NaN);
+    activeRevisionRef.current = Number.isNaN(revision) ? null : revision;
+  }, [budgetHeader]);
+
+  const setManualRevision = useCallback((manual: boolean) => {
+    manualRevisionRef.current = manual;
+  }, []);
 
   // WebSocket operations - centralized here
   const emitBudgetUpdate = useCallback(() => {
@@ -88,6 +112,24 @@ export const BudgetProvider: React.FC<ProviderProps> = ({ projectId, children })
       )
     );
   }, [ws, projectId, budgetHeader, user, userId]);
+
+  const emitClientRevisionUpdate = useCallback(
+    (clientRevisionId: number | null, previousClientRevisionId: number | null) => {
+      if (!ws || ws.readyState !== WebSocket.OPEN || !projectId) return;
+      ws.send(
+        JSON.stringify({
+          action: 'clientRevisionUpdated',
+          projectId,
+          clientRevisionId,
+          previousClientRevisionId,
+          conversationId: `project#${projectId}`,
+          username: user?.firstName || 'Someone',
+          senderId: userId,
+        }),
+      );
+    },
+    [projectId, user?.firstName, userId, ws],
+  );
 
   // Memoized selectors with deep equality
   const getStats = useCallback((): BudgetStats => {
@@ -166,12 +208,16 @@ export const BudgetProvider: React.FC<ProviderProps> = ({ projectId, children })
   }, []);
 
   // WebSocket operations object
-  const wsOps = useMemo((): BudgetWebSocketOperations => ({
-    emitBudgetUpdate,
-    emitLineLock,
-    emitLineUnlock,
-    emitTimelineUpdate,
-  }), [emitBudgetUpdate, emitLineLock, emitLineUnlock, emitTimelineUpdate]);
+  const wsOps = useMemo(
+    (): BudgetWebSocketOperations => ({
+      emitBudgetUpdate,
+      emitLineLock,
+      emitLineUnlock,
+      emitTimelineUpdate,
+      emitClientRevisionUpdate,
+    }),
+    [emitBudgetUpdate, emitLineLock, emitLineUnlock, emitTimelineUpdate, emitClientRevisionUpdate],
+  );
 
   useEffect(() => {
     if (!ws) return;
@@ -197,28 +243,53 @@ export const BudgetProvider: React.FC<ProviderProps> = ({ projectId, children })
         return;
       }
       
+      const parseRevision = (value: unknown): number | null => {
+        if (typeof value === "number" && !Number.isNaN(value)) return value;
+        if (typeof value === "string") {
+          const parsed = Number(value);
+          return Number.isNaN(parsed) ? null : parsed;
+        }
+        return null;
+      };
+
+      const messageRevision = parseRevision(messageData.revision);
+      const currentRevision = activeRevisionRef.current;
+      const shouldProcessRevisionScoped =
+        messageRevision == null ||
+        currentRevision == null ||
+        Number(messageRevision) === Number(currentRevision);
+
       // Handle budgetUpdated messages
       if (messageData.action === "budgetUpdated") {
+        if (!shouldProcessRevisionScoped) {
+          return;
+        }
         refreshRef.current();
         return;
       }
-      
+
       // Handle lineLocked messages - update internal state and dispatch window events
       if (messageData.action === "lineLocked" || messageData.action === "lockLineUpdated") {
+        if (!shouldProcessRevisionScoped) {
+          return;
+        }
         if (messageData.senderId !== userId) {
           const lineId = messageData.lineId as string;
           if (lineId) {
-            lockedLinesRef.current = lockedLinesRef.current.includes(lineId) 
-              ? lockedLinesRef.current 
+            lockedLinesRef.current = lockedLinesRef.current.includes(lineId)
+              ? lockedLinesRef.current
               : [...lockedLinesRef.current, lineId];
           }
         }
         window.dispatchEvent(new CustomEvent("lineLocked", { detail: data }));
         return;
       }
-      
-      // Handle lineUnlocked messages - update internal state and dispatch window events  
+
+      // Handle lineUnlocked messages - update internal state and dispatch window events
       if (messageData.action === "lineUnlocked") {
+        if (!shouldProcessRevisionScoped) {
+          return;
+        }
         if (messageData.senderId !== userId) {
           const lineId = messageData.lineId as string;
           if (lineId) {
@@ -226,6 +297,44 @@ export const BudgetProvider: React.FC<ProviderProps> = ({ projectId, children })
           }
         }
         window.dispatchEvent(new CustomEvent("lineUnlocked", { detail: data }));
+        return;
+      }
+
+      if (messageData.action === "clientRevisionUpdated") {
+        const clientRevision = parseRevision(messageData.clientRevisionId);
+        const previousClientRevision = parseRevision(
+          messageData.previousClientRevisionId,
+        );
+
+        setBudgetHeader((prev) => {
+          if (!prev) return prev;
+          const nextClientRevision = clientRevision ?? null;
+          if ((prev as Record<string, unknown>).clientRevisionId === nextClientRevision) {
+            return prev;
+          }
+          return {
+            ...(prev as Record<string, unknown>),
+            clientRevisionId: nextClientRevision,
+          } as typeof prev;
+        });
+
+        window.dispatchEvent(
+          new CustomEvent("clientRevisionUpdated", { detail: data }),
+        );
+
+        const shouldAutoSwitch =
+          !manualRevisionRef.current &&
+          previousClientRevision != null &&
+          currentRevision != null &&
+          Number(previousClientRevision) === Number(currentRevision);
+
+        const noPreviousClient =
+          !manualRevisionRef.current && previousClientRevision == null;
+
+        if (shouldAutoSwitch || noPreviousClient || (!manualRevisionRef.current && currentRevision == null)) {
+          refreshRef.current(clientRevision ?? null);
+        }
+
         return;
       }
     };
@@ -247,20 +356,34 @@ export const BudgetProvider: React.FC<ProviderProps> = ({ projectId, children })
   }, [ws, projectId, userId]);
 
   const value = useMemo(
-    () => ({ 
-      budgetHeader, 
-      budgetItems, 
-      setBudgetHeader, 
-      setBudgetItems, 
-      refresh, 
+    () => ({
+      budgetHeader,
+      budgetItems,
+      setBudgetHeader,
+      setBudgetItems,
+      refresh,
       loading,
       getStats,
       getPie,
       getRows,
       getLocks,
       wsOps,
+      setManualRevision,
     }),
-    [budgetHeader, budgetItems, setBudgetHeader, setBudgetItems, refresh, loading, getStats, getPie, getRows, getLocks, wsOps]
+    [
+      budgetHeader,
+      budgetItems,
+      setBudgetHeader,
+      setBudgetItems,
+      refresh,
+      loading,
+      getStats,
+      getPie,
+      getRows,
+      getLocks,
+      wsOps,
+      setManualRevision,
+    ]
   );
 
   return <BudgetContext.Provider value={value}>{children}</BudgetContext.Provider>;

--- a/frontend/src/dashboard/project/features/budget/context/types.ts
+++ b/frontend/src/dashboard/project/features/budget/context/types.ts
@@ -17,6 +17,10 @@ export type BudgetWebSocketOperations = {
   emitLineLock: (lineId: string) => void;
   emitLineUnlock: (lineId: string) => void;
   emitTimelineUpdate: (events: unknown[]) => void;
+  emitClientRevisionUpdate: (
+    clientRevisionId: number | null,
+    previousClientRevisionId: number | null,
+  ) => void;
 };
 
 

--- a/frontend/src/dashboard/project/features/budget/context/useBudget.ts
+++ b/frontend/src/dashboard/project/features/budget/context/useBudget.ts
@@ -1,5 +1,5 @@
-import { useState, useEffect, useCallback } from "react";
-import { fetchBudgetHeader, fetchBudgetItems } from "@/shared/utils/api";
+import { useState, useEffect, useCallback, useRef } from "react";
+import { fetchBudgetHeaders, fetchBudgetItems } from "@/shared/utils/api";
 
 function shallowEqualObjects(
   a: Record<string, unknown> | null,
@@ -38,15 +38,36 @@ interface BudgetData {
 const budgetCache = new Map<string, BudgetData>();
 const inflight = new Map<string, Promise<BudgetData>>();
 
-async function fetchData(projectId: string, force = false): Promise<BudgetData> {
+type FetchOptions = {
+  force?: boolean;
+  preferredRevision?: number | null;
+};
+
+const buildFetchKey = (projectId: string, revision: number | null): string =>
+  `${projectId}::${revision ?? "default"}`;
+
+async function fetchData(
+  projectId: string,
+  options: FetchOptions = {},
+): Promise<BudgetData> {
   if (!projectId) return { header: null, items: [] };
 
-  if (!force && budgetCache.has(projectId)) {
-    return budgetCache.get(projectId)!;
+  const { force = false, preferredRevision = null } = options;
+  const cached = budgetCache.get(projectId);
+  const cachedRevision = Number(cached?.header?.revision ?? NaN);
+
+  if (
+    !force &&
+    cached &&
+    (preferredRevision == null || preferredRevision === cachedRevision)
+  ) {
+    return cached;
   }
 
-  if (inflight.has(projectId)) {
-    return inflight.get(projectId)!;
+  const fetchKey = buildFetchKey(projectId, preferredRevision);
+
+  if (!force && inflight.has(fetchKey)) {
+    return inflight.get(fetchKey)!;
   }
 
   const promise = (async () => {
@@ -56,7 +77,26 @@ async function fetchData(projectId: string, force = false): Promise<BudgetData> 
     // Simple exponential backoff for 429 errors
     while (true) {
       try {
-        const header = await fetchBudgetHeader(projectId);
+        const headers = await fetchBudgetHeaders(projectId);
+
+        let header: BudgetHeader | null = null;
+        if (preferredRevision != null) {
+          header = headers.find(
+            (candidate) =>
+              Number(candidate?.revision ?? NaN) === preferredRevision,
+          ) ?? null;
+        }
+
+        if (!header) {
+          header =
+            headers.find(
+              (candidate) =>
+                candidate?.clientRevisionId != null &&
+                Number(candidate.clientRevisionId) ===
+                  Number(candidate.revision ?? NaN),
+            ) ?? headers[0] ?? null;
+        }
+
         let items: BudgetItem[] = [];
         if (header?.budgetId) {
           items = await fetchBudgetItems(header.budgetId, header.revision);
@@ -77,11 +117,11 @@ async function fetchData(projectId: string, force = false): Promise<BudgetData> 
     }
   })();
 
-  inflight.set(projectId, promise);
+  inflight.set(fetchKey, promise);
   try {
     return await promise;
   } finally {
-    inflight.delete(projectId);
+    inflight.delete(fetchKey);
   }
 }
 
@@ -101,13 +141,21 @@ export async function prefetchBudgetData(projectId: string): Promise<void> {
 
 export default function useBudgetData(projectId: string | undefined) {
   const cached = projectId ? budgetCache.get(projectId) : null;
-  const [budgetHeader, setBudgetHeader] = useState<BudgetHeader | null>(
+  const [budgetHeader, setBudgetHeaderState] = useState<BudgetHeader | null>(
     cached ? cached.header : null,
   );
   const [budgetItems, setBudgetItemsState] = useState<BudgetItem[]>(
     cached ? cached.items : [],
   );
   const [loading, setLoading] = useState(!cached);
+  const initialRevisionValue = (() => {
+    if (!cached?.header) return null;
+    const raw = (cached.header as Record<string, unknown>).revision;
+    if (raw == null) return null;
+    const parsed = Number(raw);
+    return Number.isNaN(parsed) ? null : parsed;
+  })();
+  const activeRevisionRef = useRef<number | null>(initialRevisionValue);
 
   useEffect(() => {
     let ignore = false;
@@ -121,11 +169,21 @@ export default function useBudgetData(projectId: string | undefined) {
 
       setLoading(true);
       try {
-        const { header, items } = await fetchData(projectId);
+        const { header, items } = await fetchData(projectId, {
+          preferredRevision: activeRevisionRef.current,
+        });
         if (!ignore) {
-          setBudgetHeader((prev) =>
-            shallowEqualObjects(prev, header) ? prev : header,
-          );
+          setBudgetHeaderState((prev) => {
+            if (shallowEqualObjects(prev, header)) return prev;
+            const revision =
+              header && header?.revision != null
+                ? Number((header as Record<string, unknown>).revision as number)
+                : null;
+            activeRevisionRef.current = Number.isNaN(revision)
+              ? null
+              : revision;
+            return header;
+          });
           setBudgetItemsState((prev) =>
             shallowEqualArrays(prev, items) ? prev : items,
           );
@@ -133,7 +191,10 @@ export default function useBudgetData(projectId: string | undefined) {
       } catch (err) {
         console.error("Error fetching budget data", err);
         if (!ignore) {
-          setBudgetHeader(null);
+          setBudgetHeaderState(() => {
+            activeRevisionRef.current = null;
+            return null;
+          });
           setBudgetItemsState([]);
         }
       } finally {
@@ -146,25 +207,47 @@ export default function useBudgetData(projectId: string | undefined) {
     };
   }, [projectId]);
 
-  const refresh = useCallback(async () => {
-    if (!projectId) return null;
-    setLoading(true);
-    try {
-      const data = await fetchData(projectId, true);
-      setBudgetHeader((prev) =>
-        shallowEqualObjects(prev, data.header) ? prev : data.header,
-      );
-      setBudgetItemsState((prev) =>
-        shallowEqualArrays(prev, data.items) ? prev : data.items,
-      );
-      return data;
-    } catch (err) {
-      console.error("Error refreshing budget data", err);
-      return null;
-    } finally {
-      setLoading(false);
-    }
-  }, [projectId]);
+  const refresh = useCallback(
+    async (preferredRevision?: number | null) => {
+      if (!projectId) return null;
+      setLoading(true);
+      try {
+        if (preferredRevision != null && !Number.isNaN(preferredRevision)) {
+          activeRevisionRef.current = preferredRevision;
+        }
+        const data = await fetchData(projectId, {
+          force: true,
+          preferredRevision:
+            preferredRevision != null && !Number.isNaN(preferredRevision)
+              ? preferredRevision
+              : activeRevisionRef.current,
+        });
+        setBudgetHeaderState((prev) => {
+          if (shallowEqualObjects(prev, data.header)) return prev;
+          const revision =
+            data.header && data.header?.revision != null
+              ? Number(
+                  (data.header as Record<string, unknown>).revision as number,
+                )
+              : null;
+          activeRevisionRef.current = Number.isNaN(revision)
+            ? null
+            : revision;
+          return data.header;
+        });
+        setBudgetItemsState((prev) =>
+          shallowEqualArrays(prev, data.items) ? prev : data.items,
+        );
+        return data;
+      } catch (err) {
+        console.error("Error refreshing budget data", err);
+        return null;
+      } finally {
+        setLoading(false);
+      }
+    },
+    [projectId],
+  );
 
   const setBudgetItems = useCallback(
     (items: BudgetItem[]) => {
@@ -182,13 +265,25 @@ export default function useBudgetData(projectId: string | undefined) {
   );
 
   const updateBudgetHeader = useCallback(
-    (headerOrUpdater: BudgetHeader | ((prev: BudgetHeader | null) => BudgetHeader)) => {
+    (
+      headerOrUpdater:
+        | BudgetHeader
+        | null
+        | ((prev: BudgetHeader | null) => BudgetHeader | null),
+    ) => {
       if (!projectId) return;
-      setBudgetHeader((prev) => {
+      setBudgetHeaderState((prev) => {
         const next =
           typeof headerOrUpdater === "function"
-            ? (headerOrUpdater as (p: BudgetHeader | null) => BudgetHeader)(prev)
+            ? (headerOrUpdater as (p: BudgetHeader | null) => BudgetHeader | null)(prev)
             : headerOrUpdater;
+        const nextRevision =
+          next && next?.revision != null
+            ? Number((next as Record<string, unknown>).revision as number)
+            : null;
+        activeRevisionRef.current = Number.isNaN(nextRevision)
+          ? null
+          : nextRevision;
         if (shallowEqualObjects(prev, next)) return prev;
         const cached = budgetCache.get(projectId) || {
           header: null,

--- a/frontend/src/dashboard/project/features/budget/pages/BudgetPage.tsx
+++ b/frontend/src/dashboard/project/features/budget/pages/BudgetPage.tsx
@@ -78,8 +78,9 @@ const BudgetPageContent = () => {
     setBudgetHeader,
     setBudgetItems,
     wsOps,
+    setManualRevision,
   } = useBudget();
-  const { emitBudgetUpdate } = wsOps;
+  const { emitBudgetUpdate, emitClientRevisionUpdate } = wsOps;
 
   // Simplified state for remaining functionality
   const [error, setError] = useState(null);
@@ -257,8 +258,32 @@ const BudgetPageContent = () => {
   }, [activeProject?.projectId, computeGroupsAndClients]);
 
   useEffect(() => {
+    setManualRevision(false);
     refresh();
-  }, [refresh]);
+    return () => {
+      setManualRevision(false);
+    };
+  }, [refresh, setManualRevision]);
+
+  useEffect(() => {
+    const handler = (event: Event) => {
+      const detail = (event as CustomEvent<Record<string, unknown>>).detail;
+      if (!detail || typeof detail !== "object") return;
+      const targetProject = detail.projectId;
+      if (
+        activeProject?.projectId &&
+        targetProject &&
+        String(targetProject) === String(activeProject.projectId)
+      ) {
+        refresh();
+      }
+    };
+
+    window.addEventListener("clientRevisionUpdated", handler as EventListener);
+    return () => {
+      window.removeEventListener("clientRevisionUpdated", handler as EventListener);
+    };
+  }, [activeProject?.projectId, refresh]);
 
   const handleNewRevision = async (duplicate = false, fromRevision = null) => {
     if (!activeProject?.projectId || !budgetHeader) return;
@@ -354,6 +379,7 @@ const BudgetPageContent = () => {
       }
 
       setBudgetHeader(newHeader);
+      setManualRevision(true);
       setBudgetItems(newItems);
       computeGroupsAndClients(newItems, newHeader);
       const revs = await fetchBudgetHeaders(activeProject.projectId);
@@ -373,6 +399,7 @@ const BudgetPageContent = () => {
       setBudgetHeader((prev) => (prev ? { ...prev, ...header } : header));
       setBudgetItems(items);
       computeGroupsAndClients(items, header);
+      setManualRevision(rev !== header.clientRevisionId);
     } catch (err) {
       console.error('Error switching revision', err);
     }
@@ -400,10 +427,12 @@ const BudgetPageContent = () => {
             nextHeader.revision
           );
           setBudgetHeader(nextHeader);
+          setManualRevision(nextHeader.clientRevisionId !== nextHeader.revision);
           setBudgetItems(nextItems);
           computeGroupsAndClients(nextItems, nextHeader);
         } else {
           setBudgetHeader(null);
+          setManualRevision(false);
           setBudgetItems([]);
           setAreaGroups([]);
           setInvoiceGroups([]);
@@ -417,9 +446,38 @@ const BudgetPageContent = () => {
   };
 
   const handleSetClientRevision = async (rev) => {
-    console.log('Set client revision requested:', rev);
-    setRevisions((prev) => prev.map((h) => ({ ...h, clientRevisionId: rev })));
-    setBudgetHeader((prev) => (prev ? { ...prev, clientRevisionId: rev } : prev));
+    if (!activeProject?.projectId) return;
+    const previousClientRevision = Number(
+      (budgetHeader as Record<string, unknown>)?.clientRevisionId ?? NaN,
+    );
+    try {
+      await Promise.all(
+        revisions.map((h) =>
+          updateBudgetItem(activeProject.projectId, h.budgetItemId, {
+            clientRevisionId: rev,
+            revision: h.revision,
+          })
+        )
+      );
+      const updated = await fetchBudgetHeaders(activeProject.projectId);
+      setRevisions(updated);
+      setBudgetHeader((prev) => {
+        if (!prev) return prev;
+        const match = updated.find((h) => h.revision === prev.revision);
+        return match ? { ...prev, clientRevisionId: match.clientRevisionId } : prev;
+      });
+      const normalizedRev = Number(rev);
+      const nextClientRevision = Number.isNaN(normalizedRev)
+        ? null
+        : normalizedRev;
+      setManualRevision(nextClientRevision == null);
+      const previousNormalized = Number.isNaN(previousClientRevision)
+        ? null
+        : previousClientRevision;
+      emitClientRevisionUpdate(nextClientRevision, previousNormalized);
+    } catch (err) {
+      console.error('Error setting client revision', err);
+    }
   };
 
   const parseFile = async (file) => {


### PR DESCRIPTION
## Summary
- gate budget WebSocket handlers by revision and add manual revision tracking so users stay on their selected revision
- add a clientRevisionUpdated broadcast and refresh logic to keep the selected client revision, budget overview, and invoice preview in sync across users
- allow budget data refreshes to request a preferred revision and persist client revision changes on the server

## Testing
- npm run test -- BudgetProvider

------
https://chatgpt.com/codex/tasks/task_e_68d659be8c448324ba2cd7566cf95c8b