### PR TITLE
Cache favicons for message links and stabilize previews

### DIFF
--- a/backend/websocket/default.mjs
+++ b/backend/websocket/default.mjs
@@ -10,17 +10,126 @@
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocumentClient, ScanCommand, PutCommand, UpdateCommand, DeleteCommand, QueryCommand, GetCommand, BatchWriteCommand } from "@aws-sdk/lib-dynamodb";
 import { ApiGatewayManagementApiClient, PostToConnectionCommand } from "@aws-sdk/client-apigatewaymanagementapi";
+import { S3Client, HeadObjectCommand, PutObjectCommand } from "@aws-sdk/client-s3";
 import { randomUUID } from "crypto";
 import { v4 as uuid } from "uuid";
+import { getFileUrl } from "/opt/nodejs/utils/files.mjs";
 
 const dynamoClient = new DynamoDBClient({});
 const dynamoDb = DynamoDBDocumentClient.from(dynamoClient);
 const apigwManagementApi = new ApiGatewayManagementApiClient({
   endpoint: process.env.WEBSOCKET_ENDPOINT,
 });
+const REGION = process.env.AWS_REGION || "us-west-2";
+const FILE_BUCKET = process.env.FILE_BUCKET || "mylg-files-v12";
+const FAVICON_PREFIX = process.env.FAVICON_PREFIX || "public/favicons";
+const s3Client = new S3Client({ region: REGION });
 const inboxTable = process.env.INBOX_TABLE;
 const notificationsTable = process.env.NOTIFICATIONS_TABLE;
 const projectsTable = process.env.PROJECTS_TABLE;
+
+const TRAILING_PUNCTUATION_REGEX = /[)\],.!?]+$/;
+const URL_REGEX = /https?:\/\/[^\s<>"]+/i;
+const DEFAULT_FAVICON_SVG =
+  "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><rect width='16' height='16' rx='3' fill='#4ea1f3'/><path d='M5.75 10.25l4.5-4.5M6.5 5.75h3.75V9.5' fill='none' stroke='#fff' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/></svg>";
+
+function sanitizeDomain(hostname = "") {
+  return String(hostname).toLowerCase().replace(/[^a-z0-9.-]/g, "-");
+}
+
+async function ensureCachedFavicon(url) {
+  if (!FILE_BUCKET || !url) return null;
+
+  let hostname = "";
+  try {
+    hostname = new URL(url).hostname;
+  } catch {
+    return null;
+  }
+
+  if (!hostname) return null;
+
+  const safeDomain = sanitizeDomain(hostname);
+  const key = `${FAVICON_PREFIX}/${safeDomain}`;
+
+  try {
+    await s3Client.send(new HeadObjectCommand({ Bucket: FILE_BUCKET, Key: key }));
+    return { key, url: getFileUrl(key) };
+  } catch (err) {
+    if (err?.$metadata?.httpStatusCode !== 404) {
+      console.warn("⚠️ Failed to HEAD cached favicon", { domain: hostname, err: err?.message });
+    }
+  }
+
+  const sources = [
+    `https://${hostname}/favicon.ico`,
+    `https://${hostname}/favicon.png`,
+    `https://${hostname}/apple-touch-icon.png`,
+    `https://${hostname}/apple-touch-icon-precomposed.png`,
+    `https://www.google.com/s2/favicons?sz=64&domain=${hostname}`,
+  ];
+
+  let iconBuffer = null;
+  let contentType = "image/png";
+
+  for (const source of sources) {
+    try {
+      const response = await fetch(source, { redirect: "follow" });
+      if (!response?.ok) continue;
+      const arrayBuffer = await response.arrayBuffer();
+      if (!arrayBuffer || !arrayBuffer.byteLength) continue;
+      iconBuffer = Buffer.from(arrayBuffer);
+      const headerType = response.headers?.get?.("content-type");
+      if (headerType) contentType = headerType;
+      break;
+    } catch (err) {
+      console.warn("⚠️ Failed to fetch favicon", { source, err: err?.message });
+    }
+  }
+
+  if (!iconBuffer) {
+    iconBuffer = Buffer.from(DEFAULT_FAVICON_SVG, "utf8");
+    contentType = "image/svg+xml";
+  }
+
+  try {
+    await s3Client.send(
+      new PutObjectCommand({
+        Bucket: FILE_BUCKET,
+        Key: key,
+        Body: iconBuffer,
+        ContentType: contentType,
+        CacheControl: "public, max-age=2592000, immutable",
+        Metadata: { domain: hostname, source: "messages-link-preview" },
+      })
+    );
+  } catch (err) {
+    console.error("❌ Failed to store cached favicon", { domain: hostname, err });
+    return null;
+  }
+
+  return { key, url: getFileUrl(key) };
+}
+
+async function buildLinkPreviewFromText(text) {
+  if (typeof text !== "string" || !text.trim()) return null;
+  const match = text.match(URL_REGEX);
+  if (!match || !match[0]) return null;
+  const rawUrl = match[0].replace(TRAILING_PUNCTUATION_REGEX, "");
+
+  try {
+    // Validate URL
+    new URL(rawUrl);
+  } catch {
+    return null;
+  }
+
+  const cached = await ensureCachedFavicon(rawUrl);
+  if (cached?.key) {
+    return { url: rawUrl, faviconKey: cached.key, faviconUrl: cached.url };
+  }
+  return { url: rawUrl };
+}
 
 export const handler = async (event) => {
   console.log("📩 Received WS Message:", JSON.stringify(event, null, 2));
@@ -439,6 +548,15 @@ const handleSendMessage = async (payload) => {
       };
     });
 
