### PR TITLE
Persist AllProjects filter selections

### DIFF
--- a/frontend/src/dashboard/home/components/AllProjects.tsx
+++ b/frontend/src/dashboard/home/components/AllProjects.tsx
@@ -13,7 +13,12 @@ import SVGThumbnail from './SvgThumbnail';
 import Spinner from '../../../shared/ui/Spinner';
 import AvatarStack from '../../../shared/ui/AvatarStack';
 import { ProjectsFilterMenu } from './ProjectsFilterMenu';
-import { useProjectFilters } from './hooks/useProjectFilters';
+import {
+  PROJECT_FILTERS_STORAGE_KEY,
+  readStoredProjectFilters,
+  useProjectFilters,
+  writeStoredProjectFilters,
+} from './hooks/useProjectFilters';
 import {
   parseProjectStatusToNumber,
   useProjectKpis,
@@ -104,7 +109,10 @@ const AllProjects: React.FC = () => {
     return stored === 'grid' || stored === 'list' ? stored : 'list';
   });
   const [menuOpenId, setMenuOpenId] = useState<string | null>(null);
-  const [showPendingOnly, setShowPendingOnly] = useState(false);
+  const [showPendingOnly, setShowPendingOnly] = useState(() => {
+    const stored = readStoredProjectFilters(PROJECT_FILTERS_STORAGE_KEY);
+    return Boolean(stored.showPendingOnly);
+  });
   const menuRefs = useRef<Record<string, HTMLDivElement | null>>({});
 
   useEffect(() => {
@@ -151,6 +159,7 @@ const AllProjects: React.FC = () => {
     defaultSortOption: 'titleAsc',
     queryMatcher,
     statusFilterPredicate,
+    storageKey: PROJECT_FILTERS_STORAGE_KEY,
   });
 
   const filteredProjects = useMemo(
@@ -299,6 +308,10 @@ const AllProjects: React.FC = () => {
       setShowPendingOnly(false);
     }
   }, [filteredProjects.length]);
+
+  useEffect(() => {
+    writeStoredProjectFilters(PROJECT_FILTERS_STORAGE_KEY, { showPendingOnly });
+  }, [showPendingOnly]);
 
   const handleShowAllProjectsChip = useCallback(() => {
     setScope('all');

--- a/frontend/src/dashboard/home/components/hooks/useProjectFilters.test.ts
+++ b/frontend/src/dashboard/home/components/hooks/useProjectFilters.test.ts
@@ -123,6 +123,44 @@ describe("useProjectFilters", () => {
     expect(result.current.filteredProjects).toHaveLength(1);
     expect(result.current.filteredProjects[0]?.projectId).toBe("custom-2");
   });
+
+  it("restores persisted filters when a storage key is provided", () => {
+    const storageKey = "use-project-filters-test";
+
+    window.localStorage.setItem(
+      storageKey,
+      JSON.stringify({
+        scope: "all",
+        query: "beta",
+        statusFilter: "archived",
+        sortOption: "titleDesc",
+      })
+    );
+
+    const { result } = renderHook(() =>
+      useProjectFilters({
+        projects,
+        recentsLimit: 3,
+        storageKey,
+        defaultScope: "recents",
+        defaultSortOption: "dateNewest",
+      })
+    );
+
+    expect(result.current.scope).toBe("all");
+    expect(result.current.query).toBe("beta");
+    expect(result.current.statusTriggerLabel).toBe("archived");
+    expect(result.current.sortTriggerLabel).toBe("Title (Z-A)");
+
+    act(() => {
+      result.current.setScope("recents");
+    });
+
+    const stored = JSON.parse(window.localStorage.getItem(storageKey) || "{}");
+    expect(stored.scope).toBe("recents");
+
+    window.localStorage.removeItem(storageKey);
+  });
 });
 
 

--- a/frontend/src/dashboard/home/components/hooks/useProjectFilters.ts
+++ b/frontend/src/dashboard/home/components/hooks/useProjectFilters.ts
@@ -15,6 +15,47 @@ import type { ProjectWithMeta } from "../../utils/types";
 
 export type SortOption = "titleAsc" | "titleDesc" | "dateNewest" | "dateOldest";
 
