### PR TITLE
Adjust mobile project layout and tasks styling

### DIFF
--- a/frontend/src/dashboard/home/styles/components/calendar.css
+++ b/frontend/src/dashboard/home/styles/components/calendar.css
@@ -167,6 +167,7 @@
   .timeline-location-row {
     flex-direction: column;
     gap: 12px;
+    height: auto;
   }
 
   .location-wrapper,
@@ -175,6 +176,37 @@
     max-width: 100%;
     flex: none;
     min-width: 0;
+    height: auto;
+  }
+}
+
+.project-mobile-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding-top: 12px;
+}
+
+.project-mobile-stack .location-wrapper,
+.project-mobile-stack .tasks-wrapper {
+  width: 100%;
+  max-width: 100%;
+  flex: none;
+}
+
+.project-mobile-stack .tasks-wrapper > .tasks-component {
+  min-height: 0;
+}
+
+@media (max-width: 768px) {
+  .project-mobile-stack {
+    gap: 10px;
+    padding-top: 10px;
+  }
+
+  .project-mobile-stack .location-wrapper,
+  .project-mobile-stack .tasks-wrapper {
+    min-height: 0;
   }
 }
 
@@ -255,24 +287,40 @@
 
 .suggestions-list {
   position: absolute;
-  background: #ffffff;
-  color: #000;
+  background: rgba(17, 18, 19, 0.94);
+  color: var(--text-primary, #f6f7fb);
   width: 100%;
-  max-height: 150px;
+  max-height: 180px;
   overflow-y: auto;
-  border-radius: 4px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.45);
   z-index: 1100;
   top: 100%;
   left: 0;
+  padding: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
 }
 
