### PR TITLE
Enable task navigation from week widget tooltips

### DIFF
--- a/frontend/src/dashboard/home/components/AllProjectsCalendar.tsx
+++ b/frontend/src/dashboard/home/components/AllProjectsCalendar.tsx
@@ -491,18 +491,54 @@ const AllProjectsCalendar: React.FC = () => {
     const activeProjects = rangeMap[key] ?? [];
     const dayEvents = eventsMap[key] ?? [];
 
-    const byId: Record<string, { id: string; title?: string; color?: string; time?: string; badge?: string; note?: string }> = {};
-    activeProjects.forEach(p => {
+    const makeOnSelect = (projectId: string, title?: string) => () => {
+      const project =
+        activeProjects.find((p) => p.projectId === projectId) ||
+        projectsWithLanes.find((p) => p.projectId === projectId) ||
+        (projects?.find((p) => p.projectId === projectId) as Project | undefined);
+      if (project) {
+        void handleProjectClick(project, key ?? undefined);
+        return;
+      }
+      void handleProjectClick(
+        { projectId, title } as Project,
+        key ?? undefined
+      );
+    };
+
+    const byId: Record<
+      string,
+      {
+        id: string;
+        title?: string;
+        color?: string;
+        time?: string;
+        badge?: string;
+        note?: string;
+        onSelect?: () => void;
+      }
+    > = {};
+
+    activeProjects.forEach((p) => {
       byId[p.projectId] = {
         id: p.projectId,
         title: p.title,
         color: colorMap[p.projectId] || getColor(p.projectId),
+        onSelect: makeOnSelect(p.projectId, p.title),
       };
     });
-    dayEvents.forEach(ev => {
+
+    dayEvents.forEach((ev) => {
       const id = ev.projectId;
-      byId[id] = byId[id] || { id, title: ev.title, color: colorMap[id] || getColor(id) };
-      if (ev.description) byId[id].note = (ev.description as string);
+      if (!byId[id]) {
+        byId[id] = {
+          id,
+          title: ev.title,
+          color: colorMap[id] || getColor(id),
+          onSelect: makeOnSelect(id, ev.title),
+        };
+      }
+      if (ev.description) byId[id].note = ev.description as string;
     });
 
     return Object.values(byId);

--- a/frontend/src/dashboard/home/components/AllProjectsWeekWidget.tsx
+++ b/frontend/src/dashboard/home/components/AllProjectsWeekWidget.tsx
@@ -1,7 +1,9 @@
 import React, { useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import WeekWidget, { type Track, type Dot } from "./WeekWidget";
 import { useData } from "@/app/contexts/useData";
 import { getColor } from "@/shared/utils/colorUtils";
+import { getProjectDashboardPath } from "@/shared/utils/projectUrl";
 
 type TimelineEvent = { date?: string; description?: string; [k: string]: unknown };
 type Project = {
@@ -22,9 +24,35 @@ function sameDay(a: Date | null, b: Date | null) {
   return !!(a && b) && a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth() && a.getDate() === b.getDate();
 }
 
+function getDateKey(date: Date | null | undefined) {
+  if (!date) return undefined;
+  const utc = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+  return utc.toISOString().slice(0, 10);
+}
+
 export default function AllProjectsWeekWidget({ className = "" }: { className?: string }) {
-  const { projects = [] } = useData() as { projects: Project[] };
+  const navigate = useNavigate();
+  const { projects = [], fetchProjectDetails } = useData() as {
+    projects: Project[];
+    fetchProjectDetails?: (projectId: string) => Promise<boolean>;
+  };
   const [weekOf, setWeekOf] = useState<Date>(new Date());
+
+  const handleNavigateToProject = async (project: Project, flashDate?: Date | null) => {
+    if (!project?.projectId) return;
+    if (typeof fetchProjectDetails === "function") {
+      try {
+        await fetchProjectDetails(project.projectId);
+      } catch (error) {
+        console.error("Failed to prefetch project", error);
+      }
+    }
+
+    const dateKey = getDateKey(flashDate ?? null);
+    navigate(getProjectDashboardPath(project.projectId, project.title), {
+      state: dateKey ? { flashDate: dateKey } : undefined,
+    });
+  };
 
   // Map for consistent colors
   const colorMap = useMemo(() => {
@@ -60,7 +88,7 @@ export default function AllProjectsWeekWidget({ className = "" }: { className?: 
   // 👉 Tooltip data for a tapped day (projects running that day + same-day events)
   const getTooltipItems = (date: Date) => {
     const day = toDay(date)!;
-    const items: { id: string; title?: string; color?: string; note?: string }[] = [];
+    const items: { id: string; title?: string; color?: string; note?: string; onSelect?: () => void }[] = [];
 
     for (const p of projects) {
       const color = colorMap[p.projectId] || "#FA3356";
@@ -68,15 +96,30 @@ export default function AllProjectsWeekWidget({ className = "" }: { className?: 
       const end = toDay(p.finishline);
 
       if (start && end && day >= start && day <= end) {
-        items.push({ id: p.projectId, title: p.title || p.projectId, color });
+        items.push({
+          id: p.projectId,
+          title: p.title || p.projectId,
+          color,
+          onSelect: () => void handleNavigateToProject(p, day),
+        });
       }
       for (const ev of p.timelineEvents ?? []) {
         const d = toDay(ev.date);
         if (sameDay(d, day)) {
           const note = (ev.description as string) || undefined;
           const hit = items.find((i) => i.id === p.projectId);
-          if (hit) hit.note ??= note;
-          else items.push({ id: p.projectId, title: p.title || p.projectId, color, note });
+          if (hit) {
+            hit.note ??= note;
+            if (!hit.onSelect) hit.onSelect = () => void handleNavigateToProject(p, day);
+          } else {
+            items.push({
+              id: p.projectId,
+              title: p.title || p.projectId,
+              color,
+              note,
+              onSelect: () => void handleNavigateToProject(p, day),
+            });
+          }
         }
       }
     }

--- a/frontend/src/dashboard/home/components/WeekWidget.tsx
+++ b/frontend/src/dashboard/home/components/WeekWidget.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState, useEffect } from "react";
+import React, { useMemo, useState, useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
 import { startOfWeek, endOfWeek, addDays } from "../utils/dateUtils";
 import "./week-widget.css";
@@ -111,6 +111,13 @@ export default function WeekWidget({
   const [tooltipDate, setTooltipDate] = useState<Date | null>(null);
   const [anchor, setAnchor] = useState<{ x: number; y: number } | null>(null);
   const [showAll, setShowAll] = useState(false);
+  const tooltipRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!tooltipDate) {
+      tooltipRef.current = null;
+    }
+  }, [tooltipDate]);
 
   // Build tooltip items; fallback to dots if callback returns none
   const items = useMemo(() => {
@@ -133,7 +140,15 @@ export default function WeekWidget({
   useEffect(() => {
     if (!tooltipDate) return;
     const close = (e: MouseEvent | TouchEvent | KeyboardEvent | Event) => {
-      if ((e as KeyboardEvent).type === "keydown" && (e as KeyboardEvent).key !== "Escape") return;
+      const type = e.type;
+      if (type === "keydown") {
+        if ((e as KeyboardEvent).key !== "Escape") return;
+      } else if (type === "mousedown" || type === "touchstart") {
+        const target = e.target as Node | null;
+        if (target && tooltipRef.current?.contains(target)) {
+          return;
+        }
+      }
       setTooltipDate(null);
       setAnchor(null);
       setShowAll(false);
@@ -171,6 +186,9 @@ export default function WeekWidget({
         className={`ww-top-tooltip compact ${overflow && !showAll ? "has-overflow" : ""}`}
         role="dialog"
         aria-label="Day details"
+        ref={(node) => {
+          tooltipRef.current = node;
+        }}
         style={
           {
             position: "fixed",

--- a/frontend/src/dashboard/home/components/WeekWidget.tsx
+++ b/frontend/src/dashboard/home/components/WeekWidget.tsx
@@ -5,7 +5,15 @@ import "./week-widget.css";
 
 export type Track = { id: string; color: string; start: Date | string | number; end: Date | string | number };
 export type Dot = { date: Date | string | number; color?: string };
-type TooltipItem = { id: string; title?: string; color?: string; time?: string; badge?: string; note?: string };
+type TooltipItem = {
+  id: string;
+  title?: string;
+  color?: string;
+  time?: string;
+  badge?: string;
+  note?: string;
+  onSelect?: () => void;
+};
 
 type Props = {
   weekOf: Date;
@@ -108,10 +116,17 @@ export default function WeekWidget({
   const items = useMemo(() => {
     if (!tooltipDate) return [];
     const cb = getTooltipItems?.(tooltipDate) ?? [];
-    if (cb.length) return cb;
+    if (cb.length) {
+      return [...cb].sort((a, b) => Number(Boolean(b.note)) - Number(Boolean(a.note)));
+    }
     const k = dateKey(tooltipDate);
     const dayDots = dotMap.get(k) || [];
-    return dayDots.map((c, i) => ({ id: `dot-${k}-${i}`, title: "Event", color: c } as TooltipItem));
+    return dayDots
+      .map(
+        (c, i) =>
+          ({ id: `dot-${k}-${i}`, title: "Event", color: c } satisfies TooltipItem)
+      )
+      .sort((a, b) => Number(Boolean(b.note)) - Number(Boolean(a.note)));
   }, [tooltipDate, getTooltipItems, dotMap]);
 
   // Close on outside / ESC / scroll-resize (keeps it simple on mobile)
@@ -170,7 +185,29 @@ export default function WeekWidget({
         }
       >
         {list.map((it) => (
-          <div key={it.id} className="ww-tt-item">
+          <div
+            key={it.id}
+            className={`ww-tt-item${it.onSelect ? " ww-tt-item--action" : ""}`}
+            role={it.onSelect ? "button" : undefined}
+            tabIndex={it.onSelect ? 0 : undefined}
+            onClick={() => {
+              if (!it.onSelect) return;
+              it.onSelect();
+              setTooltipDate(null);
+              setAnchor(null);
+              setShowAll(false);
+            }}
+            onKeyDown={(e) => {
+              if (!it.onSelect) return;
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                it.onSelect();
+                setTooltipDate(null);
+                setAnchor(null);
+                setShowAll(false);
+              }
+            }}
+          >
             <span className="ww-tt-dot" style={{ background: it.color || "#999" }} />
             <div className="ww-tt-body">
               <div className="ww-tt-title">{it.title ?? "Untitled"}</div>

--- a/frontend/src/dashboard/home/components/WeekWidgetDesktop.tsx
+++ b/frontend/src/dashboard/home/components/WeekWidgetDesktop.tsx
@@ -5,7 +5,15 @@ import "./week-widget.css";
 
 export type Track = { id: string; color: string; start: Date | string | number; end: Date | string | number };
 export type Dot = { date: Date | string | number; color?: string };
-type TooltipItem = { id: string; title?: string; color?: string; time?: string; badge?: string; note?: string };
+type TooltipItem = {
+  id: string;
+  title?: string;
+  color?: string;
+  time?: string;
+  badge?: string;
+  note?: string;
+  onSelect?: () => void;
+};
 
 type Props = {
   weekOf: Date;
@@ -104,10 +112,17 @@ export default function WeekWidgetDesktop({
   const items = useMemo(() => {
     if (!tooltipDate) return [];
     const cb = getTooltipItems?.(tooltipDate) ?? [];
-    if (cb.length) return cb;
+    if (cb.length) {
+      return [...cb].sort((a, b) => Number(Boolean(b.note)) - Number(Boolean(a.note)));
+    }
     const k = dateKey(tooltipDate);
     const dayDots = dotMap.get(k) || [];
-    return dayDots.map((c, i) => ({ id: `dot-${k}-${i}`, title: "Event", color: c } as TooltipItem));
+    return dayDots
+      .map(
+        (c, i) =>
+          ({ id: `dot-${k}-${i}`, title: "Event", color: c } satisfies TooltipItem)
+      )
+      .sort((a, b) => Number(Boolean(b.note)) - Number(Boolean(a.note)));
   }, [tooltipDate, getTooltipItems, dotMap]);
 
   // Close on outside / ESC / scroll-resize
@@ -166,7 +181,29 @@ export default function WeekWidgetDesktop({
         }
       >
         {list.map((it) => (
-          <div key={it.id} className="ww-tt-item">
+          <div
+            key={it.id}
+            className={`ww-tt-item${it.onSelect ? " ww-tt-item--action" : ""}`}
+            role={it.onSelect ? "button" : undefined}
+            tabIndex={it.onSelect ? 0 : undefined}
+            onClick={() => {
+              if (!it.onSelect) return;
+              it.onSelect();
+              setTooltipDate(null);
+              setAnchor(null);
+              setShowAll(false);
+            }}
+            onKeyDown={(e) => {
+              if (!it.onSelect) return;
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                it.onSelect();
+                setTooltipDate(null);
+                setAnchor(null);
+                setShowAll(false);
+              }
+            }}
+          >
             <span className="ww-tt-dot" style={{ background: it.color || "#999" }} />
             <div className="ww-tt-body">
               <div className="ww-tt-title">{it.title ?? "Untitled"}</div>

--- a/frontend/src/dashboard/home/components/week-widget.css
+++ b/frontend/src/dashboard/home/components/week-widget.css
@@ -215,6 +215,24 @@
   column-gap:8px;
   align-items:start;
   padding:3px 0;
+  outline: none;
+}
+
+.ww-tt-item--action{
+  cursor: pointer;
+  padding:3px 6px;
+  margin:0 -6px;
+  border-radius:6px;
+}
+
+.ww-tt-item--action:hover,
+.ww-tt-item--action:focus-visible{
+  background: rgba(255,255,255,0.08);
+}
+
+.ww-tt-item--action:focus-visible{
+  outline:2px solid rgba(250,51,86,0.55);
+  outline-offset:2px;
 }
 
 .ww-tt-dot{

--- a/frontend/src/dashboard/home/pages/DashboardHome.tsx
+++ b/frontend/src/dashboard/home/pages/DashboardHome.tsx
@@ -131,7 +131,7 @@ const WelcomeScreen: React.FC = () => {
   // 👉 Tooltip data for a tapped day (projects running that day + same-day events)
   const getTooltipItems = (date: Date) => {
     const day = toDay(date)!;
-    const items: { id: string; title?: string; color?: string; note?: string }[] = [];
+    const items: { id: string; title?: string; color?: string; note?: string; onSelect?: () => void }[] = [];
 
     for (const p of (projects as ProjectWithDetails[])) {
       const color = colorMap[p.projectId] || "#FA3356";
@@ -139,15 +139,30 @@ const WelcomeScreen: React.FC = () => {
       const end = toDay(p.finishline);
 
       if (start && end && day >= start && day <= end) {
-        items.push({ id: p.projectId, title: p.title || p.projectId, color });
+        items.push({
+          id: p.projectId,
+          title: p.title || p.projectId,
+          color,
+          onSelect: () => void handleNavigateToProject({ projectId: p.projectId }),
+        });
       }
       for (const ev of p.timelineEvents ?? []) {
         const d = toDay(ev.date);
         if (sameDay(d, day)) {
           const note = (ev.description as string) || undefined;
           const hit = items.find((i) => i.id === p.projectId);
-          if (hit) hit.note ??= note;
-          else items.push({ id: p.projectId, title: p.title || p.projectId, color, note });
+          if (hit) {
+            hit.note ??= note;
+            if (!hit.onSelect) hit.onSelect = () => void handleNavigateToProject({ projectId: p.projectId });
+          } else {
+            items.push({
+              id: p.projectId,
+              title: p.title || p.projectId,
+              color,
+              note,
+              onSelect: () => void handleNavigateToProject({ projectId: p.projectId }),
+            });
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary
- allow week widget tooltip items to trigger project navigation so tasks are reachable from mobile and desktop views
- prioritize tooltip entries with timeline notes and close the tooltip once an item is selected for smoother navigation
- style tooltip list rows for interactive focus and hover feedback when they are clickable

## Testing
- npm run lint *(fails because of pre-existing lint errors in unrelated gallery files)*
- npx eslint src/dashboard/home/components/WeekWidget.tsx src/dashboard/home/components/WeekWidgetDesktop.tsx src/dashboard/home/components/AllProjectsWeekWidget.tsx src/dashboard/home/components/AllProjectsCalendar.tsx src/dashboard/home/pages/DashboardHome.tsx


------
https://chatgpt.com/codex/tasks/task_e_68d65cf5948c8324a054bd0b0373a583