### PR TITLE
Fix mobile project layout and drawer styling

### DIFF
--- a/frontend/src/dashboard/home/styles/components/calendar.css
+++ b/frontend/src/dashboard/home/styles/components/calendar.css
@@ -116,8 +116,15 @@
 
 @media (max-height: 900px) {
   .timeline-location-row {
-    
+
     height: 50vh;
+  }
+}
+
+@media (max-width: 768px) {
+  .timeline-location-row {
+    height: auto;
+    min-height: 0;
   }
 }
 

--- a/frontend/src/dashboard/home/styles/components/page-layouts.css
+++ b/frontend/src/dashboard/home/styles/components/page-layouts.css
@@ -120,6 +120,26 @@
   flex: .7;
 }
 
+@media (max-width: 768px) {
+  .dashboard-layout {
+    height: auto;
+    min-height: 0;
+    overflow: visible;
+  }
+
+  .column-2 {
+    height: auto;
+    min-height: 0;
+  }
+
+  .overview-layout {
+    height: auto;
+    min-height: 0;
+    gap: 16px;
+    padding-bottom: 16px;
+  }
+}
+
 .column-new-project-description {
   max-height: 400px;
   display: flex;

--- a/frontend/src/dashboard/project/components/Tasks/TasksComponentMobile.module.css
+++ b/frontend/src/dashboard/project/components/Tasks/TasksComponentMobile.module.css
@@ -155,39 +155,46 @@
   padding: 1rem;
   border-radius: 12px;
   font-size: 0.85rem;
-  color: var(--text-secondary, #64748b);
-  background: rgba(15, 23, 42, 0.04);
+  color: var(--text-secondary, rgba(246, 247, 251, 0.72));
+  background: rgba(12, 13, 16, 0.65);
+  border: 1px solid rgba(255, 255, 255, 0.08);
 }
 
 .error {
-  color: #b91c1c;
-  background: rgba(185, 28, 28, 0.08);
+  color: #fca5a5;
+  background: rgba(127, 29, 29, 0.45);
+  border-color: rgba(248, 113, 113, 0.32);
 }
 
 .loading {
-  color: var(--text-tertiary, #94a3b8);
+  color: var(--text-tertiary, rgba(246, 247, 251, 0.6));
 }
 
 .drawerOverlay {
   position: fixed;
   inset: 0;
-  background: rgba(15, 23, 42, 0.55);
-  backdrop-filter: blur(2px);
+  background: rgba(5, 6, 7, 0.72);
+  backdrop-filter: blur(6px);
   display: flex;
   justify-content: center;
   align-items: flex-end;
-  z-index: 1000;
+  padding: clamp(12px, 4vh, 24px) 12px 12px;
+  z-index: 1600;
 }
 
 .drawer {
   width: min(720px, 100%);
-  max-height: 92vh;
-  background: var(--surface-card, #ffffff);
-  border-radius: 20px 20px 0 0;
-  box-shadow: 0 -12px 32px rgba(15, 23, 42, 0.35);
+  max-height: min(92vh, 92dvh);
+  background:
+    linear-gradient(135deg, rgba(17, 18, 19, 0.94), rgba(5, 6, 7, 0.98));
+  border-radius: 24px 24px 16px 16px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: 0 -18px 48px rgba(0, 0, 0, 0.45);
   overflow: hidden;
   display: flex;
   flex-direction: column;
+  color: var(--text-primary, #f6f7fb);
+  backdrop-filter: blur(12px);
   animation: drawer-slide-up 220ms ease-out;
 }
 
@@ -195,8 +202,9 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0.75rem 1.25rem;
-  border-bottom: 1px solid rgba(15, 23, 42, 0.06);
+  gap: 0.75rem;
+  padding: 1rem 1.5rem 0.75rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
 }
 
 .drawerTitleGroup {
@@ -208,35 +216,38 @@
 .drawerTitle {
   font-size: 1rem;
   font-weight: 600;
-  color: var(--text-primary, #0f172a);
+  color: var(--text-primary, #f6f7fb);
 }
 
 .drawerSubtitle {
   font-size: 0.8rem;
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary, rgba(246, 247, 251, 0.7));
 }
 
 .closeButton {
-  background: none;
-  border: none;
-  padding: 0.25rem;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  padding: 0.35rem;
   border-radius: 999px;
-  color: var(--text-secondary, #64748b);
+  color: var(--text-primary, #f6f7fb);
   display: inline-flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
+  transition: transform 0.2s ease, background 0.2s ease, border-color 0.2s ease;
 }
 
 .closeButton:hover,
 .closeButton:focus-visible {
-  background: rgba(15, 23, 42, 0.08);
-  color: var(--text-primary, #0f172a);
+  background: rgba(255, 255, 255, 0.14);
+  border-color: rgba(255, 255, 255, 0.24);
+  color: var(--text-primary, #ffffff);
+  transform: translateY(-1px);
 }
 
 .drawerContent {
   overflow-y: auto;
-  padding: 1.25rem;
+  padding: 1.5rem;
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
@@ -246,7 +257,8 @@
   height: 220px;
   border-radius: 16px;
   overflow: hidden;
-  border: 1px solid rgba(15, 23, 42, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.03);
 }
 
 .mapEmpty {
@@ -255,8 +267,9 @@
   align-items: center;
   justify-content: center;
   border-radius: 16px;
-  border: 1px dashed rgba(148, 163, 184, 0.6);
-  color: var(--text-tertiary, #94a3b8);
+  border: 1px dashed rgba(148, 163, 184, 0.5);
+  color: var(--text-tertiary, rgba(246, 247, 251, 0.6));
+  background: rgba(12, 13, 16, 0.65);
   font-size: 0.85rem;
   text-align: center;
   padding: 0 1.5rem;
@@ -266,12 +279,17 @@
   display: flex;
   flex-direction: column;
   gap: 0.85rem;
+  padding: 1.15rem 1.25rem;
+  border-radius: 18px;
+  background: rgba(17, 18, 19, 0.92);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02), 0 18px 48px rgba(0, 0, 0, 0.35);
 }
 
 .sectionHeading {
   font-size: 0.95rem;
   font-weight: 600;
-  color: var(--text-primary, #0f172a);
+  color: var(--text-primary, #f6f7fb);
 }
 
 .drawerTaskList {
@@ -287,10 +305,11 @@
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
-  padding: 0.75rem;
-  border-radius: 12px;
-  border: 1px solid rgba(15, 23, 42, 0.08);
-  background: rgba(248, 250, 252, 0.65);
+  padding: 0.85rem 0.9rem;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(12, 13, 16, 0.75);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
 }
 
 .drawerTaskTop {
@@ -303,7 +322,7 @@
 .drawerTaskTitle {
   font-size: 0.95rem;
   font-weight: 600;
-  color: var(--text-primary, #0f172a);
+  color: var(--text-primary, #ffffff);
 }
 
 .drawerTaskMeta {
@@ -311,13 +330,28 @@
   flex-direction: column;
   gap: 0.25rem;
   font-size: 0.8rem;
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary, rgba(246, 247, 251, 0.7));
 }
 
 .metaLine {
   display: inline-flex;
   align-items: center;
   gap: 0.35rem;
+}
+
+.statusBadge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: rgba(255, 255, 255, 0.12);
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(246, 247, 251, 0.95);
 }
 
 .createForm {
@@ -332,10 +366,11 @@
   width: 100%;
   padding: 0.65rem 0.75rem;
   border-radius: 10px;
-  border: 1px solid rgba(15, 23, 42, 0.12);
+  border: 1px solid rgba(255, 255, 255, 0.12);
   font-size: 0.9rem;
-  color: var(--text-primary, #0f172a);
-  background: #ffffff;
+  color: var(--text-primary, #f6f7fb);
+  background: rgba(12, 13, 16, 0.78);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
 }
 
 .textarea {
@@ -368,12 +403,12 @@
 }
 
 .successMessage {
-  color: #047857;
+  color: #4ade80;
   font-size: 0.8rem;
 }
 
 .formError {
-  color: #b91c1c;
+  color: #f87171;
   font-size: 0.8rem;
 }
 


### PR DESCRIPTION
## Summary
- allow the project overview layout to grow vertically on mobile screens so the gallery and tasks sections no longer overlap
- restyle the mobile task drawer to reuse the dashboard color palette and improve overlay layering

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68da1be552448324867f5e765d1ec40d