+  let linkPreview = null;
+  if (typeof text === "string" && text.trim()) {
+    try {
+      linkPreview = await buildLinkPreviewFromText(text);
+    } catch (err) {
+      console.warn("⚠️ Failed to build link preview", { conversationId: finalConversationId, err });
+    }
+  }
+
   const messageItem = {
     messageId: `MESSAGE#${String(timestamp).padStart(13, "0")}#${uuid()}`,
     senderId,
@@ -452,6 +570,7 @@ const handleSendMessage = async (payload) => {
     reactions: {},
     attachments: cleanAttachments,
     ...(conversationType === "dm" && recipientId ? { recipientId } : {}),
+    ...(linkPreview ? { linkPreview } : {}),
   };
 
   if (conversationType === "project") {
@@ -629,6 +748,13 @@ const handleEditMessage = async (payload) => {
     return { statusCode: 400, body: "Missing fields" };
   }
 
+  let linkPreview = null;
+  try {
+    linkPreview = await buildLinkPreviewFromText(text);
+  } catch (err) {
+    console.warn("⚠️ Failed to rebuild link preview on edit", { conversationId, messageId, err });
+  }
+
   const eventPayload = {
     action: "editMessage",
     conversationType,
@@ -639,6 +765,7 @@ const handleEditMessage = async (payload) => {
     editedBy,
     timestamp,
     projectId,
+    linkPreview: linkPreview || null,
   };
 
   if (conversationType === "dm") {
@@ -647,13 +774,15 @@ const handleEditMessage = async (payload) => {
       await dynamoDb.send(new UpdateCommand({
         TableName: process.env.MESSAGES_TABLE,
         Key: { conversationId, messageId },
-        UpdateExpression: "SET #t = :text, edited = :edited, editedAt = :editedAt, editedBy = :editedBy",
+        UpdateExpression:
+          "SET #t = :text, edited = :edited, editedAt = :editedAt, editedBy = :editedBy, linkPreview = :linkPreview",
         ExpressionAttributeNames: { "#t": "text" },
         ExpressionAttributeValues: {
           ":text": text,
           ":edited": true,
           ":editedAt": editedAt || new Date().toISOString(),
           ":editedBy": editedBy,
+          ":linkPreview": linkPreview || null,
         },
       }));
       console.log("✅ DM message updated in DB:", messageId);
@@ -674,13 +803,15 @@ const handleEditMessage = async (payload) => {
       await dynamoDb.send(new UpdateCommand({
         TableName: process.env.PROJECT_MESSAGES_TABLE,
         Key: { projectId, messageId },
-        UpdateExpression: "SET #t = :text, edited = :edited, editedAt = :editedAt, editedBy = :editedBy",
+        UpdateExpression:
+          "SET #t = :text, edited = :edited, editedAt = :editedAt, editedBy = :editedBy, linkPreview = :linkPreview",
         ExpressionAttributeNames: { "#t": "text" },
         ExpressionAttributeValues: {
           ":text": text,
           ":edited": true,
           ":editedAt": editedAt || new Date().toISOString(),
           ":editedBy": editedBy,
+          ":linkPreview": linkPreview || null,
         },
       }));
       console.log("✅ Project message updated in DB:", messageId);

--- a/frontend/src/app/contexts/SocketProvider.tsx
+++ b/frontend/src/app/contexts/SocketProvider.tsx
@@ -248,7 +248,9 @@ export const SocketProvider: React.FC<React.PropsWithChildren> = ({ children }) 
                 return {
                   ...prev,
                   messages: msgs.map((m) =>
-                    m.messageId === data.messageId ? { ...m, text: data.text, edited: true, editedAt: data.editedAt } : m
+                    m.messageId === data.messageId
+                      ? { ...m, text: data.text, edited: true, editedAt: data.editedAt, linkPreview: data.linkPreview || null }
+                      : m
                   ),
                 };
               });
@@ -302,7 +304,9 @@ export const SocketProvider: React.FC<React.PropsWithChildren> = ({ children }) 
                 return {
                   ...prev,
                   [projectId]: msgs.map((m) =>
-                    m.messageId === data.messageId ? { ...m, text: data.text, edited: true, editedAt: data.editedAt } : m
+                    m.messageId === data.messageId
+                      ? { ...m, text: data.text, edited: true, editedAt: data.editedAt, linkPreview: data.linkPreview || null }
+                      : m
                   ),
                 };
               });

--- a/frontend/src/dashboard/features/messages/MessageItem.tsx
+++ b/frontend/src/dashboard/features/messages/MessageItem.tsx
@@ -42,6 +42,79 @@ interface MessageItemProps {
   onReact?: (messageId: string, emoji: Emoji) => void;
 }
 
+const DEFAULT_FAVICON_DATA_URI =
+  "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Crect width='16' height='16' rx='3' fill='%234ea1f3'/%3E%3Cpath d='M5.75 10.25l4.5-4.5M6.5 5.75h3.75V9.5' fill='none' stroke='white' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E";
+const TRAILING_PUNCTUATION_REGEX = /[)\],.!?]+$/;
+const VIDEO_HOST_REGEX = /(?:youtu\.be|youtube\.com|vimeo\.com)/i;
+const FAVICON_IMAGE_STYLE: React.CSSProperties = {
+  width: 20,
+  height: 20,
+  objectFit: "contain",
+  display: "block",
+};
+const ICON_WRAPPER_STYLE: React.CSSProperties = {
+  width: 20,
+  height: 20,
+  marginRight: 6,
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  flexShrink: 0,
+};
+const LINK_CONTAINER_STYLE: React.CSSProperties = { maxWidth: "300px" };
+const LINK_ANCHOR_STYLE: React.CSSProperties = {
+  color: "#4ea1f3",
+  display: "flex",
+  alignItems: "center",
+  gap: 6,
+  textDecoration: "none",
+};
+const LINK_TEXT_STYLE: React.CSSProperties = {
+  overflowWrap: "anywhere",
+  wordBreak: "break-word",
+};
+
+type LinkPreviewData = { url: string; faviconSrc?: string } | null;
+
+const FaviconImage = React.memo(({ src }: { src?: string }) => {
+  const [errored, setErrored] = useState(false);
+
+  React.useEffect(() => {
+    setErrored(false);
+  }, [src]);
+
+  const finalSrc = !errored && src ? src : DEFAULT_FAVICON_DATA_URI;
+
+  return (
+    <img
+      src={finalSrc}
+      alt=""
+      loading="lazy"
+      decoding="async"
+      width={20}
+      height={20}
+      style={FAVICON_IMAGE_STYLE}
+      onError={() => {
+        if (!errored) setErrored(true);
+      }}
+    />
+  );
+}, (prev, next) => prev.src === next.src);
+
+const LinkPreviewRow = React.memo(
+  ({ url, faviconSrc }: { url: string; faviconSrc?: string }) => (
+    <div style={LINK_CONTAINER_STYLE}>
+      <a href={url} target="_blank" rel="noopener noreferrer" style={LINK_ANCHOR_STYLE}>
+        <span style={ICON_WRAPPER_STYLE}>
+          <FaviconImage src={faviconSrc} />
+        </span>
+        <span style={LINK_TEXT_STYLE}>{url}</span>
+      </a>
+    </div>
+  ),
+  (prev, next) => prev.url === next.url && prev.faviconSrc === next.faviconSrc
+);
+
 const MessageItem: React.FC<MessageItemProps> = ({
   msg,
   prevMsg,
@@ -103,57 +176,26 @@ const MessageItem: React.FC<MessageItemProps> = ({
   const urlRegex = /(https?:\/\/[^\s]+)/;
   const matchedUrl = text.match(urlRegex)?.[0];
 
-  const RenderLinkContent: React.FC<{ url: string }> = ({ url }) => {
-    if (/youtu\.be|youtube\.com|vimeo\.com/.test(url)) {
-      return (
-        <div style={{ maxWidth: "300px" }}>
-          <ReactPlayer src={url} width="100%" height="200px" controls />
-        </div>
-      );
-    }
-    let domain = "";
-    try {
-      domain = new URL(url).hostname;
-    } catch {
-      domain = "";
-    }
-    const defaultIcon =
-      "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Crect width='16' height='16' rx='3' fill='%234ea1f3'/%3E%3Cpath d='M5.75 10.25l4.5-4.5M6.5 5.75h3.75V9.5' fill='none' stroke='white' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E";
-    const fallbackIcon =
-      domain !== ""
-        ? `https://icons.duckduckgo.com/ip3/${domain}.ico`
-        : undefined;
-    const faviconUrl =
-      domain !== ""
-        ? `https://www.google.com/s2/favicons?sz=64&domain=${domain}`
-        : fallbackIcon ?? defaultIcon;
-    return (
-      <div style={{ maxWidth: "300px" }}>
-        <a
-          href={url}
-          target="_blank"
-          rel="noopener noreferrer"
-          style={{ color: "#4ea1f3", display: "flex", alignItems: "center" }}
-        >
-          <img
-            src={faviconUrl}
-            alt=""
-            style={{ width: 16, height: 16, marginRight: 4 }}
-            referrerPolicy="no-referrer"
-            onError={(event) => {
-              if (fallbackIcon && event.currentTarget.src !== fallbackIcon) {
-                event.currentTarget.src = fallbackIcon;
-                return;
-              }
-              event.currentTarget.onerror = null;
-              event.currentTarget.src = defaultIcon;
-            }}
-          />
-          {url}
-        </a>
-      </div>
-    );
-  };
+  const linkPreviewData: LinkPreviewData = useMemo(() => {
+    const preview = msg.linkPreview || null;
+    const previewUrl = typeof preview?.url === "string" ? preview.url : undefined;
+    const candidate = previewUrl || matchedUrl || "";
+    if (!candidate) return null;
+
+    const trimmed = candidate.trim();
+    if (!trimmed) return null;
+
+    const sanitizedUrl = trimmed.replace(TRAILING_PUNCTUATION_REGEX, "");
+    if (!sanitizedUrl) return null;
+
+    const faviconSource = preview?.faviconUrl || preview?.faviconKey;
+    const normalizedFavicon = faviconSource ? normalizeFileUrl(faviconSource) : undefined;
+
+    return {
+      url: sanitizedUrl,
+      faviconSrc: normalizedFavicon,
+    };
+  }, [matchedUrl, msg.linkPreview?.url, msg.linkPreview?.faviconKey, msg.linkPreview?.faviconUrl]);
 
   const messageDate = new Date(msg.timestamp);
   const formattedDate = messageDate.toLocaleDateString("en-US", {
@@ -209,8 +251,15 @@ const MessageItem: React.FC<MessageItemProps> = ({
         </div>
       );
     }
-    if (matchedUrl) {
-      return <RenderLinkContent url={matchedUrl} />;
+    if (linkPreviewData) {
+      if (VIDEO_HOST_REGEX.test(linkPreviewData.url)) {
+        return (
+          <div style={{ maxWidth: "300px" }}>
+            <ReactPlayer src={linkPreviewData.url} width="100%" height="200px" controls />
+          </div>
+        );
+      }
+      return <LinkPreviewRow url={linkPreviewData.url} faviconSrc={linkPreviewData.faviconSrc} />;
     }
     return text;
   };

--- a/frontend/src/dashboard/features/messages/Messages.tsx
+++ b/frontend/src/dashboard/features/messages/Messages.tsx
@@ -740,7 +740,7 @@ const fetchMessages = async () => {
           ...prev,
           messages: msgs.map((m) =>
             m.messageId === message.messageId
-              ? { ...m, text: newText, edited: true, editedAt: ts }
+              ? { ...m, text: newText, edited: true, editedAt: ts, linkPreview: null }
               : m
           ),
         };

--- a/frontend/src/dashboard/features/messages/ProjectMessagesThread.tsx
+++ b/frontend/src/dashboard/features/messages/ProjectMessagesThread.tsx
@@ -100,6 +100,11 @@ type Message = {
   file?: FileObj;
   attachments?: Attachment[]; // NEW: explicit attachments
   reactions?: Record<string, string[]>; // emoji -> [userId]
+  linkPreview?: {
+    url?: string;
+    faviconKey?: string;
+    faviconUrl?: string;
+  } | null;
 };
 
 type GetProjectMessagesResponse =
@@ -900,7 +905,7 @@ const ProjectMessagesThread: React.FC<ProjectMessagesThreadProps> = ({
           : [];
         const updated = msgs.map((m) =>
           m.messageId === message.messageId
-            ? { ...m, text: newText, edited: true, editedAt: ts }
+            ? { ...m, text: newText, edited: true, editedAt: ts, linkPreview: null }
             : m
         );
         setWithTTL(pmKey(projectId), updated);
@@ -1052,22 +1057,25 @@ const ProjectMessagesThread: React.FC<ProjectMessagesThreadProps> = ({
                 Looks quiet. Drop your first idea here.
               </div>
             ) : (
-              displayMessages.map((msg, index) => (
-                <MessageItem
-                  key={msg.messageId || msg.optimisticId || String(msg.timestamp)}
-                  msg={msg as ChatMessage}
-                  prevMsg={displayMessages[index - 1] as ChatMessage}
-                  userData={userData}
-                  allUsers={allUsers}
-                  openPreviewModal={openPreviewModal}
-                  folderKey={folderKey}
-                  renderFilePreview={renderFilePreview}
-                  getFileNameFromUrl={getFileNameFromUrl}
-                  onDelete={(m: ChatMessage) => setDeleteTarget(m as Message)}
-                  onEditRequest={(m: ChatMessage) => setEditTarget(m as Message)}
-                  onReact={reactToMessage}
-                />
-              ))
+              displayMessages.map((msg, index) => {
+                const messageKey = msg.messageId || msg.optimisticId || `temp-${index}`;
+                return (
+                  <MessageItem
+                    key={messageKey}
+                    msg={msg as ChatMessage}
+                    prevMsg={displayMessages[index - 1] as ChatMessage}
+                    userData={userData}
+                    allUsers={allUsers}
+                    openPreviewModal={openPreviewModal}
+                    folderKey={folderKey}
+                    renderFilePreview={renderFilePreview}
+                    getFileNameFromUrl={getFileNameFromUrl}
+                    onDelete={(m: ChatMessage) => setDeleteTarget(m as Message)}
+                    onEditRequest={(m: ChatMessage) => setEditTarget(m as Message)}
+                    onReact={reactToMessage}
+                  />
+                );
+              })
             )}
             {messages.length > 0 && <div />}
           </div>

--- a/frontend/src/dashboard/features/messages/components/ChatWindow.tsx
+++ b/frontend/src/dashboard/features/messages/components/ChatWindow.tsx
@@ -125,22 +125,25 @@ const ChatWindow: React.FC<ChatWindowProps & {
             Looks quiet. Drop your first idea here.
           </div>
         ) : (
-          displayMessages.map((msg, index) => (
-            <MessageItem
-              key={msg.optimisticId || msg.messageId || String(msg.timestamp)}
-              msg={msg as ChatMessage}
-              prevMsg={displayMessages[index - 1] as ChatMessage}
-              userData={userData}
-              allUsers={allUsers}
-              openPreviewModal={openPreviewModal}
-              folderKey={folderKey}
-              renderFilePreview={renderFilePreview}
-              getFileNameFromUrl={getFileNameFromUrl}
-              onDelete={onDelete}
-              onEditRequest={onEditRequest}
-              onReact={onReact}
-            />
-          ))
+          displayMessages.map((msg, index) => {
+            const messageKey = msg.messageId || msg.optimisticId || `temp-${index}`;
+            return (
+              <MessageItem
+                key={messageKey}
+                msg={msg as ChatMessage}
+                prevMsg={displayMessages[index - 1] as ChatMessage}
+                userData={userData}
+                allUsers={allUsers}
+                openPreviewModal={openPreviewModal}
+                folderKey={folderKey}
+                renderFilePreview={renderFilePreview}
+                getFileNameFromUrl={getFileNameFromUrl}
+                onDelete={onDelete}
+                onEditRequest={onEditRequest}
+                onReact={onReact}
+              />
+            );
+          })
         )}
         <div ref={messagesEndRef} />
       </div>

--- a/frontend/src/shared/utils/messageUtils.ts
+++ b/frontend/src/shared/utils/messageUtils.ts
@@ -19,6 +19,11 @@ export interface BaseMessage {
   conversationId?: string;
   read?: boolean;
   reactions?: Record<string, string[]>;
+  linkPreview?: {
+    url?: string;
+    faviconKey?: string;
+    faviconUrl?: string;
+  } | null;
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
## Summary
- cache conversation link favicons to S3 during send/edit and persist the link preview metadata on messages
- memoize the message link preview UI to load cached icons from our bucket with fixed sizing and fallback artwork
- stabilize message list keys and edit flows so cached previews survive updates without unnecessary reloads

## Testing
- npm run test -- MessageItem

------
https://chatgpt.com/codex/tasks/task_e_68daec51e1188324b2ae37c90319ab72