### PR TITLE
Improve mobile gallery carousel layout

### DIFF
--- a/frontend/src/dashboard/project/components/Gallery/GalleryTrigger.tsx
+++ b/frontend/src/dashboard/project/components/Gallery/GalleryTrigger.tsx
@@ -53,7 +53,7 @@ const GalleryTrigger: React.FC<GalleryTriggerProps> = ({
 }) => {
   const isCompact = useCompactGalleryLayout();
   const hasGalleries = galleries.length > 0;
-  const maxVisibleThumbs = isCompact ? 2 : 3;
+  const maxVisibleThumbs = isCompact ? 6 : 3;
   const visibleCount = Math.min(maxVisibleThumbs, galleries.length);
   const visibleGalleries = galleries.slice(0, visibleCount);
   const hiddenCount = galleries.length - visibleCount;
@@ -89,26 +89,55 @@ const GalleryTrigger: React.FC<GalleryTriggerProps> = ({
       <div className={styles.thumbsColumn}>
         {hasGalleries ? (
           <div className={styles.carouselSection}>
-            <div className={styles.thumbnailCarousel} aria-label="Gallery previews">
+            <div
+              className={styles.thumbnailCarousel}
+              aria-label="Gallery preview thumbnails"
+            >
               {visibleGalleries.map((galleryItem, idx) => {
                 const previewUrl = getPreviewUrl(galleryItem);
+                const galleryName = galleryItem.name?.trim() || `Gallery ${idx + 1}`;
+
                 return (
-                  <div className={styles.thumbnailTile} key={galleryItem.slug || idx}>
+                  <button
+                    key={galleryItem.slug || idx}
+                    type="button"
+                    className={styles.thumbnailButton}
+                    aria-label={`Open ${galleryName}`}
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      onOpenModal();
+                    }}
+                  >
                     {previewUrl ? (
-                      <img src={getFileUrl(previewUrl)} alt={galleryItem.name || "Gallery preview"} />
+                      <img
+                        src={getFileUrl(previewUrl)}
+                        alt={galleryName}
+                        loading="lazy"
+                      />
                     ) : (
-                      <div className={styles.thumbnailPlaceholder}>
-                        <GalleryVerticalEnd size={28} />
-                      </div>
+                      <span className={styles.thumbnailPlaceholder}>
+                        <GalleryVerticalEnd size={24} aria-hidden="true" />
+                      </span>
                     )}
-                  </div>
+                  </button>
                 );
               })}
               {hiddenCount > 0 && (
-                <div className={`${styles.thumbnailTile} ${styles.moreTile}`}>+{hiddenCount}</div>
+                <button
+                  type="button"
+                  className={`${styles.thumbnailButton} ${styles.moreTile}`}
+                  aria-label={`View ${hiddenCount} more galleries`}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    onOpenModal();
+                  }}
+                >
+                  +{hiddenCount}
+                </button>
               )}
             </div>
-            {/* Entire container navigates to the galleries list; individual button removed */}
+            <span className={`${styles.carouselEdge} ${styles.carouselEdgeLeft}`} aria-hidden="true" />
+            <span className={`${styles.carouselEdge} ${styles.carouselEdgeRight}`} aria-hidden="true" />
           </div>
         ) : (
           <div className={styles.emptyState}>No galleries yet</div>

--- a/frontend/src/dashboard/project/components/Gallery/gallery-component.module.css
+++ b/frontend/src/dashboard/project/components/Gallery/gallery-component.module.css
@@ -1,4 +1,5 @@
 .galleryTrigger {
+  --row-h: clamp(120px, 18vw + 72px, 168px);
   cursor: pointer;
   display: flex;
   /* Ensure a strict two-column row layout even if parent styles try to override */
@@ -7,11 +8,14 @@
   justify-content: space-between;
   width: 100%;
   flex: 0 1 auto;
+  min-height: var(--row-h);
   transition: transform 0.2s ease;
   flex-wrap: nowrap;
   gap: 12px;
   padding: clamp(16px, 4vw, 24px);
   box-sizing: border-box;
+  background-color: rgba(12, 12, 12, 0.75);
+  border-radius: 16px;
 }
 
 /* Two columns inside the trigger */
@@ -67,59 +71,62 @@
   align-items: flex-end;
   gap: 10px;
   width: 100%;
+  position: relative;
 }
 
 .thumbnailCarousel {
-  display: flex;
-  flex-wrap: nowrap;
+  --thumb-column: calc(var(--row-h) * 0.78);
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: var(--thumb-column);
   gap: 12px;
   width: 100%;
   justify-content: flex-end;
-  overflow-x: auto;
-  padding: 4px 0;
-  scroll-behavior: smooth;
-}
-
-.thumbnailCarousel::-webkit-scrollbar {
-  height: 6px;
-}
-
-.thumbnailCarousel::-webkit-scrollbar-thumb {
-  background: rgba(255, 255, 255, 0.2);
-  border-radius: 999px;
-}
-
-.thumbnailCarousel::-webkit-scrollbar-track {
-  background: transparent;
-}
-
-.thumbnailTile {
-  flex: 0 1 clamp(110px, 24vw, 150px);
-  aspect-ratio: 4 / 3;
-  border-radius: 14px;
-  border: 2px solid rgba(255, 255, 255, 0.25);
-  background: rgba(255, 255, 255, 0.05);
-  overflow: hidden;
-  display: flex;
   align-items: center;
-  justify-content: center;
+  padding: 4px 0;
+}
+
+
+.thumbnailButton {
+  display: grid;
+  place-items: center;
+  position: relative;
+  overflow: hidden;
+  border: none;
+  padding: 0;
+  margin: 0;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.05);
   color: rgba(255, 255, 255, 0.65);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  transition: transform 0.2s ease, border-color 0.2s ease, background 0.2s ease;
