### PR TITLE
Add quick task creation flow to tasks list drawer

### DIFF
--- a/frontend/src/dashboard/home/hooks/useTasksOverview.ts
+++ b/frontend/src/dashboard/home/hooks/useTasksOverview.ts
@@ -80,6 +80,12 @@ export type TasksOverviewStats = {
   overdue: number;
 };
 
+export type TasksOverviewProjectOption = {
+  id: string;
+  name: string;
+  color?: string;
+};
+
 function parseDueDate(value?: unknown): Date | null {
   if (value == null || value === "") return null;
 
@@ -151,6 +157,7 @@ export function useTasksOverview() {
   const navigate = useNavigate();
 
   const [tasks, setTasks] = useState<NormalizedTask[]>([]);
+  const [reloadToken, setReloadToken] = useState(0);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(false);
 
@@ -240,7 +247,11 @@ export function useTasksOverview() {
     return () => {
       cancelled = true;
     };
-  }, [projects]);
+  }, [projects, reloadToken]);
+
+  const refreshTasks = useCallback(() => {
+    setReloadToken((token) => token + 1);
+  }, []);
 
   const {
     completed,
@@ -400,6 +411,18 @@ export function useTasksOverview() {
     navigate("/dashboard/tasks");
   }, [navigate]);
 
+  const projectOptions: TasksOverviewProjectOption[] = useMemo(
+    () =>
+      projects
+        .filter((project): project is Project & { projectId: string } => Boolean(project?.projectId))
+        .map((project) => ({
+          id: project.projectId,
+          name: project.title || project.projectId,
+          color: project.color || getColor(project.projectId),
+        })),
+    [projects]
+  );
+
   const primaryProjectName = primaryProjectId
     ? projectMap.get(primaryProjectId)?.title ?? primaryProjectId
     : undefined;
@@ -416,6 +439,8 @@ export function useTasksOverview() {
     undatedTasks,
     completedThisWeek,
     navigateToProject,
+    refreshTasks,
+    projectOptions,
     primaryProjectId,
     primaryProjectName,
   };

--- a/frontend/src/dashboard/home/pages/TasksListPage.module.css
+++ b/frontend/src/dashboard/home/pages/TasksListPage.module.css
@@ -201,6 +201,165 @@
   font-weight: 600;
 }
 
