### PR TITLE
Transform tasks page into bottom drawer

### DIFF
--- a/frontend/src/dashboard/home/components/MobileTasksOverviewCard.tsx
+++ b/frontend/src/dashboard/home/components/MobileTasksOverviewCard.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 
 import { useTasksOverview } from "../hooks/useTasksOverview";
 import styles from "./MobileTasksOverviewCard.module.css";
@@ -10,6 +10,7 @@ type MobileTasksOverviewCardProps = {
 
 const MobileTasksOverviewCard: React.FC<MobileTasksOverviewCardProps> = ({ className }) => {
   const { loading, error, stats, groups } = useTasksOverview();
+  const location = useLocation();
 
   const formatStatValue = (value: number): string | number => {
     if (error) return "—";
@@ -37,7 +38,12 @@ const MobileTasksOverviewCard: React.FC<MobileTasksOverviewCardProps> = ({ class
     >
       <header className={styles.header}>
         <h3 className={styles.title}>Tasks</h3>
-        <Link to="/dashboard/tasks" className={styles.viewAllButton} aria-label="View all tasks">
+        <Link
+          to="/dashboard/tasks"
+          className={styles.viewAllButton}
+          aria-label="View all tasks"
+          state={{ from: `${location.pathname}${location.search}` }}
+        >
           View all
         </Link>
       </header>

--- a/frontend/src/dashboard/home/components/TasksOverviewCard.tsx
+++ b/frontend/src/dashboard/home/components/TasksOverviewCard.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import { Plus, MoreHorizontal } from "lucide-react";
 
 import { useTasksOverview } from "../hooks/useTasksOverview";
@@ -11,6 +11,7 @@ type TasksOverviewCardProps = {
 const TasksOverviewCard: React.FC<TasksOverviewCardProps> = ({ className }) => {
   const { loading, error, stats, groups, handleNavigateToPrimary, canNavigateToProject } =
     useTasksOverview();
+  const location = useLocation();
 
   const formatStatValue = (value: number): string | number => {
     if (error) return "—";
@@ -42,6 +43,7 @@ const TasksOverviewCard: React.FC<TasksOverviewCardProps> = ({ className }) => {
             to="/dashboard/tasks"
             className={styles.iconButton}
             aria-label="View all tasks"
+            state={{ from: `${location.pathname}${location.search}` }}
           >
             <MoreHorizontal size={18} strokeWidth={2} />
           </Link>

--- a/frontend/src/dashboard/home/pages/TasksListPage.module.css
+++ b/frontend/src/dashboard/home/pages/TasksListPage.module.css
@@ -1,8 +1,65 @@
-.wrapper {
-  min-height: 100dvh;
+.drawerOverlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1400;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  padding: 24px 16px 0;
+  background: rgba(5, 6, 7, 0.72);
+  backdrop-filter: blur(6px);
+}
+
+.drawer {
+  width: min(1040px, 100%);
+  max-height: min(92dvh, 980px);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  border-radius: 28px 28px 0 0;
+  border: 1px solid rgba(255, 255, 255, 0.1);
   background: var(--dashboard-bg, var(--bg1, #050607));
-  padding: 32px 16px 96px;
   color: var(--text-primary, #f6f7fb);
+  box-shadow: 0 -18px 48px rgba(0, 0, 0, 0.45);
+  transform-origin: bottom center;
+  animation: tasks-drawer-slide-up 220ms ease-out;
+}
+
+.drawerHeader {
+  display: flex;
+  justify-content: flex-end;
+  padding: 16px 24px 0;
+}
+
+.closeButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.08);
+  color: inherit;
+  cursor: pointer;
+  transition: transform 0.2s ease, background 0.2s ease, border-color 0.2s ease;
+}
+
+.closeButton:hover,
+.closeButton:focus-visible {
+  background: rgba(255, 255, 255, 0.18);
+  border-color: rgba(255, 255, 255, 0.28);
+  outline: none;
+}
+
+.closeButton:active {
+  transform: translateY(1px);
+}
+
+.drawerContent {
+  flex: 1;
+  overflow: auto;
+  padding: 32px 24px 96px;
 }
 
 .container {
@@ -298,8 +355,25 @@
 }
 
 @media (max-width: 720px) {
-  .wrapper {
-    padding: 24px 12px 72px;
+  .drawerOverlay {
+    padding: 16px 12px 0;
+  }
+
+  .drawer {
+    border-radius: 24px 24px 0 0;
+  }
+
+  .drawerHeader {
+    padding: 12px 16px 0;
+  }
+
+  .closeButton {
+    width: 36px;
+    height: 36px;
+  }
+
+  .drawerContent {
+    padding: 24px 16px calc(80px + env(safe-area-inset-bottom, 16px));
   }
 
   .section {
@@ -319,5 +393,17 @@
 
   .primaryAction {
     width: 100%;
+  }
+}
+
+@keyframes tasks-drawer-slide-up {
+  from {
+    transform: translateY(24px);
+    opacity: 0;
+  }
+
+  to {
+    transform: translateY(0);
+    opacity: 1;
   }
 }

--- a/frontend/src/dashboard/home/pages/TasksListPage.tsx
+++ b/frontend/src/dashboard/home/pages/TasksListPage.tsx
@@ -1,5 +1,7 @@
-import React, { useMemo } from "react";
-import { Play } from "lucide-react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { Play, ChevronDown } from "lucide-react";
+import { createPortal } from "react-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 
 import { useTasksOverview, type TasksOverviewListItem } from "../hooks/useTasksOverview";
 import { endOfWeek } from "@/dashboard/home/utils/dateUtils";
@@ -72,6 +74,61 @@ const TaskList: React.FC<TaskListProps> = ({ tasks, emptyLabel, onStart, showCom
 };
 
 const TasksListPage: React.FC = () => {
+  const [mounted, setMounted] = useState(false);
+  const navigate = useNavigate();
+  const location = useLocation();
+  const locationState = (location.state as { from?: string } | undefined) ?? undefined;
+  const returnTo = locationState?.from;
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  useEffect(() => {
+    if (!mounted || typeof document === "undefined") return;
+    const { style } = document.body;
+    const originalOverflow = style.overflow;
+    style.overflow = "hidden";
+    return () => {
+      style.overflow = originalOverflow;
+    };
+  }, [mounted]);
+
+  const handleClose = useCallback(() => {
+    if (returnTo) {
+      navigate(returnTo, { replace: true });
+      return;
+    }
+
+    if (typeof window !== "undefined" && window.history.length > 1) {
+      navigate(-1);
+    } else {
+      navigate("/dashboard");
+    }
+  }, [navigate, returnTo]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        handleClose();
+      }
+    };
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [handleClose]);
+
+  const onOverlayMouseDown = useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      if (event.target === event.currentTarget) {
+        handleClose();
+      }
+    },
+    [handleClose]
+  );
+
   const {
     loading,
     error,
@@ -136,137 +193,167 @@ const TasksListPage: React.FC = () => {
     ? `Review everything on your radar and jump straight back into ${primaryProjectName}.`
     : "Review every task across your projects and start where you left off.";
 
-  return (
-    <div className={`dashboard-wrapper ${styles.wrapper}`}>
-      <div className={styles.container}>
-        <header className={styles.header}>
-          <div className={styles.headingGroup}>
-            <h1 className={styles.title}>All tasks</h1>
-            <p className={styles.subtitle}>{introMessage}</p>
-          </div>
+  const titleId = "tasks-drawer-title";
+
+  if (!mounted || typeof document === "undefined") {
+    return null;
+  }
+
+  return createPortal(
+    <div className={styles.drawerOverlay} role="presentation" onMouseDown={onOverlayMouseDown}>
+      <div
+        className={styles.drawer}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        onMouseDown={(event) => event.stopPropagation()}
+      >
+        <div className={styles.drawerHeader}>
           <button
             type="button"
-            className={styles.primaryAction}
-            onClick={handleNavigateToPrimary}
-            disabled={!canNavigateToProject}
+            className={styles.closeButton}
+            onClick={handleClose}
+            aria-label="Close tasks"
           >
-            <Play size={18} strokeWidth={2.5} />
-            Start next task
+            <ChevronDown size={20} strokeWidth={2.5} />
           </button>
-        </header>
+        </div>
 
-        <section className={styles.statsGrid} aria-label="Task summary">
-          <div className={styles.statCard}>
-            <span className={styles.statLabel}>Completed this week</span>
-            <span className={styles.statValue}>{stats.completed}</span>
-          </div>
-          <div className={styles.statCard}>
-            <span className={styles.statLabel}>Due soon</span>
-            <span className={styles.statValue}>{stats.dueSoon}</span>
-          </div>
-          <div className={styles.statCard}>
-            <span className={styles.statLabel}>Overdue</span>
-            <span className={styles.statValue}>{stats.overdue}</span>
-          </div>
-        </section>
-
-        {error ? (
-          <div className={styles.emptyState}>We couldn't load tasks right now. Please try again later.</div>
-        ) : loading ? (
-          <div className={styles.emptyState}>Loading your tasks…</div>
-        ) : !hasAnyTask ? (
-          <div className={styles.emptyState}>
-            You don't have any active tasks. Add a task from a project to see it appear here.
-          </div>
-        ) : (
-          <div className={styles.sections}>
-            <section className={`${styles.section} ${styles.sectionOverdue}`} aria-labelledby="tasks-overdue-heading">
-              <span className={styles.sectionAccent} aria-hidden="true" />
-              <div className={styles.sectionTitleRow}>
-                <h2 id="tasks-overdue-heading" className={styles.sectionTitle}>
-                  Overdue
-                </h2>
-                <p className={styles.sectionCaption}>Tasks that slipped past their due date.</p>
+        <div className={styles.drawerContent}>
+          <div className={styles.container}>
+            <header className={styles.header}>
+              <div className={styles.headingGroup}>
+                <h1 id={titleId} className={styles.title}>
+                  All tasks
+                </h1>
+                <p className={styles.subtitle}>{introMessage}</p>
               </div>
-              <TaskList
-                tasks={overdueTasks}
-                emptyLabel="No overdue tasks. Nice work keeping things on track!"
-                onStart={(task) => navigateToProject(task.projectId)}
-              />
+              <button
+                type="button"
+                className={styles.primaryAction}
+                onClick={handleNavigateToPrimary}
+                disabled={!canNavigateToProject}
+              >
+                <Play size={18} strokeWidth={2.5} />
+                Start next task
+              </button>
+            </header>
+
+            <section className={styles.statsGrid} aria-label="Task summary">
+              <div className={styles.statCard}>
+                <span className={styles.statLabel}>Completed this week</span>
+                <span className={styles.statValue}>{stats.completed}</span>
+              </div>
+              <div className={styles.statCard}>
+                <span className={styles.statLabel}>Due soon</span>
+                <span className={styles.statValue}>{stats.dueSoon}</span>
+              </div>
+              <div className={styles.statCard}>
+                <span className={styles.statLabel}>Overdue</span>
+                <span className={styles.statValue}>{stats.overdue}</span>
+              </div>
             </section>
 
-            <section className={`${styles.section} ${styles.sectionDueSoon}`} aria-labelledby="tasks-due-soon-heading">
-              <span className={styles.sectionAccent} aria-hidden="true" />
-              <div className={styles.sectionTitleRow}>
-                <h2 id="tasks-due-soon-heading" className={styles.sectionTitle}>
-                  Due this week
-                </h2>
-                <p className={styles.sectionCaption}>Everything scheduled between now and the end of the week.</p>
+            {error ? (
+              <div className={styles.emptyState}>We couldn't load tasks right now. Please try again later.</div>
+            ) : loading ? (
+              <div className={styles.emptyState}>Loading your tasks…</div>
+            ) : !hasAnyTask ? (
+              <div className={styles.emptyState}>
+                You don't have any active tasks. Add a task from a project to see it appear here.
               </div>
-              {dueSoonGroups.length ? (
-                dueSoonGroups.map((group) => (
-                  <div key={group.label} className={styles.group}>
-                    <h3 className={styles.groupTitle}>{group.label}</h3>
-                    <TaskList
-                      tasks={group.tasks}
-                      emptyLabel="All set for this day."
-                      onStart={(task) => navigateToProject(task.projectId)}
-                    />
+            ) : (
+              <div className={styles.sections}>
+                <section className={`${styles.section} ${styles.sectionOverdue}`} aria-labelledby="tasks-overdue-heading">
+                  <span className={styles.sectionAccent} aria-hidden="true" />
+                  <div className={styles.sectionTitleRow}>
+                    <h2 id="tasks-overdue-heading" className={styles.sectionTitle}>
+                      Overdue
+                    </h2>
+                    <p className={styles.sectionCaption}>Tasks that slipped past their due date.</p>
                   </div>
-                ))
-              ) : (
-                <div className={styles.sectionEmpty}>No tasks due for the rest of this week.</div>
-              )}
-            </section>
+                  <TaskList
+                    tasks={overdueTasks}
+                    emptyLabel="No overdue tasks. Nice work keeping things on track!"
+                    onStart={(task) => navigateToProject(task.projectId)}
+                  />
+                </section>
 
-            <section className={`${styles.section} ${styles.sectionUpcoming}`} aria-labelledby="tasks-upcoming-heading">
-              <span className={styles.sectionAccent} aria-hidden="true" />
-              <div className={styles.sectionTitleRow}>
-                <h2 id="tasks-upcoming-heading" className={styles.sectionTitle}>
-                  Coming up
-                </h2>
-                <p className={styles.sectionCaption}>Preview what's planned beyond this week.</p>
-              </div>
-              <TaskList
-                tasks={upcomingTasks}
-                emptyLabel="No future tasks yet. When you plan ahead they'll show up here."
-                onStart={(task) => navigateToProject(task.projectId)}
-              />
-            </section>
+                <section className={`${styles.section} ${styles.sectionDueSoon}`} aria-labelledby="tasks-due-soon-heading">
+                  <span className={styles.sectionAccent} aria-hidden="true" />
+                  <div className={styles.sectionTitleRow}>
+                    <h2 id="tasks-due-soon-heading" className={styles.sectionTitle}>
+                      Due this week
+                    </h2>
+                    <p className={styles.sectionCaption}>Everything scheduled between now and the end of the week.</p>
+                  </div>
+                  {dueSoonGroups.length ? (
+                    dueSoonGroups.map((group) => (
+                      <div key={group.label} className={styles.group}>
+                        <h3 className={styles.groupTitle}>{group.label}</h3>
+                        <TaskList
+                          tasks={group.tasks}
+                          emptyLabel="All set for this day."
+                          onStart={(task) => navigateToProject(task.projectId)}
+                        />
+                      </div>
+                    ))
+                  ) : (
+                    <div className={styles.sectionEmpty}>No tasks due for the rest of this week.</div>
+                  )}
+                </section>
 
-            <section className={`${styles.section} ${styles.sectionUndated}`} aria-labelledby="tasks-undated-heading">
-              <span className={styles.sectionAccent} aria-hidden="true" />
-              <div className={styles.sectionTitleRow}>
-                <h2 id="tasks-undated-heading" className={styles.sectionTitle}>
-                  No due date
-                </h2>
-                <p className={styles.sectionCaption}>Ideas or tasks to tackle when you're ready.</p>
-              </div>
-              <TaskList
-                tasks={undatedTasks}
-                emptyLabel="Nothing in your backlog without a due date."
-                onStart={(task) => navigateToProject(task.projectId)}
-              />
-            </section>
+                <section className={`${styles.section} ${styles.sectionUpcoming}`} aria-labelledby="tasks-upcoming-heading">
+                  <span className={styles.sectionAccent} aria-hidden="true" />
+                  <div className={styles.sectionTitleRow}>
+                    <h2 id="tasks-upcoming-heading" className={styles.sectionTitle}>
+                      Coming up
+                    </h2>
+                    <p className={styles.sectionCaption}>Preview what's planned beyond this week.</p>
+                  </div>
+                  <TaskList
+                    tasks={upcomingTasks}
+                    emptyLabel="No future tasks yet. When you plan ahead they'll show up here."
+                    onStart={(task) => navigateToProject(task.projectId)}
+                  />
+                </section>
 
-            <section className={`${styles.section} ${styles.sectionCompleted}`} aria-labelledby="tasks-completed-heading">
-              <span className={styles.sectionAccent} aria-hidden="true" />
-              <div className={styles.sectionTitleRow}>
-                <h2 id="tasks-completed-heading" className={styles.sectionTitle}>
-                  Completed this week
-                </h2>
-                <p className={styles.sectionCaption}>Recently wrapped up items within the current week.</p>
+                <section className={`${styles.section} ${styles.sectionUndated}`} aria-labelledby="tasks-undated-heading">
+                  <span className={styles.sectionAccent} aria-hidden="true" />
+                  <div className={styles.sectionTitleRow}>
+                    <h2 id="tasks-undated-heading" className={styles.sectionTitle}>
+                      No due date
+                    </h2>
+                    <p className={styles.sectionCaption}>Ideas or tasks to tackle when you're ready.</p>
+                  </div>
+                  <TaskList
+                    tasks={undatedTasks}
+                    emptyLabel="Nothing in your backlog without a due date."
+                    onStart={(task) => navigateToProject(task.projectId)}
+                  />
+                </section>
+
+                <section className={`${styles.section} ${styles.sectionCompleted}`} aria-labelledby="tasks-completed-heading">
+                  <span className={styles.sectionAccent} aria-hidden="true" />
+                  <div className={styles.sectionTitleRow}>
+                    <h2 id="tasks-completed-heading" className={styles.sectionTitle}>
+                      Completed this week
+                    </h2>
+                    <p className={styles.sectionCaption}>Recently wrapped up items within the current week.</p>
+                  </div>
+                  <TaskList
+                    tasks={completedThisWeek}
+                    emptyLabel="No completed tasks this week yet."
+                    showCompleted
+                  />
+                </section>
               </div>
-              <TaskList
-                tasks={completedThisWeek}
-                emptyLabel="No completed tasks this week yet."
-                showCompleted
-              />
-            </section>
+            )}
           </div>
-        )}
+        </div>
       </div>
-    </div>
+    </div>,
+    document.body
   );
 };
 


### PR DESCRIPTION
## Summary
- render the dashboard tasks page inside a bottom sheet drawer with a close affordance and escape/overlay handling
- lock background scrolling while the drawer is open and animate the drawer with new styles
- preserve navigation context by passing the source route when linking to the tasks view

## Testing
- npm run test *(fails: existing suite contains numerous unrelated failing specs, run aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68d8778bd588832484389562a8d394b3