### PR TITLE
feat: redesign mobile tasks map view

### DIFF
--- a/frontend/src/dashboard/project/components/Tasks/TasksComponentMobile.module.css
+++ b/frontend/src/dashboard/project/components/Tasks/TasksComponentMobile.module.css
@@ -170,58 +170,100 @@
   color: var(--text-tertiary, rgba(246, 247, 251, 0.6));
 }
 
-.drawerOverlay {
+
+.sheetOverlay {
   position: fixed;
   inset: 0;
-  background: rgba(5, 6, 7, 0.72);
-  backdrop-filter: blur(6px);
-  display: flex;
-  justify-content: center;
-  align-items: flex-start;
-  
   z-index: 1600;
+  background: #050608;
+  color: var(--text-primary, #f6f7fb);
+  overflow: hidden;
 }
 
-.drawer {
-  width: min(720px, 100%);
-  max-height: min(100vh, 100dvh);
-  background:
-    linear-gradient(135deg, rgba(17, 18, 19, 0.94), rgba(5, 6, 7, 0.98));
-  border-radius: 24px 24px 16px 16px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  box-shadow: 0 -18px 48px rgba(0, 0, 0, 0.45);
-  overflow: hidden;
+.mapCanvas {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.mapMessage {
+  position: absolute;
+  left: 50%;
+  bottom: calc(env(safe-area-inset-bottom, 0) + 1.5rem);
+  transform: translateX(-50%);
+  padding: 0.6rem 1.1rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  line-height: 1.35;
+  background: rgba(10, 12, 16, 0.82);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  backdrop-filter: blur(6px);
+  text-align: center;
+  pointer-events: none;
+  max-width: min(92%, 340px);
+}
+
+.mapMessageMuted {
+  color: rgba(246, 247, 251, 0.78);
+}
+
+.mapMessageError {
+  color: #fecaca;
+  border-color: rgba(248, 113, 113, 0.35);
+  background: rgba(127, 29, 29, 0.5);
+}
+
+.sheet {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  height: 100%;
   display: flex;
   flex-direction: column;
+  border-radius: 28px 28px 0 0;
+  background:
+    linear-gradient(160deg, rgba(16, 18, 22, 0.96), rgba(4, 5, 6, 0.98));
+  box-shadow: 0 -28px 72px rgba(0, 0, 0, 0.52);
   color: var(--text-primary, #f6f7fb);
-  backdrop-filter: blur(12px);
-  animation: drawer-slide-up 220ms ease-out;
+  pointer-events: auto;
 }
 
-.drawerHeader {
+.sheetHandle {
+  width: 64px;
+  height: 6px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.24);
+  margin: calc(env(safe-area-inset-top, 0) + 0.65rem) auto 0.75rem;
+  pointer-events: auto;
+}
+
+.sheetHeader {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 0.75rem;
-  padding: 1rem 1.5rem 0.75rem;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 0 1.5rem 0.5rem;
+  pointer-events: auto;
 }
 
-.drawerTitleGroup {
+.sheetTitleGroup {
   display: flex;
   flex-direction: column;
-  gap: 0.15rem;
+  gap: 0.2rem;
 }
 
-.drawerTitle {
+.sheetTitle {
   font-size: 1rem;
   font-weight: 600;
   color: var(--text-primary, #f6f7fb);
 }
 
-.drawerSubtitle {
-  font-size: 0.8rem;
+.sheetSubtitle {
+  font-size: 0.82rem;
   color: var(--text-secondary, rgba(246, 247, 251, 0.7));
+  line-height: 1.35;
 }
 
 .closeButton {
@@ -245,51 +287,43 @@
   transform: translateY(-1px);
 }
 
-.drawerContent {
+.sheetScrollArea {
+  flex: 1;
   overflow-y: auto;
-  
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
+  padding: 0 1.5rem calc(env(safe-area-inset-bottom, 0) + 2.5rem);
 }
 
-.mapContainer {
-  height: 220px;
-  border-radius: 16px;
-  overflow: hidden;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.03);
-}
-
-.mapEmpty {
-  height: 220px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 16px;
-  border: 1px dashed rgba(148, 163, 184, 0.5);
-  color: var(--text-tertiary, rgba(246, 247, 251, 0.6));
-  background: rgba(12, 13, 16, 0.65);
-  font-size: 0.85rem;
-  text-align: center;
-  padding: 0 1.5rem;
-}
-
-.drawerSection {
+.sheetSection {
   display: flex;
   flex-direction: column;
-  gap: 0.85rem;
-  padding: 1.15rem 1.25rem;
-  border-radius: 18px;
-  background: rgba(17, 18, 19, 0.92);
-  
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02), 0 18px 48px rgba(0, 0, 0, 0.35);
+  gap: 0.9rem;
+  padding: 1.15rem 1.1rem;
+  border-radius: 20px;
+  background: rgba(13, 15, 18, 0.9);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02), 0 20px 48px rgba(0, 0, 0, 0.4);
+}
+
+.sectionHeadingRow {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
 }
 
 .sectionHeading {
   font-size: 0.95rem;
   font-weight: 600;
   color: var(--text-primary, #f6f7fb);
+}
+
+.sectionHint {
+  font-size: 0.8rem;
+  color: var(--text-tertiary, rgba(246, 247, 251, 0.6));
+  text-align: right;
 }
 
 .drawerTaskList {
@@ -302,14 +336,42 @@
 }
 
 .drawerTaskItem {
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-  padding: 0.85rem 0.9rem;
-  border-radius: 14px;
+  border-radius: 16px;
   border: 1px solid rgba(255, 255, 255, 0.08);
   background: rgba(12, 13, 16, 0.75);
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+  overflow: hidden;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.drawerTaskItemActive {
+  border-color: color-mix(in srgb, var(--brand, #fa3356) 60%, transparent);
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--brand, #fa3356) 55%, transparent),
+    0 20px 46px rgba(250, 51, 86, 0.22);
+}
+
+.taskItemButton {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  padding: 0.9rem 1rem;
+  background: transparent;
+  border: none;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.taskItemButton:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.taskItemButton:focus-visible {
+  outline: 2px solid var(--brand, #fa3356);
+  outline-offset: 2px;
 }
 
 .drawerTaskTop {
@@ -410,21 +472,4 @@
 .formError {
   color: #f87171;
   font-size: 0.8rem;
-}
-
-@keyframes drawer-slide-up {
-  from {
-    transform: translateY(24px);
-    opacity: 0;
-  }
-  to {
-    transform: translateY(0);
-    opacity: 1;
-  }
-}
-
-@media (min-width: 768px) {
-  .section {
-    padding: 1.5rem;
-  }
 }

--- a/frontend/src/dashboard/project/components/Tasks/TasksComponentMobile.tsx
+++ b/frontend/src/dashboard/project/components/Tasks/TasksComponentMobile.tsx
@@ -1,6 +1,7 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { Plus, MapPin, Calendar, ChevronDown } from "lucide-react";
+import { motion, useDragControls, useMotionValue, animate, type PanInfo } from "framer-motion";
 
 import Map from "@/shared/ui/Map";
 import { createTask, fetchTasks } from "@/shared/utils/api";
@@ -183,11 +184,21 @@ function isSameDay(a: Date, b: Date): boolean {
   );
 }
 
-function buildMarkerThumbnail(color?: string) {
+function buildMarkerThumbnail(
+  color?: string,
+  options: { active?: boolean } = {},
+): { url: string; size: number } | undefined {
   if (!color) return undefined;
-  const svg = `<?xml version="1.0" encoding="UTF-8"?>\n<svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><circle cx="16" cy="16" r="14" fill="${color}" stroke="white" stroke-width="4"/></svg>`;
-  return `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`;
+  const size = options.active ? 40 : 32;
+  const radius = size / 2 - (options.active ? 6 : 4);
+  const highlightRing = options.active
+    ? `<circle cx="${size / 2}" cy="${size / 2}" r="${radius + 4}" fill="rgba(255,255,255,0.16)" />`
+    : "";
+  const svg = `<?xml version="1.0" encoding="UTF-8"?>\n<svg width="${size}" height="${size}" viewBox="0 0 ${size} ${size}" xmlns="http://www.w3.org/2000/svg">${highlightRing}<circle cx="${size / 2}" cy="${size / 2}" r="${radius}" fill="${color}" stroke="white" stroke-width="${options.active ? 6 : 4}"/></svg>`;
+  return { url: `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`, size };
 }
+
+const SNAP_POINTS = [0.2, 0.5, 1] as const;
 
 const TasksComponentMobile: React.FC<TasksComponentMobileProps> = ({
   projectId = "",
@@ -198,12 +209,45 @@ const TasksComponentMobile: React.FC<TasksComponentMobileProps> = ({
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [drawerOpen, setDrawerOpen] = useState(false);
+  const [isSheetVisible, setSheetVisible] = useState(false);
+  const [sheetSnapIndex, setSheetSnapIndex] = useState<0 | 1 | 2>(1);
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
   const [dueDate, setDueDate] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const [formError, setFormError] = useState<string | null>(null);
+  const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
+  const [viewportHeight, setViewportHeight] = useState(() =>
+    typeof window === "undefined" ? 0 : window.innerHeight,
+  );
+  const sheetY = useMotionValue(viewportHeight || 0);
+  const dragControls = useDragControls();
+  const taskRefs = useRef<Record<string, HTMLLIElement | null>>({});
+  const closingRef = useRef(false);
+
+  const computeSnapOffset = useCallback(
+    (index: 0 | 1 | 2) => {
+      if (!viewportHeight) return 0;
+      const fraction = SNAP_POINTS[index];
+      return Math.max(viewportHeight * (1 - fraction), 0);
+    },
+    [viewportHeight],
+  );
+
+  const animateToSnap = useCallback(
+    (index: 0 | 1 | 2) => {
+      if (!viewportHeight) return;
+      const target = computeSnapOffset(index);
+      void animate(sheetY, target, {
+        type: "spring",
+        stiffness: 280,
+        damping: 32,
+        mass: 0.9,
+      });
+    },
+    [computeSnapOffset, sheetY, viewportHeight],
+  );
 
   const refreshTasks = useCallback(async () => {
     if (!projectId) {
@@ -233,16 +277,62 @@ const TasksComponentMobile: React.FC<TasksComponentMobileProps> = ({
   }, [refreshTasks]);
 
   useEffect(() => {
-    if (!drawerOpen) return;
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        setDrawerOpen(false);
-      }
-    };
+    if (!isSheetVisible) {
+      sheetY.set(viewportHeight || 0);
+    }
+  }, [isSheetVisible, sheetY, viewportHeight]);
 
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [drawerOpen]);
+  useEffect(() => {
+    if (typeof window === "undefined" || !isSheetVisible) return;
+    const update = () => setViewportHeight(window.innerHeight);
+    update();
+    window.addEventListener("resize", update);
+    window.addEventListener("orientationchange", update);
+    return () => {
+      window.removeEventListener("resize", update);
+      window.removeEventListener("orientationchange", update);
+    };
+  }, [isSheetVisible]);
+
+  useEffect(() => {
+    if (!isSheetVisible || typeof document === "undefined") return;
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [isSheetVisible]);
+
+  useEffect(() => {
+    if (!isSheetVisible || !drawerOpen || !viewportHeight) return;
+    closingRef.current = false;
+    sheetY.set(viewportHeight + 80);
+  }, [drawerOpen, isSheetVisible, sheetY, viewportHeight]);
+
+  useEffect(() => {
+    if (!isSheetVisible || closingRef.current || !viewportHeight) return;
+    animateToSnap(sheetSnapIndex);
+  }, [animateToSnap, isSheetVisible, sheetSnapIndex, viewportHeight]);
+
+  useEffect(() => {
+    if (!selectedTaskId || !isSheetVisible) return;
+    const target = taskRefs.current[selectedTaskId];
+    if (target) {
+      target.scrollIntoView({ block: "center", behavior: "smooth" });
+    }
+  }, [isSheetVisible, selectedTaskId]);
+
+  useEffect(() => {
+    const ids = new Set(tasks.map((task) => task.id));
+    Object.keys(taskRefs.current).forEach((key) => {
+      if (!ids.has(key)) {
+        delete taskRefs.current[key];
+      }
+    });
+    if (selectedTaskId && !ids.has(selectedTaskId)) {
+      setSelectedTaskId(null);
+    }
+  }, [selectedTaskId, tasks]);
 
   const stats = useMemo(() => computeStats(tasks), [tasks]);
 
@@ -268,18 +358,27 @@ const TasksComponentMobile: React.FC<TasksComponentMobileProps> = ({
     [tasks],
   );
 
-  const mapLocation = mapTasks[0]?.location ?? DEFAULT_LOCATION;
-  const mapAddress = mapTasks[0]?.address ?? projectName ?? "Project";
+  const focusedTask = useMemo(
+    () => mapTasks.find((task) => task.id === selectedTaskId) ?? mapTasks[0] ?? null,
+    [mapTasks, selectedTaskId],
+  );
+
+  const mapLocation = focusedTask?.location ?? DEFAULT_LOCATION;
+  const mapAddress = focusedTask?.address ?? projectName ?? "Project";
 
   const mapMarkers = useMemo(
     () =>
-      mapTasks.map((task) => ({
-        id: task.id,
-        lat: task.location!.lat,
-        lng: task.location!.lng,
-        thumbnail: buildMarkerThumbnail(projectColor),
-      })),
-    [mapTasks, projectColor],
+      mapTasks.map((task) => {
+        const markerVisual = buildMarkerThumbnail(projectColor, { active: task.id === selectedTaskId });
+        return {
+          id: task.id,
+          lat: task.location!.lat,
+          lng: task.location!.lng,
+          thumbnail: markerVisual?.url,
+          size: markerVisual?.size,
+        };
+      }),
+    [mapTasks, projectColor, selectedTaskId],
   );
 
   const statusMessage = useMemo(() => {
@@ -305,22 +404,101 @@ const TasksComponentMobile: React.FC<TasksComponentMobileProps> = ({
     return `${sameDayCount} ${noun} due ${dueFormatter.format(nextDue.dueDate)}.`;
   }, [error, loading, tasks]);
 
-  const handleOpenDrawer = () => {
+  const handleOpenDrawer = useCallback(() => {
+    setSheetSnapIndex(1);
+    setSheetVisible(true);
     setDrawerOpen(true);
     setFormError(null);
     setSuccessMessage(null);
-  };
+  }, []);
 
-  const handleCloseDrawer = () => {
-    setDrawerOpen(false);
+  const handleCloseDrawer = useCallback(() => {
     setFormError(null);
-  };
+    setSuccessMessage(null);
+    setSelectedTaskId(null);
+
+    if (!isSheetVisible || closingRef.current) {
+      setDrawerOpen(false);
+      setSheetVisible(false);
+      return;
+    }
+
+    setDrawerOpen(false);
+    closingRef.current = true;
+
+    if (!viewportHeight) {
+      closingRef.current = false;
+      setSheetVisible(false);
+      sheetY.set(0);
+      return;
+    }
+
+    const animation = animate(sheetY, viewportHeight + 80, {
+      duration: 0.25,
+      ease: [0.22, 0.61, 0.36, 1],
+    });
+
+    animation.then(
+      () => {
+        closingRef.current = false;
+        setSheetVisible(false);
+        sheetY.set(viewportHeight);
+      },
+      () => {
+        closingRef.current = false;
+        setSheetVisible(false);
+        sheetY.set(viewportHeight);
+      },
+    );
+  }, [isSheetVisible, sheetY, viewportHeight]);
+
+  useEffect(() => {
+    if (!drawerOpen) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        handleCloseDrawer();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [drawerOpen, handleCloseDrawer]);
+
+  const handleMarkerSelect = useCallback(
+    (taskId: string) => {
+      if (closingRef.current) return;
+      setSelectedTaskId(taskId);
+      setFormError(null);
+      setSuccessMessage(null);
+
+      if (!isSheetVisible) {
+        setSheetSnapIndex(2);
+        setSheetVisible(true);
+        setDrawerOpen(true);
+        return;
+      }
+
+      if (sheetSnapIndex !== 2) {
+        setSheetSnapIndex(2);
+      } else {
+        animateToSnap(2);
+      }
+    },
+    [animateToSnap, isSheetVisible, sheetSnapIndex],
+  );
 
   const resetForm = () => {
     setTitle("");
     setDescription("");
     setDueDate("");
   };
+
+  const handleTaskSelect = useCallback((taskId: string) => {
+    setSelectedTaskId(taskId);
+    setFormError(null);
+    setSuccessMessage(null);
+  }, []);
 
   const handleCreateTask = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -365,92 +543,168 @@ const TasksComponentMobile: React.FC<TasksComponentMobileProps> = ({
   };
 
   const renderDrawer = () => {
-    if (!drawerOpen || typeof document === "undefined") {
+    if (!isSheetVisible || typeof document === "undefined") {
       return null;
     }
 
-    const handleOverlayMouseDown = (event: React.MouseEvent<HTMLDivElement>) => {
-      if (event.target === event.currentTarget) {
+    const startDrag = (event: React.PointerEvent<HTMLElement>) => {
+      if (event.pointerType === "mouse" && event.button !== 0) return;
+      event.preventDefault();
+      dragControls.start(event);
+    };
+
+    const handleSheetDragEnd = (_: MouseEvent | TouchEvent | PointerEvent, __: PanInfo) => {
+      if (closingRef.current) return;
+      const currentOffset = sheetY.get();
+      const collapsedOffset = computeSnapOffset(0);
+      const hideThreshold = Math.max(viewportHeight * 0.2, 120);
+
+      if (currentOffset > collapsedOffset + hideThreshold) {
         handleCloseDrawer();
+        return;
+      }
+
+      const nearest = SNAP_POINTS.reduce<{ index: 0 | 1 | 2; distance: number }>(
+        (acc, _, index) => {
+          const idx = index as 0 | 1 | 2;
+          const target = computeSnapOffset(idx);
+          const distance = Math.abs(currentOffset - target);
+          if (distance < acc.distance) {
+            return { index: idx, distance };
+          }
+          return acc;
+        },
+        { index: sheetSnapIndex, distance: Number.POSITIVE_INFINITY },
+      );
+
+      if (nearest.index !== sheetSnapIndex) {
+        setSheetSnapIndex(nearest.index);
+      } else {
+        animateToSnap(nearest.index);
       }
     };
 
+    const mapStatus = error
+      ? { message: error, variant: "error" as const }
+      : loading
+        ? { message: "Loading tasks…", variant: "muted" as const }
+        : mapMarkers.length
+          ? null
+          : { message: "Add locations to your tasks to see them appear on the map.", variant: "muted" as const };
+
     return createPortal(
-      <div className={styles.drawerOverlay} role="presentation" onMouseDown={handleOverlayMouseDown}>
-        <div className={styles.drawer} role="dialog" aria-modal="true" aria-label="Project tasks quick view" onMouseDown={(event) => event.stopPropagation()}>
-          <div className={styles.drawerHeader}>
-            <div className={styles.drawerTitleGroup}>
-              <span className={styles.drawerTitle}>Project tasks</span>
-              <span className={styles.drawerSubtitle}>
-                {projectName ? `Everything happening in ${projectName}` : "Keep work on track"}
+      <div className={styles.sheetOverlay} role="dialog" aria-modal="true" aria-label="Project tasks map view">
+        <div className={styles.mapCanvas}>
+          <Map
+            location={mapLocation}
+            address={mapAddress}
+            scrollWheelZoom={false}
+            dragging={true}
+            touchZoom={true}
+            showUserLocation={false}
+            otherUsers={mapMarkers}
+            onOtherMarkerClick={handleMarkerSelect}
+          />
+          {mapStatus ? (
+            <div
+              className={`${styles.mapMessage} ${
+                mapStatus.variant === "error" ? styles.mapMessageError : styles.mapMessageMuted
+              }`}
+            >
+              {mapStatus.message}
+            </div>
+          ) : null}
+        </div>
+
+        <motion.div
+          className={styles.sheet}
+          drag="y"
+          dragControls={dragControls}
+          dragListener={false}
+          dragMomentum={false}
+          dragElastic={{ top: 0.08, bottom: 0.35 }}
+          dragConstraints={{ top: 0, bottom: Math.max(viewportHeight + 80, 160) }}
+          onDragEnd={handleSheetDragEnd}
+          style={{ y: sheetY }}
+        >
+          <div className={styles.sheetHandle} onPointerDown={startDrag} role="presentation" />
+          <div
+            className={styles.sheetHeader}
+            onPointerDown={(event) => {
+              const target = event.target as HTMLElement;
+              if (target.closest("button")) return;
+              startDrag(event);
+            }}
+          >
+            <div className={styles.sheetTitleGroup}>
+              <span className={styles.sheetTitle}>Project tasks</span>
+              <span className={styles.sheetSubtitle}>
+                {focusedTask
+                  ? `${focusedTask.title}${focusedTask.address ? ` • ${focusedTask.address}` : ""}`
+                  : projectName
+                    ? `Everything happening in ${projectName}`
+                    : "Keep work on track"}
               </span>
             </div>
-            <button type="button" className={styles.closeButton} onClick={handleCloseDrawer} aria-label="Close tasks drawer">
+            <button type="button" className={styles.closeButton} onClick={handleCloseDrawer} aria-label="Close tasks view">
               <ChevronDown size={20} strokeWidth={2.5} />
             </button>
           </div>
 
-          <div className={styles.drawerContent}>
-            <section className={styles.drawerSection} aria-label="Task map">
-              <h3 className={styles.sectionHeading}>Task map</h3>
-              {error ? (
-                <div className={styles.mapEmpty}>{error}</div>
-              ) : loading ? (
-                <div className={styles.mapEmpty}>Loading tasks…</div>
-              ) : mapTasks.length ? (
-                <div className={styles.mapContainer}>
-                  <Map
-                    location={mapLocation}
-                    address={mapAddress}
-                    scrollWheelZoom={false}
-                    dragging={true}
-                    touchZoom={true}
-                    showUserLocation={false}
-                    otherUsers={mapMarkers}
-                  />
-                </div>
-              ) : (
-                <div className={styles.mapEmpty}>
-                  Add locations to your tasks to see them appear on the map.
-                </div>
-              )}
-            </section>
-
-            <section className={styles.drawerSection} aria-label="All project tasks">
-              <h3 className={styles.sectionHeading}>Task list</h3>
+          <div className={styles.sheetScrollArea}>
+            <section className={styles.sheetSection} aria-label="All project tasks">
+              <div className={styles.sectionHeadingRow}>
+                <h3 className={styles.sectionHeading}>Task list</h3>
+                <span className={styles.sectionHint}>{statusMessage}</span>
+              </div>
               {error ? (
                 <div className={styles.error}>{error}</div>
               ) : loading ? (
                 <div className={styles.loading}>Loading tasks…</div>
               ) : drawerTasks.length ? (
                 <ul className={styles.drawerTaskList}>
-                  {drawerTasks.map((task) => (
-                    <li key={task.id} className={styles.drawerTaskItem}>
-                      <div className={styles.drawerTaskTop}>
-                        <span className={styles.drawerTaskTitle}>{task.title}</span>
-                        <span className={styles.statusBadge}>
-                          {task.status === "done" ? "Completed" : task.status.replace(/_/g, " ")}
-                        </span>
-                      </div>
-                      <div className={styles.drawerTaskMeta}>
-                        <span className={styles.metaLine}>
-                          <Calendar size={14} aria-hidden="true" /> {formatDueLabel(task)}
-                        </span>
-                        {task.address ? (
-                          <span className={styles.metaLine}>
-                            <MapPin size={14} aria-hidden="true" /> {task.address}
-                          </span>
-                        ) : null}
-                      </div>
-                    </li>
-                  ))}
+                  {drawerTasks.map((task) => {
+                    const isActive = selectedTaskId === task.id;
+                    return (
+                      <li
+                        key={task.id}
+                        ref={(node) => {
+                          taskRefs.current[task.id] = node;
+                        }}
+                        className={`${styles.drawerTaskItem} ${isActive ? styles.drawerTaskItemActive : ""}`}
+                      >
+                        <button
+                          type="button"
+                          className={styles.taskItemButton}
+                          onClick={() => handleTaskSelect(task.id)}
+                        >
+                          <div className={styles.drawerTaskTop}>
+                            <span className={styles.drawerTaskTitle}>{task.title}</span>
+                            <span className={styles.statusBadge}>
+                              {task.status === "done" ? "Completed" : task.status.replace(/_/g, " ")}
+                            </span>
+                          </div>
+                          <div className={styles.drawerTaskMeta}>
+                            <span className={styles.metaLine}>
+                              <Calendar size={14} aria-hidden="true" /> {formatDueLabel(task)}
+                            </span>
+                            {task.address ? (
+                              <span className={styles.metaLine}>
+                                <MapPin size={14} aria-hidden="true" /> {task.address}
+                              </span>
+                            ) : null}
+                          </div>
+                        </button>
+                      </li>
+                    );
+                  })}
                 </ul>
               ) : (
                 <div className={styles.empty}>No tasks yet. Create one to get started.</div>
               )}
             </section>
 
-            <section className={styles.drawerSection} aria-label="Create a quick task">
+            <section className={styles.sheetSection} aria-label="Create a quick task">
               <h3 className={styles.sectionHeading}>Create quick task</h3>
               <form className={styles.createForm} onSubmit={handleCreateTask}>
                 <input
@@ -486,7 +740,7 @@ const TasksComponentMobile: React.FC<TasksComponentMobileProps> = ({
               </form>
             </section>
           </div>
-        </div>
+        </motion.div>
       </div>,
       document.body,
     );

--- a/frontend/src/shared/ui/Map.tsx
+++ b/frontend/src/shared/ui/Map.tsx
@@ -18,6 +18,8 @@ interface UserLocation {
   lng: number;
   thumbnail?: string;
   accuracy?: number;
+  size?: number;
+  isHighlighted?: boolean;
 }
 
 interface LatLng {
@@ -38,6 +40,7 @@ interface MapProps {
   onLocationChange?: (loc: LatLng) => void;
   otherUsers?: UserLocation[];
   onUserLocation?: (loc: { lat: number; lng: number; accuracy: number }) => void;
+  onOtherMarkerClick?: (id: string) => void;
 }
 
 const Map = forwardRef<MapRef, MapProps>(
@@ -55,6 +58,7 @@ const Map = forwardRef<MapRef, MapProps>(
       onLocationChange,
       otherUsers = [],
       onUserLocation,
+      onOtherMarkerClick,
     },
     ref,
   ) => {
@@ -295,11 +299,14 @@ const Map = forwardRef<MapRef, MapProps>(
 
       users.forEach((u) => {
         const userLatLng: [number, number] = [u.lat, u.lng];
+        const size = Math.max(16, Math.round(u.size ?? (u.thumbnail ? 32 : 24)));
+        const isSvgThumbnail = typeof u.thumbnail === 'string' && u.thumbnail.startsWith('data:image/svg+xml');
+        const border = u.thumbnail && !isSvgThumbnail ? 2 : 0;
         const iconHtml = u.thumbnail
-          ? `<img src="${u.thumbnail}" style="width:32px;height:32px;border-radius:50%;border:2px solid white;" />`
-          : `<svg width="24" height="24" viewBox="0 0 24 24"><path fill="#ff5722" stroke="white" stroke-width="2" d="M12 2C8.1 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7z"/><circle cx="12" cy="9" r="3" fill="white"/></svg>`;
-        const iconSize: [number, number] = u.thumbnail ? [32, 32] : [24, 24];
-        const iconAnchor: [number, number] = u.thumbnail ? [16, 16] : [12, 24];
+          ? `<img src="${u.thumbnail}" style="width:${size}px;height:${size}px;border-radius:50%;border:${border}px solid white;" />`
+          : `<svg width="${size}" height="${size}" viewBox="0 0 24 24"><path fill="#ff5722" stroke="white" stroke-width="2" d="M12 2C8.1 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7z"/><circle cx="12" cy="9" r="3" fill="white"/></svg>`;
+        const iconSize: [number, number] = [size, size];
+        const iconAnchor: [number, number] = [size / 2, size];
         const icon = L.divIcon({ html: iconHtml, className: '', iconSize, iconAnchor });
 
         if (markers[u.id]) {
@@ -307,6 +314,11 @@ const Map = forwardRef<MapRef, MapProps>(
           markers[u.id].setIcon(icon);
         } else {
           markers[u.id] = L.marker(userLatLng, { icon }).addTo(mapInstance.current!);
+        }
+
+        markers[u.id].off('click');
+        if (onOtherMarkerClick) {
+          markers[u.id].on('click', () => onOtherMarkerClick(u.id));
         }
 
         const radius = u.accuracy || 0;
@@ -340,7 +352,7 @@ const Map = forwardRef<MapRef, MapProps>(
       if (latLngs.length > 1) {
         mapInstance.current!.fitBounds(L.latLngBounds(latLngs), { padding: [50, 50] });
       }
-    }, [otherUsers]);
+    }, [otherUsers, onOtherMarkerClick]);
 
     useEffect(() => {
       if (!mapInstance.current || !isEditable) return;


### PR DESCRIPTION
## Summary
- refactor the mobile tasks quick view into a full-screen map with a draggable bottom sheet
- link task list interactions with map markers and highlight the active task
- refresh the mobile drawer styling for independent scrolling and safe-area spacing

## Testing
- npm run test -- --run *(fails: existing suite contains unrelated failing specs, run aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68dae867d55c83249817a94812b3339a