### PR TITLE
Fix WeekWidget tooltip project navigation

### DIFF
--- a/frontend/src/dashboard/home/components/AllProjectsWeekWidget.tsx
+++ b/frontend/src/dashboard/home/components/AllProjectsWeekWidget.tsx
@@ -1,7 +1,9 @@
 import React, { useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import WeekWidget, { type Track, type Dot } from "./WeekWidget";
 import { useData } from "@/app/contexts/useData";
 import { getColor } from "@/shared/utils/colorUtils";
+import { getProjectDashboardPath } from "@/shared/utils/projectUrl";
 
 type TimelineEvent = { date?: string; description?: string; [k: string]: unknown };
 type Project = {
@@ -25,6 +27,7 @@ function sameDay(a: Date | null, b: Date | null) {
 export default function AllProjectsWeekWidget({ className = "" }: { className?: string }) {
   const { projects = [] } = useData() as { projects: Project[] };
   const [weekOf, setWeekOf] = useState<Date>(new Date());
+  const navigate = useNavigate();
 
   // Map for consistent colors
   const colorMap = useMemo(() => {
@@ -60,7 +63,7 @@ export default function AllProjectsWeekWidget({ className = "" }: { className?: 
   // 👉 Tooltip data for a tapped day (projects running that day + same-day events)
   const getTooltipItems = (date: Date) => {
     const day = toDay(date)!;
-    const items: { id: string; title?: string; color?: string; note?: string }[] = [];
+    const items: { id: string; title?: string; color?: string; note?: string; onClick?: () => void }[] = [];
 
     for (const p of projects) {
       const color = colorMap[p.projectId] || "#FA3356";
@@ -68,15 +71,29 @@ export default function AllProjectsWeekWidget({ className = "" }: { className?: 
       const end = toDay(p.finishline);
 
       if (start && end && day >= start && day <= end) {
-        items.push({ id: p.projectId, title: p.title || p.projectId, color });
+        items.push({
+          id: p.projectId,
+          title: p.title || p.projectId,
+          color,
+          onClick: () => navigate(getProjectDashboardPath(p.projectId, p.title)),
+        });
       }
       for (const ev of p.timelineEvents ?? []) {
         const d = toDay(ev.date);
         if (sameDay(d, day)) {
           const note = (ev.description as string) || undefined;
           const hit = items.find((i) => i.id === p.projectId);
-          if (hit) hit.note ??= note;
-          else items.push({ id: p.projectId, title: p.title || p.projectId, color, note });
+          if (hit) {
+            hit.note ??= note;
+          } else {
+            items.push({
+              id: p.projectId,
+              title: p.title || p.projectId,
+              color,
+              note,
+              onClick: () => navigate(getProjectDashboardPath(p.projectId, p.title)),
+            });
+          }
         }
       }
     }

--- a/frontend/src/dashboard/home/components/WeekWidget.tsx
+++ b/frontend/src/dashboard/home/components/WeekWidget.tsx
@@ -1,11 +1,19 @@
-import React, { useMemo, useState, useEffect } from "react";
+import React, { useMemo, useState, useEffect, useCallback } from "react";
 import { createPortal } from "react-dom";
 import { startOfWeek, endOfWeek, addDays } from "../utils/dateUtils";
 import "./week-widget.css";
 
 export type Track = { id: string; color: string; start: Date | string | number; end: Date | string | number };
 export type Dot = { date: Date | string | number; color?: string };
-type TooltipItem = { id: string; title?: string; color?: string; time?: string; badge?: string; note?: string };
+type TooltipItem = {
+  id: string;
+  title?: string;
+  color?: string;
+  time?: string;
+  badge?: string;
+  note?: string;
+  onClick?: () => void;
+};
 
 type Props = {
   weekOf: Date;
@@ -114,14 +122,18 @@ export default function WeekWidget({
     return dayDots.map((c, i) => ({ id: `dot-${k}-${i}`, title: "Event", color: c } as TooltipItem));
   }, [tooltipDate, getTooltipItems, dotMap]);
 
+  const closeTooltip = useCallback(() => {
+    setTooltipDate(null);
+    setAnchor(null);
+    setShowAll(false);
+  }, []);
+
   // Close on outside / ESC / scroll-resize (keeps it simple on mobile)
   useEffect(() => {
     if (!tooltipDate) return;
     const close = (e: MouseEvent | TouchEvent | KeyboardEvent | Event) => {
       if ((e as KeyboardEvent).type === "keydown" && (e as KeyboardEvent).key !== "Escape") return;
-      setTooltipDate(null);
-      setAnchor(null);
-      setShowAll(false);
+      closeTooltip();
     };
     window.addEventListener("mousedown", close, { passive: true });
     window.addEventListener("touchstart", close, { passive: true });
@@ -135,7 +147,7 @@ export default function WeekWidget({
       window.removeEventListener("scroll", close as EventListener);
       window.removeEventListener("resize", close as EventListener);
     };
-  }, [tooltipDate]);
+  }, [tooltipDate, closeTooltip]);
 
   // Compute tooltip position (fixed, via portal)
   const tip = useMemo(() => {
@@ -169,16 +181,40 @@ export default function WeekWidget({
           } as React.CSSProperties
         }
       >
-        {list.map((it) => (
-          <div key={it.id} className="ww-tt-item">
-            <span className="ww-tt-dot" style={{ background: it.color || "#999" }} />
-            <div className="ww-tt-body">
-              <div className="ww-tt-title">{it.title ?? "Untitled"}</div>
-              {it.note && <div className="ww-tt-note">{it.note}</div>}
-              {it.time && <div className="ww-tt-time">{it.time}</div>}
+        {list.map((it) => {
+          const content = (
+            <>
+              <span className="ww-tt-dot" style={{ background: it.color || "#999" }} />
+              <div className="ww-tt-body">
+                <div className="ww-tt-title">{it.title ?? "Untitled"}</div>
+                {it.note && <div className="ww-tt-note">{it.note}</div>}
+                {it.time && <div className="ww-tt-time">{it.time}</div>}
+              </div>
+            </>
+          );
+
+          if (typeof it.onClick === "function") {
+            return (
+              <button
+                key={it.id}
+                type="button"
+                className="ww-tt-item"
+                onClick={() => {
+                  it.onClick?.();
+                  closeTooltip();
+                }}
+              >
+                {content}
+              </button>
+            );
+          }
+
+          return (
+            <div key={it.id} className="ww-tt-item">
+              {content}
             </div>
-          </div>
-        ))}
+          );
+        })}
         {overflow > 0 && !showAll && (
           <button
             className="ww-tt-more-pill"
@@ -189,7 +225,7 @@ export default function WeekWidget({
           </button>
         )}
 
-        <button className="ww-tt-close" onClick={() => { setTooltipDate(null); setAnchor(null); setShowAll(false); }} aria-label="Close">
+        <button className="ww-tt-close" onClick={closeTooltip} aria-label="Close">
           <svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true">
             <path d="M6 6 L18 18 M18 6 L6 18" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/>
           </svg>
@@ -197,7 +233,7 @@ export default function WeekWidget({
       </div>,
       document.body
     );
-  }, [mobile, tooltipDate, items, anchor, showAll]);
+  }, [mobile, tooltipDate, items, anchor, showAll, closeTooltip]);
 
   const containerClass = [
     "week-widget",
@@ -230,9 +266,9 @@ export default function WeekWidget({
             const same = tooltipDate && dateKey(tooltipDate) === k;
             onSelectDate?.(day);
             if (same) {
-              setTooltipDate(null);
-              setAnchor(null);
+              closeTooltip();
             } else {
+              setShowAll(false);
               const rect = el.getBoundingClientRect();
               setAnchor({ x: rect.left + rect.width / 2, y: rect.top });
               setTooltipDate(day);

--- a/frontend/src/dashboard/home/components/week-widget.css
+++ b/frontend/src/dashboard/home/components/week-widget.css
@@ -217,6 +217,24 @@
   padding:3px 0;
 }
 
+button.ww-tt-item{
+  width:100%;
+  background:none;
+  border:none;
+  color:inherit;
+  font:inherit;
+  text-align:left;
+  cursor:pointer;
+  -webkit-tap-highlight-color:transparent;
+  padding:3px 0;
+}
+
+button.ww-tt-item:focus-visible{
+  outline:2px solid rgba(250,51,86,0.55);
+  outline-offset:2px;
+  border-radius:6px;
+}
+
 .ww-tt-dot{
   width:5px;                      /* smaller dot */
   height:5px;


### PR DESCRIPTION
## Summary
- add support for clickable tooltip entries in the WeekWidget and close logic reuse
- update the AllProjectsWeekWidget tooltip items to navigate directly to project dashboards
- adjust tooltip styling to accommodate button semantics

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d664a31b188324bdca698f434b0d63