+export type StoredProjectFilters = {
+  scope?: "recents" | "all";
+  query?: string;
+  statusFilter?: string;
+  sortOption?: SortOption;
+  showPendingOnly?: boolean;
+};
+
+export const PROJECT_FILTERS_STORAGE_KEY = "all-projects-filters";
+
+const isBrowser = typeof window !== "undefined";
+
+const readFromStorage = (storageKey?: string): StoredProjectFilters => {
+  if (!storageKey || !isBrowser) return {};
+
+  try {
+    const raw = window.localStorage.getItem(storageKey);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") return {};
+    return parsed as StoredProjectFilters;
+  } catch {
+    return {};
+  }
+};
+
+const writeToStorage = (storageKey: string | undefined, patch: StoredProjectFilters): void => {
+  if (!storageKey || !isBrowser) return;
+
+  try {
+    const existing = readFromStorage(storageKey);
+    const next = { ...existing, ...patch } satisfies StoredProjectFilters;
+    window.localStorage.setItem(storageKey, JSON.stringify(next));
+  } catch {
+    // Ignore storage write errors (e.g., quota exceeded)
+  }
+};
+
+export const readStoredProjectFilters = readFromStorage;
+export const writeStoredProjectFilters = writeToStorage;
+
 type UseProjectFiltersArgs = {
   projects: ProjectLike[];
   recentsLimit: number;
@@ -25,6 +66,7 @@ type UseProjectFiltersArgs = {
     normalizedQuery: string
   ) => boolean;
   statusFilterPredicate?: (status: string) => boolean;
+  storageKey?: string;
 };
 
 type UseProjectFiltersResult = {
@@ -64,12 +106,34 @@ export const useProjectFilters = ({
   defaultSortOption = "dateNewest",
   queryMatcher,
   statusFilterPredicate,
+  storageKey,
 }: UseProjectFiltersArgs): UseProjectFiltersResult => {
   const [filtersOpen, setFiltersOpen] = useState(false);
-  const [scope, setScope] = useState<"recents" | "all">(defaultScope);
-  const [query, setQuery] = useState("");
-  const [statusFilter, setStatusFilter] = useState("");
-  const [sortOption, setSortOption] = useState<SortOption>(defaultSortOption);
+  const initialFiltersRef = useRef<StoredProjectFilters | null>(null);
+
+  if (initialFiltersRef.current === null) {
+    initialFiltersRef.current = readFromStorage(storageKey);
+  }
+
+  const [scope, setScopeState] = useState<"recents" | "all">(() => {
+    const storedScope = initialFiltersRef.current?.scope;
+    if (storedScope === "recents" || storedScope === "all") return storedScope;
+    return defaultScope;
+  });
+
+  const [query, setQueryState] = useState(() => initialFiltersRef.current?.query ?? "");
+
+  const [statusFilter, setStatusFilterState] = useState(
+    () => initialFiltersRef.current?.statusFilter ?? ""
+  );
+
+  const [sortOption, setSortOptionState] = useState<SortOption>(() => {
+    const storedOption = initialFiltersRef.current?.sortOption;
+    if (storedOption && SORT_OPTIONS.some((option) => option.value === storedOption)) {
+      return storedOption;
+    }
+    return defaultSortOption;
+  });
 
   const filtersRef = useRef<HTMLDivElement | null>(null);
   const filtersId = useMemo(() => createRandomId("projects-filters"), []);
@@ -138,7 +202,7 @@ export const useProjectFilters = ({
   const statusDropdown = useDropdown({
     options: statusOptions,
     selectedValue: statusFilter,
-    onSelect: setStatusFilter,
+    onSelect: setStatusFilterState,
     idPrefix: "projects-status",
   });
 
@@ -147,7 +211,7 @@ export const useProjectFilters = ({
   const sortDropdown = useDropdown({
     options: sortOptions,
     selectedValue: sortOption,
-    onSelect: setSortOption,
+    onSelect: setSortOptionState,
     idPrefix: "projects-sort",
   });
 
@@ -224,6 +288,24 @@ export const useProjectFilters = ({
     return found ? found.label : sortOptions[0]?.label || "Sort";
   }, [sortOption, sortOptions]);
 
+  useEffect(() => {
+    if (!statusFilter) return;
+
+    const hasStatus = statusOptions.some((option) => option.value === statusFilter);
+    if (!hasStatus) {
+      setStatusFilterState("");
+    }
+  }, [statusFilter, statusOptions]);
+
+  useEffect(() => {
+    writeToStorage(storageKey, {
+      scope,
+      query,
+      statusFilter,
+      sortOption,
+    });
+  }, [scope, query, statusFilter, sortOption, storageKey]);
+
   return {
     filtersOpen,
     toggleFilters,
@@ -231,11 +313,11 @@ export const useProjectFilters = ({
     filtersRef,
     filtersId,
     scope,
-    setScope,
+    setScope: setScopeState,
     query,
-    setQuery,
+    setQuery: setQueryState,
     statusFilter,
-    setStatusFilter,
+    setStatusFilter: setStatusFilterState,
     statusOptions,
     statusTriggerLabel,
     statusDropdown,


### PR DESCRIPTION
## Summary
- persist AllProjects filter inputs using shared storage helpers
- restore the Pending toggle from local storage and merge with filter persistence
- cover filter state persistence with a dedicated hook test

## Testing
- `npx vitest run src/dashboard/home/components/hooks/useProjectFilters.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68d87029d1d88324b5b2adcae419e1b8