### PR TITLE
Fix gallery layout on mobile

### DIFF
--- a/frontend/src/dashboard/home/styles/components/calendar.css
+++ b/frontend/src/dashboard/home/styles/components/calendar.css
@@ -67,6 +67,12 @@
   flex: 2 1 0;
 }
 
+.budget-calendar-layout--stacked .budget-column > *,
+.budget-calendar-layout--stacked .budget-column .budget-overview-card,
+.budget-calendar-layout--stacked .budget-column .view-gallery {
+  flex: none;
+}
+
 @media (max-width: 1024px) {
   .budget-calendar-layout {
     grid-template-columns: minmax(0, 1fr);

--- a/frontend/src/dashboard/project/components/Gallery/GalleryTrigger.tsx
+++ b/frontend/src/dashboard/project/components/Gallery/GalleryTrigger.tsx
@@ -23,7 +23,6 @@ const GalleryTrigger: React.FC<GalleryTriggerProps> = ({
   return (
     <div
       className={`dashboard-item view-gallery ${styles.galleryTrigger}`}
-      style={{ display: "flex", flexDirection: "row", gap: 12 }}
       onClick={onOpenModal}
       role="button"
       tabIndex={0}
@@ -35,7 +34,7 @@ const GalleryTrigger: React.FC<GalleryTriggerProps> = ({
       }}
     >
       {/* Two equal columns: title (left) and thumbnails (right) */}
-      <div className={styles.titleColumn} style={{ flex: "0 0 38%" }}>
+      <div className={styles.titleColumn}>
         <div className={styles.topRow}>
           <span>Galleries</span>
          
@@ -49,10 +48,7 @@ const GalleryTrigger: React.FC<GalleryTriggerProps> = ({
         )}
       </div>
 
-      <div
-        className={styles.thumbsColumn}
-        style={{ flex: "1 1 62%", display: "flex", alignItems: "center", justifyContent: "flex-end" }}
-      >
+      <div className={styles.thumbsColumn}>
         {hasGalleries ? (
           <div className={styles.carouselSection}>
             <div className={styles.thumbnailCarousel} aria-label="Gallery previews">

--- a/frontend/src/dashboard/project/components/Gallery/gallery-component.module.css
+++ b/frontend/src/dashboard/project/components/Gallery/gallery-component.module.css
@@ -9,6 +9,9 @@
   flex: 0 1 auto;
   transition: transform 0.2s ease;
   flex-wrap: nowrap;
+  gap: 12px;
+  padding: clamp(16px, 4vw, 24px);
+  box-sizing: border-box;
 }
 
 /* Two columns inside the trigger */
@@ -17,7 +20,6 @@
   width: auto;
   max-width: 100%;
   box-sizing: border-box;
-  flex: 1 1 0%;
 }
 
 .titleColumn {
@@ -25,7 +27,7 @@
   flex-direction: column;
   justify-content: flex-start; /* align title to top */
   padding-right: 12px;
-  flex-basis: clamp(220px, 38%, 320px);
+  flex: 0 0 clamp(220px, 38%, 320px);
 }
 
 .thumbsColumn {
@@ -34,6 +36,7 @@
   justify-content: flex-end; /* thumbnails aligned to the right area */
   padding-left: 12px;
   min-height: 56px;
+  flex: 1 1 62%;
 }
 
 
@@ -172,13 +175,15 @@
 
   .titleColumn,
   .thumbsColumn {
-    flex-basis: 100%;
+    flex: 0 0 auto;
+    width: 100%;
     padding-right: 0;
     padding-left: 0;
   }
 
   .thumbsColumn {
     justify-content: flex-start;
+    align-items: stretch;
   }
 
   .carouselSection {
@@ -191,6 +196,10 @@
 
   .viewAllButton {
     align-self: flex-start;
+  }
+
+  .thumbnailTile {
+    flex: 0 0 clamp(88px, 32vw, 120px);
   }
 }
 


### PR DESCRIPTION
## Summary
- remove inline flex sizing so the gallery card can stack cleanly under the budget overview on mobile
- adjust gallery styles to provide responsive padding, column widths, and thumbnail sizing for compact layouts
- stop forcing equal flex heights when the budget/calendar layout collapses into a single column

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68d8785f7d408324880b1be67fb7f6b8