+  transition: transform 0.2s ease, border-color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+  aspect-ratio: 5 / 4;
+  width: 100%;
+  min-width: 0;
+  isolation: isolate;
+  background-clip: padding-box;
+  cursor: pointer;
 }
 
-.thumbnailTile img {
+.thumbnailButton img {
   width: 100%;
   height: 100%;
   object-fit: cover;
+  display: block;
 }
 
-.thumbnailTile:hover {
+.thumbnailButton:focus-visible {
+  outline: 2px solid rgba(250, 51, 86, 0.65);
+  outline-offset: 2px;
+  box-shadow: 0 0 0 4px rgba(250, 51, 86, 0.2);
+}
+
+.thumbnailButton:hover {
   transform: translateY(-2px);
-  border-color: #FA3356;
   background: rgba(250, 51, 86, 0.12);
+  color: #FA3356;
 }
 
 .thumbnailPlaceholder {
@@ -129,12 +136,36 @@
   align-items: center;
   justify-content: center;
   background: rgba(12, 12, 12, 0.65);
+  color: rgba(255, 255, 255, 0.65);
 }
 
 .moreTile {
   background: rgba(250, 51, 86, 0.15);
-  border-color: #FA3356;
   color: #FA3356;
+}
+
+.moreTile:hover {
+  background: rgba(250, 51, 86, 0.22);
+}
+
+.carouselEdge {
+  position: absolute;
+  inset-block: 4px;
+  width: 32px;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  display: none;
+}
+
+.carouselEdgeLeft {
+  left: 0;
+  background: linear-gradient(90deg, rgba(12, 12, 12, 0.95) 0%, rgba(12, 12, 12, 0) 100%);
+}
+
+.carouselEdgeRight {
+  right: 0;
+  background: linear-gradient(270deg, rgba(12, 12, 12, 0.95) 0%, rgba(12, 12, 12, 0) 100%);
 }
 
 .viewAllButton {
@@ -151,12 +182,6 @@
   transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
 }
 
-.viewAllButton:hover {
-  background: rgba(250, 51, 86, 0.15);
-  border-color: #FA3356;
-  transform: translateY(-1px);
-}
-
 .emptyState {
   font-size: 0.82rem;
   opacity: 0.7;
@@ -168,6 +193,7 @@
 
 @media (max-width: 768px) {
   .galleryTrigger {
+    --row-h: clamp(108px, 10vw + 96px, 148px);
     flex-direction: row !important;
     align-items: center !important;
     padding: clamp(12px, 3vw, 16px);
@@ -193,12 +219,11 @@
   }
 
   .thumbnailCarousel {
-    justify-content: flex-end;
-    gap: 8px;
+    justify-content: flex-start;
+    gap: 10px;
   }
 
-  .thumbnailTile {
-    flex: 0 0 clamp(72px, 28vw, 110px);
+  .thumbnailButton {
     border-radius: 12px;
   }
 
@@ -215,6 +240,7 @@
 
 @media (max-width: 540px) {
   .galleryTrigger {
+    --row-h: clamp(104px, 12vw + 84px, 138px);
     padding: 12px;
     gap: 8px;
   }
@@ -228,11 +254,54 @@
   }
 
   .thumbnailCarousel {
+    gap: 8px;
+  }
+}
+
+@media (max-width: 480px) {
+  .thumbnailCarousel {
+    overflow-x: auto;
+    overscroll-behavior-x: contain;
+    scroll-snap-type: x mandatory;
+    padding: 6px 12px;
+    margin: 0 -12px;
+  }
+
+  .thumbnailCarousel::-webkit-scrollbar {
+    height: 6px;
+  }
+
+  .thumbnailCarousel::-webkit-scrollbar-thumb {
+    background: rgba(255, 255, 255, 0.18);
+    border-radius: 999px;
+  }
+
+  .thumbnailCarousel::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  .thumbnailButton {
+    scroll-snap-align: center;
+  }
+
+  .carouselEdge {
+    display: block;
+    opacity: 1;
+  }
+}
+
+@media (max-width: 330px) {
+  .galleryTrigger {
+    --row-h: clamp(90px, 20vw + 64px, 124px);
+  }
+
+  .thumbnailCarousel {
+    --thumb-column: clamp(70px, calc(var(--row-h) * 0.7), 110px);
     gap: 6px;
   }
 
-  .thumbnailTile {
-    flex: 0 0 clamp(68px, 34vw, 96px);
+  .thumbnailButton {
+    border-radius: 10px;
   }
 }
 


### PR DESCRIPTION
## Summary
- reserve the Galleries card height with a row token and convert thumbnails into buttons with consistent aspect ratios
- enable a scroll-snap carousel with gradient edge overlays and lazy-loaded previews on compact widths
- tune responsive sizing clamps for very narrow screens and provide accessible focus treatments on a dark background

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68daeb6d46b083249db4af29184895ec