### PR TITLE
Add mobile tasks overview for project page

### DIFF
--- a/frontend/src/dashboard/home/styles/components/calendar.css
+++ b/frontend/src/dashboard/home/styles/components/calendar.css
@@ -103,6 +103,11 @@
   height: 85vh;
 }
 
+.timeline-location-row--tasks-only {
+  height: auto;
+  min-height: 0;
+}
+
 .timeline-location-row > * {
   flex: 1 1 0;
   min-width: 0;
@@ -160,6 +165,11 @@
 .tasks-wrapper {
   flex: 1 1 70%;
   width: 70%;
+}
+
+.timeline-location-row--tasks-only .tasks-wrapper {
+  width: 100%;
+  flex: 1 1 auto;
 }
 
 /* Responsive: stack vertically on narrower viewports */

--- a/frontend/src/dashboard/project/components/Tasks/TasksComponentMobile.module.css
+++ b/frontend/src/dashboard/project/components/Tasks/TasksComponentMobile.module.css
@@ -1,0 +1,384 @@
+.section {
+  background: var(--surface-card, #ffffff);
+  border-radius: 16px;
+  box-shadow: 0 12px 32px -16px rgba(15, 23, 42, 0.35);
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.headingGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.title {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--text-primary, #0f172a);
+}
+
+.subtitle {
+  font-size: 0.875rem;
+  line-height: 1.4;
+  color: var(--text-secondary, #64748b);
+}
+
+.headerActions {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.primaryButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  border-radius: 9999px;
+  border: none;
+  padding: 0.5rem 0.9rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #ffffff;
+  background: var(--brand, #fa3356);
+  cursor: pointer;
+  transition: transform 160ms ease, box-shadow 160ms ease;
+}
+
+.primaryButton:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.primaryButton:not(:disabled):hover,
+.primaryButton:not(:disabled):focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 16px -12px rgba(250, 51, 86, 0.75);
+}
+
+.statsRow {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.75rem;
+}
+
+.statCard {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  border-radius: 12px;
+  padding: 0.75rem;
+  background: var(--surface-subtle, #f8fafc);
+}
+
+.statLabel {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-tertiary, #94a3b8);
+}
+
+.statValue {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--text-primary, #0f172a);
+}
+
+.taskList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.taskItem {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 0.85rem;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.04);
+}
+
+.taskTitle {
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: var(--text-primary, #0f172a);
+}
+
+.taskMeta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  text-align: right;
+  font-size: 0.75rem;
+  color: var(--text-tertiary, #94a3b8);
+}
+
+.statusBadge {
+  padding: 0.15rem 0.55rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: #ffffff;
+  background: var(--brand, #fa3356);
+}
+
+.empty,
+.error,
+.loading {
+  padding: 1rem;
+  border-radius: 12px;
+  font-size: 0.85rem;
+  color: var(--text-secondary, #64748b);
+  background: rgba(15, 23, 42, 0.04);
+}
+
+.error {
+  color: #b91c1c;
+  background: rgba(185, 28, 28, 0.08);
+}
+
+.loading {
+  color: var(--text-tertiary, #94a3b8);
+}
+
+.drawerOverlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.55);
+  backdrop-filter: blur(2px);
+  display: flex;
+  justify-content: center;
+  align-items: flex-end;
+  z-index: 1000;
+}
+
+.drawer {
+  width: min(720px, 100%);
+  max-height: 92vh;
+  background: var(--surface-card, #ffffff);
+  border-radius: 20px 20px 0 0;
+  box-shadow: 0 -12px 32px rgba(15, 23, 42, 0.35);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  animation: drawer-slide-up 220ms ease-out;
+}
+
+.drawerHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1.25rem;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.06);
+}
+
+.drawerTitleGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.drawerTitle {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-primary, #0f172a);
+}
+
+.drawerSubtitle {
+  font-size: 0.8rem;
+  color: var(--text-secondary, #64748b);
+}
+
+.closeButton {
+  background: none;
+  border: none;
+  padding: 0.25rem;
+  border-radius: 999px;
+  color: var(--text-secondary, #64748b);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.closeButton:hover,
+.closeButton:focus-visible {
+  background: rgba(15, 23, 42, 0.08);
+  color: var(--text-primary, #0f172a);
+}
+
+.drawerContent {
+  overflow-y: auto;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.mapContainer {
+  height: 220px;
+  border-radius: 16px;
+  overflow: hidden;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.mapEmpty {
+  height: 220px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 16px;
+  border: 1px dashed rgba(148, 163, 184, 0.6);
+  color: var(--text-tertiary, #94a3b8);
+  font-size: 0.85rem;
+  text-align: center;
+  padding: 0 1.5rem;
+}
+
+.drawerSection {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.sectionHeading {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text-primary, #0f172a);
+}
+
+.drawerTaskList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.drawerTaskItem {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 0.75rem;
+  border-radius: 12px;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  background: rgba(248, 250, 252, 0.65);
+}
+
+.drawerTaskTop {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.drawerTaskTitle {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text-primary, #0f172a);
+}
+
+.drawerTaskMeta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.8rem;
+  color: var(--text-secondary, #64748b);
+}
+
+.metaLine {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.createForm {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.input,
+.textarea,
+.dateInput {
+  width: 100%;
+  padding: 0.65rem 0.75rem;
+  border-radius: 10px;
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  font-size: 0.9rem;
+  color: var(--text-primary, #0f172a);
+  background: #ffffff;
+}
+
+.textarea {
+  min-height: 96px;
+  resize: vertical;
+}
+
+.formActions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.submitButton {
+  border: none;
+  border-radius: 999px;
+  background: var(--brand, #fa3356);
+  color: #ffffff;
+  font-weight: 600;
+  font-size: 0.9rem;
+  padding: 0.6rem 1.2rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  cursor: pointer;
+}
+
+.submitButton:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.successMessage {
+  color: #047857;
+  font-size: 0.8rem;
+}
+
+.formError {
+  color: #b91c1c;
+  font-size: 0.8rem;
+}
+
+@keyframes drawer-slide-up {
+  from {
+    transform: translateY(24px);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+@media (min-width: 768px) {
+  .section {
+    padding: 1.5rem;
+  }
+}

--- a/frontend/src/dashboard/project/components/Tasks/TasksComponentMobile.module.css
+++ b/frontend/src/dashboard/project/components/Tasks/TasksComponentMobile.module.css
@@ -1,141 +1,152 @@
-.section {
-  background: var(--surface-card, #ffffff);
-  border-radius: 16px;
-  box-shadow: 0 12px 32px -16px rgba(15, 23, 42, 0.35);
-  padding: 1.25rem;
+.card {
   display: flex;
   flex-direction: column;
-  gap: 1.25rem;
+  gap: 12px;
+  padding: 14px 16px;
+  color: rgba(255, 255, 255, 0.92);
+  background:
+    radial-gradient(120% 120% at 100% 0%, color-mix(in srgb, var(--brand, #fa3356) 12%, transparent) 0%, transparent 60%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.08) 0%, rgba(255, 255, 255, 0) 70%),
+    var(--bg2, #111213);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: var(--radius-squircle, 20px);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
 }
 
 .header {
   display: flex;
-  justify-content: space-between;
   align-items: flex-start;
-  gap: 1rem;
+  justify-content: space-between;
+  gap: 12px;
 }
 
 .headingGroup {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: 4px;
 }
 
 .title {
-  font-size: 1.125rem;
+  margin: 0;
+  font-size: 16px;
   font-weight: 600;
-  color: var(--text-primary, #0f172a);
+  letter-spacing: -0.01em;
 }
 
 .subtitle {
-  font-size: 0.875rem;
-  line-height: 1.4;
-  color: var(--text-secondary, #64748b);
-}
-
-.headerActions {
-  display: flex;
-  gap: 0.75rem;
-  align-items: center;
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.35;
+  color: rgba(255, 255, 255, 0.7);
 }
 
 .primaryButton {
   display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
-  border-radius: 9999px;
-  border: none;
-  padding: 0.5rem 0.9rem;
-  font-size: 0.875rem;
+  gap: 8px;
+  padding: 8px 14px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.14);
+  color: rgba(255, 255, 255, 0.95);
+  font-size: 13px;
   font-weight: 600;
-  color: #ffffff;
-  background: var(--brand, #fa3356);
+  line-height: 1;
   cursor: pointer;
-  transition: transform 160ms ease, box-shadow 160ms ease;
+  transition: background 160ms ease, transform 160ms ease;
 }
 
 .primaryButton:disabled {
-  opacity: 0.6;
+  opacity: 0.55;
   cursor: not-allowed;
 }
 
 .primaryButton:not(:disabled):hover,
 .primaryButton:not(:disabled):focus-visible {
+  background: rgba(255, 255, 255, 0.22);
   transform: translateY(-1px);
-  box-shadow: 0 10px 16px -12px rgba(250, 51, 86, 0.75);
 }
 
-.statsRow {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-  gap: 0.75rem;
+.primaryButton:focus-visible {
+  outline: 2px solid var(--color-focus, var(--brand, #fa3356));
+  outline-offset: 2px;
+}
+
+.statRow {
+  display: flex;
+  gap: 9px;
 }
 
 .statCard {
+  flex: 1 1 0;
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
-  border-radius: 12px;
-  padding: 0.75rem;
-  background: var(--surface-subtle, #f8fafc);
+  justify-content: center;
+  gap: 4px;
+  padding: 10px 12px;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.07);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  min-height: 60px;
 }
 
-.statLabel {
-  font-size: 0.75rem;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--text-tertiary, #94a3b8);
+.statOk {
+  background: color-mix(in srgb, var(--color-success, #4caf50) 12%, transparent);
+  border-color: color-mix(in srgb, var(--color-success, #4caf50) 34%, transparent);
+}
+
+.statDanger {
+  background: color-mix(in srgb, var(--color-error, #ef5350) 14%, transparent);
+  border-color: color-mix(in srgb, var(--color-error, #ef5350) 36%, transparent);
+}
+
+.statWarn {
+  background: color-mix(in srgb, var(--color-warning, #ff9800) 14%, transparent);
+  border-color: color-mix(in srgb, var(--color-warning, #ff9800) 36%, transparent);
 }
 
 .statValue {
-  font-size: 1.25rem;
+  font-size: 18px;
   font-weight: 600;
-  color: var(--text-primary, #0f172a);
 }
 
-.taskList {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-}
-
-.taskItem {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 0.75rem;
-  padding: 0.75rem 0.85rem;
-  border-radius: 12px;
-  background: rgba(15, 23, 42, 0.04);
-}
-
-.taskTitle {
-  font-size: 0.95rem;
-  font-weight: 500;
-  color: var(--text-primary, #0f172a);
-}
-
-.taskMeta {
-  display: flex;
-  flex-direction: column;
-  gap: 0.15rem;
-  text-align: right;
-  font-size: 0.75rem;
-  color: var(--text-tertiary, #94a3b8);
-}
-
-.statusBadge {
-  padding: 0.15rem 0.55rem;
-  border-radius: 999px;
-  font-size: 0.7rem;
-  font-weight: 600;
-  letter-spacing: 0.02em;
+.statLabel {
+  font-size: 11px;
   text-transform: uppercase;
-  color: #ffffff;
-  background: var(--brand, #fa3356);
+  letter-spacing: 0.06em;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.status {
+  margin: 0;
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.72);
+  line-height: 1.35;
+}
+
+.status strong {
+  color: rgba(255, 255, 255, 0.9);
+}
+
+@media (max-width: 480px) {
+  .card {
+    padding: 12px 14px;
+    gap: 10px;
+  }
+
+  .primaryButton {
+    padding: 7px 12px;
+    font-size: 12px;
+  }
+
+  .statRow {
+    gap: 7px;
+  }
+
+  .statCard {
+    padding: 9px 10px;
+    border-radius: 15px;
+  }
 }
 
 .empty,

--- a/frontend/src/dashboard/project/components/Tasks/TasksComponentMobile.tsx
+++ b/frontend/src/dashboard/project/components/Tasks/TasksComponentMobile.tsx
@@ -175,6 +175,14 @@ function computeStats(tasks: QuickTask[]) {
   return { completed, overdue, dueSoon };
 }
 
+function isSameDay(a: Date, b: Date): boolean {
+  return (
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate()
+  );
+}
+
 function buildMarkerThumbnail(color?: string) {
   if (!color) return undefined;
   const svg = `<?xml version="1.0" encoding="UTF-8"?>\n<svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><circle cx="16" cy="16" r="14" fill="${color}" stroke="white" stroke-width="4"/></svg>`;
@@ -238,18 +246,11 @@ const TasksComponentMobile: React.FC<TasksComponentMobileProps> = ({
 
   const stats = useMemo(() => computeStats(tasks), [tasks]);
 
-  const activeTasks = useMemo(() => {
-    const openTasks = tasks.filter((task) => task.status !== "done");
-    return openTasks
-      .slice()
-      .sort((a, b) => {
-        if (a.dueDate && b.dueDate) return a.dueDate.getTime() - b.dueDate.getTime();
-        if (a.dueDate) return -1;
-        if (b.dueDate) return 1;
-        return a.title.localeCompare(b.title);
-      })
-      .slice(0, 3);
-  }, [tasks]);
+  const formatStatValue = (value: number): string | number => {
+    if (error) return "—";
+    if (loading) return "…";
+    return value;
+  };
 
   const drawerTasks = useMemo(() => {
     return tasks
@@ -280,6 +281,29 @@ const TasksComponentMobile: React.FC<TasksComponentMobileProps> = ({
       })),
     [mapTasks, projectColor],
   );
+
+  const statusMessage = useMemo(() => {
+    if (error) return "We couldn’t load tasks right now.";
+    if (loading) return "Loading tasks…";
+    if (!tasks.length) return "No tasks for this project yet.";
+
+    const openTasks = tasks.filter((task) => task.status !== "done");
+    if (!openTasks.length) return "You're all caught up.";
+
+    const datedTasks = openTasks.filter((task): task is QuickTask & { dueDate: Date } => Boolean(task.dueDate));
+    if (!datedTasks.length) {
+      const noun = openTasks.length === 1 ? "task" : "tasks";
+      return `${openTasks.length} open ${noun} with no due date yet.`;
+    }
+
+    const sorted = datedTasks
+      .slice()
+      .sort((a, b) => a.dueDate.getTime() - b.dueDate.getTime());
+    const nextDue = sorted[0];
+    const sameDayCount = sorted.filter((task) => isSameDay(task.dueDate, nextDue.dueDate)).length;
+    const noun = sameDayCount === 1 ? "task" : "tasks";
+    return `${sameDayCount} ${noun} due ${dueFormatter.format(nextDue.dueDate)}.`;
+  }, [error, loading, tasks]);
 
   const handleOpenDrawer = () => {
     setDrawerOpen(true);
@@ -469,58 +493,43 @@ const TasksComponentMobile: React.FC<TasksComponentMobileProps> = ({
   };
 
   return (
-    <section className={styles.section} aria-label="Project tasks overview">
+    <section className={styles.card} aria-label="Project tasks overview">
       <header className={styles.header}>
         <div className={styles.headingGroup}>
           <h3 className={styles.title}>Tasks</h3>
           <p className={styles.subtitle}>
             {projectName
-              ? `Track what's happening on ${projectName}.`
-              : "Track what's happening on this project."}
+              ? `Keep ${projectName} moving forward.`
+              : "Keep this project moving forward."}
           </p>
         </div>
-        <div className={styles.headerActions}>
-          <button type="button" className={styles.primaryButton} onClick={handleOpenDrawer} disabled={loading}>
-            <Plus size={16} strokeWidth={2.25} />
-            Open tasks
-          </button>
-        </div>
+        <button
+          type="button"
+          className={styles.primaryButton}
+          onClick={handleOpenDrawer}
+          disabled={loading}
+        >
+          <Plus size={16} strokeWidth={2.25} />
+          Open tasks
+        </button>
       </header>
 
-      <div className={styles.statsRow} aria-label="Task summary">
-        <div className={styles.statCard}>
-          <span className={styles.statLabel}>Completed</span>
-          <span className={styles.statValue}>{stats.completed}</span>
+      <div className={styles.statRow} aria-label="Task summary">
+        <div className={`${styles.statCard} ${styles.statOk}`}>
+          <span className={styles.statValue}>{formatStatValue(stats.completed)}</span>
+          <span className={styles.statLabel}>Done</span>
         </div>
-        <div className={styles.statCard}>
+        <div className={`${styles.statCard} ${styles.statDanger}`}>
+          <span className={styles.statValue}>{formatStatValue(stats.overdue)}</span>
           <span className={styles.statLabel}>Overdue</span>
-          <span className={styles.statValue}>{stats.overdue}</span>
         </div>
-        <div className={styles.statCard}>
+        <div className={`${styles.statCard} ${styles.statWarn}`}>
+          <span className={styles.statValue}>{formatStatValue(stats.dueSoon)}</span>
           <span className={styles.statLabel}>Due soon</span>
-          <span className={styles.statValue}>{stats.dueSoon}</span>
         </div>
       </div>
 
-      {error ? (
-        <div className={styles.error}>{error}</div>
-      ) : loading ? (
-        <div className={styles.loading}>Loading tasks…</div>
-      ) : activeTasks.length ? (
-        <ul className={styles.taskList}>
-          {activeTasks.map((task) => (
-            <li key={task.id} className={styles.taskItem}>
-              <span className={styles.taskTitle}>{task.title}</span>
-              <span className={styles.taskMeta}>
-                <span>{formatDueLabel(task)}</span>
-                <span>{task.status === "done" ? "Completed" : task.status.replace(/_/g, " ")}</span>
-              </span>
-            </li>
-          ))}
-        </ul>
-      ) : (
-        <div className={styles.empty}>No active tasks right now.</div>
-      )}
+      <p className={styles.status}>{statusMessage}</p>
 
       {renderDrawer()}
     </section>

--- a/frontend/src/dashboard/project/components/Tasks/TasksComponentMobile.tsx
+++ b/frontend/src/dashboard/project/components/Tasks/TasksComponentMobile.tsx
@@ -1,0 +1,530 @@
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { createPortal } from "react-dom";
+import { Plus, MapPin, Calendar, ChevronDown } from "lucide-react";
+
+import Map from "@/shared/ui/Map";
+import { createTask, fetchTasks } from "@/shared/utils/api";
+
+import styles from "./TasksComponentMobile.module.css";
+
+type Status = "todo" | "in_progress" | "done" | string;
+
+type RawTask = {
+  taskId?: string;
+  id?: string;
+  projectId?: string;
+  title?: string;
+  name?: string;
+  description?: string;
+  status?: Status;
+  dueAt?: string | number | Date;
+  due_at?: string | number | Date;
+  dueDate?: string | number | Date;
+  due_date?: string | number | Date;
+  due?: string | number | Date;
+  location?: unknown;
+  address?: string;
+  [key: string]: unknown;
+};
+
+type QuickTask = {
+  id: string;
+  title: string;
+  description?: string;
+  status: Status;
+  dueDate: Date | null;
+  address?: string;
+  location?: { lat: number; lng: number } | null;
+};
+
+type TasksComponentMobileProps = {
+  projectId?: string;
+  projectName?: string;
+  projectColor?: string;
+};
+
+const dueFormatter = new Intl.DateTimeFormat(undefined, {
+  month: "short",
+  day: "numeric",
+  weekday: "short",
+});
+
+const DEFAULT_LOCATION = { lat: 37.0902, lng: -95.7129 }; // Geographic centre of contiguous US
+
+function parseDueDate(value?: unknown): Date | null {
+  if (value == null || value === "") return null;
+
+  if (value instanceof Date) {
+    const copy = new Date(value.getTime());
+    return Number.isNaN(copy.getTime()) ? null : copy;
+  }
+
+  if (typeof value === "number") {
+    const byNumber = new Date(value);
+    return Number.isNaN(byNumber.getTime()) ? null : byNumber;
+  }
+
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+
+    const direct = new Date(trimmed);
+    if (!Number.isNaN(direct.getTime())) {
+      return direct;
+    }
+
+    if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
+      const iso = new Date(`${trimmed}T00:00:00`);
+      return Number.isNaN(iso.getTime()) ? null : iso;
+    }
+  }
+
+  return null;
+}
+
+function parseLocation(value: unknown): { lat: number; lng: number } | null {
+  if (!value) return null;
+  if (Array.isArray(value) && value.length >= 2) {
+    const [latRaw, lngRaw] = value;
+    const lat = Number(latRaw);
+    const lng = Number(lngRaw);
+    if (!Number.isNaN(lat) && !Number.isNaN(lng)) {
+      return { lat, lng };
+    }
+  }
+
+  if (typeof value === "object") {
+    const latCandidate = (value as Record<string, unknown>).lat ??
+      (value as Record<string, unknown>).latitude ??
+      (value as Record<string, unknown>).y;
+    const lngCandidate = (value as Record<string, unknown>).lng ??
+      (value as Record<string, unknown>).lon ??
+      (value as Record<string, unknown>).longitude ??
+      (value as Record<string, unknown>).x;
+    const lat = Number(latCandidate);
+    const lng = Number(lngCandidate);
+    if (!Number.isNaN(lat) && !Number.isNaN(lng)) {
+      return { lat, lng };
+    }
+  }
+
+  if (typeof value === "string") {
+    try {
+      const parsed = JSON.parse(value);
+      return parseLocation(parsed);
+    } catch {
+      const [latPart, lngPart] = value.split(/[,\s]+/);
+      const lat = Number(latPart);
+      const lng = Number(lngPart);
+      if (!Number.isNaN(lat) && !Number.isNaN(lng)) {
+        return { lat, lng };
+      }
+    }
+  }
+
+  return null;
+}
+
+function normalizeTask(raw: RawTask): QuickTask | null {
+  const id = raw.taskId || raw.id;
+  const title = (raw.title || raw.name || "").toString().trim();
+  if (!id) return null;
+
+  return {
+    id,
+    title: title || "Untitled task",
+    description: typeof raw.description === "string" ? raw.description : undefined,
+    status: (raw.status as Status) || "todo",
+    dueDate: parseDueDate(
+      raw.dueAt ?? raw.due_at ?? raw.dueDate ?? raw.due_date ?? raw.due,
+    ),
+    address: typeof raw.address === "string" ? raw.address : undefined,
+    location: parseLocation(raw.location),
+  };
+}
+
+function formatDueLabel(task: QuickTask): string {
+  if (!task.dueDate) return "No due date";
+  return dueFormatter.format(task.dueDate);
+}
+
+function computeStats(tasks: QuickTask[]) {
+  const now = new Date();
+  const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const inSevenDays = new Date(startOfToday.getTime() + 7 * 24 * 60 * 60 * 1000);
+
+  let completed = 0;
+  let overdue = 0;
+  let dueSoon = 0;
+
+  tasks.forEach((task) => {
+    if (task.status === "done") {
+      completed += 1;
+      return;
+    }
+
+    if (!task.dueDate) return;
+
+    if (task.dueDate < startOfToday) {
+      overdue += 1;
+    } else if (task.dueDate <= inSevenDays) {
+      dueSoon += 1;
+    }
+  });
+
+  return { completed, overdue, dueSoon };
+}
+
+function buildMarkerThumbnail(color?: string) {
+  if (!color) return undefined;
+  const svg = `<?xml version="1.0" encoding="UTF-8"?>\n<svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><circle cx="16" cy="16" r="14" fill="${color}" stroke="white" stroke-width="4"/></svg>`;
+  return `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`;
+}
+
+const TasksComponentMobile: React.FC<TasksComponentMobileProps> = ({
+  projectId = "",
+  projectName,
+  projectColor,
+}) => {
+  const [tasks, setTasks] = useState<QuickTask[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [dueDate, setDueDate] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const refreshTasks = useCallback(async () => {
+    if (!projectId) {
+      setTasks([]);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetchTasks(projectId);
+      const normalized = (response || [])
+        .map((raw: RawTask) => normalizeTask(raw))
+        .filter((task): task is QuickTask => Boolean(task));
+      setTasks(normalized);
+    } catch (err) {
+      console.error("Failed to load project tasks", err);
+      setError("We couldn't load tasks for this project. Please try again.");
+      setTasks([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [projectId]);
+
+  useEffect(() => {
+    void refreshTasks();
+  }, [refreshTasks]);
+
+  useEffect(() => {
+    if (!drawerOpen) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setDrawerOpen(false);
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [drawerOpen]);
+
+  const stats = useMemo(() => computeStats(tasks), [tasks]);
+
+  const activeTasks = useMemo(() => {
+    const openTasks = tasks.filter((task) => task.status !== "done");
+    return openTasks
+      .slice()
+      .sort((a, b) => {
+        if (a.dueDate && b.dueDate) return a.dueDate.getTime() - b.dueDate.getTime();
+        if (a.dueDate) return -1;
+        if (b.dueDate) return 1;
+        return a.title.localeCompare(b.title);
+      })
+      .slice(0, 3);
+  }, [tasks]);
+
+  const drawerTasks = useMemo(() => {
+    return tasks
+      .slice()
+      .sort((a, b) => {
+        const aTime = a.dueDate ? a.dueDate.getTime() : Number.POSITIVE_INFINITY;
+        const bTime = b.dueDate ? b.dueDate.getTime() : Number.POSITIVE_INFINITY;
+        if (aTime === bTime) return a.title.localeCompare(b.title);
+        return aTime - bTime;
+      });
+  }, [tasks]);
+
+  const mapTasks = useMemo(
+    () => tasks.filter((task) => task.location && !Number.isNaN(task.location.lat) && !Number.isNaN(task.location.lng)),
+    [tasks],
+  );
+
+  const mapLocation = mapTasks[0]?.location ?? DEFAULT_LOCATION;
+  const mapAddress = mapTasks[0]?.address ?? projectName ?? "Project";
+
+  const mapMarkers = useMemo(
+    () =>
+      mapTasks.map((task) => ({
+        id: task.id,
+        lat: task.location!.lat,
+        lng: task.location!.lng,
+        thumbnail: buildMarkerThumbnail(projectColor),
+      })),
+    [mapTasks, projectColor],
+  );
+
+  const handleOpenDrawer = () => {
+    setDrawerOpen(true);
+    setFormError(null);
+    setSuccessMessage(null);
+  };
+
+  const handleCloseDrawer = () => {
+    setDrawerOpen(false);
+    setFormError(null);
+  };
+
+  const resetForm = () => {
+    setTitle("");
+    setDescription("");
+    setDueDate("");
+  };
+
+  const handleCreateTask = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!projectId) return;
+
+    const trimmedTitle = title.trim();
+    if (!trimmedTitle) {
+      setSuccessMessage(null);
+      setFormError("Give the task a name before saving.");
+      return;
+    }
+
+    setSubmitting(true);
+    setFormError(null);
+    setSuccessMessage(null);
+
+    let dueIso: string | undefined;
+    if (dueDate) {
+      const parsed = new Date(`${dueDate}T00:00:00`);
+      if (!Number.isNaN(parsed.getTime())) {
+        dueIso = parsed.toISOString();
+      }
+    }
+
+    try {
+      await createTask({
+        projectId,
+        title: trimmedTitle,
+        description: description.trim() || undefined,
+        dueDate: dueIso,
+        status: "todo",
+      });
+      setSuccessMessage("Task created. It'll appear here shortly.");
+      resetForm();
+      void refreshTasks();
+    } catch (err) {
+      console.error("Failed to create project task", err);
+      setFormError("We couldn't create that task. Please try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const renderDrawer = () => {
+    if (!drawerOpen || typeof document === "undefined") {
+      return null;
+    }
+
+    const handleOverlayMouseDown = (event: React.MouseEvent<HTMLDivElement>) => {
+      if (event.target === event.currentTarget) {
+        handleCloseDrawer();
+      }
+    };
+
+    return createPortal(
+      <div className={styles.drawerOverlay} role="presentation" onMouseDown={handleOverlayMouseDown}>
+        <div className={styles.drawer} role="dialog" aria-modal="true" aria-label="Project tasks quick view" onMouseDown={(event) => event.stopPropagation()}>
+          <div className={styles.drawerHeader}>
+            <div className={styles.drawerTitleGroup}>
+              <span className={styles.drawerTitle}>Project tasks</span>
+              <span className={styles.drawerSubtitle}>
+                {projectName ? `Everything happening in ${projectName}` : "Keep work on track"}
+              </span>
+            </div>
+            <button type="button" className={styles.closeButton} onClick={handleCloseDrawer} aria-label="Close tasks drawer">
+              <ChevronDown size={20} strokeWidth={2.5} />
+            </button>
+          </div>
+
+          <div className={styles.drawerContent}>
+            <section className={styles.drawerSection} aria-label="Task map">
+              <h3 className={styles.sectionHeading}>Task map</h3>
+              {error ? (
+                <div className={styles.mapEmpty}>{error}</div>
+              ) : loading ? (
+                <div className={styles.mapEmpty}>Loading tasks…</div>
+              ) : mapTasks.length ? (
+                <div className={styles.mapContainer}>
+                  <Map
+                    location={mapLocation}
+                    address={mapAddress}
+                    scrollWheelZoom={false}
+                    dragging={true}
+                    touchZoom={true}
+                    showUserLocation={false}
+                    otherUsers={mapMarkers}
+                  />
+                </div>
+              ) : (
+                <div className={styles.mapEmpty}>
+                  Add locations to your tasks to see them appear on the map.
+                </div>
+              )}
+            </section>
+
+            <section className={styles.drawerSection} aria-label="All project tasks">
+              <h3 className={styles.sectionHeading}>Task list</h3>
+              {error ? (
+                <div className={styles.error}>{error}</div>
+              ) : loading ? (
+                <div className={styles.loading}>Loading tasks…</div>
+              ) : drawerTasks.length ? (
+                <ul className={styles.drawerTaskList}>
+                  {drawerTasks.map((task) => (
+                    <li key={task.id} className={styles.drawerTaskItem}>
+                      <div className={styles.drawerTaskTop}>
+                        <span className={styles.drawerTaskTitle}>{task.title}</span>
+                        <span className={styles.statusBadge}>
+                          {task.status === "done" ? "Completed" : task.status.replace(/_/g, " ")}
+                        </span>
+                      </div>
+                      <div className={styles.drawerTaskMeta}>
+                        <span className={styles.metaLine}>
+                          <Calendar size={14} aria-hidden="true" /> {formatDueLabel(task)}
+                        </span>
+                        {task.address ? (
+                          <span className={styles.metaLine}>
+                            <MapPin size={14} aria-hidden="true" /> {task.address}
+                          </span>
+                        ) : null}
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <div className={styles.empty}>No tasks yet. Create one to get started.</div>
+              )}
+            </section>
+
+            <section className={styles.drawerSection} aria-label="Create a quick task">
+              <h3 className={styles.sectionHeading}>Create quick task</h3>
+              <form className={styles.createForm} onSubmit={handleCreateTask}>
+                <input
+                  type="text"
+                  className={styles.input}
+                  placeholder="Task name"
+                  value={title}
+                  onChange={(event) => setTitle(event.target.value)}
+                  disabled={submitting}
+                />
+                <textarea
+                  className={styles.textarea}
+                  placeholder="Description (optional)"
+                  value={description}
+                  onChange={(event) => setDescription(event.target.value)}
+                  disabled={submitting}
+                />
+                <input
+                  type="date"
+                  className={styles.dateInput}
+                  value={dueDate}
+                  onChange={(event) => setDueDate(event.target.value)}
+                  disabled={submitting}
+                />
+                {formError ? <div className={styles.formError}>{formError}</div> : null}
+                {successMessage ? <div className={styles.successMessage}>{successMessage}</div> : null}
+                <div className={styles.formActions}>
+                  <button type="submit" className={styles.submitButton} disabled={submitting}>
+                    <Plus size={18} strokeWidth={2.5} />
+                    Create task
+                  </button>
+                </div>
+              </form>
+            </section>
+          </div>
+        </div>
+      </div>,
+      document.body,
+    );
+  };
+
+  return (
+    <section className={styles.section} aria-label="Project tasks overview">
+      <header className={styles.header}>
+        <div className={styles.headingGroup}>
+          <h3 className={styles.title}>Tasks</h3>
+          <p className={styles.subtitle}>
+            {projectName
+              ? `Track what's happening on ${projectName}.`
+              : "Track what's happening on this project."}
+          </p>
+        </div>
+        <div className={styles.headerActions}>
+          <button type="button" className={styles.primaryButton} onClick={handleOpenDrawer} disabled={loading}>
+            <Plus size={16} strokeWidth={2.25} />
+            Open tasks
+          </button>
+        </div>
+      </header>
+
+      <div className={styles.statsRow} aria-label="Task summary">
+        <div className={styles.statCard}>
+          <span className={styles.statLabel}>Completed</span>
+          <span className={styles.statValue}>{stats.completed}</span>
+        </div>
+        <div className={styles.statCard}>
+          <span className={styles.statLabel}>Overdue</span>
+          <span className={styles.statValue}>{stats.overdue}</span>
+        </div>
+        <div className={styles.statCard}>
+          <span className={styles.statLabel}>Due soon</span>
+          <span className={styles.statValue}>{stats.dueSoon}</span>
+        </div>
+      </div>
+
+      {error ? (
+        <div className={styles.error}>{error}</div>
+      ) : loading ? (
+        <div className={styles.loading}>Loading tasks…</div>
+      ) : activeTasks.length ? (
+        <ul className={styles.taskList}>
+          {activeTasks.map((task) => (
+            <li key={task.id} className={styles.taskItem}>
+              <span className={styles.taskTitle}>{task.title}</span>
+              <span className={styles.taskMeta}>
+                <span>{formatDueLabel(task)}</span>
+                <span>{task.status === "done" ? "Completed" : task.status.replace(/_/g, " ")}</span>
+              </span>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <div className={styles.empty}>No active tasks right now.</div>
+      )}
+
+      {renderDrawer()}
+    </section>
+  );
+};
+
+export default TasksComponentMobile;

--- a/frontend/src/dashboard/project/components/Tasks/index.ts
+++ b/frontend/src/dashboard/project/components/Tasks/index.ts
@@ -1,2 +1,3 @@
 // Tasks Components Barrel Export
 export { default as TasksComponent } from './TasksComponent';
+export { default as TasksComponentMobile } from './TasksComponentMobile';

--- a/frontend/src/dashboard/project/project.tsx
+++ b/frontend/src/dashboard/project/project.tsx
@@ -13,6 +13,7 @@ import type { QuickLinksRef } from "@/dashboard/project/components/Shared/QuickL
 import LocationComponent from "@/dashboard/project/components/Shared/LocationComponent";
 import FileManagerComponent from "@/dashboard/project/components/FileManager/FileManager";
 import TasksComponent from "@/dashboard/project/components/Tasks/TasksComponent";
+import TasksComponentMobile from "@/dashboard/project/components/Tasks/TasksComponentMobile";
 import { BudgetProvider } from "@/dashboard/project/features/budget/context/BudgetProvider";
 import { useData } from "@/app/contexts/useData";
 import { useSocket } from "@/app/contexts/useSocket";
@@ -25,6 +26,7 @@ import { getProjectDashboardPath } from "@/shared/utils/projectUrl";
 import Spinner from "@/shared/ui/Spinner";
 
 const MOBILE_LAYOUT_WIDTH = 640;
+const TASKS_MOBILE_WIDTH = 768;
 
 interface LocationState {
   flashDate?: string;
@@ -51,6 +53,10 @@ const SingleProject: React.FC = () => {
   const [isMobileBudgetLayout, setIsMobileBudgetLayout] = useState(() => {
     if (typeof window === "undefined") return false;
     return window.innerWidth <= MOBILE_LAYOUT_WIDTH;
+  });
+  const [isMobileTasksLayout, setIsMobileTasksLayout] = useState(() => {
+    if (typeof window === "undefined") return false;
+    return window.innerWidth <= TASKS_MOBILE_WIDTH;
   });
 
   const projectNameFromPath = useMemo(() => {
@@ -134,7 +140,9 @@ const SingleProject: React.FC = () => {
   useEffect(() => {
     if (typeof window === "undefined") return;
     const handleResize = () => {
-      setIsMobileBudgetLayout(window.innerWidth <= MOBILE_LAYOUT_WIDTH);
+      const width = window.innerWidth;
+      setIsMobileBudgetLayout(width <= MOBILE_LAYOUT_WIDTH);
+      setIsMobileTasksLayout(width <= TASKS_MOBILE_WIDTH);
     };
     handleResize();
     window.addEventListener("resize", handleResize);
@@ -400,11 +408,19 @@ const SingleProject: React.FC = () => {
             />
           </div>
           <div className="tasks-wrapper">
-            <TasksComponent
-              projectId={resolvedActiveProject.projectId}
-              userId={userId}
-              team={resolvedActiveProject.team}
-            />
+            {isMobileTasksLayout ? (
+              <TasksComponentMobile
+                projectId={resolvedActiveProject.projectId}
+                projectName={resolvedActiveProject.title}
+                projectColor={resolvedActiveProject.color as string | undefined}
+              />
+            ) : (
+              <TasksComponent
+                projectId={resolvedActiveProject.projectId}
+                userId={userId}
+                team={resolvedActiveProject.team}
+              />
+            )}
           </div>
         </div>
       </div>

--- a/frontend/src/dashboard/project/project.tsx
+++ b/frontend/src/dashboard/project/project.tsx
@@ -400,13 +400,19 @@ const SingleProject: React.FC = () => {
           onActiveProjectChange={handleActiveProjectChange}
         /> */}
 
-        <div className="dashboard-layout timeline-location-row">
-          <div className="location-wrapper">
-            <LocationComponent
-              activeProject={resolvedActiveProject}
-              onActiveProjectChange={handleActiveProjectChange}
-            />
-          </div>
+        <div
+          className={`dashboard-layout timeline-location-row${
+            isMobileTasksLayout ? " timeline-location-row--tasks-only" : ""
+          }`}
+        >
+          {!isMobileTasksLayout && (
+            <div className="location-wrapper">
+              <LocationComponent
+                activeProject={resolvedActiveProject}
+                onActiveProjectChange={handleActiveProjectChange}
+              />
+            </div>
+          )}
           <div className="tasks-wrapper">
             {isMobileTasksLayout ? (
               <TasksComponentMobile


### PR DESCRIPTION
## Summary
- add a project-scoped mobile tasks component that surfaces stats, a bottom drawer, and quick task creation
- wire the new mobile view into the project page with responsive detection while keeping the desktop table intact
- style the mobile drawer experience including task list, map container, and form states

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d9c5b5450883249bfe6d32419cd9c4