+.createOverlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1500;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 32px 16px;
+  background: rgba(5, 6, 7, 0.72);
+  backdrop-filter: blur(6px);
+}
+
+.createModal {
+  width: min(520px, 100%);
+  border-radius: 24px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(13, 14, 16, 0.95);
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.45);
+  padding: 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  color: var(--text-primary, #f6f7fb);
+}
+
+.createHeader {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.createHeader h2 {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 600;
+}
+
+.createDescription {
+  margin: 0;
+  color: var(--text-secondary, rgba(246, 247, 251, 0.72));
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.createForm {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.fieldLabel {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-size: 0.95rem;
+  color: var(--text-primary, #f6f7fb);
+}
+
+.selectInput,
+.textInput,
+.textarea {
+  width: 100%;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(24, 26, 29, 0.9);
+  color: inherit;
+  padding: 12px 14px;
+  font-size: 0.95rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.selectInput:focus,
+.textInput:focus,
+.textarea:focus {
+  outline: none;
+  border-color: rgba(250, 51, 86, 0.65);
+  box-shadow: 0 0 0 3px rgba(250, 51, 86, 0.2);
+}
+
+.textarea {
+  min-height: 96px;
+  resize: vertical;
+}
+
+.fieldOptional {
+  font-size: 0.85rem;
+  color: var(--text-tertiary, rgba(246, 247, 251, 0.55));
+  margin-left: 6px;
+}
+
+.emptyProjects {
+  margin: -4px 0 4px;
+  color: var(--text-tertiary, rgba(246, 247, 251, 0.65));
+  font-size: 0.9rem;
+}
+
+.feedback {
+  border-radius: 12px;
+  padding: 10px 12px;
+  font-size: 0.9rem;
+}
+
+.feedbackError {
+  background: rgba(250, 51, 86, 0.15);
+  color: #ff9aa9;
+  border: 1px solid rgba(250, 51, 86, 0.35);
+}
+
+.feedbackSuccess {
+  background: rgba(34, 197, 94, 0.16);
+  color: #a6f4c5;
+  border: 1px solid rgba(34, 197, 94, 0.35);
+}
+
+.formActions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+  margin-top: 8px;
+}
+
+.secondaryButton,
+.submitButton {
+  border-radius: 999px;
+  padding: 10px 18px;
+  font-weight: 600;
+  font-size: 0.95rem;
+  cursor: pointer;
+  border: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+}
+
+.secondaryButton {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text-primary, #f6f7fb);
+}
+
+.secondaryButton:hover:not(:disabled) {
+  transform: translateY(-1px);
+}
+
+.submitButton {
+  background: linear-gradient(135deg, rgba(250, 51, 86, 0.9), rgba(250, 51, 86, 0.7));
+  color: #fff;
+  box-shadow: 0 14px 32px rgba(250, 51, 86, 0.35);
+}
+
+.submitButton:hover:not(:disabled) {
+  transform: translateY(-1px);
+}
+
+.secondaryButton:disabled,
+.submitButton:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  box-shadow: none;
+  transform: none;
+}
+
 .sectionCaption {
   margin: 0;
   color: var(--text-tertiary, rgba(246, 247, 251, 0.6));

--- a/frontend/src/dashboard/home/pages/TasksListPage.tsx
+++ b/frontend/src/dashboard/home/pages/TasksListPage.tsx
@@ -1,10 +1,15 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
-import { Play, ChevronDown } from "lucide-react";
+import { Plus, ChevronDown } from "lucide-react";
 import { createPortal } from "react-dom";
 import { useLocation, useNavigate } from "react-router-dom";
 
-import { useTasksOverview, type TasksOverviewListItem } from "../hooks/useTasksOverview";
+import {
+  useTasksOverview,
+  type TasksOverviewListItem,
+  type TasksOverviewProjectOption,
+} from "../hooks/useTasksOverview";
 import { endOfWeek } from "@/dashboard/home/utils/dateUtils";
+import { createTask } from "@/shared/utils/api";
 import styles from "./TasksListPage.module.css";
 
 const dayLabelFormatter = new Intl.DateTimeFormat(undefined, {
@@ -30,6 +35,220 @@ type TaskListProps = {
   emptyLabel: string;
   onStart?: (task: TasksOverviewListItem) => void;
   showCompleted?: boolean;
+};
+
+type QuickTaskModalProps = {
+  open: boolean;
+  onClose: () => void;
+  projects: TasksOverviewProjectOption[];
+  onCreated: () => void;
+};
+
+const QuickCreateTaskModal: React.FC<QuickTaskModalProps> = ({
+  open,
+  onClose,
+  projects,
+  onCreated,
+}) => {
+  const [projectId, setProjectId] = useState<string>("");
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [dueDate, setDueDate] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      setProjectId("");
+      setTitle("");
+      setDescription("");
+      setDueDate("");
+      setSubmitting(false);
+      setErrorMessage(null);
+      setSuccessMessage(null);
+      return;
+    }
+
+    setErrorMessage(null);
+    setSuccessMessage(null);
+
+    if (!projects.length) {
+      setProjectId("");
+      return;
+    }
+
+    if (!projectId || !projects.some((project) => project.id === projectId)) {
+      setProjectId(projects[0].id);
+    }
+  }, [open, projects, projectId]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        if (!submitting) {
+          onClose();
+        }
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [open, onClose, submitting]);
+
+  if (!open || typeof document === "undefined") {
+    return null;
+  }
+
+  const hasProjects = projects.length > 0;
+
+  const handleOverlayMouseDown = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (event.target === event.currentTarget && !submitting) {
+      onClose();
+    }
+  };
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const targetProjectId = projectId || projects[0]?.id || "";
+    if (!targetProjectId) {
+      setErrorMessage("Add a project before creating tasks.");
+      return;
+    }
+
+    const trimmedTitle = title.trim();
+    if (!trimmedTitle) {
+      setErrorMessage("Give the task a name before saving.");
+      return;
+    }
+
+    setSubmitting(true);
+    setErrorMessage(null);
+
+    let dueDateIso: string | undefined;
+    if (dueDate) {
+      const parsed = new Date(`${dueDate}T00:00:00`);
+      dueDateIso = Number.isNaN(parsed.getTime()) ? undefined : parsed.toISOString();
+    }
+
+    try {
+      await createTask({
+        projectId: targetProjectId,
+        title: trimmedTitle,
+        description: description.trim() || undefined,
+        dueDate: dueDateIso,
+        status: "todo",
+      });
+      setSuccessMessage("Task created. You'll see it in your lists shortly.");
+      setTitle("");
+      setDescription("");
+      setDueDate("");
+      onCreated();
+    } catch (error) {
+      console.error("Failed to create task", error);
+      setErrorMessage("We couldn't create that task. Please try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return createPortal(
+    <div className={styles.createOverlay} role="presentation" onMouseDown={handleOverlayMouseDown}>
+      <div
+        className={styles.createModal}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="quick-task-title"
+        onMouseDown={(event) => event.stopPropagation()}
+      >
+        <div className={styles.createHeader}>
+          <h2 id="quick-task-title">Create a task</h2>
+          <p className={styles.createDescription}>
+            Launch work for any project on your radar without leaving this view.
+          </p>
+        </div>
+        <form className={styles.createForm} onSubmit={handleSubmit}>
+          <label className={styles.fieldLabel}>
+            Project
+            <select
+              className={styles.selectInput}
+              value={projectId}
+              onChange={(event) => setProjectId(event.target.value)}
+              disabled={!hasProjects || submitting}
+            >
+              {projects.map((project) => (
+                <option key={project.id} value={project.id}>
+                  {project.name}
+                </option>
+              ))}
+            </select>
+          </label>
+          {!hasProjects ? (
+            <p className={styles.emptyProjects}>Add a project to start creating tasks.</p>
+          ) : null}
+          <label className={styles.fieldLabel}>
+            Task name
+            <input
+              type="text"
+              className={styles.textInput}
+              value={title}
+              onChange={(event) => setTitle(event.target.value)}
+              placeholder="What needs to get done?"
+              disabled={submitting}
+            />
+          </label>
+          <label className={styles.fieldLabel}>
+            Due date <span className={styles.fieldOptional}>(optional)</span>
+            <input
+              type="date"
+              className={styles.textInput}
+              value={dueDate}
+              onChange={(event) => setDueDate(event.target.value)}
+              disabled={submitting}
+            />
+          </label>
+          <label className={styles.fieldLabel}>
+            Notes <span className={styles.fieldOptional}>(optional)</span>
+            <textarea
+              className={styles.textarea}
+              value={description}
+              onChange={(event) => setDescription(event.target.value)}
+              rows={3}
+              placeholder="Add context or links."
+              disabled={submitting}
+            />
+          </label>
+          {errorMessage ? (
+            <div className={`${styles.feedback} ${styles.feedbackError}`}>{errorMessage}</div>
+          ) : null}
+          {successMessage ? (
+            <div className={`${styles.feedback} ${styles.feedbackSuccess}`}>{successMessage}</div>
+          ) : null}
+          <div className={styles.formActions}>
+            <button
+              type="button"
+              className={styles.secondaryButton}
+              onClick={onClose}
+              disabled={submitting}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className={styles.submitButton}
+              disabled={!hasProjects || submitting}
+            >
+              Save task
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>,
+    document.body
+  );
 };
 
 const TaskList: React.FC<TaskListProps> = ({ tasks, emptyLabel, onStart, showCompleted }) => {
@@ -137,10 +356,19 @@ const TasksListPage: React.FC = () => {
     undatedTasks,
     completedThisWeek,
     navigateToProject,
-    handleNavigateToPrimary,
-    canNavigateToProject,
-    primaryProjectName,
+    refreshTasks,
+    projectOptions,
   } = useTasksOverview();
+
+  const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
+
+  const openCreateModal = useCallback(() => {
+    setIsCreateModalOpen(true);
+  }, []);
+
+  const closeCreateModal = useCallback(() => {
+    setIsCreateModalOpen(false);
+  }, []);
 
   const { overdueTasks, dueSoonTasks, upcomingTasks } = useMemo(() => {
     const now = new Date();
@@ -189,9 +417,9 @@ const TasksListPage: React.FC = () => {
     undatedTasks.length > 0 ||
     completedThisWeek.length > 0;
 
-  const introMessage = primaryProjectName
-    ? `Review everything on your radar and jump straight back into ${primaryProjectName}.`
-    : "Review every task across your projects and start where you left off.";
+  const introMessage = projectOptions.length
+    ? "Review everything on your radar and kick off the next task for whichever project needs attention."
+    : "Review everything on your radar and add tasks whenever you have a project to assign them to.";
 
   const titleId = "tasks-drawer-title";
 
@@ -199,7 +427,7 @@ const TasksListPage: React.FC = () => {
     return null;
   }
 
-  return createPortal(
+  const drawer = (
     <div className={styles.drawerOverlay} role="presentation" onMouseDown={onOverlayMouseDown}>
       <div
         className={styles.drawer}
@@ -231,11 +459,12 @@ const TasksListPage: React.FC = () => {
               <button
                 type="button"
                 className={styles.primaryAction}
-                onClick={handleNavigateToPrimary}
-                disabled={!canNavigateToProject}
+                onClick={openCreateModal}
+                disabled={!projectOptions.length}
+                aria-label="Create a task for any project"
               >
-                <Play size={18} strokeWidth={2.5} />
-                Start next task
+                <Plus size={18} strokeWidth={2.5} />
+                Create task
               </button>
             </header>
 
@@ -352,8 +581,19 @@ const TasksListPage: React.FC = () => {
           </div>
         </div>
       </div>
-    </div>,
-    document.body
+    </div>
+  );
+
+  return (
+    <>
+      {createPortal(drawer, document.body)}
+      <QuickCreateTaskModal
+        open={isCreateModalOpen}
+        onClose={closeCreateModal}
+        projects={projectOptions}
+        onCreated={refreshTasks}
+      />
+    </>
   );
 };
 


### PR DESCRIPTION
## Summary
- expose project options and a refresh helper from the tasks overview hook
- update the tasks list drawer messaging and primary action to open a quick task creator
- add styles and UI for the new cross-project task creation modal

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d87db448d483249ff35d024384fc4e