### PR TITLE
feat: add mobile project week widget and tweak budget card

### DIFF
--- a/frontend/src/dashboard/home/components/WeekWidget.tsx
+++ b/frontend/src/dashboard/home/components/WeekWidget.tsx
@@ -25,6 +25,8 @@ type Props = {
   onSelectDate?: (d: Date) => void;
   getTooltipItems?: (date: Date) => TooltipItem[];
   isMobile?: boolean;
+  onDateTap?: (day: Date, meta: { anchor: HTMLButtonElement }) => void;
+  registerDayRef?: (day: Date, key: string, node: HTMLButtonElement | null) => void;
 };
 
 function toDate(v: Date | string | number) {
@@ -48,6 +50,8 @@ export default function WeekWidget({
   onSelectDate,
   getTooltipItems,
   isMobile,
+  onDateTap,
+  registerDayRef,
 }: Props) {
   const weekStart = startOfWeek(weekOf);
   const weekEnd = endOfWeek(weekOf);
@@ -278,9 +282,10 @@ export default function WeekWidget({
           const isToday = dateKey(new Date()) === k;
           const isSelected = dateKey(weekOf) === k;
 
-          const handleTap = (el: HTMLElement) => {
+          const handleTap = (el: HTMLButtonElement) => {
             const same = tooltipDate && dateKey(tooltipDate) === k;
             onSelectDate?.(day);
+            onDateTap?.(day, { anchor: el });
             if (same) {
               setTooltipDate(null);
               setAnchor(null);
@@ -292,13 +297,16 @@ export default function WeekWidget({
           };
 
           return (
-            <div
+            <button
               key={k}
               className={`week-day ${isToday ? "today" : ""} ${isSelected ? "selected" : ""}`}
-              onClick={(e) => handleTap(e.currentTarget as HTMLElement)}             // always open on tap
-              onPointerUp={(e) => { if (e.pointerType === "touch") handleTap(e.currentTarget as HTMLElement); }} // touch reliability
-              role="button"
+              onClick={(e) => handleTap(e.currentTarget as HTMLButtonElement)}
+              onPointerUp={(e) => {
+                if (e.pointerType === "touch") handleTap(e.currentTarget as HTMLButtonElement);
+              }}
+              type="button"
               aria-label={day.toDateString()}
+              ref={(node) => registerDayRef?.(day, k, node)}
             >
               <div className="day-name">{day.toLocaleDateString(undefined, { weekday: "short" })}</div>
               <div className="day-number">{day.getDate()}</div>
@@ -341,7 +349,7 @@ export default function WeekWidget({
                   </span>
                 )}
               </div>
-            </div>
+            </button>
           );
         })}
       </div>

--- a/frontend/src/dashboard/home/components/week-widget.css
+++ b/frontend/src/dashboard/home/components/week-widget.css
@@ -62,10 +62,22 @@
   border-radius: 10px;
   background: rgba(255,255,255,0.02);
   border: 1px solid rgba(255,255,255,0.08);
+  display: block;
+  width: 100%;
+  font: inherit;
+  color: inherit;
+  appearance: none;
 }
 .week-day:hover { background: rgba(255,255,255,0.05); }
 .week-day.today { outline: 1px solid rgba(255,255,255,0.18); }
 .week-day.selected { background: rgba(255,255,255,0.08); }
+.week-day:focus-visible {
+  outline: 2px solid rgba(255,255,255,0.45);
+  outline-offset: 2px;
+}
+.week-day::-moz-focus-inner {
+  border: 0;
+}
 
 .day-name { font-size: 11px; color: rgba(255,255,255,0.6); }
 .day-number { font-size: 14px; font-weight: 600; color: #fff; line-height: 1.1; margin-top: 2px; }

--- a/frontend/src/dashboard/home/styles/components/dashboard-cards.css
+++ b/frontend/src/dashboard/home/styles/components/dashboard-cards.css
@@ -273,20 +273,20 @@
 /* Mobile adjustments for dashboard cards */
 @media (max-width: var(--breakpoint-sm)) {
   .dashboard-item.budget {
-    padding: 15px;
+    padding: 12px;
     flex-direction: column;
     align-items: stretch;
-    gap: 16px;
-    min-height: 180px;
+    gap: 12px;
+    min-height: 150px;
   }
   .budget-overview-card {
-    gap: 12px;
+    gap: 10px;
   }
   .budget-overview-summary {
     gap: 4px;
   }
   .budget-overview-header {
-    gap: 8px;
+    gap: 6px;
   }
   .budget-overview-revision {
     margin-left: 6px;
@@ -296,7 +296,7 @@
     margin-top: 6px;
   }
   .budget-overview-amount {
-    margin-top: 4px;
+    margin-top: 2px;
   }
   .budget-overview-invoice-icon {
     margin-left: 4px;

--- a/frontend/src/dashboard/project/components/Shared/calendar/ProjectWeekWidget.tsx
+++ b/frontend/src/dashboard/project/components/Shared/calendar/ProjectWeekWidget.tsx
@@ -1,0 +1,220 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import WeekWidget, { type Dot, type Track } from "@/dashboard/home/components/WeekWidget";
+import { addDays, startOfWeek } from "@/dashboard/home/utils/dateUtils";
+import { getColor } from "@/shared/utils/colorUtils";
+import { DayPopover, DaySheet } from "./DayOverlay";
+import { useCalendarController } from "./useCalendarController";
+import type { CalendarBaseProps } from "./CalendarBase";
+import { formatHours, getDateKey, safeParse } from "./utils";
+import "./project-week-widget.css";
+
+type ProjectWeekWidgetProps = Omit<CalendarBaseProps, "wrapperClassName" | "dayHeaderIdPrefix"> & {
+  className?: string;
+};
+
+const ensureFallbackAnchor = (() => {
+  let fallback: HTMLButtonElement | null = null;
+  return () => {
+    if (fallback) return fallback;
+    if (typeof document === "undefined") {
+      return null;
+    }
+    fallback = document.createElement("button");
+    fallback.type = "button";
+    fallback.style.display = "none";
+    document.body.appendChild(fallback);
+    return fallback;
+  };
+})();
+
+const ProjectWeekWidget: React.FC<ProjectWeekWidgetProps> = ({
+  project,
+  initialFlashDate,
+  onDateSelect,
+  onWrapperClick,
+  showEventList = false,
+  className = "",
+}) => {
+  const controller = useCalendarController({
+    project,
+    initialFlashDate,
+    onDateSelect,
+    onWrapperClick,
+    dayHeaderIdPrefix: "project-week-widget-day",
+    showEventList,
+  });
+
+  const { wrapperHandlers, startDate, endDate, projectColor, selectedKey, eventsByDate, openDay, overlayState, modal } =
+    controller;
+
+  const [weekOf, setWeekOf] = useState<Date>(() => {
+    return safeParse(initialFlashDate) || safeParse(selectedKey) || new Date();
+  });
+
+  useEffect(() => {
+    const parsed = safeParse(selectedKey);
+    if (!parsed) return;
+    const currentKey = getDateKey(weekOf);
+    const nextKey = getDateKey(parsed);
+    if (currentKey !== nextKey) {
+      setWeekOf(parsed);
+    }
+  }, [selectedKey, weekOf]);
+
+  const handleWeekChange = useCallback(
+    (weekStartDate: Date) => {
+      const currentStart = startOfWeek(weekOf);
+      const offset = Math.max(
+        0,
+        Math.min(6, Math.round((weekOf.getTime() - currentStart.getTime()) / 86400000))
+      );
+      const target = addDays(weekStartDate, offset);
+      setWeekOf(target);
+    },
+    [weekOf]
+  );
+
+  const handleSelectDate = useCallback(
+    (date: Date) => {
+      setWeekOf(date);
+      onDateSelect?.(getDateKey(date));
+    },
+    [onDateSelect]
+  );
+
+  const registerDayRef = useRef<Record<string, HTMLButtonElement | null>>({});
+
+  const handleRegisterDayRef = useCallback((day: Date, key: string, node: HTMLButtonElement | null) => {
+    if (node) {
+      registerDayRef.current[key] = node;
+    } else {
+      delete registerDayRef.current[key];
+    }
+  }, []);
+
+  const getAnchorForKey = useCallback(
+    (key: string) => {
+      return registerDayRef.current[key] || ensureFallbackAnchor();
+    },
+    []
+  );
+
+  const tracks = useMemo<Track[]>(() => {
+    if (!startDate || !endDate) return [];
+    return [
+      {
+        id: "project-range",
+        color: projectColor,
+        start: startDate,
+        end: endDate,
+      },
+    ];
+  }, [startDate, endDate, projectColor]);
+
+  const dots = useMemo<Dot[]>(() => {
+    return Object.entries(eventsByDate).reduce<Dot[]>((acc, [key, items]) => {
+      const parsed = safeParse(key);
+      if (!parsed) return acc;
+      items.forEach((event, index) => {
+        const color = projectColor || getColor(event.description || event.id || `${key}-${index}`);
+        acc.push({ date: parsed, color });
+      });
+      return acc;
+    }, []);
+  }, [eventsByDate, projectColor]);
+
+  const getTooltipItems = useCallback(
+    (date: Date) => {
+      const key = getDateKey(date);
+      if (!key) return [];
+
+      const dayEvents = eventsByDate[key] || [];
+
+      const items = dayEvents.map((event, index) => ({
+        id: event.id || `${key}-event-${index}`,
+        title: event.description || "Untitled Event",
+        time: formatHours(event.hours) || undefined,
+        color: projectColor || getColor(event.description || event.id || key),
+        onSelect: () => {
+          const anchor = getAnchorForKey(key);
+          if (anchor) {
+            openDay(anchor, { date, dayKey: key, inMonth: true });
+          }
+          overlayState.onEdit(event);
+        },
+      }));
+
+      items.push({
+        id: `${key}-add-event`,
+        title: "Add Event",
+        note: dayEvents.length ? "Schedule another timeline item" : "Schedule a timeline event",
+        color: projectColor,
+        onSelect: () => {
+          const anchor = getAnchorForKey(key);
+          if (anchor) {
+            openDay(anchor, { date, dayKey: key, inMonth: true });
+          }
+          overlayState.onNew();
+        },
+      });
+
+      return items;
+    },
+    [eventsByDate, getAnchorForKey, openDay, overlayState, projectColor]
+  );
+
+  const weekWidgetClass = ["project-week-widget", className].filter(Boolean).join(" ");
+
+  return (
+    <div
+      className={weekWidgetClass}
+      onClick={wrapperHandlers.onClick}
+      onMouseEnter={wrapperHandlers.onMouseEnter}
+      onMouseMove={wrapperHandlers.onMouseMove}
+      onMouseLeave={wrapperHandlers.onMouseLeave}
+      role="presentation"
+    >
+      <WeekWidget
+        weekOf={weekOf}
+        tracks={tracks}
+        dots={dots}
+        onPrevWeek={handleWeekChange}
+        onNextWeek={handleWeekChange}
+        onSelectDate={handleSelectDate}
+        getTooltipItems={getTooltipItems}
+        registerDayRef={handleRegisterDayRef}
+        className="project-week-widget-inner"
+        isMobile
+      />
+
+      {overlayState.isOpen && overlayState.dayKey && (
+        overlayState.isMobile ? (
+          <DaySheet
+            headerId={overlayState.headerId}
+            dateLabel={overlayState.dateLabel}
+            events={overlayState.events}
+            onClose={overlayState.close}
+            onNew={overlayState.onNew}
+            onEdit={overlayState.onEdit}
+            onDelete={overlayState.onDelete}
+          />
+        ) : overlayState.anchor ? (
+          <DayPopover
+            anchor={overlayState.anchor}
+            headerId={overlayState.headerId}
+            dateLabel={overlayState.dateLabel}
+            events={overlayState.events}
+            onClose={() => overlayState.close()}
+            onNew={overlayState.onNew}
+            onEdit={overlayState.onEdit}
+            onDelete={overlayState.onDelete}
+          />
+        ) : null
+      )}
+
+      {modal.component}
+    </div>
+  );
+};
+
+export default ProjectWeekWidget;

--- a/frontend/src/dashboard/project/components/Shared/calendar/project-week-widget.css
+++ b/frontend/src/dashboard/project/components/Shared/calendar/project-week-widget.css
@@ -1,0 +1,36 @@
+.project-week-widget {
+  position: relative;
+}
+
+.project-week-widget-inner {
+  width: 100%;
+}
+
+.project-week-widget-inner.week-widget {
+  margin: 0;
+  box-shadow: none;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: var(--surface-card, rgba(20, 20, 20, 0.9));
+}
+
+.project-week-widget-inner.week-widget .week-widget-header {
+  margin-bottom: 8px;
+}
+
+.project-week-widget-inner.week-widget .week-nav-btn {
+  border-color: rgba(255, 255, 255, 0.14);
+}
+
+.project-week-widget-inner.week-widget .week-day {
+  border-color: rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.project-week-widget-inner.week-widget .week-day:hover {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.project-week-widget-inner.week-widget .week-day.selected {
+  background: rgba(255, 255, 255, 0.12);
+}

--- a/frontend/src/dashboard/project/project.tsx
+++ b/frontend/src/dashboard/project/project.tsx
@@ -7,6 +7,7 @@ import GalleryComponent from "@/dashboard/project/components/Gallery/GalleryComp
 
 import ProjectPageLayout from "@/dashboard/project/components/Shared/ProjectPageLayout";
 import CalendarOverviewCard from "@/dashboard/project/components/Shared/calendar/CalendarOverviewCard";
+import ProjectWeekWidget from "@/dashboard/project/components/Shared/calendar/ProjectWeekWidget";
 import QuickLinksComponent from "@/dashboard/project/components/Shared/QuickLinksComponent";
 import type { QuickLinksRef } from "@/dashboard/project/components/Shared/QuickLinksComponent";
 import LocationComponent from "@/dashboard/project/components/Shared/LocationComponent";
@@ -261,9 +262,8 @@ const SingleProject: React.FC = () => {
     };
   }, [ws, resolvedActiveProject?.projectId]);
 
-  const calendarOverviewCard = (
-    <CalendarOverviewCard
-      project={resolvedActiveProject as {
+  const calendarProject = resolvedActiveProject
+    ? (resolvedActiveProject as {
         projectId: string;
         title?: string;
         color?: string;
@@ -289,13 +289,28 @@ const SingleProject: React.FC = () => {
         invoiceBrandPhone?: string;
         clientPhone?: string;
         clientEmail?: string;
-      }}
+      })
+    : null;
+
+  const calendarOverviewCard = calendarProject ? (
+    <CalendarOverviewCard
+      project={calendarProject}
       initialFlashDate={flashDate}
       showEventList={false}
       onWrapperClick={openCalendarPage}
       onDateSelect={noop}
     />
-  );
+  ) : null;
+
+  const calendarWeekWidget = calendarProject ? (
+    <ProjectWeekWidget
+      project={calendarProject}
+      initialFlashDate={flashDate}
+      showEventList={false}
+      onWrapperClick={openCalendarPage}
+      onDateSelect={noop}
+    />
+  ) : null;
 
   const shouldShowLoader = Boolean(
     projectId &&
@@ -363,7 +378,7 @@ const SingleProject: React.FC = () => {
           <div className="budget-column">
             <BudgetOverviewCard projectId={resolvedActiveProject.projectId} />
             {isMobileBudgetLayout && (
-              <div className="budget-calendar-mobile-card">{calendarOverviewCard}</div>
+              <div className="budget-calendar-mobile-card">{calendarWeekWidget}</div>
             )}
 
             <GalleryComponent />


### PR DESCRIPTION
## Summary
- add a ProjectWeekWidget for the project page mobile view that reuses calendar controller logic and surfaces add-event actions
- expose button anchors in WeekWidget and apply mobile-friendly styling updates to support the new tooltip flow
- trim the mobile budget card spacing/height to reduce the visual footprint

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d861d9f4588324ac68b1bfe136050a