### PR TITLE
Ensure gallery card maintains consistent height on mobile

### DIFF
--- a/frontend/src/dashboard/home/styles/components/calendar.css
+++ b/frontend/src/dashboard/home/styles/components/calendar.css
@@ -60,12 +60,17 @@
 
 .budget-calendar-layout .budget-column .view-gallery {
   flex: 2 1 0;
+  min-height: clamp(120px, 18vw + 72px, 168px);
 }
 
 .budget-calendar-layout--stacked .budget-column > *,
 .budget-calendar-layout--stacked .budget-column .budget-overview-card,
 .budget-calendar-layout--stacked .budget-column .view-gallery {
   flex: none;
+}
+
+.budget-calendar-layout--stacked .budget-column .view-gallery {
+  min-height: clamp(188px, 24vw + 132px, 236px);
 }
 
 /* Mobile stacked layout height optimization */

--- a/frontend/src/dashboard/project/components/Gallery/GalleryTrigger.tsx
+++ b/frontend/src/dashboard/project/components/Gallery/GalleryTrigger.tsx
@@ -58,9 +58,18 @@ const GalleryTrigger: React.FC<GalleryTriggerProps> = ({
   const visibleGalleries = galleries.slice(0, visibleCount);
   const hiddenCount = galleries.length - visibleCount;
 
+  const triggerClassName = [
+    "dashboard-item",
+    "view-gallery",
+    styles.galleryTrigger,
+    !hasGalleries ? styles.galleryTriggerEmpty : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
   return (
     <div
-      className={`dashboard-item view-gallery ${styles.galleryTrigger}`}
+      className={triggerClassName}
       onClick={onOpenModal}
       role="button"
       tabIndex={0}

--- a/frontend/src/dashboard/project/components/Gallery/gallery-component.module.css
+++ b/frontend/src/dashboard/project/components/Gallery/gallery-component.module.css
@@ -18,6 +18,23 @@
   border-radius: 16px;
 }
 
+.galleryTriggerEmpty {
+  --row-h: clamp(168px, 10vw + 156px, 220px);
+  align-items: stretch !important;
+}
+
+.galleryTriggerEmpty .thumbsColumn {
+  align-items: stretch;
+}
+
+.galleryTriggerEmpty .emptyState {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100%;
+  width: 100%;
+}
+
 /* Two columns inside the trigger */
 .titleColumn,
 .thumbsColumn {
@@ -200,6 +217,10 @@
     gap: 10px;
   }
 
+  .galleryTriggerEmpty {
+    --row-h: clamp(196px, 24vw + 132px, 244px);
+  }
+
   .titleColumn {
     flex: 1 1 54%;
     padding-right: 8px;
@@ -243,6 +264,10 @@
     --row-h: clamp(104px, 12vw + 84px, 138px);
     padding: 12px;
     gap: 8px;
+  }
+
+  .galleryTriggerEmpty {
+    --row-h: clamp(188px, 26vw + 120px, 236px);
   }
 
   .titleColumn {
@@ -293,6 +318,10 @@
 @media (max-width: 330px) {
   .galleryTrigger {
     --row-h: clamp(90px, 20vw + 64px, 124px);
+  }
+
+  .galleryTriggerEmpty {
+    --row-h: clamp(176px, 34vw + 108px, 220px);
   }
 
   .thumbnailCarousel {


### PR DESCRIPTION
## Summary
- keep the gallery trigger card height consistent when galleries are absent
- stretch the empty state placeholder to fill the card and adjust mobile row height variables
- enforce a matching minimum height for the gallery card inside the budget/calendar layout, including stacked mobile view

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68daef3ff0d88324b9ce56bf7dd6dbb8