### PR TITLE
feat: persist working budget revision sessions

### DIFF
--- a/frontend/src/dashboard/project/features/budget/ClientInvoicePreviewModal.tsx
+++ b/frontend/src/dashboard/project/features/budget/ClientInvoicePreviewModal.tsx
@@ -3,6 +3,7 @@ import React from "react";
 
 import InvoicePreviewModal from "@/dashboard/project/features/budget/components/InvoicePreviewModal";
 import { BudgetProvider } from "@/dashboard/project/features/budget/context/BudgetProvider";
+import { BudgetRevisionSessionProvider } from "@/dashboard/project/features/budget/context/BudgetRevisionSessionContext";
 import { Project } from "@/app/contexts/DataProvider";
 
 interface RevisionLike {
@@ -23,16 +24,18 @@ const ClientInvoicePreviewModal: React.FC<ClientInvoicePreviewModalProps> = ({
   revision,
   project,
 }) => (
-  <BudgetProvider projectId={project?.projectId}>
-    <InvoicePreviewModal
-      isOpen={isOpen}
-      onRequestClose={onRequestClose}
-      revision={revision}
-      project={project}
-      showSidebar={false}
-      allowSave={false}
-    />
-  </BudgetProvider>
+  <BudgetRevisionSessionProvider>
+    <BudgetProvider projectId={project?.projectId}>
+      <InvoicePreviewModal
+        isOpen={isOpen}
+        onRequestClose={onRequestClose}
+        revision={revision}
+        project={project}
+        showSidebar={false}
+        allowSave={false}
+      />
+    </BudgetProvider>
+  </BudgetRevisionSessionProvider>
 );
 
 export default ClientInvoicePreviewModal;

--- a/frontend/src/dashboard/project/features/budget/components/EventEditModal.test.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/EventEditModal.test.tsx
@@ -41,6 +41,7 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import { vi, test, expect, beforeAll } from "vitest";
 import EventEditModal from "./EventEditModal";
 import { BudgetProvider } from "../context/BudgetProvider";
+import { BudgetRevisionSessionProvider } from "../context/BudgetRevisionSessionContext";
 import { DataProvider } from "../../../../../app/contexts/DataProvider";
 import { AuthProvider } from "../../../../../app/contexts/AuthContext";
 
@@ -54,17 +55,19 @@ test("uses last event date as default after adding", () => {
   render(
     <AuthProvider>
       <DataProvider>
-        <BudgetProvider projectId="p1">
-          <EventEditModal
-            isOpen={true}
-            onRequestClose={() => {}}
-            projectId="p1"
-            budgetItemId="LINE-1"
-            events={[]}
-            defaultDate="2024-05-01"
-            defaultDescription=""
-          />
-        </BudgetProvider>
+        <BudgetRevisionSessionProvider>
+          <BudgetProvider projectId="p1">
+            <EventEditModal
+              isOpen={true}
+              onRequestClose={() => {}}
+              projectId="p1"
+              budgetItemId="LINE-1"
+              events={[]}
+              defaultDate="2024-05-01"
+              defaultDescription=""
+            />
+          </BudgetProvider>
+        </BudgetRevisionSessionProvider>
       </DataProvider>
     </AuthProvider>
   );
@@ -89,19 +92,21 @@ test("uses last event date as default after adding", () => {
 test("displays event description for existing events", () => {
   render(
     <DataProvider>
-      <BudgetProvider projectId="p1">
-        <EventEditModal
-          isOpen={true}
-          onRequestClose={() => {}}
-          projectId="p1"
-          budgetItemId="LINE-1"
-          events={[
-            { id: "1", date: "2024-05-01", hours: 2, description: "Setup" },
-          ]}
-          defaultDate="2024-05-01"
-          defaultDescription=""
-        />
-      </BudgetProvider>
+      <BudgetRevisionSessionProvider>
+        <BudgetProvider projectId="p1">
+          <EventEditModal
+            isOpen={true}
+            onRequestClose={() => {}}
+            projectId="p1"
+            budgetItemId="LINE-1"
+            events={[
+              { id: "1", date: "2024-05-01", hours: 2, description: "Setup" },
+            ]}
+            defaultDate="2024-05-01"
+            defaultDescription=""
+          />
+        </BudgetProvider>
+      </BudgetRevisionSessionProvider>
     </DataProvider>
   );
 

--- a/frontend/src/dashboard/project/features/budget/context/BudgetProvider.test.tsx
+++ b/frontend/src/dashboard/project/features/budget/context/BudgetProvider.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { render } from "@testing-library/react";
 import { vi } from "vitest";
 import { BudgetProvider } from "./BudgetProvider";
+import { BudgetRevisionSessionProvider } from "./BudgetRevisionSessionContext";
 import { useBudget } from "./BudgetContext";
 
 // Mock the dependencies
@@ -94,9 +95,11 @@ const TestComponent = () => {
 describe("BudgetProvider", () => {
   test("provides memoized selectors with correct data", () => {
     const { getByTestId } = render(
-      <BudgetProvider projectId="test-project">
-        <TestComponent />
-      </BudgetProvider>
+      <BudgetRevisionSessionProvider>
+        <BudgetProvider projectId="test-project">
+          <TestComponent />
+        </BudgetProvider>
+      </BudgetRevisionSessionProvider>
     );
 
     // Test that stats are calculated correctly
@@ -126,9 +129,11 @@ describe("BudgetProvider", () => {
     };
 
     const { getByTestId } = render(
-      <BudgetProvider projectId="test-project">
-        <TestComponentNoCosts />
-      </BudgetProvider>
+      <BudgetRevisionSessionProvider>
+        <BudgetProvider projectId="test-project">
+          <TestComponentNoCosts />
+        </BudgetProvider>
+      </BudgetRevisionSessionProvider>
     );
 
     // Should use ballpark when no final costs

--- a/frontend/src/dashboard/project/features/budget/context/BudgetProvider.tsx
+++ b/frontend/src/dashboard/project/features/budget/context/BudgetProvider.tsx
@@ -5,16 +5,61 @@ import { useData } from "@/app/contexts/useData";
 import { normalizeMessage } from "@/shared/utils/websocketUtils";
 import { BudgetContext } from "./BudgetContext";
 import type { BudgetStats, PieDataItem, BudgetWebSocketOperations } from "./types";
+import { useBudgetRevisionSession } from "./BudgetRevisionSessionContext";
+
+const normalizeRevision = (value: unknown): number | null => {
+  if (typeof value === "number" && !Number.isNaN(value)) return value;
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value);
+    return Number.isNaN(parsed) ? null : parsed;
+  }
+  return null;
+};
+
+const extractDocVersion = (header: Record<string, unknown> | null): number | null => {
+  if (!header) return null;
+  const shape = header as {
+    docVersion?: unknown;
+    version?: unknown;
+    updatedAt?: unknown;
+  };
+  const candidate = typeof shape.docVersion === "number" ? shape.docVersion : shape.version;
+  if (typeof candidate === "number" && Number.isFinite(candidate)) {
+    return candidate;
+  }
+  const updatedAt = shape.updatedAt;
+  if (typeof updatedAt === "number" && Number.isFinite(updatedAt)) {
+    return updatedAt;
+  }
+  if (typeof updatedAt === "string" && updatedAt.trim() !== "") {
+    const parsed = Date.parse(updatedAt);
+    if (!Number.isNaN(parsed)) return parsed;
+  }
+  return null;
+};
 
 interface ProviderProps extends PropsWithChildren {
   projectId?: string;
 }
 
 export const BudgetProvider: React.FC<ProviderProps> = ({ projectId, children }) => {
-  const { budgetHeader, budgetItems, setBudgetHeader, setBudgetItems, refresh, loading } = useBudgetData(projectId);
+  const {
+    workingRevisionId,
+    syncFromServerSnapshot,
+    setWorkingRevisionId,
+    setDocVersion,
+  } = useBudgetRevisionSession();
+  const {
+    budgetHeader,
+    budgetItems,
+    setBudgetHeader,
+    setBudgetItems,
+    refresh,
+    loading,
+  } = useBudgetData(projectId, { revision: workingRevisionId ?? undefined });
   const { ws } = useSocket();
   const { user, userId } = useData();
-  
+
   const refreshRef = useRef(refresh);
   const lockedLinesRef = useRef<string[]>([]);
   
@@ -172,6 +217,26 @@ export const BudgetProvider: React.FC<ProviderProps> = ({ projectId, children })
     emitLineUnlock,
     emitTimelineUpdate,
   }), [emitBudgetUpdate, emitLineLock, emitLineUnlock, emitTimelineUpdate]);
+
+  useEffect(() => {
+    if (!budgetHeader) {
+      syncFromServerSnapshot(null, null, null);
+      return;
+    }
+    const budgetId =
+      typeof budgetHeader.budgetId === "string" && budgetHeader.budgetId.trim() !== ""
+        ? budgetHeader.budgetId
+        : null;
+    const revision = normalizeRevision(budgetHeader.revision);
+    const docVersion = extractDocVersion(budgetHeader);
+    syncFromServerSnapshot(budgetId, revision, docVersion);
+    if (revision != null && workingRevisionId == null) {
+      setWorkingRevisionId(revision, { persist: false, markOverride: false });
+    }
+    if (docVersion != null) {
+      setDocVersion(docVersion, { persist: false });
+    }
+  }, [budgetHeader, syncFromServerSnapshot, workingRevisionId, setWorkingRevisionId, setDocVersion]);
 
   useEffect(() => {
     if (!ws) return;

--- a/frontend/src/dashboard/project/features/budget/context/BudgetRevisionSessionContext.tsx
+++ b/frontend/src/dashboard/project/features/budget/context/BudgetRevisionSessionContext.tsx
@@ -1,0 +1,267 @@
+import React, { createContext, useCallback, useContext, useMemo, useState } from "react";
+
+export type BudgetRevisionSessionValue = {
+  budgetId: string | null;
+  workingRevisionId: number | null;
+  docVersion: number;
+  hasUserOverride: boolean;
+  setWorkingRevisionId: (revision: number | null, options?: { persist?: boolean; markOverride?: boolean }) => void;
+  setDocVersion: (version: number, options?: { persist?: boolean }) => void;
+  syncFromServerSnapshot: (
+    budgetId: string | null,
+    revision: number | null,
+    version?: number | null,
+  ) => void;
+  clearOverride: () => void;
+};
+
+const defaultValue: BudgetRevisionSessionValue = {
+  budgetId: null,
+  workingRevisionId: null,
+  docVersion: 0,
+  hasUserOverride: false,
+  setWorkingRevisionId: () => {},
+  setDocVersion: () => {},
+  syncFromServerSnapshot: () => {},
+  clearOverride: () => {},
+};
+
+const BudgetRevisionSessionContext = createContext<BudgetRevisionSessionValue>(defaultValue);
+
+const STORAGE_PREFIX = "budget-revision-session:";
+
+type PersistedSession = {
+  revision: number | null;
+  version: number | null;
+};
+
+const isFiniteNumber = (value: unknown): value is number =>
+  typeof value === "number" && Number.isFinite(value);
+
+function normalizeRevision(input: unknown): number | null {
+  if (typeof input === "number" && !Number.isNaN(input)) return input;
+  if (typeof input === "string" && input.trim() !== "") {
+    const parsed = Number(input);
+    return Number.isNaN(parsed) ? null : parsed;
+  }
+  return null;
+}
+
+function readPersistedSession(budgetId: string): PersistedSession | null {
+  if (typeof window === "undefined" || !window?.localStorage) return null;
+  try {
+    const raw = window.localStorage.getItem(`${STORAGE_PREFIX}${budgetId}`);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<PersistedSession>;
+    const revision = normalizeRevision(parsed?.revision);
+    const version = isFiniteNumber(parsed?.version) ? parsed?.version ?? null : null;
+    return { revision, version };
+  } catch (err) {
+    console.warn("Failed to read persisted budget session", err);
+    return null;
+  }
+}
+
+function persistSession(budgetId: string, session: PersistedSession): void {
+  if (typeof window === "undefined" || !window?.localStorage) return;
+  if (!budgetId) return;
+  try {
+    const payload: PersistedSession = {
+      revision: normalizeRevision(session.revision),
+      version: isFiniteNumber(session.version) ? session.version : null,
+    };
+    window.localStorage.setItem(`${STORAGE_PREFIX}${budgetId}`, JSON.stringify(payload));
+  } catch (err) {
+    console.warn("Failed to persist budget session", err);
+  }
+}
+
+function clearPersistedSession(budgetId: string): void {
+  if (typeof window === "undefined" || !window?.localStorage) return;
+  if (!budgetId) return;
+  try {
+    window.localStorage.removeItem(`${STORAGE_PREFIX}${budgetId}`);
+  } catch (err) {
+    console.warn("Failed to clear budget session", err);
+  }
+}
+
+type SessionState = {
+  budgetId: string | null;
+  workingRevisionId: number | null;
+  docVersion: number;
+  userPinned: boolean;
+};
+
+const initialState: SessionState = {
+  budgetId: null,
+  workingRevisionId: null,
+  docVersion: 0,
+  userPinned: false,
+};
+
+type ProviderProps = React.PropsWithChildren<unknown>;
+
+export const BudgetRevisionSessionProvider: React.FC<ProviderProps> = ({ children }) => {
+  const [state, setState] = useState<SessionState>(initialState);
+
+  const syncFromServerSnapshot = useCallback<BudgetRevisionSessionValue["syncFromServerSnapshot"]>(
+    (incomingBudgetId, incomingRevision, incomingVersion) => {
+      setState((prev) => {
+        if (!incomingBudgetId) {
+          if (
+            prev.budgetId === null &&
+            prev.workingRevisionId === null &&
+            prev.docVersion === 0 &&
+            !prev.userPinned
+          ) {
+            return prev;
+          }
+          return initialState;
+        }
+
+        const normalizedRevision = normalizeRevision(incomingRevision);
+        const normalizedVersion = isFiniteNumber(incomingVersion) ? incomingVersion : null;
+
+        if (incomingBudgetId !== prev.budgetId) {
+          const persisted = readPersistedSession(incomingBudgetId);
+          const revisionFromStorage = persisted?.revision ?? normalizedRevision;
+          const versionFromStorage =
+            persisted?.version ?? normalizedVersion ?? (prev.docVersion || 0);
+
+          if (persisted) {
+            return {
+              budgetId: incomingBudgetId,
+              workingRevisionId: revisionFromStorage,
+              docVersion: versionFromStorage ?? 0,
+              userPinned: persisted.revision != null,
+            };
+          }
+
+          persistSession(incomingBudgetId, {
+            revision: revisionFromStorage,
+            version: versionFromStorage,
+          });
+
+          return {
+            budgetId: incomingBudgetId,
+            workingRevisionId: revisionFromStorage,
+            docVersion: versionFromStorage ?? 0,
+            userPinned: false,
+          };
+        }
+
+        let nextRevision = prev.workingRevisionId;
+        if (!prev.userPinned && normalizedRevision != null) {
+          nextRevision = normalizedRevision;
+        }
+
+        const nextVersion = normalizedVersion ?? prev.docVersion;
+
+        if (prev.budgetId) {
+          persistSession(prev.budgetId, { revision: nextRevision, version: nextVersion });
+        }
+
+        if (
+          nextRevision === prev.workingRevisionId &&
+          nextVersion === prev.docVersion &&
+          prev.userPinned === prev.userPinned
+        ) {
+          return prev;
+        }
+
+        return {
+          budgetId: prev.budgetId,
+          workingRevisionId: nextRevision,
+          docVersion: nextVersion,
+          userPinned: prev.userPinned,
+        };
+      });
+    },
+    [],
+  );
+
+  const setWorkingRevisionId = useCallback<BudgetRevisionSessionValue["setWorkingRevisionId"]>(
+    (revision, options = {}) => {
+      const { persist = true, markOverride } = options;
+      setState((prev) => {
+        const nextRevision = normalizeRevision(revision);
+        const shouldMarkOverride =
+          typeof markOverride === "boolean" ? markOverride : persist;
+        const nextState: SessionState = {
+          budgetId: prev.budgetId,
+          workingRevisionId: nextRevision,
+          docVersion: prev.docVersion,
+          userPinned: shouldMarkOverride ? true : prev.userPinned && nextRevision != null,
+        };
+
+        if (prev.budgetId && persist) {
+          if (nextRevision == null) {
+            clearPersistedSession(prev.budgetId);
+          } else {
+            persistSession(prev.budgetId, {
+              revision: nextRevision,
+              version: prev.docVersion,
+            });
+          }
+        }
+
+        if (
+          nextState.workingRevisionId === prev.workingRevisionId &&
+          nextState.userPinned === prev.userPinned
+        ) {
+          return prev;
+        }
+        return nextState;
+      });
+    },
+    [],
+  );
+
+  const setDocVersion = useCallback<BudgetRevisionSessionValue["setDocVersion"]>(
+    (version, options = {}) => {
+      const { persist = true } = options;
+      setState((prev) => {
+        const nextVersion = isFiniteNumber(version) ? version : prev.docVersion;
+        if (nextVersion === prev.docVersion) return prev;
+        if (prev.budgetId && persist) {
+          persistSession(prev.budgetId, {
+            revision: prev.workingRevisionId,
+            version: nextVersion,
+          });
+        }
+        return { ...prev, docVersion: nextVersion };
+      });
+    },
+    [],
+  );
+
+  const clearOverride = useCallback(() => {
+    setState((prev) => ({ ...prev, userPinned: false }));
+  }, []);
+
+  const value = useMemo<BudgetRevisionSessionValue>(
+    () => ({
+      budgetId: state.budgetId,
+      workingRevisionId: state.workingRevisionId,
+      docVersion: state.docVersion,
+      hasUserOverride: state.userPinned,
+      setWorkingRevisionId,
+      setDocVersion,
+      syncFromServerSnapshot,
+      clearOverride,
+    }),
+    [state, setWorkingRevisionId, setDocVersion, syncFromServerSnapshot, clearOverride],
+  );
+
+  return (
+    <BudgetRevisionSessionContext.Provider value={value}>
+      {children}
+    </BudgetRevisionSessionContext.Provider>
+  );
+};
+
+export const useBudgetRevisionSession = (): BudgetRevisionSessionValue =>
+  useContext(BudgetRevisionSessionContext);
+
+export default BudgetRevisionSessionContext;

--- a/frontend/src/dashboard/project/features/budget/context/useBudget.ts
+++ b/frontend/src/dashboard/project/features/budget/context/useBudget.ts
@@ -1,5 +1,5 @@
-import { useState, useEffect, useCallback } from "react";
-import { fetchBudgetHeader, fetchBudgetItems } from "@/shared/utils/api";
+import { useState, useEffect, useCallback, useRef } from "react";
+import { fetchBudgetHeaders, fetchBudgetItems } from "@/shared/utils/api";
 
 function shallowEqualObjects(
   a: Record<string, unknown> | null,
@@ -32,21 +32,40 @@ type BudgetItem = Record<string, unknown>;
 interface BudgetData {
   header: BudgetHeader | null;
   items: BudgetItem[];
+  headers: BudgetHeader[];
 }
 
 // In-memory cache and in-flight trackers keyed by projectId
 const budgetCache = new Map<string, BudgetData>();
 const inflight = new Map<string, Promise<BudgetData>>();
 
-async function fetchData(projectId: string, force = false): Promise<BudgetData> {
-  if (!projectId) return { header: null, items: [] };
+const cacheKey = (projectId: string, revision: number | null): string =>
+  `${projectId || "__none__"}::${revision != null ? revision : "__default__"}`;
 
-  if (!force && budgetCache.has(projectId)) {
-    return budgetCache.get(projectId)!;
+const normalizeRevision = (value: unknown): number | null => {
+  if (typeof value === "number" && !Number.isNaN(value)) return value;
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value);
+    return Number.isNaN(parsed) ? null : parsed;
+  }
+  return null;
+};
+
+async function fetchData(
+  projectId: string,
+  revision: number | null,
+  force = false,
+): Promise<BudgetData> {
+  if (!projectId) return { header: null, items: [], headers: [] };
+
+  const key = cacheKey(projectId, revision);
+
+  if (!force && budgetCache.has(key)) {
+    return budgetCache.get(key)!;
   }
 
-  if (inflight.has(projectId)) {
-    return inflight.get(projectId)!;
+  if (inflight.has(key)) {
+    return inflight.get(key)!;
   }
 
   const promise = (async () => {
@@ -56,13 +75,24 @@ async function fetchData(projectId: string, force = false): Promise<BudgetData> 
     // Simple exponential backoff for 429 errors
     while (true) {
       try {
-        const header = await fetchBudgetHeader(projectId);
-        let items: BudgetItem[] = [];
-        if (header?.budgetId) {
-          items = await fetchBudgetItems(header.budgetId, header.revision);
+        const headers = await fetchBudgetHeaders(projectId);
+        let selected: BudgetHeader | null = null;
+        if (revision != null) {
+          selected = headers.find((h) => Number(h.revision ?? NaN) === revision) || null;
         }
-        const result: BudgetData = { header, items };
-        budgetCache.set(projectId, result);
+        if (!selected) {
+          const client = headers.find(
+            (h) => h.clientRevisionId != null && h.clientRevisionId === h.revision,
+          );
+          selected = client || headers[0] || null;
+        }
+
+        let items: BudgetItem[] = [];
+        if (selected?.budgetId) {
+          items = await fetchBudgetItems(selected.budgetId, selected.revision);
+        }
+        const result: BudgetData = { header: selected, items, headers };
+        budgetCache.set(key, result);
         return result;
       } catch (err: unknown) {
         const msg = String((err as { message?: string })?.message || "");
@@ -77,11 +107,11 @@ async function fetchData(projectId: string, force = false): Promise<BudgetData> 
     }
   })();
 
-  inflight.set(projectId, promise);
+  inflight.set(key, promise);
   try {
     return await promise;
   } finally {
-    inflight.delete(projectId);
+    inflight.delete(key);
   }
 }
 
@@ -90,24 +120,41 @@ async function fetchData(projectId: string, force = false): Promise<BudgetData> 
  * component state. This allows subsequent calls to the hook to render
  * immediately with cached data.
  */
-export async function prefetchBudgetData(projectId: string): Promise<void> {
-  if (!projectId || budgetCache.has(projectId)) return;
+export async function prefetchBudgetData(projectId: string, revision?: number | null): Promise<void> {
+  if (!projectId) return;
+  const normalizedRevision = revision != null && !Number.isNaN(revision) ? revision : null;
+  const key = cacheKey(projectId, normalizedRevision);
+  if (budgetCache.has(key)) return;
   try {
-    await fetchData(projectId);
+    await fetchData(projectId, normalizedRevision);
   } catch (err) {
     console.error("Error prefetching budget data", err);
   }
 }
 
-export default function useBudgetData(projectId: string | undefined) {
-  const cached = projectId ? budgetCache.get(projectId) : null;
+interface UseBudgetDataOptions {
+  revision?: number | null;
+}
+
+export default function useBudgetData(
+  projectId: string | undefined,
+  options: UseBudgetDataOptions = {},
+) {
+  const normalizedRevision =
+    options.revision != null && !Number.isNaN(options.revision)
+      ? Number(options.revision)
+      : null;
+  const cached = projectId ? budgetCache.get(cacheKey(projectId, normalizedRevision)) : null;
   const [budgetHeader, setBudgetHeader] = useState<BudgetHeader | null>(
     cached ? cached.header : null,
   );
   const [budgetItems, setBudgetItemsState] = useState<BudgetItem[]>(
     cached ? cached.items : [],
   );
+  const [headers, setHeaders] = useState<BudgetHeader[]>(cached ? cached.headers : []);
   const [loading, setLoading] = useState(!cached);
+  const initialRevision = normalizeRevision(cached?.header?.revision) ?? normalizedRevision ?? null;
+  const currentRevisionRef = useRef<number | null>(initialRevision);
 
   useEffect(() => {
     let ignore = false;
@@ -115,13 +162,14 @@ export default function useBudgetData(projectId: string | undefined) {
       if (!projectId) {
         setBudgetHeader(null);
         setBudgetItemsState([]);
+        setHeaders([]);
         setLoading(false);
         return;
       }
 
       setLoading(true);
       try {
-        const { header, items } = await fetchData(projectId);
+        const { header, items, headers: allHeaders } = await fetchData(projectId, normalizedRevision);
         if (!ignore) {
           setBudgetHeader((prev) =>
             shallowEqualObjects(prev, header) ? prev : header,
@@ -129,12 +177,15 @@ export default function useBudgetData(projectId: string | undefined) {
           setBudgetItemsState((prev) =>
             shallowEqualArrays(prev, items) ? prev : items,
           );
+          setHeaders(allHeaders);
+          currentRevisionRef.current = normalizeRevision(header?.revision);
         }
       } catch (err) {
         console.error("Error fetching budget data", err);
         if (!ignore) {
           setBudgetHeader(null);
           setBudgetItemsState([]);
+          setHeaders([]);
         }
       } finally {
         if (!ignore) setLoading(false);
@@ -144,19 +195,21 @@ export default function useBudgetData(projectId: string | undefined) {
     return () => {
       ignore = true;
     };
-  }, [projectId]);
+  }, [projectId, normalizedRevision]);
 
   const refresh = useCallback(async () => {
     if (!projectId) return null;
     setLoading(true);
     try {
-      const data = await fetchData(projectId, true);
+      const data = await fetchData(projectId, normalizedRevision, true);
       setBudgetHeader((prev) =>
         shallowEqualObjects(prev, data.header) ? prev : data.header,
       );
       setBudgetItemsState((prev) =>
         shallowEqualArrays(prev, data.items) ? prev : data.items,
       );
+      setHeaders(data.headers);
+      currentRevisionRef.current = normalizeRevision(data.header?.revision) ?? currentRevisionRef.current;
       return data;
     } catch (err) {
       console.error("Error refreshing budget data", err);
@@ -164,7 +217,7 @@ export default function useBudgetData(projectId: string | undefined) {
     } finally {
       setLoading(false);
     }
-  }, [projectId]);
+  }, [projectId, normalizedRevision]);
 
   const setBudgetItems = useCallback(
     (items: BudgetItem[]) => {
@@ -172,13 +225,15 @@ export default function useBudgetData(projectId: string | undefined) {
       setBudgetItemsState((prev) =>
         shallowEqualArrays(prev, items) ? prev : items,
       );
-      const cached = budgetCache.get(projectId) || {
-        header: null,
+      const key = cacheKey(projectId, currentRevisionRef.current ?? normalizedRevision ?? null);
+      const cachedEntry = budgetCache.get(key) || {
+        header: null as BudgetHeader | null,
         items: [] as BudgetItem[],
+        headers: [] as BudgetHeader[],
       };
-      budgetCache.set(projectId, { header: cached.header, items });
+      budgetCache.set(key, { header: cachedEntry.header, items, headers: cachedEntry.headers });
     },
-    [projectId],
+    [projectId, normalizedRevision],
   );
 
   const updateBudgetHeader = useCallback(
@@ -190,15 +245,18 @@ export default function useBudgetData(projectId: string | undefined) {
             ? (headerOrUpdater as (p: BudgetHeader | null) => BudgetHeader)(prev)
             : headerOrUpdater;
         if (shallowEqualObjects(prev, next)) return prev;
-        const cached = budgetCache.get(projectId) || {
-          header: null,
+        const key = cacheKey(projectId, currentRevisionRef.current ?? normalizedRevision ?? null);
+        const cachedEntry = budgetCache.get(key) || {
+          header: null as BudgetHeader | null,
           items: [] as BudgetItem[],
+          headers: [] as BudgetHeader[],
         };
-        budgetCache.set(projectId, { header: next, items: cached.items });
+        budgetCache.set(key, { header: next, items: cachedEntry.items, headers: cachedEntry.headers });
+        currentRevisionRef.current = normalizeRevision(next?.revision) ?? currentRevisionRef.current;
         return next;
       });
     },
-    [projectId],
+    [projectId, normalizedRevision],
   );
 
   return {
@@ -208,6 +266,7 @@ export default function useBudgetData(projectId: string | undefined) {
     setBudgetItems,
     refresh,
     loading,
+    headers,
   };
 }
 

--- a/frontend/src/dashboard/project/features/budget/pages/BudgetPage.tsx
+++ b/frontend/src/dashboard/project/features/budget/pages/BudgetPage.tsx
@@ -29,6 +29,7 @@ import BudgetEventManager from "@/dashboard/project/features/budget/components/B
 import BudgetTableLogic from "@/dashboard/project/features/budget/components/BudgetTableLogic";
 import { BudgetProvider} from "@/dashboard/project/features/budget/context/BudgetProvider";
 import { useBudget } from "@/dashboard/project/features/budget/context/BudgetContext";
+import { useBudgetRevisionSession, BudgetRevisionSessionProvider } from "@/dashboard/project/features/budget/context/BudgetRevisionSessionContext";
 import { useData } from "@/app/contexts/useData";
 import type { Project, TimelineEvent } from "@/app/contexts/DataProvider";
 import { getProjectDashboardPath } from "@/shared/utils/projectUrl";
@@ -45,6 +46,15 @@ import { v4 as uuid } from "uuid";
 
 
 const TABLE_BOTTOM_MARGIN = 20;
+
+const normalizeRevisionValue = (value: unknown): number | null => {
+  if (typeof value === "number" && !Number.isNaN(value)) return value;
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value);
+    return Number.isNaN(parsed) ? null : parsed;
+  }
+  return null;
+};
 
 // Inner component that uses the budget context
 const BudgetPageContent = () => {
@@ -80,6 +90,10 @@ const BudgetPageContent = () => {
     wsOps,
   } = useBudget();
   const { emitBudgetUpdate } = wsOps;
+  const {
+    workingRevisionId,
+    setWorkingRevisionId,
+  } = useBudgetRevisionSession();
 
   // Simplified state for remaining functionality
   const [error, setError] = useState(null);
@@ -241,8 +255,19 @@ const BudgetPageContent = () => {
     try {
       const revs = await fetchBudgetHeaders(activeProject.projectId);
       setRevisions(revs);
-      const header =
-        revs.find((h) => h.revision === h.clientRevisionId) || revs[0] || null;
+      let header: Record<string, any> | null = null;
+      if (workingRevisionId != null) {
+        header =
+          revs.find((h) => Number(h.revision ?? NaN) === Number(workingRevisionId)) || null;
+      }
+      if (!header) {
+        header =
+          revs.find((h) => h.revision === h.clientRevisionId) || revs[0] || null;
+        const normalized = normalizeRevisionValue(header?.revision);
+        if (normalized != null && workingRevisionId == null) {
+          setWorkingRevisionId(normalized, { persist: false, markOverride: false });
+        }
+      }
       if (header) {
         if (header.budgetId) {
           const items = await fetchBudgetItems(header.budgetId, header.revision);
@@ -254,7 +279,12 @@ const BudgetPageContent = () => {
     } catch (err) {
       console.error("Error fetching budget header", err);
     }
-  }, [activeProject?.projectId, computeGroupsAndClients]);
+  }, [
+    activeProject?.projectId,
+    computeGroupsAndClients,
+    workingRevisionId,
+    setWorkingRevisionId,
+  ]);
 
   useEffect(() => {
     refresh();
@@ -358,6 +388,7 @@ const BudgetPageContent = () => {
       computeGroupsAndClients(newItems, newHeader);
       const revs = await fetchBudgetHeaders(activeProject.projectId);
       setRevisions(revs);
+      setWorkingRevisionId(newRev);
       emitBudgetUpdate();
     } catch (err) {
       console.error('Error creating new revision', err);
@@ -373,6 +404,7 @@ const BudgetPageContent = () => {
       setBudgetHeader((prev) => (prev ? { ...prev, ...header } : header));
       setBudgetItems(items);
       computeGroupsAndClients(items, header);
+      setWorkingRevisionId(rev);
     } catch (err) {
       console.error('Error switching revision', err);
     }
@@ -402,12 +434,14 @@ const BudgetPageContent = () => {
           setBudgetHeader(nextHeader);
           setBudgetItems(nextItems);
           computeGroupsAndClients(nextItems, nextHeader);
+          setWorkingRevisionId(normalizeRevisionValue(nextHeader.revision));
         } else {
           setBudgetHeader(null);
           setBudgetItems([]);
           setAreaGroups([]);
           setInvoiceGroups([]);
           setClients([]);
+          setWorkingRevisionId(null);
         }
       }
       emitBudgetUpdate();
@@ -689,11 +723,13 @@ const BudgetPageContent = () => {
 // Main component that provides the budget context
 const BudgetPage = () => {
   const { activeProject } = useData();
-  
+
   return (
-    <BudgetProvider projectId={activeProject?.projectId}>
-      <BudgetPageContent />
-    </BudgetProvider>
+    <BudgetRevisionSessionProvider>
+      <BudgetProvider projectId={activeProject?.projectId}>
+        <BudgetPageContent />
+      </BudgetProvider>
+    </BudgetRevisionSessionProvider>
   );
 };
 

--- a/frontend/src/dashboard/project/features/calendar/calendar.tsx
+++ b/frontend/src/dashboard/project/features/calendar/calendar.tsx
@@ -6,6 +6,7 @@ import { useSocket } from '@/app/contexts/SocketContext';
 import { useNavigate, useParams, useLocation } from 'react-router-dom';
 import { getProjectDashboardPath } from '@/shared/utils/projectUrl';
 import { BudgetProvider } from '@/dashboard/project/features/budget/context/BudgetProvider';
+import { BudgetRevisionSessionProvider } from '@/dashboard/project/features/budget/context/BudgetRevisionSessionContext';
 import type { Project } from '@/app/contexts/DataProvider';
 import type { QuickLinksRef } from '@/dashboard/project/components';
 import { useProjectPalette } from '@/dashboard/project/hooks/useProjectPalette';
@@ -176,15 +177,17 @@ const CalendarPage: React.FC = () => {
       />
 
       <div className="dashboard-layout calendar-layout" style={{ paddingBottom: '5px' }}>
-        <BudgetProvider projectId={activeProject?.projectId}>
-          <ProjectCalendar
-            project={activeProject as ProjectCalendarProject}
-            initialFlashDate={null}
-            onDateSelect={(d: string) => {
-              setTimelineDate(d);
-            }}
-          />
-        </BudgetProvider>
+        <BudgetRevisionSessionProvider>
+          <BudgetProvider projectId={activeProject?.projectId}>
+            <ProjectCalendar
+              project={activeProject as ProjectCalendarProject}
+              initialFlashDate={null}
+              onDateSelect={(d: string) => {
+                setTimelineDate(d);
+              }}
+            />
+          </BudgetProvider>
+        </BudgetRevisionSessionProvider>
         <TimelineChart
           project={activeProject as {
             color?: string;

--- a/frontend/src/dashboard/project/project.tsx
+++ b/frontend/src/dashboard/project/project.tsx
@@ -13,6 +13,7 @@ import LocationComponent from "@/dashboard/project/components/Shared/LocationCom
 import FileManagerComponent from "@/dashboard/project/components/FileManager/FileManager";
 import TasksComponent from "@/dashboard/project/components/Tasks/TasksComponent";
 import { BudgetProvider } from "@/dashboard/project/features/budget/context/BudgetProvider";
+import { BudgetRevisionSessionProvider } from "@/dashboard/project/features/budget/context/BudgetRevisionSessionContext";
 import { useData } from "@/app/contexts/useData";
 import { useSocket } from "@/app/contexts/useSocket";
 import { useParams, useNavigate, useLocation } from "react-router-dom";
@@ -340,9 +341,10 @@ const SingleProject: React.FC = () => {
   );
 
   const projectContent = resolvedActiveProject ? (
-    <BudgetProvider projectId={resolvedActiveProject.projectId}>
-      <div className="overview-layout">
-        <QuickLinksComponent ref={quickLinksRef} hideTrigger />
+    <BudgetRevisionSessionProvider>
+      <BudgetProvider projectId={resolvedActiveProject.projectId}>
+        <div className="overview-layout">
+          <QuickLinksComponent ref={quickLinksRef} hideTrigger />
 
         {FileManagerComponent && (
           <FileManagerComponent
@@ -393,7 +395,8 @@ const SingleProject: React.FC = () => {
           </div>
         </div>
       </div>
-    </BudgetProvider>
+      </BudgetProvider>
+    </BudgetRevisionSessionProvider>
   ) : null;
 
   // Render


### PR DESCRIPTION
## Summary
- add a BudgetRevisionSessionProvider to remember working budget revisions and doc versions per user session
- update the budget data/provider stack to respect the session working revision and persist it across loads
- wrap project, calendar, and preview entry points (and related tests) with the new revision session context

## Testing
- npm run test *(fails: broader suite contains unrelated failing specs and was aborted)*
- npx vitest run src/dashboard/project/features/budget/context/BudgetProvider.test.tsx src/dashboard/project/features/budget/components/EventEditModal.test.tsx *(hangs under current environment; aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68d6603a938883249b7374c0a775839b