### PR TITLE
feat: redesign project week widget calendar

### DIFF
--- a/frontend/src/dashboard/project/components/Shared/calendar/ProjectWeekWidget.tsx
+++ b/frontend/src/dashboard/project/components/Shared/calendar/ProjectWeekWidget.tsx
@@ -1,31 +1,17 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import WeekWidget, { type Dot, type Track } from "@/dashboard/home/components/WeekWidget";
-import { addDays, startOfWeek } from "@/dashboard/home/utils/dateUtils";
-import { getColor } from "@/shared/utils/colorUtils";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { addDays, endOfWeek, startOfWeek } from "@/dashboard/home/utils/dateUtils";
 import { DayPopover, DaySheet } from "./DayOverlay";
 import { useCalendarController } from "./useCalendarController";
 import type { CalendarBaseProps } from "./CalendarBase";
-import { formatHours, getDateKey, safeParse } from "./utils";
+import { getDateKey, safeParse } from "./utils";
 import "./project-week-widget.css";
+import CalendarGrid from "./CalendarGrid";
 
 type ProjectWeekWidgetProps = Omit<CalendarBaseProps, "wrapperClassName" | "dayHeaderIdPrefix"> & {
   className?: string;
 };
 
-const ensureFallbackAnchor = (() => {
-  let fallback: HTMLButtonElement | null = null;
-  return () => {
-    if (fallback) return fallback;
-    if (typeof document === "undefined") {
-      return null;
-    }
-    fallback = document.createElement("button");
-    fallback.type = "button";
-    fallback.style.display = "none";
-    document.body.appendChild(fallback);
-    return fallback;
-  };
-})();
+type WeekRow = Array<{ date: Date; key: string; inMonth: boolean }>;
 
 const ProjectWeekWidget: React.FC<ProjectWeekWidgetProps> = ({
   project,
@@ -44,8 +30,21 @@ const ProjectWeekWidget: React.FC<ProjectWeekWidgetProps> = ({
     showEventList,
   });
 
-  const { wrapperHandlers, startDate, endDate, projectColor, selectedKey, eventsByDate, openDay, overlayState, modal } =
-    controller;
+  const {
+    wrapperHandlers,
+    startDate,
+    endDate,
+    projectColor,
+    selectedKey,
+    todayKey,
+    flashKey,
+    rangeSet,
+    eventsByDate,
+    openDay,
+    overlayState,
+    modal,
+    weekdayLabels,
+  } = controller;
 
   const [weekOf, setWeekOf] = useState<Date>(() => {
     return safeParse(initialFlashDate) || safeParse(selectedKey) || new Date();
@@ -74,96 +73,44 @@ const ProjectWeekWidget: React.FC<ProjectWeekWidgetProps> = ({
     [weekOf]
   );
 
-  const handleSelectDate = useCallback(
-    (date: Date) => {
-      setWeekOf(date);
-      onDateSelect?.(getDateKey(date));
-    },
-    [onDateSelect]
-  );
-
-  const registerDayRef = useRef<Record<string, HTMLButtonElement | null>>({});
-
-  const handleRegisterDayRef = useCallback((day: Date, key: string, node: HTMLButtonElement | null) => {
-    if (node) {
-      registerDayRef.current[key] = node;
-    } else {
-      delete registerDayRef.current[key];
-    }
-  }, []);
-
-  const getAnchorForKey = useCallback(
-    (key: string) => {
-      return registerDayRef.current[key] || ensureFallbackAnchor();
-    },
-    []
-  );
-
-  const tracks = useMemo<Track[]>(() => {
-    if (!startDate || !endDate) return [];
-    return [
-      {
-        id: "project-range",
-        color: projectColor,
-        start: startDate,
-        end: endDate,
-      },
-    ];
-  }, [startDate, endDate, projectColor]);
-
-  const dots = useMemo<Dot[]>(() => {
-    return Object.entries(eventsByDate).reduce<Dot[]>((acc, [key, items]) => {
-      const parsed = safeParse(key);
-      if (!parsed) return acc;
-      items.forEach((event, index) => {
-        const color = projectColor || getColor(event.description || event.id || `${key}-${index}`);
-        acc.push({ date: parsed, color });
-      });
-      return acc;
-    }, []);
-  }, [eventsByDate, projectColor]);
-
-  const getTooltipItems = useCallback(
-    (date: Date) => {
-      const key = getDateKey(date);
-      if (!key) return [];
-
-      const dayEvents = eventsByDate[key] || [];
-
-      const items = dayEvents.map((event, index) => ({
-        id: event.id || `${key}-event-${index}`,
-        title: event.description || "Untitled Event",
-        time: formatHours(event.hours) || undefined,
-        color: projectColor || getColor(event.description || event.id || key),
-        onSelect: () => {
-          const anchor = getAnchorForKey(key);
-          if (anchor) {
-            openDay(anchor, { date, dayKey: key, inMonth: true });
-          }
-          overlayState.onEdit(event);
-        },
-      }));
-
-      items.push({
-        id: `${key}-add-event`,
-        title: "Add Event",
-        note: dayEvents.length ? "Schedule another timeline item" : "Schedule a timeline event",
-        color: projectColor,
-        onSelect: () => {
-          const anchor = getAnchorForKey(key);
-          if (anchor) {
-            openDay(anchor, { date, dayKey: key, inMonth: true });
-          }
-          overlayState.onNew();
-        },
-      });
-
-      return items;
-    },
-    [eventsByDate, getAnchorForKey, openDay, overlayState, projectColor]
-  );
-
   const weekWidgetClass = ["project-week-widget", className].filter(Boolean).join(" ");
+
+  const weekStart = useMemo(() => startOfWeek(weekOf), [weekOf]);
+  const weekEnd = useMemo(() => endOfWeek(weekOf), [weekOf]);
+  const weekTitle = useMemo(() => {
+    const startLabel = weekStart.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+    const endLabel = weekEnd.toLocaleDateString(undefined, {
+      month: weekStart.getMonth() === weekEnd.getMonth() ? undefined : "short",
+      day: "numeric",
+    });
+    const yearLabel = weekEnd.toLocaleDateString(undefined, { year: "numeric" });
+    return `${startLabel} – ${endLabel} ${yearLabel}`;
+  }, [weekStart, weekEnd]);
+
+  const weekDays = useMemo<WeekRow>(() => {
+    const row: WeekRow = [];
+    for (let index = 0; index < 7; index += 1) {
+      const date = addDays(weekStart, index);
+      const key = getDateKey(date);
+      if (!key) continue;
+      row.push({
+        date,
+        key,
+        inMonth: date.getMonth() === weekOf.getMonth(),
+      });
+    }
+    return row;
+  }, [weekStart, weekOf]);
+
+  const handlePrevWeek = useCallback(() => {
+    const prev = addDays(weekStart, -7);
+    handleWeekChange(prev);
+  }, [handleWeekChange, weekStart]);
+
+  const handleNextWeek = useCallback(() => {
+    const next = addDays(weekStart, 7);
+    handleWeekChange(next);
+  }, [handleWeekChange, weekStart]);
 
   return (
     <div
@@ -174,18 +121,26 @@ const ProjectWeekWidget: React.FC<ProjectWeekWidgetProps> = ({
       onMouseLeave={wrapperHandlers.onMouseLeave}
       role="presentation"
     >
-      <WeekWidget
-        weekOf={weekOf}
-        tracks={tracks}
-        dots={dots}
-        onPrevWeek={handleWeekChange}
-        onNextWeek={handleWeekChange}
-        onSelectDate={handleSelectDate}
-        getTooltipItems={getTooltipItems}
-        registerDayRef={handleRegisterDayRef}
-        className="project-week-widget-inner"
-        isMobile
-      />
+      <div className="project-week-widget-inner">
+        <div className="calendar-content">
+          <CalendarGrid
+            monthTitle={weekTitle}
+            weekdayLabels={weekdayLabels}
+            weeks={[weekDays]}
+            startDate={startDate}
+            endDate={endDate}
+            projectColor={projectColor}
+            selectedKey={selectedKey}
+            todayKey={todayKey}
+            flashKey={flashKey}
+            rangeSet={rangeSet}
+            eventsByDate={eventsByDate}
+            onDayOpen={openDay}
+            onPrevMonth={handlePrevWeek}
+            onNextMonth={handleNextWeek}
+          />
+        </div>
+      </div>
 
       {overlayState.isOpen && overlayState.dayKey && (
         overlayState.isMobile ? (

--- a/frontend/src/dashboard/project/components/Shared/calendar/project-week-widget.css
+++ b/frontend/src/dashboard/project/components/Shared/calendar/project-week-widget.css
@@ -4,33 +4,155 @@
 
 .project-week-widget-inner {
   width: 100%;
+  border-radius: 28px;
+  border: 2px solid rgba(255, 255, 255, 0.1);
+  background: var(--bg2, #111213);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04), 0 18px 48px rgba(0, 0, 0, 0.45);
+  overflow: hidden;
 }
 
-.project-week-widget-inner.week-widget {
-  margin: 0;
-  box-shadow: none;
-  border-radius: 16px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  background: var(--surface-card, rgba(20, 20, 20, 0.9));
+.project-week-widget-inner .calendar-content {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 24px 24px 20px;
 }
 
-.project-week-widget-inner.week-widget .week-widget-header {
-  margin-bottom: 8px;
+.project-week-widget-inner .month-widget {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
-.project-week-widget-inner.week-widget .week-nav-btn {
+.project-week-widget-inner .month-widget-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.project-week-widget-inner .month-title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: rgba(255, 255, 255, 0.92);
+}
+
+.project-week-widget-inner .month-nav-btn {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 10px;
+  color: rgba(255, 255, 255, 0.9);
+  padding: 6px 10px;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.project-week-widget-inner .month-nav-btn:hover {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.18);
+}
+
+.project-week-widget-inner .calendar-weekdays {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 4px;
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(255, 255, 255, 0.48);
+}
+
+.project-week-widget-inner .calendar-weekday {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+}
+
+.project-week-widget-inner .calendar-weeks {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.project-week-widget-inner .calendar-week {
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 4px;
+  padding-bottom: 8px;
+  overflow: visible;
+}
+
+.project-week-widget-inner .calendar-week-track {
+  border-radius: 999px;
+}
+
+.project-week-widget-inner .calendar-day-wrapper {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  z-index: 2;
+}
+
+.project-week-widget-inner .calendar-day {
+  position: relative;
+  min-height: 44px;
+  padding: 10px 16px;
+  border-radius: 40px;
+  border: none;
+  background: none;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.15s ease;
+  cursor: pointer;
+  color: inherit;
+  font: inherit;
+  text-align: center;
+  outline: none;
+  appearance: none;
+}
+
+.project-week-widget-inner .calendar-day:hover {
+  background: rgba(255, 255, 255, 0.05);
   border-color: rgba(255, 255, 255, 0.14);
 }
 
-.project-week-widget-inner.week-widget .week-day {
-  border-color: rgba(255, 255, 255, 0.12);
-  background: rgba(255, 255, 255, 0.04);
+.project-week-widget-inner .calendar-day:focus-visible {
+  outline: 2px solid #fa3356;
+  outline-offset: 2px;
+  box-shadow: 0 0 0 3px rgba(250, 51, 86, 0.15);
 }
 
-.project-week-widget-inner.week-widget .week-day:hover {
-  background: rgba(255, 255, 255, 0.08);
+.project-week-widget-inner .calendar-day.today {
+  outline: 1px solid rgba(255, 255, 255, 0.18);
 }
 
-.project-week-widget-inner.week-widget .week-day.selected {
+.project-week-widget-inner .calendar-day.selected {
   background: rgba(255, 255, 255, 0.12);
+  transform: translateY(-1px);
+}
+
+.project-week-widget-inner .calendar-day.in-range::before {
+  content: "";
+  position: absolute;
+  inset: 4px;
+  border-radius: 32px;
+  background: rgba(255, 255, 255, 0.04);
+  z-index: -1;
+}
+
+.project-week-widget-inner .tile-date-number {
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.92);
+}
+
+.project-week-widget-inner .day-dots {
+  display: flex;
+  justify-content: center;
 }


### PR DESCRIPTION
## Summary
- replace the project week widget with a dedicated calendar-based view that reuses the project calendar controller
- update the week widget layout and styling to mirror the project calendar while focusing on a single week

## Testing
- npm run lint -- --max-warnings=0

------
https://chatgpt.com/codex/tasks/task_e_68d875c254e0832488985d31d29a385b