### PR TITLE
Handle legacy gallery slugs in project ID routing

### DIFF
--- a/frontend/src/app/routes.tsx
+++ b/frontend/src/app/routes.tsx
@@ -150,8 +150,8 @@ const ActualRoutes: React.FC<ActualRoutesProps> = ({ location }) => {
           } 
         />
         
-        <Route 
-          path="/gallery/:projectSlug/:gallerySlug" 
+        <Route
+          path="/gallery/:projectId/:gallerySlug"
           element={
             <motion.div
               initial="initial"

--- a/frontend/src/dashboard/project/components/Gallery/hooks/useGalleryController.ts
+++ b/frontend/src/dashboard/project/components/Gallery/hooks/useGalleryController.ts
@@ -1,4 +1,4 @@
-import { DragEventHandler, useEffect, useMemo, useRef, useState } from "react";
+import { DragEventHandler, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { toast } from "react-toastify";
 
@@ -314,12 +314,23 @@ const useGalleryController = (): GalleryController => {
   const legacyCount = legacyGalleries.length;
   const hasGalleries = combinedGalleries.length > 0;
 
+  const resolveProjectRouteKey = useCallback(() => {
+    if (activeProjectId) return activeProjectId;
+    if (activeProjectTitle) return slugify(activeProjectTitle);
+    return null;
+  }, [activeProjectId, activeProjectTitle]);
+
   const handleTriggerClick = async () => {
     if (combinedGalleries.length > 0) {
       const lastGallery = combinedGalleries[combinedGalleries.length - 1];
       const slug = lastGallery.slug || slugify(lastGallery.name || "");
+      const projectKey = resolveProjectRouteKey();
+      if (!projectKey) {
+        console.warn("Cannot navigate to gallery without an active project reference");
+        return;
+      }
       await fetchProjects(1);
-      navigate(`/gallery/${slugify(activeProjectTitle || "")}/${slug}`);
+      navigate(`/gallery/${projectKey}/${slug}`);
     } else {
       openModal();
     }
@@ -337,8 +348,13 @@ const useGalleryController = (): GalleryController => {
       return;
     }
 
+    const projectKey = resolveProjectRouteKey();
+    if (!projectKey) {
+      console.warn("Cannot navigate to gallery without an active project reference");
+      return;
+    }
     await fetchProjects(1);
-    navigate(`/gallery/${slugify(activeProjectTitle || "")}/${slug}`);
+    navigate(`/gallery/${projectKey}/${slug}`);
   };
 
   const isEditing = editingIndex !== null;

--- a/frontend/src/dashboard/project/features/gallery/GalleryPage.extra.test.tsx
+++ b/frontend/src/dashboard/project/features/gallery/GalleryPage.extra.test.tsx
@@ -4,6 +4,36 @@ import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 
+const createProjectsContextValue = (overrides: Record<string, unknown> = {}) => ({
+  projects: [],
+  setProjects: vi.fn(),
+  setUserProjects: vi.fn(),
+  isLoading: false,
+  setIsLoading: vi.fn(),
+  loadingProfile: false,
+  activeProject: null,
+  setActiveProject: vi.fn(),
+  selectedProjects: [],
+  setSelectedProjects: vi.fn(),
+  fetchProjectDetails: vi.fn(),
+  fetchProjects: vi.fn(),
+  fetchUserProfile: vi.fn(),
+  fetchRecentActivity: vi.fn(),
+  opacity: 1,
+  setOpacity: vi.fn(),
+  settingsUpdated: false,
+  toggleSettingsUpdated: vi.fn(),
+  dmReadStatus: {},
+  setDmReadStatus: vi.fn(),
+  projectsError: false,
+  updateTimelineEvents: vi.fn(),
+  updateProjectFields: vi.fn(),
+  isAdmin: false,
+  isBuilder: false,
+  isDesigner: false,
+  ...overrides,
+});
+
 // Mock ReactModal
 vi.mock('react-modal', () => {
   const Modal = ({ children }: { children?: React.ReactNode }) => 
@@ -29,34 +59,7 @@ vi.mock('../../../../app/contexts/useUser', () => ({
 }));
 
 vi.mock('../../../../app/contexts/useProjects', () => ({
-  useProjects: vi.fn(() => ({
-    projects: [],
-    setProjects: vi.fn(),
-    setUserProjects: vi.fn(),
-    isLoading: false,
-    setIsLoading: vi.fn(),
-    loadingProfile: false,
-    activeProject: null,
-    setActiveProject: vi.fn(),
-    selectedProjects: [],
-    setSelectedProjects: vi.fn(),
-    fetchProjectDetails: vi.fn(),
-    fetchProjects: vi.fn(),
-    fetchUserProfile: vi.fn(),
-    fetchRecentActivity: vi.fn(),
-    opacity: 1,
-    setOpacity: vi.fn(),
-    settingsUpdated: false,
-    toggleSettingsUpdated: vi.fn(),
-    dmReadStatus: {},
-    setDmReadStatus: vi.fn(),
-    projectsError: false,
-    updateTimelineEvents: vi.fn(),
-    updateProjectFields: vi.fn(),
-    isAdmin: false,
-    isBuilder: false,
-    isDesigner: false,
-  })),
+  useProjects: vi.fn(() => createProjectsContextValue()),
 }));
 
 vi.mock('../../../../app/contexts/useMessages', () => ({
@@ -115,6 +118,7 @@ afterEach(() => {
 });
 
 import { useParams, useNavigate } from 'react-router-dom';
+import { useProjects } from '@/app/contexts/useProjects';
 import { fetchGalleries } from '@/shared/utils/api';
 
 // Mock CSS modules
@@ -129,6 +133,7 @@ vi.mock('./gallery-page.module.css', () => ({
 const fetchGalleriesMock = vi.mocked(fetchGalleries);
 const useParamsMock = vi.mocked(useParams);
 const useNavigateMock = vi.mocked(useNavigate);
+const useProjectsMock = vi.mocked(useProjects);
 
 describe('GalleryPage', () => {
   beforeEach(async () => {
@@ -136,10 +141,11 @@ describe('GalleryPage', () => {
       const { default: GalleryPageImport } = await import('./GalleryPage');
       GalleryPage = GalleryPageImport;
     }
+    useProjectsMock.mockReturnValue(createProjectsContextValue());
     fetchGalleriesMock.mockResolvedValue([
       { projectId: '1', name: 'client 001', slug: 'client-001', updatedSvgUrl: '/test.svg', imageUrls: ['img1.png'] },
     ]);
-    useParamsMock.mockReturnValue({ projectSlug: 'project-1', gallerySlug: 'client-001' });
+    useParamsMock.mockReturnValue({ projectId: 'project-1', gallerySlug: 'client-001' });
     useNavigateMock.mockReturnValue(vi.fn());
   });
 
@@ -167,7 +173,32 @@ describe('GalleryPage', () => {
     render(<GalleryPage projectId="1" />);
     const backButton = await screen.findByRole('button', { name: /back to dashboard/i });
     await userEvent.click(backButton);
-    expect(navigateMock).toHaveBeenCalledWith('/dashboard');
+    expect(navigateMock).toHaveBeenCalledWith('/dashboard/projects/1');
+  });
+
+  it('resolves project id when the route provides a slug', async () => {
+    const navigateMock = vi.fn();
+    useNavigateMock.mockReturnValue(navigateMock);
+    const projectsValue = createProjectsContextValue({
+      projects: [
+        {
+          projectId: '1',
+          title: 'Client 001',
+          gallery: [
+            { name: 'client 001', slug: 'client-001', updatedSvgUrl: '/test.svg', imageUrls: ['img1.png'] },
+          ],
+        },
+      ],
+    });
+    useProjectsMock.mockReturnValue(projectsValue as any);
+    useParamsMock.mockReturnValue({ projectId: 'client-001', gallerySlug: 'client-001' });
+
+    render(<GalleryPage />);
+
+    await waitFor(() => expect(fetchGalleriesMock).toHaveBeenCalledWith('1'));
+    const backButton = await screen.findByRole('button', { name: /back to dashboard/i });
+    await userEvent.click(backButton);
+    expect(navigateMock).toHaveBeenCalledWith('/dashboard/projects/1');
   });
 
   it('renders gallery page with link navigation', async () => {
@@ -176,7 +207,7 @@ describe('GalleryPage', () => {
     fetchGalleriesMock.mockResolvedValue([
       { projectId: 'project-1', name: 'link-gallery', slug: 'link', link: '/other' },
     ]);
-    useParamsMock.mockReturnValue({ projectSlug: 'project-2', gallerySlug: 'link' });
+    useParamsMock.mockReturnValue({ projectId: 'project-2', gallerySlug: 'link' });
     render(<GalleryPage projectId="1" />);
     await waitFor(() => expect(navigateMock).toHaveBeenCalledWith('/other'));
   });
@@ -196,7 +227,7 @@ describe('GalleryPage', () => {
     fetchGalleriesMock.mockResolvedValue([
       { projectId: 'project-1', name: 'secret', slug: 'secret', passwordHash: 'abc', passwordEnabled: true },
     ]);
-    useParamsMock.mockReturnValue({ projectSlug: 'project-3', gallerySlug: 'secret' });
+    useParamsMock.mockReturnValue({ projectId: 'project-3', gallerySlug: 'secret' });
     render(<GalleryPage projectId="1" />);
     const input = await screen.findByTestId('password-input');
     expect(input).toBeInTheDocument();
@@ -223,7 +254,7 @@ describe('GalleryPage', () => {
     fetchGalleriesMock.mockResolvedValue([
       { projectId: 'project-1', slug: 'pdf', updatedPdfUrl: '/dummy.pdf', imageUrls: ['img1.png'] },
     ]);
-    useParamsMock.mockReturnValue({ projectSlug: 'project-4', gallerySlug: 'pdf' });
+    useParamsMock.mockReturnValue({ projectId: 'project-4', gallerySlug: 'pdf' });
     const { default: GalleryPagePdf } = await import('./GalleryPage');
     render(<GalleryPagePdf />);
     expect(pdfjs.getDocument).toHaveBeenCalled();
@@ -247,7 +278,7 @@ describe('GalleryPage', () => {
     fetchGalleriesMock.mockResolvedValue([
       { projectId: 'project-1', slug: 'pdf', updatedPdfUrl: '/dummy.pdf' },
     ]);
-    useParamsMock.mockReturnValue({ projectSlug: 'project-5', gallerySlug: 'pdf' });
+    useParamsMock.mockReturnValue({ projectId: 'project-5', gallerySlug: 'pdf' });
     const { default: GalleryPagePdf } = await import('./GalleryPage');
     render(<GalleryPagePdf />);
     const container = await screen.findByTestId('svg-container');

--- a/frontend/src/dashboard/project/features/gallery/GalleryPage.tsx
+++ b/frontend/src/dashboard/project/features/gallery/GalleryPage.tsx
@@ -127,30 +127,45 @@ const renderScale = 2; // scale used when rendering pages in Lambda
    ============================ */
 
 const GalleryPage: FC<GalleryPageProps> = ({ projectId: propProjectId }) => {
-  const { gallerySlug, projectSlug } = useParams<{
+  const { gallerySlug, projectId: projectIdParam } = useParams<{
     gallerySlug: string;
-    projectSlug: string;
+    projectId: string;
   }>();
   const navigate = useNavigate();
 
   const { projects } = useData() as { projects?: Project[] };
 
-  const projectObj = useMemo(
-    () => (projects ? (findProjectBySlug(projects, projectSlug) as Project | undefined) : undefined),
-    [projects, projectSlug]
-  );
+  const projectMatch = useMemo(() => {
+    if (!projectIdParam || !Array.isArray(projects)) return undefined;
+    return projects.find((project) => project.projectId === projectIdParam);
+  }, [projectIdParam, projects]);
 
-  const projectId = propProjectId || projectObj?.projectId;
+  const projectFromSlug = useMemo(() => {
+    if (!projectIdParam || !Array.isArray(projects)) return undefined;
+    return findProjectBySlug(projects as Project[], projectIdParam) || undefined;
+  }, [projectIdParam, projects]);
+
+  const projectId =
+    propProjectId || projectMatch?.projectId || projectFromSlug?.projectId || projectIdParam;
 
   if (import.meta.env.DEV) {
     console.log("Loaded projects in GalleryPage:", projects);
-    console.log("Project slug:", projectSlug);
+    console.log("Project route ID or slug:", projectIdParam);
+    console.log("Matched project ID:", projectMatch?.projectId);
     console.log("Resolved project ID:", projectId);
   }
 
   if (typeof document !== "undefined") {
     ReactModal.setAppElement("#root");
   }
+
+  const handleBack = useCallback(() => {
+    if (projectId) {
+      navigate(`/dashboard/projects/${encodeURIComponent(projectId)}`);
+    } else {
+      navigate("/dashboard");
+    }
+  }, [navigate, projectId]);
 
   const [apiGalleries, setApiGalleries] = useState<Gallery[] | null>(null);
   const [loadingGalleries, setLoadingGalleries] = useState<boolean>(!!projectId);
@@ -580,7 +595,7 @@ const GalleryPage: FC<GalleryPageProps> = ({ projectId: propProjectId }) => {
           onToggleLayout={() => setUseMasonryLayout((v) => !v)}
           downloadUrl={normalizedOriginalUrl || ""}
           isPdf={isPdf}
-          onBack={() => navigate("/dashboard")}
+          onBack={handleBack}
         />
 
         {useMasonryLayout ? (

--- a/frontend/src/shared/ui/LayoutPdfButtons.tsx
+++ b/frontend/src/shared/ui/LayoutPdfButtons.tsx
@@ -23,23 +23,23 @@ const LayoutPdfButtons: React.FC<LayoutPdfButtonsProps> = ({
   backLabel = 'Back to dashboard',
 }) => (
   <div className={`${styles.container} ${className}`.trim()}>
-    <div className={styles.layoutToggle}>
-      <button
-        type="button"
-        onClick={onToggleLayout}
-        className={styles.actionButton}
-      >
-        <LayoutGrid size={16} />
-        <span>{useMasonryLayout ? 'Grid Layout' : 'Masonry Layout'}</span>
+    {onBack && (
+      <button type="button" onClick={onBack} className={styles.actionButton}>
+        <ArrowLeft size={16} />
+        <span>{backLabel}</span>
       </button>
-    </div>
+    )}
     <div className={styles.actionGroup}>
-      {onBack && (
-        <button type="button" onClick={onBack} className={styles.actionButton}>
-          <ArrowLeft size={16} />
-          <span>{backLabel}</span>
+      <div className={styles.layoutToggle}>
+        <button
+          type="button"
+          onClick={onToggleLayout}
+          className={styles.actionButton}
+        >
+          <LayoutGrid size={16} />
+          <span>{useMasonryLayout ? 'Grid Layout' : 'Masonry Layout'}</span>
         </button>
-      )}
+      </div>
       {downloadUrl && (
         <a href={getFileUrl(downloadUrl)} download className={styles.actionButton}>
           <FileDown size={16} />

--- a/frontend/src/shared/ui/layout-pdf-buttons.module.css
+++ b/frontend/src/shared/ui/layout-pdf-buttons.module.css
@@ -11,7 +11,7 @@
 
 .layoutToggle {
   display: flex;
-  flex: 1 1 auto;
+  flex: none;
 }
 
 .actionGroup {


### PR DESCRIPTION
## Summary
- resolve the gallery page's project ID from either a direct ID or legacy slug so older links keep working
- fall back to a slugified project title when gallery navigation is triggered without an ID
- extend the gallery page test harness with configurable project context data and coverage for slug-based routes

## Testing
- npm test -- src/dashboard/project/features/gallery/GalleryPage.extra.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d642db19388324a84ffc2f9f6327dd