### PR TITLE
Add dedicated tasks page and navigation

### DIFF
--- a/frontend/src/app/routes.tsx
+++ b/frontend/src/app/routes.tsx
@@ -26,6 +26,7 @@ const DashboardBudgetPage = React.lazy(() => import("../dashboard/project/featur
 const DashboardCalendarPage = React.lazy(() => import("@/dashboard/project/features/calendar/calendar"));
 const DashboardEditorPage = React.lazy(() => import("@/dashboard/project/features/editor/pages/editorpage"));
 const DashboardMoodboardPage = React.lazy(() => import("@/dashboard/project/features/moodboard/pages/MoodboardPage"));
+const DashboardTasksPage = React.lazy(() => import("@/dashboard/tasks/pages/TasksPage"));
 
 const ScrollToTop: React.FC = () => {
   const { pathname } = useLocation();
@@ -193,6 +194,7 @@ const ActualRoutes: React.FC<ActualRoutesProps> = ({ location }) => {
             path="projects/:projectId/:projectName?/editor"
             element={<DashboardEditorPage />}
           />
+          <Route path="tasks" element={<DashboardTasksPage />} />
           <Route path="new" element={<DashboardNewProject />} />
           <Route path="welcome/*" element={<Navigate to=".." replace />} />
           <Route path="*" element={<DashboardWelcome />} />

--- a/frontend/src/dashboard/home/hooks/useTasksOverview.ts
+++ b/frontend/src/dashboard/home/hooks/useTasksOverview.ts
@@ -35,7 +35,7 @@ type RawTask = {
   [key: string]: unknown;
 };
 
-type TaskStatus = "todo" | "in_progress" | "done" | string;
+export type TaskStatus = "todo" | "in_progress" | "done" | string;
 
 type NormalizedTask = {
   id: string;
@@ -47,6 +47,23 @@ type NormalizedTask = {
   projectColor: string;
   dueKey?: string;
   timeLabel?: string;
+};
+
+export type ProjectTask = {
+  id: string;
+  title: string;
+  status: TaskStatus;
+  dueDate: Date | null;
+  dueLabel?: string;
+  timeLabel?: string;
+};
+
+export type ProjectTasksOverview = {
+  projectId: string;
+  projectName: string;
+  projectColor: string;
+  openTasks: ProjectTask[];
+  completedTasks: ProjectTask[];
 };
 
 export type TasksOverviewEvent = {
@@ -331,18 +348,100 @@ export function useTasksOverview() {
 
   const canNavigateToProject = Boolean(primaryProjectId && projectMap.has(primaryProjectId));
 
+  const tasksByProject: ProjectTasksOverview[] = useMemo(() => {
+    const map = new Map<
+      string,
+      {
+        projectId: string;
+        projectName: string;
+        projectColor: string;
+        open: ProjectTask[];
+        done: ProjectTask[];
+      }
+    >();
+
+    tasks.forEach((task) => {
+      let entry = map.get(task.projectId);
+      if (!entry) {
+        entry = {
+          projectId: task.projectId,
+          projectName: task.projectName,
+          projectColor: task.projectColor,
+          open: [],
+          done: [],
+        };
+        map.set(task.projectId, entry);
+      }
+
+      const projectTask: ProjectTask = {
+        id: task.id,
+        title: task.title,
+        status: task.status,
+        dueDate: task.dueDate,
+        dueLabel: task.dueDate ? dayFormatter.format(task.dueDate) : undefined,
+        timeLabel: task.timeLabel,
+      };
+
+      if (task.status === "done") {
+        entry.done.push(projectTask);
+      } else {
+        entry.open.push(projectTask);
+      }
+    });
+
+    const sortByDueDate = (a: ProjectTask, b: ProjectTask) => {
+      const aTime = a.dueDate ? a.dueDate.getTime() : Number.POSITIVE_INFINITY;
+      const bTime = b.dueDate ? b.dueDate.getTime() : Number.POSITIVE_INFINITY;
+      if (aTime !== bTime) {
+        return aTime - bTime;
+      }
+      return a.title.localeCompare(b.title);
+    };
+
+    const sortCompleted = (a: ProjectTask, b: ProjectTask) => {
+      const aTime = a.dueDate ? a.dueDate.getTime() : Number.NEGATIVE_INFINITY;
+      const bTime = b.dueDate ? b.dueDate.getTime() : Number.NEGATIVE_INFINITY;
+      if (aTime !== bTime) {
+        return bTime - aTime;
+      }
+      return a.title.localeCompare(b.title);
+    };
+
+    return Array.from(map.values())
+      .map((entry) => ({
+        projectId: entry.projectId,
+        projectName: entry.projectName,
+        projectColor: entry.projectColor,
+        openTasks: entry.open.sort(sortByDueDate),
+        completedTasks: entry.done.sort(sortCompleted),
+      }))
+      .sort((a, b) => a.projectName.localeCompare(b.projectName));
+  }, [tasks]);
+
+  const handleNavigateToProject = useCallback(
+    (projectId?: string | null) => {
+      if (!projectId) {
+        navigate("/dashboard/projects");
+        return;
+      }
+
+      const project = projectMap.get(projectId);
+      navigate(getProjectDashboardPath(projectId, project?.title));
+    },
+    [navigate, projectMap],
+  );
+
   const handleNavigateToPrimary = useCallback(() => {
     if (!primaryProjectId) {
       navigate("/dashboard/projects");
       return;
     }
 
-    const project = projectMap.get(primaryProjectId);
-    navigate(getProjectDashboardPath(primaryProjectId, project?.title));
-  }, [navigate, primaryProjectId, projectMap]);
+    handleNavigateToProject(primaryProjectId);
+  }, [handleNavigateToProject, navigate, primaryProjectId]);
 
   const handleViewAll = useCallback(() => {
-    navigate("/dashboard/projects");
+    navigate("/dashboard/tasks");
   }, [navigate]);
 
   return {
@@ -351,8 +450,10 @@ export function useTasksOverview() {
     stats: { completed, dueSoon, overdue } satisfies TasksOverviewStats,
     groups,
     handleNavigateToPrimary,
+    handleNavigateToProject,
     handleViewAll,
     canNavigateToProject,
+    tasksByProject,
   };
 }
 

--- a/frontend/src/dashboard/home/pages/DashboardLayout.tsx
+++ b/frontend/src/dashboard/home/pages/DashboardLayout.tsx
@@ -16,6 +16,7 @@ const Dashboard: React.FC = () => {
   const getPageTitle = (): string => {
     const path = location.pathname;
     if (path.startsWith("/dashboard/projects/")) return "Dashboard - Project Details";
+    if (path.startsWith("/dashboard/tasks")) return "Dashboard - Tasks";
     switch (path) {
       case "/dashboard":
         return `Dashboard - Welcome, ${userName ?? "Guest"}`;

--- a/frontend/src/dashboard/tasks/pages/TasksPage.module.css
+++ b/frontend/src/dashboard/tasks/pages/TasksPage.module.css
@@ -1,0 +1,298 @@
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  padding: 32px 24px 48px;
+  background: var(--dashboard-surface, transparent);
+  color: var(--dashboard-text-primary, #111213);
+}
+
+.header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.titleGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 220px;
+}
+
+.title {
+  margin: 0;
+  font-size: 28px;
+  line-height: 1.1;
+  font-weight: 600;
+}
+
+.subtitle {
+  margin: 0;
+  font-size: 15px;
+  color: var(--dashboard-text-muted, rgba(17, 18, 19, 0.68));
+  max-width: 520px;
+}
+
+.summary {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.summaryStat {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 140px;
+  padding: 16px;
+  border-radius: 16px;
+  border: 1px solid rgba(17, 18, 19, 0.08);
+  background: rgba(255, 255, 255, 0.85);
+  box-shadow: 0 8px 24px rgba(17, 18, 19, 0.04);
+  backdrop-filter: blur(10px);
+}
+
+.summaryLabel {
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(17, 18, 19, 0.52);
+}
+
+.summaryValue {
+  font-size: 26px;
+  font-weight: 600;
+}
+
+.statOk {
+  border-color: color-mix(in srgb, var(--color-success, #4caf50) 40%, transparent);
+}
+
+.statWarn {
+  border-color: color-mix(in srgb, var(--color-warning, #ff9800) 40%, transparent);
+}
+
+.statDanger {
+  border-color: color-mix(in srgb, var(--color-error, #ef5350) 40%, transparent);
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.state {
+  padding: 32px;
+  border-radius: 18px;
+  border: 1px dashed rgba(17, 18, 19, 0.12);
+  background: rgba(255, 255, 255, 0.6);
+  color: rgba(17, 18, 19, 0.7);
+  text-align: center;
+  font-size: 15px;
+}
+
+.projectEmpty {
+  padding: 18px;
+  border-radius: 14px;
+  border: 1px dashed rgba(17, 18, 19, 0.12);
+  background: rgba(249, 249, 250, 0.7);
+  color: rgba(17, 18, 19, 0.6);
+  font-size: 14px;
+}
+
+.projectGrid {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.projectCard {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding: 24px;
+  border-radius: 20px;
+  border: 1px solid rgba(17, 18, 19, 0.08);
+  background: rgba(255, 255, 255, 0.95);
+  box-shadow:
+    0 18px 36px rgba(17, 18, 19, 0.08),
+    inset 0 1px 0 rgba(255, 255, 255, 0.5);
+}
+
+.projectHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.projectInfo {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.projectDot {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  box-shadow: 0 0 0 1px rgba(17, 18, 19, 0.15);
+}
+
+.projectText {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.projectTitle {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.projectMeta {
+  margin: 0;
+  font-size: 13px;
+  color: rgba(17, 18, 19, 0.6);
+}
+
+.startButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 10px 16px;
+  border-radius: 12px;
+  border: 1px solid color-mix(in srgb, var(--brand, #fa3356) 55%, transparent);
+  background: color-mix(in srgb, var(--brand, #fa3356) 18%, white 82%);
+  color: color-mix(in srgb, var(--brand, #fa3356) 82%, black 18%);
+  font-weight: 600;
+  transition: transform 0.18s ease, box-shadow 0.18s ease, background-color 0.18s ease;
+}
+
+.startButton:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 20px rgba(250, 51, 86, 0.18);
+}
+
+.startButton:focus-visible {
+  outline: 2px solid var(--color-focus, var(--brand, #fa3356));
+  outline-offset: 3px;
+}
+
+.taskList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.taskItem {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.taskText {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.taskTitle {
+  font-size: 15px;
+  font-weight: 600;
+  margin: 0;
+}
+
+.taskMeta {
+  font-size: 13px;
+  color: rgba(17, 18, 19, 0.58);
+  font-variant-numeric: tabular-nums;
+}
+
+.taskStatus {
+  flex-shrink: 0;
+  font-size: 12px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: rgba(17, 18, 19, 0.5);
+  align-self: center;
+}
+
+.completedSection {
+  border-top: 1px solid rgba(17, 18, 19, 0.08);
+  padding-top: 16px;
+}
+
+.completedSummary {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 600;
+  color: rgba(17, 18, 19, 0.66);
+}
+
+.completedSummary::-webkit-details-marker {
+  display: none;
+}
+
+.completedList {
+  list-style: none;
+  margin: 12px 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.completedItem {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  font-size: 13px;
+  color: rgba(17, 18, 19, 0.58);
+}
+
+.completedMeta {
+  font-variant-numeric: tabular-nums;
+}
+
+@media (max-width: 767px) {
+  .page {
+    padding: 24px 16px 36px;
+  }
+
+  .summary {
+    width: 100%;
+  }
+
+  .summaryStat {
+    flex: 1 1 120px;
+  }
+
+  .projectCard {
+    padding: 20px;
+  }
+
+  .taskItem {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .taskStatus {
+    align-self: flex-start;
+  }
+}

--- a/frontend/src/dashboard/tasks/pages/TasksPage.tsx
+++ b/frontend/src/dashboard/tasks/pages/TasksPage.tsx
@@ -1,0 +1,148 @@
+import React from "react";
+import { CheckCircle2, Play } from "lucide-react";
+
+import {
+  useTasksOverview,
+  type ProjectTasksOverview,
+  type ProjectTask,
+} from "@/dashboard/home/hooks/useTasksOverview";
+
+import styles from "./TasksPage.module.css";
+
+function formatStatus(status: string): string {
+  const normalized = status.toLowerCase();
+  if (normalized === "in_progress") return "In progress";
+  if (normalized === "todo") return "To do";
+  if (normalized === "done") return "Done";
+  return normalized
+    .replace(/_/g, " ")
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+const TasksPage: React.FC = () => {
+  const { loading, error, stats, tasksByProject, handleNavigateToProject } = useTasksOverview();
+
+  const formatStatValue = React.useCallback(
+    (value: number): string | number => {
+      if (error) return "—";
+      if (loading) return "…";
+      return value;
+    },
+    [error, loading],
+  );
+
+  const renderTask = (task: ProjectTask) => {
+    return (
+      <li key={task.id} className={styles.taskItem}>
+        <div className={styles.taskText}>
+          <p className={styles.taskTitle}>{task.title}</p>
+          {(task.dueLabel || task.timeLabel) && (
+            <span className={styles.taskMeta}>
+              {task.dueLabel}
+              {task.dueLabel && task.timeLabel ? " · " : ""}
+              {task.timeLabel}
+            </span>
+          )}
+        </div>
+        <span className={styles.taskStatus}>{formatStatus(task.status)}</span>
+      </li>
+    );
+  };
+
+  const renderProject = (project: ProjectTasksOverview) => {
+    const openCount = project.openTasks.length;
+    const completedCount = project.completedTasks.length;
+    const openLabel = openCount === 1 ? "task" : "tasks";
+
+    return (
+      <section key={project.projectId} className={styles.projectCard}>
+        <header className={styles.projectHeader}>
+          <div className={styles.projectInfo}>
+            <span
+              className={styles.projectDot}
+              style={{ backgroundColor: project.projectColor || "var(--brand, #fa3356)" }}
+              aria-hidden="true"
+            />
+            <div className={styles.projectText}>
+              <h2 className={styles.projectTitle}>{project.projectName}</h2>
+              <p className={styles.projectMeta}>
+                {openCount ? `${openCount} open ${openLabel}` : "No open tasks"}
+              </p>
+            </div>
+          </div>
+          <button
+            type="button"
+            className={styles.startButton}
+            onClick={() => handleNavigateToProject(project.projectId)}
+            aria-label={`Open ${project.projectName} to work on tasks`}
+          >
+            <Play size={16} /> Start tasks
+          </button>
+        </header>
+
+        {openCount ? (
+          <ul className={styles.taskList}>{project.openTasks.map(renderTask)}</ul>
+        ) : (
+          <div className={styles.projectEmpty}>All tasks for this project are up to date.</div>
+        )}
+
+        {completedCount > 0 && (
+          <details className={styles.completedSection}>
+            <summary className={styles.completedSummary}>
+              <CheckCircle2 size={16} aria-hidden="true" /> Completed ({completedCount})
+            </summary>
+            <ul className={styles.completedList}>
+              {project.completedTasks.map((task) => (
+                <li key={task.id} className={styles.completedItem}>
+                  <span>{task.title}</span>
+                  <span className={styles.completedMeta}>{task.dueLabel ?? "No due date"}</span>
+                </li>
+              ))}
+            </ul>
+          </details>
+        )}
+      </section>
+    );
+  };
+
+  return (
+    <div className={styles.page}>
+      <header className={styles.header}>
+        <div className={styles.titleGroup}>
+          <h1 className={styles.title}>All tasks</h1>
+          <p className={styles.subtitle}>
+            Review upcoming tasks across your projects and jump straight into the work that matters most.
+          </p>
+        </div>
+        <div className={styles.summary}>
+          <div className={`${styles.summaryStat} ${styles.statOk}`}>
+            <span className={styles.summaryLabel}>Completed</span>
+            <span className={styles.summaryValue}>{formatStatValue(stats.completed)}</span>
+          </div>
+          <div className={`${styles.summaryStat} ${styles.statWarn}`}>
+            <span className={styles.summaryLabel}>Due Soon</span>
+            <span className={styles.summaryValue}>{formatStatValue(stats.dueSoon)}</span>
+          </div>
+          <div className={`${styles.summaryStat} ${styles.statDanger}`}>
+            <span className={styles.summaryLabel}>Overdue</span>
+            <span className={styles.summaryValue}>{formatStatValue(stats.overdue)}</span>
+          </div>
+        </div>
+      </header>
+
+      <main className={styles.content}>
+        {error ? (
+          <div className={styles.state}>We couldn’t load tasks right now. Please try again later.</div>
+        ) : loading ? (
+          <div className={styles.state}>Loading tasks…</div>
+        ) : tasksByProject.length === 0 ? (
+          <div className={styles.state}>No tasks yet. Create a project to start planning your work.</div>
+        ) : (
+          <div className={styles.projectGrid}>{tasksByProject.map(renderProject)}</div>
+        )}
+      </main>
+    </div>
+  );
+};
+
+export default TasksPage;


### PR DESCRIPTION
## Summary
- add a `/dashboard/tasks` route with a comprehensive tasks page grouped by project and quick start actions
- extend the tasks overview hook to expose project-level groupings and navigation helpers used by both cards and the new page
- update dashboard metadata so “View all” buttons lead to the new tasks experience

## Testing
- npm run typecheck *(fails: Cannot find module 'recharts' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68d8673f4720832491adc0bb8dedbf87