-.suggestions-list div {
-  padding: 8px;
+.suggestions-list > * {
+  padding: 8px 12px;
   cursor: pointer;
+  border-radius: 10px;
+  color: inherit;
+  background: transparent;
+  border: none;
+  text-align: left;
+  font-size: 0.85rem;
+  transition: background 0.2s ease, color 0.2s ease;
 }
 
-.suggestions-list div:hover {
-  background: #eeeeee;
+.suggestions-list > *:hover,
+.suggestions-list > *:focus-visible {
+  background: rgba(250, 51, 86, 0.2);
+  color: #fff;
+  outline: none;
 }
 
 .budget-overview-revision {

--- a/frontend/src/dashboard/home/styles/components/tasks.css
+++ b/frontend/src/dashboard/home/styles/components/tasks.css
@@ -231,6 +231,171 @@
   color: rgba(255, 255, 255, 0.6);
 }
 
+.tasks-wrapper .tasks-card {
+  min-height: 0;
+}
+
+.tasks-card .ant-table,
+.tasks-card .ant-table-container,
+.tasks-card .ant-table-content,
+.tasks-card .ant-table-body,
+.tasks-card .ant-table-cell,
+.tasks-card .ant-table-thead > tr > th,
+.tasks-card .ant-table-tbody > tr > td {
+  background: transparent !important;
+  color: var(--text-primary, #f6f7fb);
+}
+
+.tasks-card .ant-table-thead > tr > th {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-secondary, rgba(246, 247, 251, 0.7));
+}
+
+.tasks-card .ant-table-tbody > tr > td {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.tasks-card .ant-table-tbody > tr:hover > td {
+  background: rgba(250, 51, 86, 0.08) !important;
+}
+
+.tasks-card .ant-table-placeholder {
+  background: transparent;
+  color: var(--text-secondary, rgba(246, 247, 251, 0.68));
+}
+
+.tasks-menu-overlay {
+  background: var(--bg2, #111213) !important;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.45);
+  border-radius: 14px !important;
+  overflow: hidden;
+}
+
+.tasks-menu-overlay .ant-select-item,
+.tasks-menu-overlay .ant-select-item-option,
+.tasks-menu-overlay .ant-dropdown-menu,
+.tasks-menu-overlay .ant-dropdown-menu-item,
+.tasks-menu-overlay .ant-picker-panel,
+.tasks-menu-overlay .ant-picker-time-panel {
+  background: transparent;
+  color: var(--text-primary, #f6f7fb);
+}
+
+.tasks-menu-overlay .ant-select-item-option-active,
+.tasks-menu-overlay .ant-select-item-option-selected,
+.tasks-menu-overlay .ant-dropdown-menu-item:hover,
+.tasks-menu-overlay .ant-dropdown-menu-item-active,
+.tasks-menu-overlay .ant-picker-cell-in-view.ant-picker-cell-selected .ant-picker-cell-inner,
+.tasks-menu-overlay .ant-picker-cell-in-view.ant-picker-cell-range-start .ant-picker-cell-inner,
+.tasks-menu-overlay .ant-picker-cell-in-view.ant-picker-cell-range-end .ant-picker-cell-inner,
+.tasks-menu-overlay .ant-picker-time-panel-column > li.ant-picker-time-panel-cell-selected .ant-picker-time-panel-cell-inner {
+  background: rgba(250, 51, 86, 0.2) !important;
+  color: #fff;
+}
+
+.tasks-menu-overlay .ant-picker-cell-inner {
+  border-radius: 8px;
+}
+
+.tasks-menu-overlay .ant-select-item-option-active:not(.ant-select-item-option-selected) {
+  background: rgba(250, 51, 86, 0.12) !important;
+}
+
+.tasks-menu-overlay .ant-select-item-option-content,
+.tasks-menu-overlay .ant-dropdown-menu-item,
+.tasks-menu-overlay .ant-picker-content {
+  font-size: 0.85rem;
+}
+
+.tasks-dark-modal .ant-modal-content {
+  background: var(--bg2, #111213);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 20px;
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.55);
+  color: var(--text-primary, #f6f7fb);
+}
+
+.tasks-dark-modal .ant-modal-header,
+.tasks-dark-modal .ant-modal-footer {
+  background: transparent;
+  border-color: rgba(255, 255, 255, 0.08);
+}
+
+.tasks-dark-modal .ant-modal-title {
+  color: var(--text-primary, #f6f7fb);
+  font-weight: 600;
+}
+
+.tasks-dark-modal .ant-modal-close {
+  color: var(--text-secondary, rgba(246, 247, 251, 0.68));
+}
+
+.tasks-dark-modal .ant-modal-close:hover {
+  color: #fff;
+}
+
+.tasks-dark-modal .ant-input,
+.tasks-dark-modal .ant-select-selector,
+.tasks-dark-modal .ant-picker,
+.tasks-dark-modal .ant-input-textarea,
+.tasks-dark-modal .ant-input-affix-wrapper {
+  background: #1f1f1f;
+  border-color: rgba(255, 255, 255, 0.16);
+  color: var(--text-primary, #f6f7fb);
+}
+
+.tasks-dark-modal .ant-input::placeholder,
+.tasks-dark-modal .ant-input-textarea::placeholder {
+  color: var(--text-tertiary, rgba(246, 247, 251, 0.5));
+}
+
+.tasks-dark-modal .ant-input:focus,
+.tasks-dark-modal .ant-select-selector:focus,
+.tasks-dark-modal .ant-picker-focused,
+.tasks-dark-modal .ant-input-affix-wrapper:focus,
+.tasks-dark-modal .ant-input-affix-wrapper-focused {
+  border-color: rgba(250, 51, 86, 0.65) !important;
+  box-shadow: 0 0 0 2px rgba(250, 51, 86, 0.2);
+}
+
+.tasks-suggestions-panel {
+  background: rgba(17, 18, 19, 0.94);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 14px;
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.45);
+  padding: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.tasks-suggestion-option {
+  background: transparent;
+  border: none;
+  color: var(--text-primary, #f6f7fb);
+  padding: 8px 12px;
+  text-align: left;
+  cursor: pointer;
+  border-radius: 10px;
+  font-size: 0.85rem;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.tasks-suggestion-option:hover,
+.tasks-suggestion-option:focus-visible {
+  background: rgba(250, 51, 86, 0.2);
+  color: #fff;
+  outline: none;
+}
+
+.tasks-suggestion-option--primary {
+  font-weight: 600;
+}
+
 
 
 

--- a/frontend/src/dashboard/project/components/Tasks/TasksComponent.tsx
+++ b/frontend/src/dashboard/project/components/Tasks/TasksComponent.tsx
@@ -116,6 +116,11 @@ const TasksComponent: React.FC<TasksComponentProps> = ({
   projectId = "",
   team = [],
 }) => {
+  const getPopupContainer = (triggerNode: HTMLElement) =>
+    triggerNode.parentElement ?? triggerNode;
+  const dropdownOverlayClass = "tasks-menu-overlay";
+  const modalRootClassName = "tasks-dark-modal";
+
   const [tasks, setTasks] = useState<Task[]>([]);
   const [isTaskModalOpen, setIsTaskModalOpen] = useState(false);
   const [editingTask, setEditingTask] = useState<Task | null>(null);
@@ -588,7 +593,11 @@ const TasksComponent: React.FC<TasksComponentProps> = ({
           { key: "delete", label: "Delete", icon: <DeleteOutlined /> },
         ];
         return (
-          <Dropdown menu={{ items, onClick: handleMenuClick(record) }} trigger={["click"]}>
+          <Dropdown
+            menu={{ items, onClick: handleMenuClick(record) }}
+            trigger={["click"]}
+            overlayClassName={dropdownOverlayClass}
+          >
             <Button
               type="text"
               size="small"
@@ -603,7 +612,51 @@ const TasksComponent: React.FC<TasksComponentProps> = ({
 
   /* Render */
   return (
-    <ConfigProvider theme={{ algorithm: theme.darkAlgorithm }}>
+    <ConfigProvider
+      theme={{
+        algorithm: theme.darkAlgorithm,
+        token: {
+          colorBgBase: "#050607",
+          colorBgContainer: "var(--bg2, #111213)",
+          colorBorder: "rgba(255, 255, 255, 0.12)",
+          colorText: "var(--text-primary, #f6f7fb)",
+          borderRadius: 12,
+          controlItemBgHover: "rgba(250, 51, 86, 0.12)",
+        },
+        components: {
+          Table: {
+            headerBg: "rgba(255, 255, 255, 0.04)",
+            headerColor: "rgba(246, 247, 251, 0.7)",
+            colorText: "var(--text-primary, #f6f7fb)",
+            rowHoverBg: "rgba(250, 51, 86, 0.08)",
+          },
+          Modal: {
+            colorBgElevated: "var(--bg2, #111213)",
+            colorText: "var(--text-primary, #f6f7fb)",
+            headerBg: "var(--bg2, #111213)",
+            borderRadiusLG: 18,
+          },
+          Select: {
+            selectorBg: "#1f1f1f",
+            colorText: "var(--text-primary, #f6f7fb)",
+            optionSelectedBg: "rgba(250, 51, 86, 0.2)",
+            optionActiveBg: "rgba(250, 51, 86, 0.12)",
+          },
+          DatePicker: {
+            colorBgContainer: "#1f1f1f",
+            colorText: "var(--text-primary, #f6f7fb)",
+            controlItemBgActive: "rgba(250, 51, 86, 0.2)",
+          },
+          Dropdown: {
+            controlItemBgHover: "rgba(250, 51, 86, 0.18)",
+          },
+          Tooltip: {
+            colorBgDefault: "rgba(17, 18, 19, 0.92)",
+            colorTextLightSolid: "#f6f7fb",
+          },
+        },
+      }}
+    >
       <div className="tasks-component">
         <div className="tasks-card">
           <Form form={assignForm} layout="vertical" className="assign-task-form">
@@ -625,21 +678,38 @@ const TasksComponent: React.FC<TasksComponentProps> = ({
                       ?.toUpperCase()
                       .includes(inputValue.toUpperCase())
                   }
+                  popupClassName={dropdownOverlayClass}
+                  getPopupContainer={getPopupContainer}
                 />
               </Form.Item>
 
               <Form.Item label="Assigned To" name="assignedTo">
-                <Select size="small" options={assigneeOptions} />
+                <Select
+                  size="small"
+                  options={assigneeOptions}
+                  popupClassName={dropdownOverlayClass}
+                  getPopupContainer={getPopupContainer}
+                />
               </Form.Item>
 
               <Form.Item label="Due Date" name="dueDate">
-                <DatePicker size="small" format="YYYY-MM-DD" />
+                <DatePicker
+                  size="small"
+                  format="YYYY-MM-DD"
+                  popupClassName={dropdownOverlayClass}
+                  getPopupContainer={getPopupContainer}
+                />
               </Form.Item>
             </div>
 
             <div className="form-row">
               <Form.Item label="Priority" name="priority">
-                <Select size="small" options={["Low", "Medium", "High"].map((p) => ({ value: p, label: p }))} />
+                <Select
+                  size="small"
+                  options={["Low", "Medium", "High"].map((p) => ({ value: p, label: p }))}
+                  popupClassName={dropdownOverlayClass}
+                  getPopupContainer={getPopupContainer}
+                />
               </Form.Item>
 
               <Form.Item label="Budget Element Id" name="budgetCode">
@@ -651,10 +721,11 @@ const TasksComponent: React.FC<TasksComponentProps> = ({
                     (option?.label as string).toLowerCase().includes(input.toLowerCase())
                   }
                   optionLabelProp="elementId"
-                  getPopupContainer={(trigger) => trigger.parentNode as HTMLElement}
+                  getPopupContainer={getPopupContainer}
                   value={assignForm.getFieldValue("budgetCode")}
                   onChange={(value) => assignForm.setFieldsValue({ budgetCode: value })}
                   popupRender={(menu) => menu}
+                  popupClassName={dropdownOverlayClass}
                 />
               </Form.Item>
 
@@ -668,47 +739,20 @@ const TasksComponent: React.FC<TasksComponentProps> = ({
                   />
                   {assignLocationSuggestions.length > 0 && (
                     <div
-                      className="suggestions-list"
-                      style={{
-                        position: "absolute",
-                        zIndex: 10,
-                        background: "#222",
-                        border: "1px solid #444",
-                        borderRadius: 4,
-                        width: "100%",
-                      }}
+                      className="suggestions-list tasks-suggestions-panel"
+                      style={{ position: "absolute", zIndex: 10, width: "100%" }}
                     >
                       {assignLocationSuggestions.map((s, idx) => (
-                        <div
+                        <button
                           key={s.place_id}
+                          type="button"
+                          className={`tasks-suggestion-option${
+                            idx === 0 ? " tasks-suggestion-option--primary" : ""
+                          }`}
                           onClick={() => handleAssignLocationSuggestionSelect(s)}
-                          style={{
-                            padding: "6px 10px",
-                            cursor: "pointer",
-                            borderBottom:
-                              idx < assignLocationSuggestions.length - 1
-                                ? "1px solid #333"
-                                : "none",
-                            background: "inherit",
-                          }}
-                          onMouseEnter={(e) => {
-                            e.currentTarget.style.background = "#eee";
-                            (e.currentTarget.firstChild as HTMLElement).style.color = "#222";
-                          }}
-                          onMouseLeave={(e) => {
-                            e.currentTarget.style.background = "inherit";
-                            (e.currentTarget.firstChild as HTMLElement).style.color = "#fff";
-                          }}
                         >
-                          <span
-                            style={{
-                              fontWeight: idx === 0 ? "bold" : "normal",
-                              color: "#fff",
-                            }}
-                          >
-                            {s.display_name}
-                          </span>
-                        </div>
+                          {s.display_name}
+                        </button>
                       ))}
                     </div>
                   )}
@@ -762,6 +806,7 @@ const TasksComponent: React.FC<TasksComponentProps> = ({
             centered
             okButtonProps={{ style: { background: "#FA3356", borderColor: "#FA3356" } }}
             forceRender
+            rootClassName={modalRootClassName}
           >
             <Form layout="vertical" form={editForm} preserve={false}>
               <Form.Item
@@ -778,11 +823,18 @@ const TasksComponent: React.FC<TasksComponentProps> = ({
                       ?.toUpperCase()
                       .includes(inputValue.toUpperCase())
                   }
+                  popupClassName={dropdownOverlayClass}
+                  getPopupContainer={getPopupContainer}
                 />
               </Form.Item>
 
               <Form.Item label="Assignee" name="assignedTo">
-                <Select size="small" options={assigneeOptions} />
+                <Select
+                  size="small"
+                  options={assigneeOptions}
+                  popupClassName={dropdownOverlayClass}
+                  getPopupContainer={getPopupContainer}
+                />
               </Form.Item>
 
               <Form.Item label="Due Date" name="dueDate">
@@ -795,7 +847,11 @@ const TasksComponent: React.FC<TasksComponentProps> = ({
 
               <Form.Item label="Budget Code" name="budgetItemId">
                 <div>
-                  <Select options={budgetOptions} />
+                  <Select
+                    options={budgetOptions}
+                    popupClassName={dropdownOverlayClass}
+                    getPopupContainer={getPopupContainer}
+                  />
                   <Input />
                 </div>
               </Form.Item>
@@ -821,14 +877,18 @@ const TasksComponent: React.FC<TasksComponentProps> = ({
                     onChange={handleLocationSearchChange}
                   />
                   {locationSuggestions.length > 0 && (
-                    <div className="suggestions-list">
-                      {locationSuggestions.map((s) => (
-                        <div
+                    <div className="suggestions-list tasks-suggestions-panel">
+                      {locationSuggestions.map((s, idx) => (
+                        <button
                           key={s.place_id}
+                          type="button"
+                          className={`tasks-suggestion-option${
+                            idx === 0 ? " tasks-suggestion-option--primary" : ""
+                          }`}
                           onClick={() => handleLocationSuggestionSelect(s)}
                         >
                           {s.display_name}
-                        </div>
+                        </button>
                       ))}
                     </div>
                   )}
@@ -845,47 +905,20 @@ const TasksComponent: React.FC<TasksComponentProps> = ({
                   />
                   {locationSuggestions.length > 0 && (
                     <div
-                      className="suggestions-list"
-                      style={{
-                        position: "absolute",
-                        zIndex: 10,
-                        background: "#222",
-                        border: "1px solid #444",
-                        borderRadius: 4,
-                        width: "100%",
-                      }}
+                      className="suggestions-list tasks-suggestions-panel"
+                      style={{ position: "absolute", zIndex: 10, width: "100%" }}
                     >
                       {locationSuggestions.map((s, idx) => (
-                        <div
+                        <button
                           key={s.place_id}
+                          type="button"
+                          className={`tasks-suggestion-option${
+                            idx === 0 ? " tasks-suggestion-option--primary" : ""
+                          }`}
                           onClick={() => handleLocationSuggestionSelect(s)}
-                          style={{
-                            padding: "6px 10px",
-                            cursor: "pointer",
-                            borderBottom:
-                              idx < locationSuggestions.length - 1
-                                ? "1px solid #333"
-                                : "none",
-                            background: "inherit",
-                          }}
-                          onMouseEnter={(e) => {
-                            e.currentTarget.style.background = "#eee";
-                            (e.currentTarget.firstChild as HTMLElement).style.color = "#222";
-                          }}
-                          onMouseLeave={(e) => {
-                            e.currentTarget.style.background = "inherit";
-                            (e.currentTarget.firstChild as HTMLElement).style.color = "#fff";
-                          }}
                         >
-                          <span
-                            style={{
-                              fontWeight: idx === 0 ? "bold" : "normal",
-                              color: "#fff",
-                            }}
-                          >
-                            {s.display_name}
-                          </span>
-                        </div>
+                          {s.display_name}
+                        </button>
                       ))}
                     </div>
                   )}
@@ -906,6 +939,7 @@ const TasksComponent: React.FC<TasksComponentProps> = ({
             onCancel={() => setIsCommentModalOpen(false)}
             centered
             okButtonProps={{ style: { background: "#FA3356", borderColor: "#FA3356" } }}
+            rootClassName={modalRootClassName}
           >
             <Input.TextArea
               value={commentText}

--- a/frontend/src/dashboard/project/project.tsx
+++ b/frontend/src/dashboard/project/project.tsx
@@ -392,21 +392,39 @@ const SingleProject: React.FC = () => {
           onActiveProjectChange={handleActiveProjectChange}
         /> */}
 
-        <div className="dashboard-layout timeline-location-row">
-          <div className="location-wrapper">
-            <LocationComponent
-              activeProject={resolvedActiveProject}
-              onActiveProjectChange={handleActiveProjectChange}
-            />
+        {isMobileBudgetLayout ? (
+          <div className="project-mobile-stack">
+            <div className="location-wrapper">
+              <LocationComponent
+                activeProject={resolvedActiveProject}
+                onActiveProjectChange={handleActiveProjectChange}
+              />
+            </div>
+            <div className="tasks-wrapper">
+              <TasksComponent
+                projectId={resolvedActiveProject.projectId}
+                userId={userId}
+                team={resolvedActiveProject.team}
+              />
+            </div>
           </div>
-          <div className="tasks-wrapper">
-            <TasksComponent
-              projectId={resolvedActiveProject.projectId}
-              userId={userId}
-              team={resolvedActiveProject.team}
-            />
+        ) : (
+          <div className="dashboard-layout timeline-location-row">
+            <div className="location-wrapper">
+              <LocationComponent
+                activeProject={resolvedActiveProject}
+                onActiveProjectChange={handleActiveProjectChange}
+              />
+            </div>
+            <div className="tasks-wrapper">
+              <TasksComponent
+                projectId={resolvedActiveProject.projectId}
+                userId={userId}
+                team={resolvedActiveProject.team}
+              />
+            </div>
           </div>
-        </div>
+        )}
       </div>
     </BudgetProvider>
   ) : null;


### PR DESCRIPTION
## Summary
- stack the project map and tasks modules in a dedicated mobile container to prevent overlap
- refresh mobile calendar suggestion list styling to match the dark palette used elsewhere
- apply dark-themed tokens, dropdown classes, and modal styling to the project tasks component so it aligns with the Task List drawer

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68da186871908324bcdfb59dec08192c