### PR TITLE
Revamp mobile tasks map view

### DIFF
--- a/frontend/src/dashboard/project/components/Tasks/TasksComponentMobile.module.css
+++ b/frontend/src/dashboard/project/components/Tasks/TasksComponentMobile.module.css
@@ -1,80 +1,154 @@
-.card {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  padding: 14px 16px;
+.container {
+  position: relative;
+  width: 100%;
+  height: 100dvh;
+  max-height: 100dvh;
+  background: #050607;
   color: rgba(255, 255, 255, 0.92);
-  background:
-    radial-gradient(120% 120% at 100% 0%, color-mix(in srgb, var(--brand, #fa3356) 12%, transparent) 0%, transparent 60%),
-    linear-gradient(180deg, rgba(255, 255, 255, 0.08) 0%, rgba(255, 255, 255, 0) 70%),
-    var(--bg2, #111213);
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  border-radius: var(--radius-squircle, 20px);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+  overflow: hidden;
 }
 
-.header {
+.mapLayer {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 50% -10%, rgba(250, 51, 86, 0.12), transparent 65%),
+    #050607;
+  z-index: 0;
+}
+
+.mapMessage {
+  position: absolute;
+  left: 50%;
+  bottom: max(1rem, env(safe-area-inset-bottom, 0.75rem));
+  transform: translateX(-50%);
+  padding: 0.65rem 1rem;
+  border-radius: 999px;
+  background: rgba(8, 10, 13, 0.82);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  box-shadow: 0 12px 28px rgba(3, 7, 18, 0.5);
+  color: rgba(246, 247, 251, 0.92);
+  font-size: 0.8rem;
+  text-align: center;
+  max-width: min(90vw, 320px);
+  pointer-events: none;
+  z-index: 10;
+}
+
+.sheet {
+  position: absolute;
+  inset: 0;
   display: flex;
-  align-items: flex-start;
+  flex-direction: column;
+  justify-content: flex-end;
+  z-index: 20;
+}
+
+.sheetSurface {
+  pointer-events: auto;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  background:
+    linear-gradient(180deg, rgba(17, 18, 19, 0.97) 0%, rgba(7, 8, 10, 0.98) 60%, rgba(5, 6, 7, 0.98) 100%);
+  border-radius: 28px 28px 0 0;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 -22px 48px rgba(0, 0, 0, 0.45);
+  backdrop-filter: blur(18px);
+  will-change: transform;
+  transition: transform 240ms cubic-bezier(0.25, 0.1, 0.25, 1);
+}
+
+.sheetHandle {
+  display: flex;
+  justify-content: center;
+  padding: 12px 0 6px;
+  cursor: grab;
+  touch-action: none;
+}
+
+.sheetHandle:active {
+  cursor: grabbing;
+}
+
+.sheetHandle:focus-visible {
+  outline: 2px solid var(--color-focus, var(--brand, #fa3356));
+  outline-offset: 4px;
+}
+
+.sheetGrabber {
+  width: 44px;
+  height: 4px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.28);
+}
+
+.sheetHeader {
+  display: flex;
+  align-items: center;
   justify-content: space-between;
-  gap: 12px;
+  gap: 0.75rem;
+  padding: 0 1.5rem 1rem;
 }
 
 .headingGroup {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 0.35rem;
 }
 
 .title {
   margin: 0;
-  font-size: 16px;
+  font-size: 1.1rem;
   font-weight: 600;
   letter-spacing: -0.01em;
 }
 
 .subtitle {
   margin: 0;
-  font-size: 12px;
-  line-height: 1.35;
-  color: rgba(255, 255, 255, 0.7);
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.72);
 }
 
-.primaryButton {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  padding: 8px 14px;
-  border-radius: 999px;
-  border: 1px solid rgba(255, 255, 255, 0.18);
-  background: rgba(255, 255, 255, 0.14);
-  color: rgba(255, 255, 255, 0.95);
-  font-size: 13px;
+.sheetContent {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.scrollRegion {
+  flex: 1;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 0 1.25rem;
+  padding-bottom: max(1.75rem, env(safe-area-inset-bottom, 1.25rem));
+  scrollbar-width: thin;
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  padding: 1.25rem;
+  border-radius: 20px;
+  background: rgba(12, 13, 16, 0.78);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.03), 0 18px 48px rgba(0, 0, 0, 0.4);
+}
+
+.sectionHeading {
+  margin: 0;
+  font-size: 0.95rem;
   font-weight: 600;
-  line-height: 1;
-  cursor: pointer;
-  transition: background 160ms ease, transform 160ms ease;
-}
-
-.primaryButton:disabled {
-  opacity: 0.55;
-  cursor: not-allowed;
-}
-
-.primaryButton:not(:disabled):hover,
-.primaryButton:not(:disabled):focus-visible {
-  background: rgba(255, 255, 255, 0.22);
-  transform: translateY(-1px);
-}
-
-.primaryButton:focus-visible {
-  outline: 2px solid var(--color-focus, var(--brand, #fa3356));
-  outline-offset: 2px;
+  color: var(--text-primary, #f6f7fb);
 }
 
 .statRow {
   display: flex;
-  gap: 9px;
+  gap: 0.75rem;
 }
 
 .statCard {
@@ -82,78 +156,146 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
-  gap: 4px;
-  padding: 10px 12px;
+  gap: 0.4rem;
+  padding: 0.9rem 1rem;
   border-radius: 16px;
-  background: rgba(255, 255, 255, 0.07);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  min-height: 60px;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  min-height: 64px;
 }
 
 .statOk {
-  background: color-mix(in srgb, var(--color-success, #4caf50) 12%, transparent);
-  border-color: color-mix(in srgb, var(--color-success, #4caf50) 34%, transparent);
+  background: color-mix(in srgb, var(--color-success, #4caf50) 18%, transparent);
+  border-color: color-mix(in srgb, var(--color-success, #4caf50) 38%, transparent);
 }
 
 .statDanger {
-  background: color-mix(in srgb, var(--color-error, #ef5350) 14%, transparent);
-  border-color: color-mix(in srgb, var(--color-error, #ef5350) 36%, transparent);
+  background: color-mix(in srgb, var(--color-error, #ef5350) 18%, transparent);
+  border-color: color-mix(in srgb, var(--color-error, #ef5350) 40%, transparent);
 }
 
 .statWarn {
-  background: color-mix(in srgb, var(--color-warning, #ff9800) 14%, transparent);
-  border-color: color-mix(in srgb, var(--color-warning, #ff9800) 36%, transparent);
+  background: color-mix(in srgb, var(--color-warning, #ff9800) 18%, transparent);
+  border-color: color-mix(in srgb, var(--color-warning, #ff9800) 40%, transparent);
 }
 
 .statValue {
-  font-size: 18px;
+  font-size: 1.25rem;
   font-weight: 600;
 }
 
 .statLabel {
-  font-size: 11px;
+  font-size: 0.7rem;
   text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: rgba(255, 255, 255, 0.7);
+  letter-spacing: 0.1em;
+  color: rgba(255, 255, 255, 0.72);
 }
 
 .status {
   margin: 0;
-  font-size: 13px;
-  color: rgba(255, 255, 255, 0.72);
-  line-height: 1.35;
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.78);
 }
 
-.status strong {
-  color: rgba(255, 255, 255, 0.9);
+.locationContainer {
+  border-radius: 18px;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(8, 10, 13, 0.75);
 }
 
-@media (max-width: 480px) {
-  .card {
-    padding: 12px 14px;
-    gap: 10px;
-  }
+.taskList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
 
-  .primaryButton {
-    padding: 7px 12px;
-    font-size: 12px;
-  }
+.taskItem {
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(11, 13, 17, 0.82);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+  transition: border-color 180ms ease, transform 180ms ease, box-shadow 180ms ease;
+  overflow: hidden;
+}
 
-  .statRow {
-    gap: 7px;
-  }
+.taskItemActive {
+  border-color: rgba(250, 51, 86, 0.65);
+  box-shadow: 0 12px 24px rgba(250, 51, 86, 0.25);
+}
 
-  .statCard {
-    padding: 9px 10px;
-    border-radius: 15px;
-  }
+.taskButton {
+  width: 100%;
+  padding: 0.95rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+  border: none;
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.taskButton:focus-visible {
+  outline: 2px solid var(--color-focus, var(--brand, #fa3356));
+  outline-offset: 2px;
+}
+
+.taskButton:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.taskTop {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.taskTitle {
+  font-size: 0.98rem;
+  font-weight: 600;
+  color: rgba(246, 247, 251, 0.95);
+}
+
+.taskMeta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  font-size: 0.82rem;
+  color: rgba(246, 247, 251, 0.75);
+}
+
+.metaLine {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.statusBadge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem 0.65rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.14);
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(246, 247, 251, 0.92);
 }
 
 .empty,
 .error,
 .loading {
   padding: 1rem;
-  border-radius: 12px;
+  border-radius: 14px;
   font-size: 0.85rem;
   color: var(--text-secondary, rgba(246, 247, 251, 0.72));
   background: rgba(12, 13, 16, 0.65);
@@ -170,203 +312,19 @@
   color: var(--text-tertiary, rgba(246, 247, 251, 0.6));
 }
 
-.drawerOverlay {
-  position: fixed;
-  inset: 0;
-  background: rgba(5, 6, 7, 0.72);
-  backdrop-filter: blur(6px);
-  display: flex;
-  justify-content: center;
-  align-items: flex-start;
-  
-  z-index: 1600;
-}
-
-.drawer {
-  width: min(720px, 100%);
-  max-height: min(100vh, 100dvh);
-  background:
-    linear-gradient(135deg, rgba(17, 18, 19, 0.94), rgba(5, 6, 7, 0.98));
-  border-radius: 24px 24px 16px 16px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  box-shadow: 0 -18px 48px rgba(0, 0, 0, 0.45);
-  overflow: hidden;
-  display: flex;
-  flex-direction: column;
-  color: var(--text-primary, #f6f7fb);
-  backdrop-filter: blur(12px);
-  animation: drawer-slide-up 220ms ease-out;
-}
-
-.drawerHeader {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.75rem;
-  padding: 1rem 1.5rem 0.75rem;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
-}
-
-.drawerTitleGroup {
-  display: flex;
-  flex-direction: column;
-  gap: 0.15rem;
-}
-
-.drawerTitle {
-  font-size: 1rem;
-  font-weight: 600;
-  color: var(--text-primary, #f6f7fb);
-}
-
-.drawerSubtitle {
-  font-size: 0.8rem;
-  color: var(--text-secondary, rgba(246, 247, 251, 0.7));
-}
-
-.closeButton {
-  background: rgba(255, 255, 255, 0.06);
-  border: 1px solid rgba(255, 255, 255, 0.14);
-  padding: 0.35rem;
-  border-radius: 999px;
-  color: var(--text-primary, #f6f7fb);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  transition: transform 0.2s ease, background 0.2s ease, border-color 0.2s ease;
-}
-
-.closeButton:hover,
-.closeButton:focus-visible {
-  background: rgba(255, 255, 255, 0.14);
-  border-color: rgba(255, 255, 255, 0.24);
-  color: var(--text-primary, #ffffff);
-  transform: translateY(-1px);
-}
-
-.drawerContent {
-  overflow-y: auto;
-  
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
-}
-
-.mapContainer {
-  height: 220px;
-  border-radius: 16px;
-  overflow: hidden;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.03);
-}
-
-.mapEmpty {
-  height: 220px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 16px;
-  border: 1px dashed rgba(148, 163, 184, 0.5);
-  color: var(--text-tertiary, rgba(246, 247, 251, 0.6));
-  background: rgba(12, 13, 16, 0.65);
-  font-size: 0.85rem;
-  text-align: center;
-  padding: 0 1.5rem;
-}
-
-.drawerSection {
-  display: flex;
-  flex-direction: column;
-  gap: 0.85rem;
-  padding: 1.15rem 1.25rem;
-  border-radius: 18px;
-  background: rgba(17, 18, 19, 0.92);
-  
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02), 0 18px 48px rgba(0, 0, 0, 0.35);
-}
-
-.sectionHeading {
-  font-size: 0.95rem;
-  font-weight: 600;
-  color: var(--text-primary, #f6f7fb);
-}
-
-.drawerTaskList {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0.65rem;
-}
-
-.drawerTaskItem {
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-  padding: 0.85rem 0.9rem;
-  border-radius: 14px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(12, 13, 16, 0.75);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
-}
-
-.drawerTaskTop {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-.drawerTaskTitle {
-  font-size: 0.95rem;
-  font-weight: 600;
-  color: var(--text-primary, #ffffff);
-}
-
-.drawerTaskMeta {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-  font-size: 0.8rem;
-  color: var(--text-secondary, rgba(246, 247, 251, 0.7));
-}
-
-.metaLine {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-}
-
-.statusBadge {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0.25rem 0.6rem;
-  border-radius: 999px;
-  border: 1px solid rgba(255, 255, 255, 0.16);
-  background: rgba(255, 255, 255, 0.12);
-  font-size: 0.7rem;
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: rgba(246, 247, 251, 0.95);
-}
-
 .createForm {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.85rem;
 }
 
 .input,
 .textarea,
 .dateInput {
   width: 100%;
-  padding: 0.65rem 0.75rem;
-  border-radius: 10px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
+  padding: 0.7rem 0.85rem;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
   font-size: 0.9rem;
   color: var(--text-primary, #f6f7fb);
   background: rgba(12, 13, 16, 0.78);
@@ -374,7 +332,7 @@
 }
 
 .textarea {
-  min-height: 96px;
+  min-height: 112px;
   resize: vertical;
 }
 
@@ -390,10 +348,10 @@
   color: #ffffff;
   font-weight: 600;
   font-size: 0.9rem;
-  padding: 0.6rem 1.2rem;
+  padding: 0.65rem 1.3rem;
   display: inline-flex;
   align-items: center;
-  gap: 0.4rem;
+  gap: 0.45rem;
   cursor: pointer;
 }
 
@@ -404,27 +362,32 @@
 
 .successMessage {
   color: #4ade80;
-  font-size: 0.8rem;
+  font-size: 0.82rem;
 }
 
 .formError {
   color: #f87171;
-  font-size: 0.8rem;
+  font-size: 0.82rem;
 }
 
-@keyframes drawer-slide-up {
-  from {
-    transform: translateY(24px);
-    opacity: 0;
+@media (max-width: 480px) {
+  .sheetHeader {
+    padding: 0 1.1rem 0.85rem;
   }
-  to {
-    transform: translateY(0);
-    opacity: 1;
-  }
-}
 
-@media (min-width: 768px) {
+  .scrollRegion {
+    padding: 0 1rem;
+  }
+
   .section {
-    padding: 1.5rem;
+    padding: 1.05rem;
+  }
+
+  .statCard {
+    padding: 0.85rem;
+  }
+
+  .taskButton {
+    padding: 0.85rem 0.9rem;
   }
 }

--- a/frontend/src/dashboard/project/components/Tasks/TasksComponentMobile.module.css
+++ b/frontend/src/dashboard/project/components/Tasks/TasksComponentMobile.module.css
@@ -1,46 +1,236 @@
-.container {
-  position: relative;
-  width: 100%;
-  height: 100dvh;
-  max-height: 100dvh;
-  background: #050607;
+.card {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 14px 16px;
   color: rgba(255, 255, 255, 0.92);
+  background:
+    radial-gradient(120% 120% at 100% 0%, color-mix(in srgb, var(--brand, #fa3356) 12%, transparent) 0%, transparent 60%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.08) 0%, rgba(255, 255, 255, 0) 70%),
+    var(--bg2, #111213);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: var(--radius-squircle, 20px);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+}
+
+.header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.headingGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.title {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.subtitle {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.35;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.primaryButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.14);
+  color: rgba(255, 255, 255, 0.95);
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1;
+  cursor: pointer;
+  transition: background 160ms ease, transform 160ms ease;
+}
+
+.primaryButton:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.primaryButton:not(:disabled):hover,
+.primaryButton:not(:disabled):focus-visible {
+  background: rgba(255, 255, 255, 0.22);
+  transform: translateY(-1px);
+}
+
+.primaryButton:focus-visible {
+  outline: 2px solid var(--color-focus, var(--brand, #fa3356));
+  outline-offset: 2px;
+}
+
+.statRow {
+  display: flex;
+  gap: 9px;
+}
+
+.statCard {
+  flex: 1 1 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 4px;
+  padding: 10px 12px;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.07);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  min-height: 60px;
+}
+
+.statOk {
+  background: color-mix(in srgb, var(--color-success, #4caf50) 12%, transparent);
+  border-color: color-mix(in srgb, var(--color-success, #4caf50) 34%, transparent);
+}
+
+.statDanger {
+  background: color-mix(in srgb, var(--color-error, #ef5350) 14%, transparent);
+  border-color: color-mix(in srgb, var(--color-error, #ef5350) 36%, transparent);
+}
+
+.statWarn {
+  background: color-mix(in srgb, var(--color-warning, #ff9800) 14%, transparent);
+  border-color: color-mix(in srgb, var(--color-warning, #ff9800) 36%, transparent);
+}
+
+.statValue {
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.statLabel {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.status {
+  margin: 0;
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.72);
+  line-height: 1.35;
+}
+
+.status strong {
+  color: rgba(255, 255, 255, 0.9);
+}
+
+@media (max-width: 480px) {
+  .card {
+    padding: 12px 14px;
+    gap: 10px;
+  }
+
+  .primaryButton {
+    padding: 7px 12px;
+    font-size: 12px;
+  }
+
+  .statRow {
+    gap: 7px;
+  }
+
+  .statCard {
+    padding: 9px 10px;
+    border-radius: 15px;
+  }
+}
+
+.empty,
+.error,
+.loading {
+  padding: 1rem;
+  border-radius: 12px;
+  font-size: 0.85rem;
+  color: var(--text-secondary, rgba(246, 247, 251, 0.72));
+  background: rgba(12, 13, 16, 0.65);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.error {
+  color: #fca5a5;
+  background: rgba(127, 29, 29, 0.45);
+  border-color: rgba(248, 113, 113, 0.32);
+}
+
+.loading {
+  color: var(--text-tertiary, rgba(246, 247, 251, 0.6));
+}
+
+.drawerOverlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1600;
+  background: #050607;
   overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  color: rgba(255, 255, 255, 0.92);
 }
 
 .mapLayer {
   position: absolute;
   inset: 0;
-  background: radial-gradient(circle at 50% -10%, rgba(250, 51, 86, 0.12), transparent 65%),
-    #050607;
   z-index: 0;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  background:
+    radial-gradient(circle at 50% -10%, rgba(250, 51, 86, 0.18), transparent 65%),
+    #050607;
+}
+
+.mapWrapper {
+  flex: 1;
+  min-height: 100%;
+  position: relative;
+  overflow: hidden;
+}
+
+.mapWrapper :global(#map) {
+  height: 100%;
+  width: 100%;
 }
 
 .mapMessage {
   position: absolute;
-  left: 50%;
   bottom: max(1rem, env(safe-area-inset-bottom, 0.75rem));
+  left: 50%;
   transform: translateX(-50%);
   padding: 0.65rem 1rem;
   border-radius: 999px;
-  background: rgba(8, 10, 13, 0.82);
+  background: rgba(8, 10, 13, 0.8);
   border: 1px solid rgba(255, 255, 255, 0.14);
-  box-shadow: 0 12px 28px rgba(3, 7, 18, 0.5);
-  color: rgba(246, 247, 251, 0.92);
+  box-shadow: 0 12px 28px rgba(3, 7, 18, 0.55);
   font-size: 0.8rem;
-  text-align: center;
-  max-width: min(90vw, 320px);
   pointer-events: none;
-  z-index: 10;
+  text-align: center;
+  color: rgba(246, 247, 251, 0.94);
 }
 
 .sheet {
-  position: absolute;
-  inset: 0;
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  height: 100%;
   display: flex;
   flex-direction: column;
   justify-content: flex-end;
-  z-index: 20;
+  pointer-events: none;
 }
 
 .sheetSurface {
@@ -53,31 +243,26 @@
     linear-gradient(180deg, rgba(17, 18, 19, 0.97) 0%, rgba(7, 8, 10, 0.98) 60%, rgba(5, 6, 7, 0.98) 100%);
   border-radius: 28px 28px 0 0;
   border: 1px solid rgba(255, 255, 255, 0.12);
-  box-shadow: 0 -22px 48px rgba(0, 0, 0, 0.45);
+  box-shadow: 0 -24px 48px rgba(0, 0, 0, 0.5);
   backdrop-filter: blur(18px);
+  transition: transform 220ms cubic-bezier(0.2, 0.8, 0.2, 1);
   will-change: transform;
-  transition: transform 240ms cubic-bezier(0.25, 0.1, 0.25, 1);
 }
 
 .sheetHandle {
   display: flex;
   justify-content: center;
-  padding: 12px 0 6px;
-  cursor: grab;
+  padding: 12px 0 4px;
   touch-action: none;
+  cursor: grab;
 }
 
 .sheetHandle:active {
   cursor: grabbing;
 }
 
-.sheetHandle:focus-visible {
-  outline: 2px solid var(--color-focus, var(--brand, #fa3356));
-  outline-offset: 4px;
-}
-
 .sheetGrabber {
-  width: 44px;
+  width: 48px;
   height: 4px;
   border-radius: 999px;
   background: rgba(255, 255, 255, 0.28);
@@ -88,26 +273,45 @@
   align-items: center;
   justify-content: space-between;
   gap: 0.75rem;
-  padding: 0 1.5rem 1rem;
+  padding: 0.75rem 1.5rem 1rem;
 }
 
-.headingGroup {
+.drawerTitleGroup {
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
+  gap: 0.15rem;
 }
 
-.title {
-  margin: 0;
-  font-size: 1.1rem;
+.drawerTitle {
+  font-size: 1rem;
   font-weight: 600;
-  letter-spacing: -0.01em;
+  color: var(--text-primary, #f6f7fb);
 }
 
-.subtitle {
-  margin: 0;
-  font-size: 0.85rem;
-  color: rgba(255, 255, 255, 0.72);
+.drawerSubtitle {
+  font-size: 0.8rem;
+  color: var(--text-secondary, rgba(246, 247, 251, 0.7));
+}
+
+.closeButton {
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  padding: 0.35rem;
+  border-radius: 999px;
+  color: var(--text-primary, #f6f7fb);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: transform 0.2s ease, background 0.2s ease, border-color 0.2s ease;
+}
+
+.closeButton:hover,
+.closeButton:focus-visible {
+  background: rgba(255, 255, 255, 0.14);
+  border-color: rgba(255, 255, 255, 0.24);
+  color: var(--text-primary, #ffffff);
+  transform: translateY(-1px);
 }
 
 .sheetContent {
@@ -126,113 +330,90 @@
   padding: 0 1.25rem;
   padding-bottom: max(1.75rem, env(safe-area-inset-bottom, 1.25rem));
   scrollbar-width: thin;
+  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
 }
 
-.section {
+.mapEmpty {
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 16px;
+  border: 1px dashed rgba(148, 163, 184, 0.4);
+  color: var(--text-tertiary, rgba(246, 247, 251, 0.7));
+  background: rgba(12, 13, 16, 0.68);
+  font-size: 0.85rem;
+  text-align: center;
+  padding: 0 1.5rem;
+  margin: 1.5rem;
+}
+
+.drawerSection {
   display: flex;
   flex-direction: column;
-  gap: 0.9rem;
-  padding: 1.25rem;
-  border-radius: 20px;
-  background: rgba(12, 13, 16, 0.78);
+  gap: 0.85rem;
+  padding: 1.15rem 1.25rem;
+  border-radius: 18px;
+  background: rgba(17, 18, 19, 0.88);
   border: 1px solid rgba(255, 255, 255, 0.08);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.03), 0 18px 48px rgba(0, 0, 0, 0.4);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02), 0 18px 40px rgba(0, 0, 0, 0.4);
 }
 
 .sectionHeading {
-  margin: 0;
   font-size: 0.95rem;
   font-weight: 600;
   color: var(--text-primary, #f6f7fb);
 }
 
-.statRow {
-  display: flex;
-  gap: 0.75rem;
-}
-
-.statCard {
-  flex: 1 1 0;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  gap: 0.4rem;
-  padding: 0.9rem 1rem;
-  border-radius: 16px;
-  background: rgba(255, 255, 255, 0.08);
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  min-height: 64px;
-}
-
-.statOk {
-  background: color-mix(in srgb, var(--color-success, #4caf50) 18%, transparent);
-  border-color: color-mix(in srgb, var(--color-success, #4caf50) 38%, transparent);
-}
-
-.statDanger {
-  background: color-mix(in srgb, var(--color-error, #ef5350) 18%, transparent);
-  border-color: color-mix(in srgb, var(--color-error, #ef5350) 40%, transparent);
-}
-
-.statWarn {
-  background: color-mix(in srgb, var(--color-warning, #ff9800) 18%, transparent);
-  border-color: color-mix(in srgb, var(--color-warning, #ff9800) 40%, transparent);
-}
-
-.statValue {
-  font-size: 1.25rem;
-  font-weight: 600;
-}
-
-.statLabel {
-  font-size: 0.7rem;
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
-  color: rgba(255, 255, 255, 0.72);
-}
-
-.status {
+.sheetCopy {
   margin: 0;
-  font-size: 0.9rem;
-  color: rgba(255, 255, 255, 0.78);
+  font-size: 0.85rem;
+  color: var(--text-secondary, rgba(246, 247, 251, 0.75));
+  line-height: 1.5;
 }
 
 .locationContainer {
-  border-radius: 18px;
-  overflow: hidden;
+  border-radius: 16px;
   border: 1px solid rgba(255, 255, 255, 0.12);
-  background: rgba(8, 10, 13, 0.75);
+  background: rgba(12, 13, 16, 0.72);
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
 }
 
-.taskList {
+.drawerTaskList {
   list-style: none;
   margin: 0;
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.9rem;
+  gap: 0.65rem;
 }
 
-.taskItem {
-  border-radius: 16px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  background: rgba(11, 13, 17, 0.82);
+.drawerTaskItem {
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(12, 13, 16, 0.75);
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
-  transition: border-color 180ms ease, transform 180ms ease, box-shadow 180ms ease;
   overflow: hidden;
 }
 
-.taskItemActive {
+.drawerTaskItemActive {
   border-color: rgba(250, 51, 86, 0.65);
-  box-shadow: 0 12px 24px rgba(250, 51, 86, 0.25);
+  box-shadow:
+    inset 0 0 0 1px rgba(250, 51, 86, 0.45),
+    0 12px 28px rgba(250, 51, 86, 0.28);
 }
 
-.taskButton {
-  width: 100%;
-  padding: 0.95rem 1rem;
+.drawerTaskButton {
   display: flex;
   flex-direction: column;
-  gap: 0.55rem;
+  align-items: flex-start;
+  gap: 0.35rem;
+  width: 100%;
+  padding: 0.85rem 0.9rem;
   border: none;
   background: transparent;
   color: inherit;
@@ -240,91 +421,66 @@
   cursor: pointer;
 }
 
-.taskButton:focus-visible {
-  outline: 2px solid var(--color-focus, var(--brand, #fa3356));
-  outline-offset: 2px;
+.drawerTaskButton:focus-visible {
+  outline: 2px solid rgba(250, 51, 86, 0.65);
+  outline-offset: 3px;
 }
 
-.taskButton:hover {
-  background: rgba(255, 255, 255, 0.04);
-}
-
-.taskTop {
+.drawerTaskTop {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 0.75rem;
+  gap: 0.5rem;
 }
 
-.taskTitle {
-  font-size: 0.98rem;
+.drawerTaskTitle {
+  font-size: 0.95rem;
   font-weight: 600;
-  color: rgba(246, 247, 251, 0.95);
+  color: var(--text-primary, #ffffff);
 }
 
-.taskMeta {
+.drawerTaskMeta {
   display: flex;
   flex-direction: column;
-  gap: 0.3rem;
-  font-size: 0.82rem;
-  color: rgba(246, 247, 251, 0.75);
+  gap: 0.25rem;
+  font-size: 0.8rem;
+  color: var(--text-secondary, rgba(246, 247, 251, 0.7));
 }
 
 .metaLine {
   display: inline-flex;
   align-items: center;
-  gap: 0.4rem;
+  gap: 0.35rem;
 }
 
 .statusBadge {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0.25rem 0.65rem;
+  padding: 0.25rem 0.6rem;
   border-radius: 999px;
-  border: 1px solid rgba(255, 255, 255, 0.18);
-  background: rgba(255, 255, 255, 0.14);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: rgba(255, 255, 255, 0.12);
   font-size: 0.7rem;
   font-weight: 600;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: rgba(246, 247, 251, 0.92);
-}
-
-.empty,
-.error,
-.loading {
-  padding: 1rem;
-  border-radius: 14px;
-  font-size: 0.85rem;
-  color: var(--text-secondary, rgba(246, 247, 251, 0.72));
-  background: rgba(12, 13, 16, 0.65);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-}
-
-.error {
-  color: #fca5a5;
-  background: rgba(127, 29, 29, 0.45);
-  border-color: rgba(248, 113, 113, 0.32);
-}
-
-.loading {
-  color: var(--text-tertiary, rgba(246, 247, 251, 0.6));
+  color: rgba(246, 247, 251, 0.95);
 }
 
 .createForm {
   display: flex;
   flex-direction: column;
-  gap: 0.85rem;
+  gap: 0.75rem;
 }
 
 .input,
 .textarea,
 .dateInput {
   width: 100%;
-  padding: 0.7rem 0.85rem;
-  border-radius: 12px;
-  border: 1px solid rgba(255, 255, 255, 0.14);
+  padding: 0.65rem 0.75rem;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
   font-size: 0.9rem;
   color: var(--text-primary, #f6f7fb);
   background: rgba(12, 13, 16, 0.78);
@@ -332,7 +488,7 @@
 }
 
 .textarea {
-  min-height: 112px;
+  min-height: 96px;
   resize: vertical;
 }
 
@@ -348,10 +504,10 @@
   color: #ffffff;
   font-weight: 600;
   font-size: 0.9rem;
-  padding: 0.65rem 1.3rem;
+  padding: 0.6rem 1.2rem;
   display: inline-flex;
   align-items: center;
-  gap: 0.45rem;
+  gap: 0.4rem;
   cursor: pointer;
 }
 
@@ -362,32 +518,27 @@
 
 .successMessage {
   color: #4ade80;
-  font-size: 0.82rem;
+  font-size: 0.8rem;
 }
 
 .formError {
   color: #f87171;
-  font-size: 0.82rem;
+  font-size: 0.8rem;
 }
 
-@media (max-width: 480px) {
-  .sheetHeader {
-    padding: 0 1.1rem 0.85rem;
+@keyframes drawer-slide-up {
+  from {
+    transform: translateY(24px);
+    opacity: 0;
   }
-
-  .scrollRegion {
-    padding: 0 1rem;
+  to {
+    transform: translateY(0);
+    opacity: 1;
   }
+}
 
+@media (min-width: 768px) {
   .section {
-    padding: 1.05rem;
-  }
-
-  .statCard {
-    padding: 0.85rem;
-  }
-
-  .taskButton {
-    padding: 0.85rem 0.9rem;
+    padding: 1.5rem;
   }
 }

--- a/frontend/src/dashboard/project/components/Tasks/TasksComponentMobile.tsx
+++ b/frontend/src/dashboard/project/components/Tasks/TasksComponentMobile.tsx
@@ -5,7 +5,8 @@ import React, {
   useRef,
   useState,
 } from "react";
-import { Plus, MapPin, Calendar } from "lucide-react";
+import { createPortal } from "react-dom";
+import { Plus, MapPin, Calendar, ChevronDown } from "lucide-react";
 
 import LeafletMap from "@/shared/ui/Map";
 import { createTask, fetchTasks } from "@/shared/utils/api";
@@ -65,11 +66,11 @@ const dueFormatter = new Intl.DateTimeFormat(undefined, {
   weekday: "short",
 });
 
-const DEFAULT_LOCATION = { lat: 37.0902, lng: -95.7129 };
+const DEFAULT_LOCATION = { lat: 37.0902, lng: -95.7129 }; // Geographic centre of contiguous US
 
 const SNAP_POINTS = {
   collapsed: 0.2,
-  mid: 0.5,
+  mid: 0.55,
   expanded: 1,
 } as const;
 
@@ -142,7 +143,7 @@ function parseLocation(value: unknown): { lat: number; lng: number } | null {
       const parsed = JSON.parse(value);
       return parseLocation(parsed);
     } catch {
-      const [latPart, lngPart] = value.split(/[\,\s]+/);
+      const [latPart, lngPart] = value.split(/[,\s]+/);
       const lat = Number(latPart);
       const lng = Number(lngPart);
       if (!Number.isNaN(lat) && !Number.isNaN(lng)) {
@@ -218,19 +219,6 @@ function buildMarkerThumbnail(color?: string) {
   return `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`;
 }
 
-const getNearestSnapPoint = (ratio: number): SnapPointKey => {
-  let nearest: SnapPointKey = "collapsed";
-  let smallestDiff = Number.POSITIVE_INFINITY;
-  (Object.entries(SNAP_POINTS) as [SnapPointKey, number][]).forEach(([key, value]) => {
-    const diff = Math.abs(value - ratio);
-    if (diff < smallestDiff) {
-      smallestDiff = diff;
-      nearest = key;
-    }
-  });
-  return nearest;
-};
-
 const TasksComponentMobile: React.FC<TasksComponentMobileProps> = ({
   projectId = "",
   projectName,
@@ -241,25 +229,19 @@ const TasksComponentMobile: React.FC<TasksComponentMobileProps> = ({
   const [tasks, setTasks] = useState<QuickTask[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [activeTaskId, setActiveTaskId] = useState<string | null>(null);
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
   const [dueDate, setDueDate] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const [formError, setFormError] = useState<string | null>(null);
-  const [sheetSnap, setSheetSnap] = useState<SnapPointKey>("collapsed");
-  const [sheetRatio, setSheetRatio] = useState<number>(SNAP_POINTS.collapsed);
-  const [isDraggingSheet, setIsDraggingSheet] = useState(false);
-  const [focusedTaskId, setFocusedTaskId] = useState<string | null>(null);
-
-  const dragStateRef = useRef<{
-    pointerId: number | null;
-    startY: number;
-    startRatio: number;
-    moved: boolean;
-  }>({ pointerId: null, startY: 0, startRatio: SNAP_POINTS.collapsed, moved: false });
-
-  const taskRefs = useRef<Map<string, HTMLLIElement>>(new Map());
+  const [sheetSnap, setSheetSnap] = useState<SnapPointKey>("mid");
+  const [sheetProgress, setSheetProgress] = useState<number>(SNAP_POINTS.mid);
+  const isDraggingRef = useRef(false);
+  const dragStateRef = useRef({ startY: 0, startProgress: SNAP_POINTS.mid });
+  const sheetProgressRef = useRef(sheetProgress);
 
   const refreshTasks = useCallback(async () => {
     if (!projectId) {
@@ -289,10 +271,67 @@ const TasksComponentMobile: React.FC<TasksComponentMobileProps> = ({
   }, [refreshTasks]);
 
   useEffect(() => {
-    if (focusedTaskId && !tasks.some((task) => task.id === focusedTaskId)) {
-      setFocusedTaskId(null);
+    if (!drawerOpen) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setDrawerOpen(false);
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [drawerOpen]);
+
+  useEffect(() => {
+    sheetProgressRef.current = sheetProgress;
+  }, [sheetProgress]);
+
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    if (!drawerOpen) return;
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [drawerOpen]);
+
+  useEffect(() => {
+    if (!drawerOpen) {
+      setSheetSnap("mid");
+      setSheetProgress(SNAP_POINTS.mid);
+      setActiveTaskId(null);
+      return;
     }
-  }, [focusedTaskId, tasks]);
+
+    setSheetSnap("mid");
+    setSheetProgress(SNAP_POINTS.mid);
+    if (tasks.length) {
+      setActiveTaskId((current) => {
+        if (current) return current;
+        const firstWithLocation = tasks.find(
+          (task) => task.location && !Number.isNaN(task.location.lat) && !Number.isNaN(task.location.lng),
+        );
+        return firstWithLocation?.id ?? tasks[0].id;
+      });
+    }
+  }, [drawerOpen, tasks]);
+
+  useEffect(() => {
+    if (isDraggingRef.current) return;
+    setSheetProgress(SNAP_POINTS[sheetSnap]);
+  }, [sheetSnap]);
+
+  useEffect(() => {
+    if (!activeTaskId) return;
+    if (tasks.some((task) => task.id === activeTaskId)) return;
+
+    const fallback = tasks.find(
+      (task) => task.location && !Number.isNaN(task.location.lat) && !Number.isNaN(task.location.lng),
+    );
+    setActiveTaskId(fallback?.id ?? tasks[0]?.id ?? null);
+  }, [activeTaskId, tasks]);
 
   const stats = useMemo(() => computeStats(tasks), [tasks]);
 
@@ -301,6 +340,94 @@ const TasksComponentMobile: React.FC<TasksComponentMobileProps> = ({
     if (loading) return "…";
     return value;
   };
+
+  const handlePointerMove = useCallback((event: PointerEvent) => {
+    if (!isDraggingRef.current) return;
+
+    const viewportHeight = window.innerHeight || 1;
+    const delta = event.clientY - dragStateRef.current.startY;
+    const nextProgress = clamp(
+      dragStateRef.current.startProgress - delta / viewportHeight,
+      SNAP_POINTS.collapsed,
+      SNAP_POINTS.expanded,
+    );
+    setSheetProgress(nextProgress);
+  }, []);
+
+  const handlePointerUp = useCallback(
+    (event: PointerEvent) => {
+      if (!isDraggingRef.current) return;
+      isDraggingRef.current = false;
+
+      window.removeEventListener("pointermove", handlePointerMove);
+      window.removeEventListener("pointerup", handlePointerUp);
+
+      try {
+        (event.target as HTMLElement | null)?.releasePointerCapture?.(
+          event.pointerId,
+        );
+      } catch {
+        // ignore cleanup failures
+      }
+
+      const current = sheetProgressRef.current;
+      let closest: SnapPointKey = SNAP_SEQUENCE[0];
+      let smallestDistance = Math.abs(SNAP_POINTS[closest] - current);
+
+      for (const key of SNAP_SEQUENCE.slice(1)) {
+        const distance = Math.abs(SNAP_POINTS[key] - current);
+        if (distance < smallestDistance) {
+          smallestDistance = distance;
+          closest = key;
+        }
+      }
+
+      setSheetSnap(closest);
+      setSheetProgress(SNAP_POINTS[closest]);
+    },
+    [handlePointerMove],
+  );
+
+  const handlePointerDown = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      if (event.pointerType === "mouse" && event.button !== 0) return;
+      event.preventDefault();
+      event.stopPropagation();
+      isDraggingRef.current = true;
+      dragStateRef.current = {
+        startY: event.clientY,
+        startProgress: sheetProgressRef.current,
+      };
+
+      event.currentTarget.setPointerCapture?.(event.pointerId);
+
+      window.addEventListener("pointermove", handlePointerMove);
+      window.addEventListener("pointerup", handlePointerUp);
+    },
+    [handlePointerMove, handlePointerUp],
+  );
+
+  useEffect(() => {
+    return () => {
+      window.removeEventListener("pointermove", handlePointerMove);
+      window.removeEventListener("pointerup", handlePointerUp);
+    };
+  }, [handlePointerMove, handlePointerUp]);
+
+  const ensureSheetSnap = useCallback((minimum: SnapPointKey) => {
+    const minValue = SNAP_POINTS[minimum];
+    setSheetSnap((current) => {
+      const currentValue = SNAP_POINTS[current];
+      if (currentValue >= minValue) {
+        return current;
+      }
+      return minimum;
+    });
+    setSheetProgress((current) => {
+      if (current >= minValue) return current;
+      return minValue;
+    });
+  }, []);
 
   const drawerTasks = useMemo(() => {
     return tasks
@@ -318,9 +445,8 @@ const TasksComponentMobile: React.FC<TasksComponentMobileProps> = ({
     [tasks],
   );
 
-  const mapLocation = activeProject?.location ?? mapTasks[0]?.location ?? DEFAULT_LOCATION;
-  const mapAddress =
-    activeProject?.address ?? mapTasks[0]?.address ?? projectName ?? "Project";
+  const mapLocation = mapTasks[0]?.location ?? DEFAULT_LOCATION;
+  const mapAddress = mapTasks[0]?.address ?? projectName ?? "Project";
 
   const mapMarkers = useMemo(
     () =>
@@ -357,125 +483,22 @@ const TasksComponentMobile: React.FC<TasksComponentMobileProps> = ({
     return `${sameDayCount} ${noun} due ${dueFormatter.format(nextDue.dueDate)}.`;
   }, [error, loading, tasks]);
 
-  const cycleSnapPoint = useCallback(() => {
-    setSheetSnap((current) => {
-      const currentIndex = SNAP_SEQUENCE.indexOf(current);
-      const nextIndex = (currentIndex + 1) % SNAP_SEQUENCE.length;
-      return SNAP_SEQUENCE[nextIndex];
-    });
-  }, []);
-
-  useEffect(() => {
-    if (isDraggingSheet) return;
-    setSheetRatio(SNAP_POINTS[sheetSnap]);
-  }, [sheetSnap, isDraggingSheet]);
-
-  const updateSheetFromPointer = useCallback((clientY: number) => {
-    if (typeof window === "undefined") return;
-    const viewportHeight = window.visualViewport?.height ?? window.innerHeight ?? 1;
-    if (!viewportHeight) return;
-
-    const { startY, startRatio } = dragStateRef.current;
-    const delta = clientY - startY;
-    const desired = startRatio * viewportHeight - delta;
-    const ratio = clamp(desired / viewportHeight, SNAP_POINTS.collapsed, SNAP_POINTS.expanded);
-    setSheetRatio(ratio);
-  }, []);
-
-  const handleHandlePointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
-    dragStateRef.current = {
-      pointerId: event.pointerId,
-      startY: event.clientY,
-      startRatio: sheetRatio,
-      moved: false,
-    };
-    event.currentTarget.setPointerCapture(event.pointerId);
-    setIsDraggingSheet(true);
+  const handleOpenDrawer = () => {
+    setDrawerOpen(true);
+    setFormError(null);
+    setSuccessMessage(null);
   };
 
-  const handleHandlePointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
-    if (!isDraggingSheet || dragStateRef.current.pointerId !== event.pointerId) return;
-    if (!dragStateRef.current.moved) {
-      const delta = Math.abs(event.clientY - dragStateRef.current.startY);
-      if (delta > 6) {
-        dragStateRef.current.moved = true;
-      }
-    }
-    updateSheetFromPointer(event.clientY);
+  const handleCloseDrawer = () => {
+    setDrawerOpen(false);
+    setFormError(null);
   };
 
-  const finishDrag = (event: React.PointerEvent<HTMLDivElement>) => {
-    if (!isDraggingSheet || dragStateRef.current.pointerId !== event.pointerId) {
-      return false;
-    }
-    event.currentTarget.releasePointerCapture(event.pointerId);
-    setIsDraggingSheet(false);
-    const ratio = clamp(sheetRatio, SNAP_POINTS.collapsed, SNAP_POINTS.expanded);
-    const nearest = getNearestSnapPoint(ratio);
-    setSheetSnap(nearest);
-    setSheetRatio(SNAP_POINTS[nearest]);
-    const moved = dragStateRef.current.moved;
-    dragStateRef.current = { pointerId: null, startY: 0, startRatio: SNAP_POINTS[nearest], moved: false };
-    return moved;
+  const resetForm = () => {
+    setTitle("");
+    setDescription("");
+    setDueDate("");
   };
-
-  const handleHandlePointerUp = (event: React.PointerEvent<HTMLDivElement>) => {
-    const moved = finishDrag(event);
-    if (!moved) {
-      cycleSnapPoint();
-    }
-  };
-
-  const handleHandlePointerCancel = (event: React.PointerEvent<HTMLDivElement>) => {
-    finishDrag(event);
-  };
-
-  const handleHandleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
-    if (event.key === "Enter" || event.key === " ") {
-      event.preventDefault();
-      cycleSnapPoint();
-    }
-    if (event.key === "ArrowUp") {
-      event.preventDefault();
-      setSheetSnap((current) => {
-        if (current === "expanded") return current;
-        if (current === "mid") return "expanded";
-        return "mid";
-      });
-    }
-    if (event.key === "ArrowDown") {
-      event.preventDefault();
-      setSheetSnap((current) => {
-        if (current === "collapsed") return current;
-        if (current === "mid") return "collapsed";
-        return "mid";
-      });
-    }
-  };
-
-  const handleMarkerSelect = useCallback((taskId: string) => {
-    setFocusedTaskId(taskId);
-    setSheetSnap((current) => (current === "expanded" ? current : "mid"));
-  }, []);
-
-  const handleTaskSelect = useCallback(
-    (task: QuickTask) => {
-      setFocusedTaskId(task.id);
-      if (task.location) {
-        setSheetSnap((current) => (current === "collapsed" ? "mid" : current));
-      }
-    },
-    [],
-  );
-
-  useEffect(() => {
-    if (!focusedTaskId || sheetSnap === "collapsed") return;
-    const element = taskRefs.current.get(focusedTaskId);
-    if (!element) return;
-    window.requestAnimationFrame(() => {
-      element.scrollIntoView({ block: "nearest", behavior: "smooth" });
-    });
-  }, [focusedTaskId, sheetSnap]);
 
   const handleCreateTask = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -509,9 +532,7 @@ const TasksComponentMobile: React.FC<TasksComponentMobileProps> = ({
         status: "todo",
       });
       setSuccessMessage("Task created. It'll appear here shortly.");
-      setTitle("");
-      setDescription("");
-      setDueDate("");
+      resetForm();
       void refreshTasks();
     } catch (err) {
       console.error("Failed to create project task", err);
@@ -521,189 +542,245 @@ const TasksComponentMobile: React.FC<TasksComponentMobileProps> = ({
     }
   };
 
-  const mapStatus = error
-    ? "We couldn't load locations for these tasks."
-    : loading
-      ? "Loading tasks…"
-      : mapTasks.length
-        ? null
-        : "Add locations to your tasks to see them appear on the map.";
+  const handleSelectTask = useCallback(
+    (taskId: string, snap: SnapPointKey = "mid") => {
+      setActiveTaskId(taskId);
+      ensureSheetSnap(snap);
+    },
+    [ensureSheetSnap],
+  );
 
-  const sheetTransform = `${(1 - sheetRatio) * 100}%`;
+  const renderDrawer = () => {
+    if (!drawerOpen || typeof document === "undefined") {
+      return null;
+    }
 
-  return (
-    <div className={styles.container} aria-label="Project tasks map view">
-      <div className={styles.mapLayer} aria-hidden={false}>
-        <LeafletMap
-          location={mapLocation}
-          address={mapAddress}
-          scrollWheelZoom={true}
-          dragging={true}
-          touchZoom={true}
-          showUserLocation={false}
-          markers={mapMarkers}
-          onMarkerSelect={handleMarkerSelect}
-          activeMarkerId={focusedTaskId}
-        />
-        {mapStatus ? <div className={styles.mapMessage}>{mapStatus}</div> : null}
-      </div>
+    const handleOverlayMouseDown = (event: React.MouseEvent<HTMLDivElement>) => {
+      if (event.target === event.currentTarget) {
+        handleCloseDrawer();
+      }
+    };
 
-      <div className={styles.sheet}>
-        <div
-          className={styles.sheetSurface}
-          style={{ transform: `translateY(${sheetTransform})`, transition: isDraggingSheet ? "none" : undefined }}
-        >
-          <div
-            className={styles.sheetHandle}
-            role="button"
-            tabIndex={0}
-            aria-label="Drag to resize the task panel"
-            onPointerDown={handleHandlePointerDown}
-            onPointerMove={handleHandlePointerMove}
-            onPointerUp={handleHandlePointerUp}
-            onPointerCancel={handleHandlePointerCancel}
-            onKeyDown={handleHandleKeyDown}
-          >
-            <span className={styles.sheetGrabber} />
+    const sheetTransform = `translateY(${(1 - sheetProgress) * 100}%)`;
+
+    return createPortal(
+      <div className={styles.drawerOverlay} role="presentation" onMouseDown={handleOverlayMouseDown}>
+        <div className={styles.mapLayer}>
+          <div className={styles.mapWrapper}>
+            {error ? (
+              <div className={styles.mapEmpty}>{error}</div>
+            ) : loading ? (
+              <div className={styles.mapEmpty}>Loading tasks…</div>
+            ) : mapTasks.length ? (
+              <LeafletMap
+                location={mapLocation}
+                address={mapAddress}
+                scrollWheelZoom={false}
+                dragging={true}
+                touchZoom={true}
+                showUserLocation={false}
+                markers={mapMarkers}
+                onMarkerSelect={(id) => handleSelectTask(id, "mid")}
+                activeMarkerId={activeTaskId}
+              />
+            ) : (
+              <div className={styles.mapEmpty}>
+                Add locations to your tasks to see them appear on the map.
+              </div>
+            )}
           </div>
-
-          <header className={styles.sheetHeader}>
-            <div className={styles.headingGroup}>
-              <h3 className={styles.title}>Tasks</h3>
-              <p className={styles.subtitle}>
-                {projectName
-                  ? `Keep ${projectName} moving forward.`
-                  : "Keep this project moving forward."}
-              </p>
+          {mapTasks.length ? (
+            <div className={styles.mapMessage}>Tap a pin to jump to its task</div>
+          ) : null}
+        </div>
+        <div
+          className={styles.sheet}
+          role="dialog"
+          aria-modal="true"
+          aria-label="Project tasks quick view"
+          onMouseDown={(event) => event.stopPropagation()}
+        >
+          <div className={styles.sheetSurface} style={{ transform: sheetTransform }}>
+            <div
+              className={styles.sheetHandle}
+              role="presentation"
+              onPointerDown={handlePointerDown}
+            >
+              <div className={styles.sheetGrabber} />
             </div>
-          </header>
-
-          <div className={styles.sheetContent}>
-            <div className={styles.scrollRegion}>
-              <section className={styles.section} aria-label="Project status">
-                <div className={styles.statRow} aria-label="Task summary">
-                  <div className={`${styles.statCard} ${styles.statOk}`}>
-                    <span className={styles.statValue}>{formatStatValue(stats.completed)}</span>
-                    <span className={styles.statLabel}>Done</span>
-                  </div>
-                  <div className={`${styles.statCard} ${styles.statDanger}`}>
-                    <span className={styles.statValue}>{formatStatValue(stats.overdue)}</span>
-                    <span className={styles.statLabel}>Overdue</span>
-                  </div>
-                  <div className={`${styles.statCard} ${styles.statWarn}`}>
-                    <span className={styles.statValue}>{formatStatValue(stats.dueSoon)}</span>
-                    <span className={styles.statLabel}>Due soon</span>
-                  </div>
-                </div>
-                <p className={styles.status}>{statusMessage}</p>
-              </section>
-
-              {activeProject && onActiveProjectChange ? (
-                <section className={styles.section} aria-label="Project location">
-                  <div className={styles.locationContainer}>
-                    <LocationComponent
-                      activeProject={activeProject}
-                      onActiveProjectChange={onActiveProjectChange}
-                    />
-                  </div>
+            <div className={styles.sheetHeader}>
+              <div className={styles.drawerTitleGroup}>
+                <span className={styles.drawerTitle}>Project tasks</span>
+                <span className={styles.drawerSubtitle}>
+                  {projectName
+                    ? `Everything happening in ${projectName}`
+                    : "Keep work on track"}
+                </span>
+              </div>
+              <button
+                type="button"
+                className={styles.closeButton}
+                onClick={handleCloseDrawer}
+                aria-label="Close tasks drawer"
+              >
+                <ChevronDown size={20} strokeWidth={2.5} />
+              </button>
+            </div>
+            <div className={styles.sheetContent}>
+              <div className={styles.scrollRegion}>
+                <section className={styles.drawerSection} aria-label="Project location">
+                  <h3 className={styles.sectionHeading}>Project location</h3>
+                  {activeProject && onActiveProjectChange ? (
+                    <div className={styles.locationContainer}>
+                      <LocationComponent
+                        activeProject={activeProject}
+                        onActiveProjectChange={onActiveProjectChange}
+                      />
+                    </div>
+                  ) : (
+                    <p className={styles.sheetCopy}>
+                      Assign locations to tasks so they can be pinned on the map.
+                    </p>
+                  )}
                 </section>
-              ) : null}
 
-              <section className={styles.section} aria-label="All project tasks">
-                <h3 className={styles.sectionHeading}>Task list</h3>
-                {error ? (
-                  <div className={styles.error}>{error}</div>
-                ) : loading ? (
-                  <div className={styles.loading}>Loading tasks…</div>
-                ) : drawerTasks.length ? (
-                  <ul className={styles.taskList}>
-                    {drawerTasks.map((task) => {
-                      const isSelected = focusedTaskId === task.id;
-                      return (
-                        <li
-                          key={task.id}
-                          ref={(element) => {
-                            if (!element) {
-                              taskRefs.current.delete(task.id);
-                            } else {
-                              taskRefs.current.set(task.id, element);
-                            }
-                          }}
-                          className={`${styles.taskItem} ${isSelected ? styles.taskItemActive : ""}`}
-                        >
-                          <button
-                            type="button"
-                            className={styles.taskButton}
-                            onClick={() => handleTaskSelect(task)}
+                <section className={styles.drawerSection} aria-label="All project tasks">
+                  <h3 className={styles.sectionHeading}>Task list</h3>
+                  {error ? (
+                    <div className={styles.error}>{error}</div>
+                  ) : loading ? (
+                    <div className={styles.loading}>Loading tasks…</div>
+                  ) : drawerTasks.length ? (
+                    <ul className={styles.drawerTaskList}>
+                      {drawerTasks.map((task) => {
+                        const isActive = task.id === activeTaskId;
+                        return (
+                          <li
+                            key={task.id}
+                            className={`${styles.drawerTaskItem} ${
+                              isActive ? styles.drawerTaskItemActive : ""
+                            }`}
                           >
-                            <div className={styles.taskTop}>
-                              <span className={styles.taskTitle}>{task.title}</span>
-                              <span className={styles.statusBadge}>
-                                {task.status === "done"
-                                  ? "Completed"
-                                  : task.status.replace(/_/g, " ")}
-                              </span>
-                            </div>
-                            <div className={styles.taskMeta}>
-                              <span className={styles.metaLine}>
-                                <Calendar size={14} aria-hidden="true" /> {formatDueLabel(task)}
-                              </span>
-                              {task.address ? (
-                                <span className={styles.metaLine}>
-                                  <MapPin size={14} aria-hidden="true" /> {task.address}
+                            <button
+                              type="button"
+                              className={styles.drawerTaskButton}
+                              onClick={() => handleSelectTask(task.id, "expanded")}
+                            >
+                              <div className={styles.drawerTaskTop}>
+                                <span className={styles.drawerTaskTitle}>{task.title}</span>
+                                <span className={styles.statusBadge}>
+                                  {task.status === "done"
+                                    ? "Completed"
+                                    : task.status.replace(/_/g, " ")}
                                 </span>
-                              ) : null}
-                            </div>
-                          </button>
-                        </li>
-                      );
-                    })}
-                  </ul>
-                ) : (
-                  <div className={styles.empty}>No tasks yet. Create one to get started.</div>
-                )}
-              </section>
+                              </div>
+                              <div className={styles.drawerTaskMeta}>
+                                <span className={styles.metaLine}>
+                                  <Calendar size={14} aria-hidden="true" /> {formatDueLabel(task)}
+                                </span>
+                                {task.address ? (
+                                  <span className={styles.metaLine}>
+                                    <MapPin size={14} aria-hidden="true" /> {task.address}
+                                  </span>
+                                ) : null}
+                              </div>
+                            </button>
+                          </li>
+                        );
+                      })}
+                    </ul>
+                  ) : (
+                    <div className={styles.empty}>No tasks yet. Create one to get started.</div>
+                  )}
+                </section>
 
-              <section className={styles.section} aria-label="Create a quick task">
-                <h3 className={styles.sectionHeading}>Create quick task</h3>
-                <form className={styles.createForm} onSubmit={handleCreateTask}>
-                  <input
-                    type="text"
-                    className={styles.input}
-                    placeholder="Task name"
-                    value={title}
-                    onChange={(event) => setTitle(event.target.value)}
-                    disabled={submitting}
-                  />
-                  <textarea
-                    className={styles.textarea}
-                    placeholder="Description (optional)"
-                    value={description}
-                    onChange={(event) => setDescription(event.target.value)}
-                    disabled={submitting}
-                  />
-                  <input
-                    type="date"
-                    className={styles.dateInput}
-                    value={dueDate}
-                    onChange={(event) => setDueDate(event.target.value)}
-                    disabled={submitting}
-                  />
-                  {formError ? <div className={styles.formError}>{formError}</div> : null}
-                  {successMessage ? <div className={styles.successMessage}>{successMessage}</div> : null}
-                  <div className={styles.formActions}>
-                    <button type="submit" className={styles.submitButton} disabled={submitting}>
-                      <Plus size={18} strokeWidth={2.5} />
-                      Create task
-                    </button>
-                  </div>
-                </form>
-              </section>
+                <section className={styles.drawerSection} aria-label="Create a quick task">
+                  <h3 className={styles.sectionHeading}>Create quick task</h3>
+                  <form className={styles.createForm} onSubmit={handleCreateTask}>
+                    <input
+                      type="text"
+                      className={styles.input}
+                      placeholder="Task name"
+                      value={title}
+                      onChange={(event) => setTitle(event.target.value)}
+                      disabled={submitting}
+                    />
+                    <textarea
+                      className={styles.textarea}
+                      placeholder="Description (optional)"
+                      value={description}
+                      onChange={(event) => setDescription(event.target.value)}
+                      disabled={submitting}
+                    />
+                    <input
+                      type="date"
+                      className={styles.dateInput}
+                      value={dueDate}
+                      onChange={(event) => setDueDate(event.target.value)}
+                      disabled={submitting}
+                    />
+                    {formError ? <div className={styles.formError}>{formError}</div> : null}
+                    {successMessage ? (
+                      <div className={styles.successMessage}>{successMessage}</div>
+                    ) : null}
+                    <div className={styles.formActions}>
+                      <button type="submit" className={styles.submitButton} disabled={submitting}>
+                        <Plus size={18} strokeWidth={2.5} />
+                        Create task
+                      </button>
+                    </div>
+                  </form>
+                </section>
+              </div>
             </div>
           </div>
         </div>
+      </div>,
+      document.body,
+    );
+  };
+
+  return (
+    <section className={styles.card} aria-label="Project tasks overview">
+      <header className={styles.header}>
+        <div className={styles.headingGroup}>
+          <h3 className={styles.title}>Tasks</h3>
+          <p className={styles.subtitle}>
+            {projectName
+              ? `Keep ${projectName} moving forward.`
+              : "Keep this project moving forward."}
+          </p>
+        </div>
+        <button
+          type="button"
+          className={styles.primaryButton}
+          onClick={handleOpenDrawer}
+          disabled={loading}
+        >
+          <Plus size={16} strokeWidth={2.25} />
+          Open tasks
+        </button>
+      </header>
+
+      <div className={styles.statRow} aria-label="Task summary">
+        <div className={`${styles.statCard} ${styles.statOk}`}>
+          <span className={styles.statValue}>{formatStatValue(stats.completed)}</span>
+          <span className={styles.statLabel}>Done</span>
+        </div>
+        <div className={`${styles.statCard} ${styles.statDanger}`}>
+          <span className={styles.statValue}>{formatStatValue(stats.overdue)}</span>
+          <span className={styles.statLabel}>Overdue</span>
+        </div>
+        <div className={`${styles.statCard} ${styles.statWarn}`}>
+          <span className={styles.statValue}>{formatStatValue(stats.dueSoon)}</span>
+          <span className={styles.statLabel}>Due soon</span>
+        </div>
       </div>
-    </div>
+
+      <p className={styles.status}>{statusMessage}</p>
+
+      {renderDrawer()}
+    </section>
   );
 };
 

--- a/frontend/src/dashboard/project/components/Tasks/TasksComponentMobile.tsx
+++ b/frontend/src/dashboard/project/components/Tasks/TasksComponentMobile.tsx
@@ -1,6 +1,11 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
-import { createPortal } from "react-dom";
-import { Plus, MapPin, Calendar, ChevronDown } from "lucide-react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { Plus, MapPin, Calendar } from "lucide-react";
 
 import Map from "@/shared/ui/Map";
 import { createTask, fetchTasks } from "@/shared/utils/api";
@@ -60,7 +65,20 @@ const dueFormatter = new Intl.DateTimeFormat(undefined, {
   weekday: "short",
 });
 
-const DEFAULT_LOCATION = { lat: 37.0902, lng: -95.7129 }; // Geographic centre of contiguous US
+const DEFAULT_LOCATION = { lat: 37.0902, lng: -95.7129 };
+
+const SNAP_POINTS = {
+  collapsed: 0.2,
+  mid: 0.5,
+  expanded: 1,
+} as const;
+
+type SnapPointKey = keyof typeof SNAP_POINTS;
+
+const SNAP_SEQUENCE: SnapPointKey[] = ["collapsed", "mid", "expanded"];
+
+const clamp = (value: number, min: number, max: number) =>
+  Math.min(Math.max(value, min), max);
 
 function parseDueDate(value?: unknown): Date | null {
   if (value == null || value === "") return null;
@@ -124,7 +142,7 @@ function parseLocation(value: unknown): { lat: number; lng: number } | null {
       const parsed = JSON.parse(value);
       return parseLocation(parsed);
     } catch {
-      const [latPart, lngPart] = value.split(/[,\s]+/);
+      const [latPart, lngPart] = value.split(/[\,\s]+/);
       const lat = Number(latPart);
       const lng = Number(lngPart);
       if (!Number.isNaN(lat) && !Number.isNaN(lng)) {
@@ -200,6 +218,19 @@ function buildMarkerThumbnail(color?: string) {
   return `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`;
 }
 
+const getNearestSnapPoint = (ratio: number): SnapPointKey => {
+  let nearest: SnapPointKey = "collapsed";
+  let smallestDiff = Number.POSITIVE_INFINITY;
+  (Object.entries(SNAP_POINTS) as [SnapPointKey, number][]).forEach(([key, value]) => {
+    const diff = Math.abs(value - ratio);
+    if (diff < smallestDiff) {
+      smallestDiff = diff;
+      nearest = key;
+    }
+  });
+  return nearest;
+};
+
 const TasksComponentMobile: React.FC<TasksComponentMobileProps> = ({
   projectId = "",
   projectName,
@@ -210,13 +241,25 @@ const TasksComponentMobile: React.FC<TasksComponentMobileProps> = ({
   const [tasks, setTasks] = useState<QuickTask[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [drawerOpen, setDrawerOpen] = useState(false);
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
   const [dueDate, setDueDate] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const [formError, setFormError] = useState<string | null>(null);
+  const [sheetSnap, setSheetSnap] = useState<SnapPointKey>("collapsed");
+  const [sheetRatio, setSheetRatio] = useState<number>(SNAP_POINTS.collapsed);
+  const [isDraggingSheet, setIsDraggingSheet] = useState(false);
+  const [focusedTaskId, setFocusedTaskId] = useState<string | null>(null);
+
+  const dragStateRef = useRef<{
+    pointerId: number | null;
+    startY: number;
+    startRatio: number;
+    moved: boolean;
+  }>({ pointerId: null, startY: 0, startRatio: SNAP_POINTS.collapsed, moved: false });
+
+  const taskRefs = useRef<Map<string, HTMLLIElement>>(new Map());
 
   const refreshTasks = useCallback(async () => {
     if (!projectId) {
@@ -246,16 +289,10 @@ const TasksComponentMobile: React.FC<TasksComponentMobileProps> = ({
   }, [refreshTasks]);
 
   useEffect(() => {
-    if (!drawerOpen) return;
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        setDrawerOpen(false);
-      }
-    };
-
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [drawerOpen]);
+    if (focusedTaskId && !tasks.some((task) => task.id === focusedTaskId)) {
+      setFocusedTaskId(null);
+    }
+  }, [focusedTaskId, tasks]);
 
   const stats = useMemo(() => computeStats(tasks), [tasks]);
 
@@ -281,8 +318,9 @@ const TasksComponentMobile: React.FC<TasksComponentMobileProps> = ({
     [tasks],
   );
 
-  const mapLocation = mapTasks[0]?.location ?? DEFAULT_LOCATION;
-  const mapAddress = mapTasks[0]?.address ?? projectName ?? "Project";
+  const mapLocation = activeProject?.location ?? mapTasks[0]?.location ?? DEFAULT_LOCATION;
+  const mapAddress =
+    activeProject?.address ?? mapTasks[0]?.address ?? projectName ?? "Project";
 
   const mapMarkers = useMemo(
     () =>
@@ -291,6 +329,7 @@ const TasksComponentMobile: React.FC<TasksComponentMobileProps> = ({
         lat: task.location!.lat,
         lng: task.location!.lng,
         thumbnail: buildMarkerThumbnail(projectColor),
+        label: task.title,
       })),
     [mapTasks, projectColor],
   );
@@ -318,22 +357,125 @@ const TasksComponentMobile: React.FC<TasksComponentMobileProps> = ({
     return `${sameDayCount} ${noun} due ${dueFormatter.format(nextDue.dueDate)}.`;
   }, [error, loading, tasks]);
 
-  const handleOpenDrawer = () => {
-    setDrawerOpen(true);
-    setFormError(null);
-    setSuccessMessage(null);
+  const cycleSnapPoint = useCallback(() => {
+    setSheetSnap((current) => {
+      const currentIndex = SNAP_SEQUENCE.indexOf(current);
+      const nextIndex = (currentIndex + 1) % SNAP_SEQUENCE.length;
+      return SNAP_SEQUENCE[nextIndex];
+    });
+  }, []);
+
+  useEffect(() => {
+    if (isDraggingSheet) return;
+    setSheetRatio(SNAP_POINTS[sheetSnap]);
+  }, [sheetSnap, isDraggingSheet]);
+
+  const updateSheetFromPointer = useCallback((clientY: number) => {
+    if (typeof window === "undefined") return;
+    const viewportHeight = window.visualViewport?.height ?? window.innerHeight ?? 1;
+    if (!viewportHeight) return;
+
+    const { startY, startRatio } = dragStateRef.current;
+    const delta = clientY - startY;
+    const desired = startRatio * viewportHeight - delta;
+    const ratio = clamp(desired / viewportHeight, SNAP_POINTS.collapsed, SNAP_POINTS.expanded);
+    setSheetRatio(ratio);
+  }, []);
+
+  const handleHandlePointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
+    dragStateRef.current = {
+      pointerId: event.pointerId,
+      startY: event.clientY,
+      startRatio: sheetRatio,
+      moved: false,
+    };
+    event.currentTarget.setPointerCapture(event.pointerId);
+    setIsDraggingSheet(true);
   };
 
-  const handleCloseDrawer = () => {
-    setDrawerOpen(false);
-    setFormError(null);
+  const handleHandlePointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (!isDraggingSheet || dragStateRef.current.pointerId !== event.pointerId) return;
+    if (!dragStateRef.current.moved) {
+      const delta = Math.abs(event.clientY - dragStateRef.current.startY);
+      if (delta > 6) {
+        dragStateRef.current.moved = true;
+      }
+    }
+    updateSheetFromPointer(event.clientY);
   };
 
-  const resetForm = () => {
-    setTitle("");
-    setDescription("");
-    setDueDate("");
+  const finishDrag = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (!isDraggingSheet || dragStateRef.current.pointerId !== event.pointerId) {
+      return false;
+    }
+    event.currentTarget.releasePointerCapture(event.pointerId);
+    setIsDraggingSheet(false);
+    const ratio = clamp(sheetRatio, SNAP_POINTS.collapsed, SNAP_POINTS.expanded);
+    const nearest = getNearestSnapPoint(ratio);
+    setSheetSnap(nearest);
+    setSheetRatio(SNAP_POINTS[nearest]);
+    const moved = dragStateRef.current.moved;
+    dragStateRef.current = { pointerId: null, startY: 0, startRatio: SNAP_POINTS[nearest], moved: false };
+    return moved;
   };
+
+  const handleHandlePointerUp = (event: React.PointerEvent<HTMLDivElement>) => {
+    const moved = finishDrag(event);
+    if (!moved) {
+      cycleSnapPoint();
+    }
+  };
+
+  const handleHandlePointerCancel = (event: React.PointerEvent<HTMLDivElement>) => {
+    finishDrag(event);
+  };
+
+  const handleHandleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      cycleSnapPoint();
+    }
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setSheetSnap((current) => {
+        if (current === "expanded") return current;
+        if (current === "mid") return "expanded";
+        return "mid";
+      });
+    }
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setSheetSnap((current) => {
+        if (current === "collapsed") return current;
+        if (current === "mid") return "collapsed";
+        return "mid";
+      });
+    }
+  };
+
+  const handleMarkerSelect = useCallback((taskId: string) => {
+    setFocusedTaskId(taskId);
+    setSheetSnap((current) => (current === "expanded" ? current : "mid"));
+  }, []);
+
+  const handleTaskSelect = useCallback(
+    (task: QuickTask) => {
+      setFocusedTaskId(task.id);
+      if (task.location) {
+        setSheetSnap((current) => (current === "collapsed" ? "mid" : current));
+      }
+    },
+    [],
+  );
+
+  useEffect(() => {
+    if (!focusedTaskId || sheetSnap === "collapsed") return;
+    const element = taskRefs.current.get(focusedTaskId);
+    if (!element) return;
+    window.requestAnimationFrame(() => {
+      element.scrollIntoView({ block: "nearest", behavior: "smooth" });
+    });
+  }, [focusedTaskId, sheetSnap]);
 
   const handleCreateTask = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -367,7 +509,9 @@ const TasksComponentMobile: React.FC<TasksComponentMobileProps> = ({
         status: "todo",
       });
       setSuccessMessage("Task created. It'll appear here shortly.");
-      resetForm();
+      setTitle("");
+      setDescription("");
+      setDueDate("");
       void refreshTasks();
     } catch (err) {
       console.error("Failed to create project task", err);
@@ -377,182 +521,189 @@ const TasksComponentMobile: React.FC<TasksComponentMobileProps> = ({
     }
   };
 
-  const renderDrawer = () => {
-    if (!drawerOpen || typeof document === "undefined") {
-      return null;
-    }
+  const mapStatus = error
+    ? "We couldn't load locations for these tasks."
+    : loading
+      ? "Loading tasks…"
+      : mapTasks.length
+        ? null
+        : "Add locations to your tasks to see them appear on the map.";
 
-    const handleOverlayMouseDown = (event: React.MouseEvent<HTMLDivElement>) => {
-      if (event.target === event.currentTarget) {
-        handleCloseDrawer();
-      }
-    };
-
-    return createPortal(
-      <div className={styles.drawerOverlay} role="presentation" onMouseDown={handleOverlayMouseDown}>
-        <div className={styles.drawer} role="dialog" aria-modal="true" aria-label="Project tasks quick view" onMouseDown={(event) => event.stopPropagation()}>
-          <div className={styles.drawerHeader}>
-            <div className={styles.drawerTitleGroup}>
-              <span className={styles.drawerTitle}>Project tasks</span>
-              <span className={styles.drawerSubtitle}>
-                {projectName ? `Everything happening in ${projectName}` : "Keep work on track"}
-              </span>
-            </div>
-            <button type="button" className={styles.closeButton} onClick={handleCloseDrawer} aria-label="Close tasks drawer">
-              <ChevronDown size={20} strokeWidth={2.5} />
-            </button>
-          </div>
-
-          <div className={styles.drawerContent}>
-            <section className={styles.drawerSection} aria-label="Project map">
-              <h3 className={styles.sectionHeading}>Project map</h3>
-              {activeProject && onActiveProjectChange ? (
-                <div className={styles.locationContainer}>
-                  <LocationComponent
-                    activeProject={activeProject}
-                    onActiveProjectChange={onActiveProjectChange}
-                  />
-                </div>
-              ) : error ? (
-                <div className={styles.mapEmpty}>{error}</div>
-              ) : loading ? (
-                <div className={styles.mapEmpty}>Loading tasks…</div>
-              ) : mapTasks.length ? (
-                <div className={styles.mapContainer}>
-                  <Map
-                    location={mapLocation}
-                    address={mapAddress}
-                    scrollWheelZoom={false}
-                    dragging={true}
-                    touchZoom={true}
-                    showUserLocation={false}
-                    otherUsers={mapMarkers}
-                  />
-                </div>
-              ) : (
-                <div className={styles.mapEmpty}>
-                  Add locations to your tasks to see them appear on the map.
-                </div>
-              )}
-            </section>
-
-            <section className={styles.drawerSection} aria-label="All project tasks">
-              <h3 className={styles.sectionHeading}>Task list</h3>
-              {error ? (
-                <div className={styles.error}>{error}</div>
-              ) : loading ? (
-                <div className={styles.loading}>Loading tasks…</div>
-              ) : drawerTasks.length ? (
-                <ul className={styles.drawerTaskList}>
-                  {drawerTasks.map((task) => (
-                    <li key={task.id} className={styles.drawerTaskItem}>
-                      <div className={styles.drawerTaskTop}>
-                        <span className={styles.drawerTaskTitle}>{task.title}</span>
-                        <span className={styles.statusBadge}>
-                          {task.status === "done" ? "Completed" : task.status.replace(/_/g, " ")}
-                        </span>
-                      </div>
-                      <div className={styles.drawerTaskMeta}>
-                        <span className={styles.metaLine}>
-                          <Calendar size={14} aria-hidden="true" /> {formatDueLabel(task)}
-                        </span>
-                        {task.address ? (
-                          <span className={styles.metaLine}>
-                            <MapPin size={14} aria-hidden="true" /> {task.address}
-                          </span>
-                        ) : null}
-                      </div>
-                    </li>
-                  ))}
-                </ul>
-              ) : (
-                <div className={styles.empty}>No tasks yet. Create one to get started.</div>
-              )}
-            </section>
-
-            <section className={styles.drawerSection} aria-label="Create a quick task">
-              <h3 className={styles.sectionHeading}>Create quick task</h3>
-              <form className={styles.createForm} onSubmit={handleCreateTask}>
-                <input
-                  type="text"
-                  className={styles.input}
-                  placeholder="Task name"
-                  value={title}
-                  onChange={(event) => setTitle(event.target.value)}
-                  disabled={submitting}
-                />
-                <textarea
-                  className={styles.textarea}
-                  placeholder="Description (optional)"
-                  value={description}
-                  onChange={(event) => setDescription(event.target.value)}
-                  disabled={submitting}
-                />
-                <input
-                  type="date"
-                  className={styles.dateInput}
-                  value={dueDate}
-                  onChange={(event) => setDueDate(event.target.value)}
-                  disabled={submitting}
-                />
-                {formError ? <div className={styles.formError}>{formError}</div> : null}
-                {successMessage ? <div className={styles.successMessage}>{successMessage}</div> : null}
-                <div className={styles.formActions}>
-                  <button type="submit" className={styles.submitButton} disabled={submitting}>
-                    <Plus size={18} strokeWidth={2.5} />
-                    Create task
-                  </button>
-                </div>
-              </form>
-            </section>
-          </div>
-        </div>
-      </div>,
-      document.body,
-    );
-  };
+  const sheetTransform = `${(1 - sheetRatio) * 100}%`;
 
   return (
-    <section className={styles.card} aria-label="Project tasks overview">
-      <header className={styles.header}>
-        <div className={styles.headingGroup}>
-          <h3 className={styles.title}>Tasks</h3>
-          <p className={styles.subtitle}>
-            {projectName
-              ? `Keep ${projectName} moving forward.`
-              : "Keep this project moving forward."}
-          </p>
-        </div>
-        <button
-          type="button"
-          className={styles.primaryButton}
-          onClick={handleOpenDrawer}
-          disabled={loading}
-        >
-          <Plus size={16} strokeWidth={2.25} />
-          Open tasks
-        </button>
-      </header>
-
-      <div className={styles.statRow} aria-label="Task summary">
-        <div className={`${styles.statCard} ${styles.statOk}`}>
-          <span className={styles.statValue}>{formatStatValue(stats.completed)}</span>
-          <span className={styles.statLabel}>Done</span>
-        </div>
-        <div className={`${styles.statCard} ${styles.statDanger}`}>
-          <span className={styles.statValue}>{formatStatValue(stats.overdue)}</span>
-          <span className={styles.statLabel}>Overdue</span>
-        </div>
-        <div className={`${styles.statCard} ${styles.statWarn}`}>
-          <span className={styles.statValue}>{formatStatValue(stats.dueSoon)}</span>
-          <span className={styles.statLabel}>Due soon</span>
-        </div>
+    <div className={styles.container} aria-label="Project tasks map view">
+      <div className={styles.mapLayer} aria-hidden={false}>
+        <Map
+          location={mapLocation}
+          address={mapAddress}
+          scrollWheelZoom={true}
+          dragging={true}
+          touchZoom={true}
+          showUserLocation={false}
+          markers={mapMarkers}
+          onMarkerSelect={handleMarkerSelect}
+          activeMarkerId={focusedTaskId}
+        />
+        {mapStatus ? <div className={styles.mapMessage}>{mapStatus}</div> : null}
       </div>
 
-      <p className={styles.status}>{statusMessage}</p>
+      <div className={styles.sheet}>
+        <div
+          className={styles.sheetSurface}
+          style={{ transform: `translateY(${sheetTransform})`, transition: isDraggingSheet ? "none" : undefined }}
+        >
+          <div
+            className={styles.sheetHandle}
+            role="button"
+            tabIndex={0}
+            aria-label="Drag to resize the task panel"
+            onPointerDown={handleHandlePointerDown}
+            onPointerMove={handleHandlePointerMove}
+            onPointerUp={handleHandlePointerUp}
+            onPointerCancel={handleHandlePointerCancel}
+            onKeyDown={handleHandleKeyDown}
+          >
+            <span className={styles.sheetGrabber} />
+          </div>
 
-      {renderDrawer()}
-    </section>
+          <header className={styles.sheetHeader}>
+            <div className={styles.headingGroup}>
+              <h3 className={styles.title}>Tasks</h3>
+              <p className={styles.subtitle}>
+                {projectName
+                  ? `Keep ${projectName} moving forward.`
+                  : "Keep this project moving forward."}
+              </p>
+            </div>
+          </header>
+
+          <div className={styles.sheetContent}>
+            <div className={styles.scrollRegion}>
+              <section className={styles.section} aria-label="Project status">
+                <div className={styles.statRow} aria-label="Task summary">
+                  <div className={`${styles.statCard} ${styles.statOk}`}>
+                    <span className={styles.statValue}>{formatStatValue(stats.completed)}</span>
+                    <span className={styles.statLabel}>Done</span>
+                  </div>
+                  <div className={`${styles.statCard} ${styles.statDanger}`}>
+                    <span className={styles.statValue}>{formatStatValue(stats.overdue)}</span>
+                    <span className={styles.statLabel}>Overdue</span>
+                  </div>
+                  <div className={`${styles.statCard} ${styles.statWarn}`}>
+                    <span className={styles.statValue}>{formatStatValue(stats.dueSoon)}</span>
+                    <span className={styles.statLabel}>Due soon</span>
+                  </div>
+                </div>
+                <p className={styles.status}>{statusMessage}</p>
+              </section>
+
+              {activeProject && onActiveProjectChange ? (
+                <section className={styles.section} aria-label="Project location">
+                  <div className={styles.locationContainer}>
+                    <LocationComponent
+                      activeProject={activeProject}
+                      onActiveProjectChange={onActiveProjectChange}
+                    />
+                  </div>
+                </section>
+              ) : null}
+
+              <section className={styles.section} aria-label="All project tasks">
+                <h3 className={styles.sectionHeading}>Task list</h3>
+                {error ? (
+                  <div className={styles.error}>{error}</div>
+                ) : loading ? (
+                  <div className={styles.loading}>Loading tasks…</div>
+                ) : drawerTasks.length ? (
+                  <ul className={styles.taskList}>
+                    {drawerTasks.map((task) => {
+                      const isSelected = focusedTaskId === task.id;
+                      return (
+                        <li
+                          key={task.id}
+                          ref={(element) => {
+                            if (!element) {
+                              taskRefs.current.delete(task.id);
+                            } else {
+                              taskRefs.current.set(task.id, element);
+                            }
+                          }}
+                          className={`${styles.taskItem} ${isSelected ? styles.taskItemActive : ""}`}
+                        >
+                          <button
+                            type="button"
+                            className={styles.taskButton}
+                            onClick={() => handleTaskSelect(task)}
+                          >
+                            <div className={styles.taskTop}>
+                              <span className={styles.taskTitle}>{task.title}</span>
+                              <span className={styles.statusBadge}>
+                                {task.status === "done"
+                                  ? "Completed"
+                                  : task.status.replace(/_/g, " ")}
+                              </span>
+                            </div>
+                            <div className={styles.taskMeta}>
+                              <span className={styles.metaLine}>
+                                <Calendar size={14} aria-hidden="true" /> {formatDueLabel(task)}
+                              </span>
+                              {task.address ? (
+                                <span className={styles.metaLine}>
+                                  <MapPin size={14} aria-hidden="true" /> {task.address}
+                                </span>
+                              ) : null}
+                            </div>
+                          </button>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                ) : (
+                  <div className={styles.empty}>No tasks yet. Create one to get started.</div>
+                )}
+              </section>
+
+              <section className={styles.section} aria-label="Create a quick task">
+                <h3 className={styles.sectionHeading}>Create quick task</h3>
+                <form className={styles.createForm} onSubmit={handleCreateTask}>
+                  <input
+                    type="text"
+                    className={styles.input}
+                    placeholder="Task name"
+                    value={title}
+                    onChange={(event) => setTitle(event.target.value)}
+                    disabled={submitting}
+                  />
+                  <textarea
+                    className={styles.textarea}
+                    placeholder="Description (optional)"
+                    value={description}
+                    onChange={(event) => setDescription(event.target.value)}
+                    disabled={submitting}
+                  />
+                  <input
+                    type="date"
+                    className={styles.dateInput}
+                    value={dueDate}
+                    onChange={(event) => setDueDate(event.target.value)}
+                    disabled={submitting}
+                  />
+                  {formError ? <div className={styles.formError}>{formError}</div> : null}
+                  {successMessage ? <div className={styles.successMessage}>{successMessage}</div> : null}
+                  <div className={styles.formActions}>
+                    <button type="submit" className={styles.submitButton} disabled={submitting}>
+                      <Plus size={18} strokeWidth={2.5} />
+                      Create task
+                    </button>
+                  </div>
+                </form>
+              </section>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
   );
 };
 

--- a/frontend/src/dashboard/project/components/Tasks/TasksComponentMobile.tsx
+++ b/frontend/src/dashboard/project/components/Tasks/TasksComponentMobile.tsx
@@ -7,7 +7,7 @@ import React, {
 } from "react";
 import { Plus, MapPin, Calendar } from "lucide-react";
 
-import Map from "@/shared/ui/Map";
+import LeafletMap from "@/shared/ui/Map";
 import { createTask, fetchTasks } from "@/shared/utils/api";
 import LocationComponent from "@/dashboard/project/components/Shared/LocationComponent";
 
@@ -534,7 +534,7 @@ const TasksComponentMobile: React.FC<TasksComponentMobileProps> = ({
   return (
     <div className={styles.container} aria-label="Project tasks map view">
       <div className={styles.mapLayer} aria-hidden={false}>
-        <Map
+        <LeafletMap
           location={mapLocation}
           address={mapAddress}
           scrollWheelZoom={true}

--- a/frontend/src/shared/ui/Map.tsx
+++ b/frontend/src/shared/ui/Map.tsx
@@ -25,6 +25,14 @@ interface LatLng {
   lng: number;
 }
 
+interface MapMarker {
+  id: string;
+  lat: number;
+  lng: number;
+  thumbnail?: string;
+  label?: string;
+}
+
 interface MapProps {
   location: LatLng;
   address: string;
@@ -38,7 +46,40 @@ interface MapProps {
   onLocationChange?: (loc: LatLng) => void;
   otherUsers?: UserLocation[];
   onUserLocation?: (loc: { lat: number; lng: number; accuracy: number }) => void;
+  markers?: MapMarker[];
+  onMarkerSelect?: (markerId: string) => void;
+  activeMarkerId?: string | null;
 }
+
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+
+const createTaskMarkerIcon = ({
+  thumbnail,
+  active,
+}: {
+  thumbnail?: string;
+  active?: boolean;
+}) => {
+  const size = active ? 40 : 32;
+  const border = active ? 4 : 3;
+  const background = thumbnail
+    ? `background-image:url('${thumbnail}');background-size:cover;background-position:center;`
+    : `background:linear-gradient(135deg, #fa3356, #fb7185);`;
+  const ring = active
+    ? 'box-shadow:0 0 0 4px rgba(250, 51, 86, 0.32), 0 16px 36px rgba(3, 7, 18, 0.55);'
+    : 'box-shadow:0 12px 28px rgba(3, 7, 18, 0.45);';
+  const borderColor = active ? '#ffffff' : 'rgba(255, 255, 255, 0.78)';
+
+  const html = `<div style="width:${size}px;height:${size}px;border-radius:50%;border:${border}px solid ${borderColor};${background}${ring}"></div>`;
+
+  return L.divIcon({
+    html,
+    className: 'task-marker-icon',
+    iconSize: [size, size],
+    iconAnchor: [size / 2, size - clamp(border * 1.5, 6, 14)],
+    popupAnchor: [0, -size / 2],
+  });
+};
 
 const Map = forwardRef<MapRef, MapProps>(
   (
@@ -55,6 +96,9 @@ const Map = forwardRef<MapRef, MapProps>(
       onLocationChange,
       otherUsers = [],
       onUserLocation,
+      markers = [],
+      onMarkerSelect,
+      activeMarkerId = null,
     },
     ref,
   ) => {
@@ -65,6 +109,8 @@ const Map = forwardRef<MapRef, MapProps>(
     const projectMarkerRef = useRef<L.Marker | null>(null);
     const otherUsersMarkersRef = useRef<Record<string, L.Marker>>({});
     const otherUsersAccuracyRef = useRef<Record<string, L.Circle>>({});
+    const interactiveMarkersRef = useRef<Record<string, L.Marker>>({});
+    const interactiveMarkerMetaRef = useRef<Record<string, MapMarker>>({});
 
     useEffect(() => {
       if (!mapRef.current || mapInstance.current) return;
@@ -179,6 +225,9 @@ const Map = forwardRef<MapRef, MapProps>(
           const b = c.getBounds();
           latLngs.push(b.getNorthEast(), b.getSouthWest());
         });
+        Object.values(interactiveMarkersRef.current).forEach((marker) => {
+          latLngs.push(marker.getLatLng());
+        });
 
         if (latLngs.length > 1) {
           mapInstance.current.fitBounds(L.latLngBounds(latLngs), { padding: [50, 50] });
@@ -196,6 +245,7 @@ const Map = forwardRef<MapRef, MapProps>(
       isEditable,
       onLocationChange,
       otherUsers,
+      markers,
     ]);
 
     useEffect(() => {
@@ -337,6 +387,9 @@ const Map = forwardRef<MapRef, MapProps>(
         const b = c.getBounds();
         latLngs.push(b.getNorthEast(), b.getSouthWest());
       });
+      Object.values(interactiveMarkersRef.current).forEach((marker) => {
+        latLngs.push(marker.getLatLng());
+      });
       if (latLngs.length > 1) {
         mapInstance.current!.fitBounds(L.latLngBounds(latLngs), { padding: [50, 50] });
       }
@@ -353,6 +406,84 @@ const Map = forwardRef<MapRef, MapProps>(
         mapInstance.current?.off('click', handleClick);
       };
     }, [isEditable, onLocationChange]);
+
+    useEffect(() => {
+      if (!mapInstance.current) return;
+      const currentMarkers = interactiveMarkersRef.current;
+      const meta = interactiveMarkerMetaRef.current;
+      const incoming = markers || [];
+
+      Object.keys(currentMarkers).forEach((id) => {
+        if (!incoming.find((marker) => marker.id === id)) {
+          mapInstance.current?.removeLayer(currentMarkers[id]);
+          currentMarkers[id].off('click');
+          delete currentMarkers[id];
+          delete meta[id];
+        }
+      });
+
+      incoming.forEach((marker) => {
+        const { id, lat, lng, thumbnail, label } = marker;
+        const latLng: [number, number] = [lat, lng];
+        meta[id] = marker;
+
+        const icon = createTaskMarkerIcon({ thumbnail, active: id === activeMarkerId });
+
+        if (currentMarkers[id]) {
+          currentMarkers[id].setLatLng(latLng);
+          currentMarkers[id].setIcon(icon);
+          if (label) {
+            currentMarkers[id].bindTooltip(label, { direction: 'top', offset: [0, -12] });
+          }
+          currentMarkers[id].off('click');
+          currentMarkers[id].on('click', () => onMarkerSelect?.(id));
+        } else {
+          const leafletMarker = L.marker(latLng, { icon });
+          if (label) {
+            leafletMarker.bindTooltip(label, { direction: 'top', offset: [0, -12] });
+          }
+          if (onMarkerSelect) {
+            leafletMarker.on('click', () => onMarkerSelect(id));
+          }
+          leafletMarker.addTo(mapInstance.current!);
+          currentMarkers[id] = leafletMarker;
+        }
+      });
+
+      return () => {
+        Object.values(currentMarkers).forEach((markerInstance) => {
+          markerInstance.closeTooltip();
+        });
+      };
+    }, [markers, onMarkerSelect, activeMarkerId]);
+
+    useEffect(() => {
+      if (!mapInstance.current) return;
+      const meta = interactiveMarkerMetaRef.current;
+      const markersMap = interactiveMarkersRef.current;
+
+      Object.entries(markersMap).forEach(([id, marker]) => {
+        const details = meta[id];
+        const icon = createTaskMarkerIcon({
+          thumbnail: details?.thumbnail,
+          active: id === activeMarkerId,
+        });
+        marker.setIcon(icon);
+        if (id !== activeMarkerId) {
+          marker.closeTooltip();
+        }
+      });
+
+      if (activeMarkerId) {
+        const activeMarker = markersMap[activeMarkerId];
+        if (activeMarker) {
+          const latLng = activeMarker.getLatLng();
+          const zoom = mapInstance.current.getZoom();
+          mapInstance.current.flyTo(latLng, Math.max(zoom, 15), { duration: 0.6 });
+          activeMarker.openTooltip();
+        }
+      }
+    }, [activeMarkerId, markers]);
 
     return <div id="map" style={{ height: '100%', width: '100%' }} ref={mapRef} />;
   },


### PR DESCRIPTION
## Summary
- make the mobile tasks experience map-first with a full-screen canvas and a snapping bottom sheet
- wire task selections to map markers so tapping pins surfaces the relevant task details in the drawer
- extend the shared map component with interactive marker support to focus and highlight active tasks

## Testing
- npm install --no-progress --loglevel=error *(fails: registry returned 403 forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68dae854c5fc8324a5eab6209bc1bc2f