### PR TITLE
Rework mobile tasks drawer with map-first layout

### DIFF
--- a/frontend/src/dashboard/project/components/Tasks/TasksComponentMobile.module.css
+++ b/frontend/src/dashboard/project/components/Tasks/TasksComponentMobile.module.css
@@ -322,6 +322,7 @@
   border-radius: 28px 28px 0 0;
   border: 1px solid rgba(255, 255, 255, 0.14);
   box-shadow: 0 -22px 48px rgba(0, 0, 0, 0.55);
+  z-index: 4;
   pointer-events: auto;
   overflow: hidden;
 }

--- a/frontend/src/dashboard/project/components/Tasks/TasksComponentMobile.module.css
+++ b/frontend/src/dashboard/project/components/Tasks/TasksComponentMobile.module.css
@@ -170,120 +170,237 @@
   color: var(--text-tertiary, rgba(246, 247, 251, 0.6));
 }
 
-.drawerOverlay {
+.sheetOverlay {
   position: fixed;
   inset: 0;
-  background: rgba(5, 6, 7, 0.72);
-  backdrop-filter: blur(6px);
-  display: flex;
-  justify-content: center;
-  align-items: flex-start;
-  
   z-index: 1600;
-}
-
-.drawer {
-  width: min(720px, 100%);
-  max-height: min(100vh, 100dvh);
-  background:
-    linear-gradient(135deg, rgba(17, 18, 19, 0.94), rgba(5, 6, 7, 0.98));
-  border-radius: 24px 24px 16px 16px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  box-shadow: 0 -18px 48px rgba(0, 0, 0, 0.45);
-  overflow: hidden;
-  display: flex;
-  flex-direction: column;
+  background: #050607;
   color: var(--text-primary, #f6f7fb);
-  backdrop-filter: blur(12px);
-  animation: drawer-slide-up 220ms ease-out;
 }
 
-.drawerHeader {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.75rem;
-  padding: 1rem 1.5rem 0.75rem;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+.mapLayer {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  pointer-events: none;
 }
 
-.drawerTitleGroup {
+.mapCanvas {
+  position: absolute;
+  inset: 0;
+  pointer-events: auto;
+}
+
+.mapGradient {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: min(45vh, 320px);
+  background: linear-gradient(180deg, rgba(5, 6, 7, 0) 0%, rgba(5, 6, 7, 0.92) 70%, rgba(5, 6, 7, 0.98) 100%);
+  pointer-events: none;
+}
+
+.mapHeader {
+  position: absolute;
+  top: 16px;
+  left: 16px;
   display: flex;
   flex-direction: column;
-  gap: 0.15rem;
+  gap: 0.25rem;
+  padding: 0.85rem 1rem;
+  border-radius: 16px;
+  background: rgba(7, 8, 10, 0.78);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  backdrop-filter: blur(16px);
+  pointer-events: auto;
+  max-width: min(280px, 85vw);
 }
 
-.drawerTitle {
-  font-size: 1rem;
+.mapProject {
+  font-size: 0.95rem;
   font-weight: 600;
   color: var(--text-primary, #f6f7fb);
 }
 
-.drawerSubtitle {
-  font-size: 0.8rem;
-  color: var(--text-secondary, rgba(246, 247, 251, 0.7));
+.mapMeta {
+  font-size: 0.75rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: rgba(246, 247, 251, 0.65);
 }
 
-.closeButton {
-  background: rgba(255, 255, 255, 0.06);
+.mapEmptyBanner {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  padding: 1rem 1.4rem;
+  border-radius: 18px;
+  background: rgba(9, 10, 12, 0.86);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  text-align: center;
+  max-width: min(320px, 90vw);
+  font-size: 0.85rem;
+  color: var(--text-secondary, rgba(246, 247, 251, 0.76));
+  backdrop-filter: blur(12px);
+  pointer-events: none;
+}
+
+.mapActiveCard {
+  position: absolute;
+  top: 84px;
+  left: 16px;
+  right: 16px;
+  max-width: min(360px, 85vw);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.95rem 1.1rem;
+  border-radius: 18px;
+  background: rgba(7, 8, 10, 0.8);
   border: 1px solid rgba(255, 255, 255, 0.14);
-  padding: 0.35rem;
-  border-radius: 999px;
-  color: var(--text-primary, #f6f7fb);
+  box-shadow: 0 22px 48px rgba(0, 0, 0, 0.45);
+  backdrop-filter: blur(14px);
+  pointer-events: auto;
+}
+
+.mapActiveTitle {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-primary, #ffffff);
+}
+
+.mapActiveMeta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.8rem;
+  color: var(--text-secondary, rgba(246, 247, 251, 0.74));
+}
+
+.sheetDismiss {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  z-index: 3;
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  padding: 0.55rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(7, 8, 10, 0.72);
+  color: var(--text-primary, #f6f7fb);
   cursor: pointer;
-  transition: transform 0.2s ease, background 0.2s ease, border-color 0.2s ease;
+  pointer-events: auto;
+  transition: background 0.2s ease, transform 0.2s ease;
 }
 
-.closeButton:hover,
-.closeButton:focus-visible {
-  background: rgba(255, 255, 255, 0.14);
-  border-color: rgba(255, 255, 255, 0.24);
-  color: var(--text-primary, #ffffff);
+.sheetDismiss:hover,
+.sheetDismiss:focus-visible {
+  background: rgba(7, 8, 10, 0.92);
   transform: translateY(-1px);
 }
 
-.drawerContent {
-  overflow-y: auto;
-  
+.sheetDismiss:focus-visible {
+  outline: 2px solid var(--brand, #fa3356);
+  outline-offset: 2px;
+}
+
+.sheet {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  margin: 0 auto;
+  width: min(720px, 100%);
+  max-height: 100vh;
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
-}
-
-.mapContainer {
-  height: 220px;
-  border-radius: 16px;
+  background: linear-gradient(180deg, rgba(7, 8, 10, 0.98), rgba(4, 5, 7, 0.98));
+  border-radius: 28px 28px 0 0;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  box-shadow: 0 -22px 48px rgba(0, 0, 0, 0.55);
+  pointer-events: auto;
   overflow: hidden;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.03);
 }
 
-.mapEmpty {
-  height: 220px;
+.sheetHandle {
+  align-self: center;
+  margin: 10px 0 4px;
+  width: 76px;
+  height: 32px;
+  border-radius: 999px;
   display: flex;
   align-items: center;
   justify-content: center;
-  border-radius: 16px;
-  border: 1px dashed rgba(148, 163, 184, 0.5);
-  color: var(--text-tertiary, rgba(246, 247, 251, 0.6));
-  background: rgba(12, 13, 16, 0.65);
-  font-size: 0.85rem;
-  text-align: center;
-  padding: 0 1.5rem;
+  background: transparent;
+  cursor: pointer;
 }
 
-.drawerSection {
+.sheetHandle:focus-visible {
+  outline: 2px solid var(--brand, #fa3356);
+  outline-offset: 2px;
+}
+
+.sheetHandleBar {
+  width: 44px;
+  height: 5px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.32);
+}
+
+.sheetHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 0 1.75rem 0.5rem;
+}
+
+.sheetTitleGroup {
   display: flex;
   flex-direction: column;
-  gap: 0.85rem;
-  padding: 1.15rem 1.25rem;
-  border-radius: 18px;
-  background: rgba(17, 18, 19, 0.92);
-  
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02), 0 18px 48px rgba(0, 0, 0, 0.35);
+  gap: 0.25rem;
+}
+
+.sheetTitle {
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.sheetSubtitle {
+  font-size: 0.85rem;
+  color: var(--text-secondary, rgba(246, 247, 251, 0.72));
+}
+
+.sheetSummary {
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+  padding: 0 1.75rem 1.25rem;
+}
+
+.sheetScrollArea {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 1.35rem;
+  padding: 0 1.5rem 1.75rem;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
+.sheetSection {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  padding: 1.1rem 1.25rem;
+  border-radius: 20px;
+  background: rgba(10, 11, 14, 0.88);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.03);
 }
 
 .sectionHeading {
@@ -292,45 +409,79 @@
   color: var(--text-primary, #f6f7fb);
 }
 
-.drawerTaskList {
+.locationContainer {
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  overflow: hidden;
+  background: rgba(7, 8, 10, 0.75);
+}
+
+.taskList {
   list-style: none;
   margin: 0;
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.65rem;
+  gap: 0.75rem;
 }
 
-.drawerTaskItem {
+.taskItem {
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: rgba(10, 11, 14, 0.82);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.taskItemActive {
+  border-color: var(--brand, #fa3356);
+  box-shadow:
+    0 18px 42px rgba(250, 51, 86, 0.32),
+    inset 0 0 0 1px rgba(250, 51, 86, 0.38);
+  transform: translateY(-2px);
+}
+
+.taskButton {
+  width: 100%;
+  border: none;
+  background: transparent;
+  color: inherit;
+  padding: 1rem 1.05rem;
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
-  padding: 0.85rem 0.9rem;
-  border-radius: 14px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(12, 13, 16, 0.75);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+  gap: 0.55rem;
+  text-align: left;
+  cursor: pointer;
 }
 
-.drawerTaskTop {
+.taskButton:focus-visible {
+  outline: 2px solid var(--brand, #fa3356);
+  outline-offset: 2px;
+}
+
+.taskTitleRow {
   display: flex;
-  justify-content: space-between;
   align-items: center;
-  gap: 0.5rem;
+  justify-content: space-between;
+  gap: 0.75rem;
 }
 
-.drawerTaskTitle {
-  font-size: 0.95rem;
+.taskTitle {
+  font-size: 1rem;
   font-weight: 600;
   color: var(--text-primary, #ffffff);
 }
 
-.drawerTaskMeta {
+.taskMeta {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
-  font-size: 0.8rem;
-  color: var(--text-secondary, rgba(246, 247, 251, 0.7));
+  gap: 0.35rem;
+  font-size: 0.85rem;
+  color: var(--text-secondary, rgba(246, 247, 251, 0.72));
+}
+
+.metaLineMuted {
+  color: var(--text-tertiary, rgba(246, 247, 251, 0.6));
 }
 
 .metaLine {
@@ -410,21 +561,4 @@
 .formError {
   color: #f87171;
   font-size: 0.8rem;
-}
-
-@keyframes drawer-slide-up {
-  from {
-    transform: translateY(24px);
-    opacity: 0;
-  }
-  to {
-    transform: translateY(0);
-    opacity: 1;
-  }
-}
-
-@media (min-width: 768px) {
-  .section {
-    padding: 1.5rem;
-  }
 }

--- a/frontend/src/dashboard/project/components/Tasks/TasksComponentMobile.tsx
+++ b/frontend/src/dashboard/project/components/Tasks/TasksComponentMobile.tsx
@@ -1,6 +1,7 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { Plus, MapPin, Calendar, ChevronDown } from "lucide-react";
+import { motion } from "framer-motion";
 
 import Map from "@/shared/ui/Map";
 import { createTask, fetchTasks } from "@/shared/utils/api";
@@ -61,6 +62,13 @@ const dueFormatter = new Intl.DateTimeFormat(undefined, {
 });
 
 const DEFAULT_LOCATION = { lat: 37.0902, lng: -95.7129 }; // Geographic centre of contiguous US
+const SNAP_POINTS = [0.2, 0.5, 1] as const;
+type SnapIndex = 0 | 1 | 2;
+
+function getViewportHeight(): number {
+  if (typeof window === "undefined") return 0;
+  return window.visualViewport?.height ?? window.innerHeight;
+}
 
 function parseDueDate(value?: unknown): Date | null {
   if (value == null || value === "") return null;
@@ -217,6 +225,31 @@ const TasksComponentMobile: React.FC<TasksComponentMobileProps> = ({
   const [submitting, setSubmitting] = useState(false);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const [formError, setFormError] = useState<string | null>(null);
+  const [snapIndex, setSnapIndex] = useState<SnapIndex>(1);
+  const [viewportHeight, setViewportHeight] = useState(() => getViewportHeight());
+  const [activeTaskId, setActiveTaskId] = useState<string | null>(null);
+  const [mapFocus, setMapFocus] = useState<{ lat: number; lng: number } | null>(null);
+  const sheetRef = useRef<HTMLDivElement | null>(null);
+  const taskListRef = useRef<HTMLUListElement | null>(null);
+  const initialScrollDoneRef = useRef(false);
+
+  const handleOpenDrawer = useCallback(() => {
+    setDrawerOpen(true);
+    setFormError(null);
+    setSuccessMessage(null);
+    setSnapIndex(0);
+    initialScrollDoneRef.current = false;
+    setViewportHeight(getViewportHeight());
+  }, []);
+
+  const handleCloseDrawer = useCallback(() => {
+    setDrawerOpen(false);
+    setFormError(null);
+    setSnapIndex(1);
+    setActiveTaskId(null);
+    setMapFocus(null);
+    initialScrollDoneRef.current = false;
+  }, []);
 
   const refreshTasks = useCallback(async () => {
     if (!projectId) {
@@ -249,12 +282,35 @@ const TasksComponentMobile: React.FC<TasksComponentMobileProps> = ({
     if (!drawerOpen) return;
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
-        setDrawerOpen(false);
+        handleCloseDrawer();
       }
     };
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [drawerOpen, handleCloseDrawer]);
+
+  useEffect(() => {
+    if (!drawerOpen) return;
+    const update = () => setViewportHeight(getViewportHeight());
+    update();
+    window.addEventListener("resize", update);
+    const viewport = window.visualViewport;
+    viewport?.addEventListener("resize", update);
+    return () => {
+      window.removeEventListener("resize", update);
+      viewport?.removeEventListener("resize", update);
+    };
+  }, [drawerOpen]);
+
+  useEffect(() => {
+    if (!drawerOpen || typeof document === "undefined") return;
+    const { body } = document;
+    const previousOverflow = body.style.overflow;
+    body.style.overflow = "hidden";
+    return () => {
+      body.style.overflow = previousOverflow;
+    };
   }, [drawerOpen]);
 
   const stats = useMemo(() => computeStats(tasks), [tasks]);
@@ -284,16 +340,124 @@ const TasksComponentMobile: React.FC<TasksComponentMobileProps> = ({
   const mapLocation = mapTasks[0]?.location ?? DEFAULT_LOCATION;
   const mapAddress = mapTasks[0]?.address ?? projectName ?? "Project";
 
+  const markerThumbnail = useMemo(() => buildMarkerThumbnail(projectColor), [projectColor]);
+
   const mapMarkers = useMemo(
     () =>
       mapTasks.map((task) => ({
         id: task.id,
         lat: task.location!.lat,
         lng: task.location!.lng,
-        thumbnail: buildMarkerThumbnail(projectColor),
+        iconUrl: markerThumbnail,
+        title: task.title,
+        isActive: task.id === activeTaskId,
       })),
-    [mapTasks, projectColor],
+    [mapTasks, markerThumbnail, activeTaskId],
   );
+
+  useEffect(() => {
+    if (!drawerOpen) return;
+    const existingIds = new Set(drawerTasks.map((task) => task.id));
+    if (activeTaskId && existingIds.has(activeTaskId)) {
+      return;
+    }
+
+    initialScrollDoneRef.current = false;
+
+    if (mapTasks.length) {
+      setActiveTaskId(mapTasks[0].id);
+    } else if (drawerTasks.length) {
+      setActiveTaskId(drawerTasks[0].id);
+    } else {
+      setActiveTaskId(null);
+    }
+  }, [drawerOpen, drawerTasks, mapTasks, activeTaskId]);
+
+  useEffect(() => {
+    if (!drawerOpen) return;
+    if (!activeTaskId) {
+      setMapFocus(null);
+      return;
+    }
+
+    const locatedTask = mapTasks.find((task) => task.id === activeTaskId);
+    if (!locatedTask?.location) {
+      setMapFocus(null);
+      return;
+    }
+
+    setMapFocus(locatedTask.location);
+
+    if (typeof window === "undefined") return;
+    const timeout = window.setTimeout(() => setMapFocus(null), 420);
+    return () => window.clearTimeout(timeout);
+  }, [activeTaskId, mapTasks, drawerOpen]);
+
+  useEffect(() => {
+    if (!drawerOpen || !activeTaskId || !taskListRef.current) return;
+    const container = taskListRef.current;
+    const target = container.querySelector<HTMLLIElement>(`[data-task-id="${activeTaskId}"]`);
+    if (!target) return;
+
+    const behavior: ScrollBehavior = initialScrollDoneRef.current ? "smooth" : "auto";
+    target.scrollIntoView({ block: "center", behavior });
+    initialScrollDoneRef.current = true;
+  }, [activeTaskId, drawerOpen]);
+
+  const sheetHeights = useMemo(() => SNAP_POINTS.map((point) => viewportHeight * point), [viewportHeight]);
+  const targetY = viewportHeight ? viewportHeight - sheetHeights[snapIndex] : 0;
+  const maxDragOffset = Math.max(0, viewportHeight - sheetHeights[0]);
+  const hasMapMarkers = mapMarkers.length > 0;
+  const selectedTask = useMemo(
+    () => drawerTasks.find((task) => task.id === activeTaskId) ?? null,
+    [drawerTasks, activeTaskId],
+  );
+
+  const handleMarkerClick = useCallback((markerId: string) => {
+    setActiveTaskId(markerId);
+    setSnapIndex((current) => (current === 0 ? 1 : current));
+  }, []);
+
+  const handleTaskSelect = useCallback((taskId: string) => {
+    setActiveTaskId(taskId);
+    setSnapIndex((current) => (current === 0 ? 1 : current));
+  }, []);
+
+  const handleHandleClick = useCallback(() => {
+    setSnapIndex((current) => {
+      if (current === 2) return 1;
+      if (current === 1) return 2;
+      return 1;
+    });
+  }, []);
+
+  const handleSnapToNearest = useCallback(() => {
+    if (!sheetRef.current || !viewportHeight) return;
+    const rect = sheetRef.current.getBoundingClientRect();
+    const visibleHeight = viewportHeight - rect.top;
+    if (visibleHeight < viewportHeight * 0.16) {
+      handleCloseDrawer();
+      return;
+    }
+
+    const ratio = visibleHeight / viewportHeight;
+    let closestIndex: SnapIndex = 0;
+    let smallestDistance = Number.POSITIVE_INFINITY;
+
+    SNAP_POINTS.forEach((point, index) => {
+      const diff = Math.abs(point - ratio);
+      if (diff < smallestDistance) {
+        smallestDistance = diff;
+        closestIndex = index as SnapIndex;
+      }
+    });
+
+    setSnapIndex(closestIndex);
+  }, [viewportHeight, handleCloseDrawer]);
+
+  const handleDragEnd = useCallback(() => {
+    handleSnapToNearest();
+  }, [handleSnapToNearest]);
 
   const statusMessage = useMemo(() => {
     if (error) return "We couldn’t load tasks right now.";
@@ -317,17 +481,6 @@ const TasksComponentMobile: React.FC<TasksComponentMobileProps> = ({
     const noun = sameDayCount === 1 ? "task" : "tasks";
     return `${sameDayCount} ${noun} due ${dueFormatter.format(nextDue.dueDate)}.`;
   }, [error, loading, tasks]);
-
-  const handleOpenDrawer = () => {
-    setDrawerOpen(true);
-    setFormError(null);
-    setSuccessMessage(null);
-  };
-
-  const handleCloseDrawer = () => {
-    setDrawerOpen(false);
-    setFormError(null);
-  };
 
   const resetForm = () => {
     setTitle("");
@@ -382,95 +535,183 @@ const TasksComponentMobile: React.FC<TasksComponentMobileProps> = ({
       return null;
     }
 
-    const handleOverlayMouseDown = (event: React.MouseEvent<HTMLDivElement>) => {
-      if (event.target === event.currentTarget) {
-        handleCloseDrawer();
-      }
-    };
+    const taskCountLabel = drawerTasks.length
+      ? `${drawerTasks.length} ${drawerTasks.length === 1 ? "task" : "tasks"}`
+      : "No tasks yet";
+
+    const mapStatusMessage = error
+      ? "We couldn’t load task locations."
+      : loading
+        ? "Loading task locations…"
+        : "Add locations to your tasks to see them appear here.";
 
     return createPortal(
-      <div className={styles.drawerOverlay} role="presentation" onMouseDown={handleOverlayMouseDown}>
-        <div className={styles.drawer} role="dialog" aria-modal="true" aria-label="Project tasks quick view" onMouseDown={(event) => event.stopPropagation()}>
-          <div className={styles.drawerHeader}>
-            <div className={styles.drawerTitleGroup}>
-              <span className={styles.drawerTitle}>Project tasks</span>
-              <span className={styles.drawerSubtitle}>
+      <div className={styles.sheetOverlay} role="presentation">
+        <div className={styles.mapLayer}>
+          <div className={styles.mapCanvas}>
+            <Map
+              location={mapLocation}
+              address={mapAddress}
+              scrollWheelZoom={false}
+              dragging={true}
+              touchZoom={true}
+              showUserLocation={false}
+              markers={mapMarkers}
+              onMarkerClick={handleMarkerClick}
+              focusLocation={mapFocus}
+              focusZoom={15}
+            />
+          </div>
+          <div className={styles.mapGradient} aria-hidden="true" />
+          <div className={styles.mapHeader}>
+            <span className={styles.mapProject}>{projectName ?? "Project tasks"}</span>
+            <span className={styles.mapMeta}>{taskCountLabel}</span>
+          </div>
+          {!hasMapMarkers ? <div className={styles.mapEmptyBanner}>{mapStatusMessage}</div> : null}
+          {selectedTask ? (
+            <div className={styles.mapActiveCard}>
+              <span className={styles.mapActiveTitle}>{selectedTask.title}</span>
+              <div className={styles.mapActiveMeta}>
+                <span className={styles.metaLine}>
+                  <Calendar size={14} aria-hidden="true" /> {formatDueLabel(selectedTask)}
+                </span>
+                {selectedTask.address ? (
+                  <span className={styles.metaLine}>
+                    <MapPin size={14} aria-hidden="true" /> {selectedTask.address}
+                  </span>
+                ) : null}
+              </div>
+            </div>
+          ) : null}
+        </div>
+        <button
+          type="button"
+          className={styles.sheetDismiss}
+          onClick={handleCloseDrawer}
+          aria-label="Close tasks drawer"
+        >
+          <ChevronDown size={22} strokeWidth={2.5} />
+        </button>
+        <motion.div
+          ref={sheetRef}
+          className={styles.sheet}
+          role="dialog"
+          aria-modal="true"
+          aria-label="Project tasks quick view"
+          drag="y"
+          dragElastic={{ top: 0.2, bottom: 0.3 }}
+          dragConstraints={{ top: 0, bottom: maxDragOffset }}
+          dragMomentum={false}
+          onDragEnd={handleDragEnd}
+          initial={{ y: viewportHeight }}
+          animate={{ y: targetY }}
+          transition={{ type: "spring", stiffness: 360, damping: 42, mass: 0.9 }}
+        >
+          <div
+            className={styles.sheetHandle}
+            role="button"
+            tabIndex={0}
+            aria-label="Toggle tasks drawer size"
+            onClick={handleHandleClick}
+            onKeyDown={(event) => {
+              if (event.key === "Enter" || event.key === " ") {
+                event.preventDefault();
+                handleHandleClick();
+              }
+            }}
+          >
+            <span className={styles.sheetHandleBar} aria-hidden="true" />
+          </div>
+          <header className={styles.sheetHeader}>
+            <div className={styles.sheetTitleGroup}>
+              <span className={styles.sheetTitle}>Project tasks</span>
+              <span className={styles.sheetSubtitle}>
                 {projectName ? `Everything happening in ${projectName}` : "Keep work on track"}
               </span>
             </div>
-            <button type="button" className={styles.closeButton} onClick={handleCloseDrawer} aria-label="Close tasks drawer">
-              <ChevronDown size={20} strokeWidth={2.5} />
-            </button>
+          </header>
+          <div className={styles.sheetSummary}>
+            <div className={styles.statRow} aria-label="Task summary">
+              <div className={`${styles.statCard} ${styles.statOk}`}>
+                <span className={styles.statValue}>{formatStatValue(stats.completed)}</span>
+                <span className={styles.statLabel}>Done</span>
+              </div>
+              <div className={`${styles.statCard} ${styles.statDanger}`}>
+                <span className={styles.statValue}>{formatStatValue(stats.overdue)}</span>
+                <span className={styles.statLabel}>Overdue</span>
+              </div>
+              <div className={`${styles.statCard} ${styles.statWarn}`}>
+                <span className={styles.statValue}>{formatStatValue(stats.dueSoon)}</span>
+                <span className={styles.statLabel}>Due soon</span>
+              </div>
+            </div>
+            <p className={styles.status}>{statusMessage}</p>
           </div>
-
-          <div className={styles.drawerContent}>
-            <section className={styles.drawerSection} aria-label="Project map">
-              <h3 className={styles.sectionHeading}>Project map</h3>
-              {activeProject && onActiveProjectChange ? (
+          <div className={styles.sheetScrollArea}>
+            {activeProject && onActiveProjectChange ? (
+              <section className={styles.sheetSection} aria-label="Project area">
+                <h3 className={styles.sectionHeading}>Project area</h3>
                 <div className={styles.locationContainer}>
                   <LocationComponent
                     activeProject={activeProject}
                     onActiveProjectChange={onActiveProjectChange}
                   />
                 </div>
-              ) : error ? (
-                <div className={styles.mapEmpty}>{error}</div>
-              ) : loading ? (
-                <div className={styles.mapEmpty}>Loading tasks…</div>
-              ) : mapTasks.length ? (
-                <div className={styles.mapContainer}>
-                  <Map
-                    location={mapLocation}
-                    address={mapAddress}
-                    scrollWheelZoom={false}
-                    dragging={true}
-                    touchZoom={true}
-                    showUserLocation={false}
-                    otherUsers={mapMarkers}
-                  />
-                </div>
-              ) : (
-                <div className={styles.mapEmpty}>
-                  Add locations to your tasks to see them appear on the map.
-                </div>
-              )}
-            </section>
+              </section>
+            ) : null}
 
-            <section className={styles.drawerSection} aria-label="All project tasks">
+            <section className={styles.sheetSection} aria-label="All project tasks">
               <h3 className={styles.sectionHeading}>Task list</h3>
               {error ? (
                 <div className={styles.error}>{error}</div>
               ) : loading ? (
                 <div className={styles.loading}>Loading tasks…</div>
               ) : drawerTasks.length ? (
-                <ul className={styles.drawerTaskList}>
-                  {drawerTasks.map((task) => (
-                    <li key={task.id} className={styles.drawerTaskItem}>
-                      <div className={styles.drawerTaskTop}>
-                        <span className={styles.drawerTaskTitle}>{task.title}</span>
-                        <span className={styles.statusBadge}>
-                          {task.status === "done" ? "Completed" : task.status.replace(/_/g, " ")}
-                        </span>
-                      </div>
-                      <div className={styles.drawerTaskMeta}>
-                        <span className={styles.metaLine}>
-                          <Calendar size={14} aria-hidden="true" /> {formatDueLabel(task)}
-                        </span>
-                        {task.address ? (
-                          <span className={styles.metaLine}>
-                            <MapPin size={14} aria-hidden="true" /> {task.address}
-                          </span>
-                        ) : null}
-                      </div>
-                    </li>
-                  ))}
+                <ul className={styles.taskList} ref={taskListRef}>
+                  {drawerTasks.map((task) => {
+                    const isActive = task.id === activeTaskId;
+                    return (
+                      <li
+                        key={task.id}
+                        data-task-id={task.id}
+                        className={`${styles.taskItem}${isActive ? ` ${styles.taskItemActive}` : ""}`}
+                      >
+                        <button
+                          type="button"
+                          className={styles.taskButton}
+                          onClick={() => handleTaskSelect(task.id)}
+                        >
+                          <div className={styles.taskTitleRow}>
+                            <span className={styles.taskTitle}>{task.title}</span>
+                            <span className={styles.statusBadge}>
+                              {task.status === "done" ? "Completed" : task.status.replace(/_/g, " ")}
+                            </span>
+                          </div>
+                          <div className={styles.taskMeta}>
+                            <span className={styles.metaLine}>
+                              <Calendar size={14} aria-hidden="true" /> {formatDueLabel(task)}
+                            </span>
+                            {task.address ? (
+                              <span className={styles.metaLine}>
+                                <MapPin size={14} aria-hidden="true" /> {task.address}
+                              </span>
+                            ) : (
+                              <span className={`${styles.metaLine} ${styles.metaLineMuted}`}>
+                                <MapPin size={14} aria-hidden="true" /> No location
+                              </span>
+                            )}
+                          </div>
+                        </button>
+                      </li>
+                    );
+                  })}
                 </ul>
               ) : (
                 <div className={styles.empty}>No tasks yet. Create one to get started.</div>
               )}
             </section>
 
-            <section className={styles.drawerSection} aria-label="Create a quick task">
+            <section className={styles.sheetSection} aria-label="Create a quick task">
               <h3 className={styles.sectionHeading}>Create quick task</h3>
               <form className={styles.createForm} onSubmit={handleCreateTask}>
                 <input
@@ -506,7 +747,7 @@ const TasksComponentMobile: React.FC<TasksComponentMobileProps> = ({
               </form>
             </section>
           </div>
-        </div>
+        </motion.div>
       </div>,
       document.body,
     );

--- a/frontend/src/dashboard/project/components/Tasks/TasksComponentMobile.tsx
+++ b/frontend/src/dashboard/project/components/Tasks/TasksComponentMobile.tsx
@@ -237,7 +237,8 @@ const TasksComponentMobile: React.FC<TasksComponentMobileProps> = ({
     setDrawerOpen(true);
     setFormError(null);
     setSuccessMessage(null);
-    setSnapIndex(0);
+    // Start the sheet in the mid snap-point so tasks are visible immediately.
+    setSnapIndex(1);
     initialScrollDoneRef.current = false;
     setViewportHeight(getViewportHeight());
   }, []);

--- a/frontend/src/shared/ui/Map.tsx
+++ b/frontend/src/shared/ui/Map.tsx
@@ -25,6 +25,15 @@ interface LatLng {
   lng: number;
 }
 
+interface MapMarker {
+  id: string;
+  lat: number;
+  lng: number;
+  iconUrl?: string;
+  title?: string;
+  isActive?: boolean;
+}
+
 interface MapProps {
   location: LatLng;
   address: string;
@@ -38,6 +47,10 @@ interface MapProps {
   onLocationChange?: (loc: LatLng) => void;
   otherUsers?: UserLocation[];
   onUserLocation?: (loc: { lat: number; lng: number; accuracy: number }) => void;
+  markers?: MapMarker[];
+  onMarkerClick?: (markerId: string) => void;
+  focusLocation?: LatLng | null;
+  focusZoom?: number;
 }
 
 const Map = forwardRef<MapRef, MapProps>(
@@ -55,6 +68,10 @@ const Map = forwardRef<MapRef, MapProps>(
       onLocationChange,
       otherUsers = [],
       onUserLocation,
+      markers = [],
+      onMarkerClick,
+      focusLocation = null,
+      focusZoom,
     },
     ref,
   ) => {
@@ -65,6 +82,23 @@ const Map = forwardRef<MapRef, MapProps>(
     const projectMarkerRef = useRef<L.Marker | null>(null);
     const otherUsersMarkersRef = useRef<Record<string, L.Marker>>({});
     const otherUsersAccuracyRef = useRef<Record<string, L.Circle>>({});
+    const customMarkersRef = useRef<Record<string, L.Marker>>({});
+    const lastFocusRef = useRef<string | null>(null);
+    const markerIdsRef = useRef<string[]>([]);
+
+    const createMarkerIcon = (iconUrl?: string, isActive?: boolean) => {
+      const markerClass = `task-marker${isActive ? ' task-marker--active' : ''}`;
+      const inner = iconUrl
+        ? `<img src="${iconUrl}" alt="" />`
+        : '<span class="task-marker__dot"></span>';
+
+      return L.divIcon({
+        html: `<div class="${markerClass}">${inner}<span class="task-marker__pointer" aria-hidden="true"></span></div>`,
+        className: '',
+        iconSize: [36, 48],
+        iconAnchor: [18, 44],
+      });
+    };
 
     useEffect(() => {
       if (!mapRef.current || mapInstance.current) return;
@@ -179,6 +213,9 @@ const Map = forwardRef<MapRef, MapProps>(
           const b = c.getBounds();
           latLngs.push(b.getNorthEast(), b.getSouthWest());
         });
+        Object.values(customMarkersRef.current).forEach((marker) => {
+          latLngs.push(marker.getLatLng());
+        });
 
         if (latLngs.length > 1) {
           mapInstance.current.fitBounds(L.latLngBounds(latLngs), { padding: [50, 50] });
@@ -278,14 +315,14 @@ const Map = forwardRef<MapRef, MapProps>(
 
     useEffect(() => {
       if (!mapInstance.current) return;
-      const markers = otherUsersMarkersRef.current;
+      const userMarkers = otherUsersMarkersRef.current;
       const circles = otherUsersAccuracyRef.current;
       const users = otherUsers || [];
 
-      Object.keys(markers).forEach((id) => {
+      Object.keys(userMarkers).forEach((id) => {
         if (!users.find((u) => u.id === id)) {
-          mapInstance.current?.removeLayer(markers[id]);
-          delete markers[id];
+          mapInstance.current?.removeLayer(userMarkers[id]);
+          delete userMarkers[id];
           if (circles[id]) {
             mapInstance.current?.removeLayer(circles[id]);
             delete circles[id];
@@ -302,11 +339,11 @@ const Map = forwardRef<MapRef, MapProps>(
         const iconAnchor: [number, number] = u.thumbnail ? [16, 16] : [12, 24];
         const icon = L.divIcon({ html: iconHtml, className: '', iconSize, iconAnchor });
 
-        if (markers[u.id]) {
-          markers[u.id].setLatLng(userLatLng);
-          markers[u.id].setIcon(icon);
+        if (userMarkers[u.id]) {
+          userMarkers[u.id].setLatLng(userLatLng);
+          userMarkers[u.id].setIcon(icon);
         } else {
-          markers[u.id] = L.marker(userLatLng, { icon }).addTo(mapInstance.current!);
+          userMarkers[u.id] = L.marker(userLatLng, { icon }).addTo(mapInstance.current!);
         }
 
         const radius = u.accuracy || 0;
@@ -332,15 +369,109 @@ const Map = forwardRef<MapRef, MapProps>(
           latLngs.push(b.getNorthEast(), b.getSouthWest());
         }
       }
-      Object.values(markers).forEach((m) => latLngs.push(m.getLatLng()));
+      Object.values(userMarkers).forEach((m) => latLngs.push(m.getLatLng()));
       Object.values(circles).forEach((c) => {
         const b = c.getBounds();
         latLngs.push(b.getNorthEast(), b.getSouthWest());
       });
+      Object.values(customMarkersRef.current).forEach((marker) => latLngs.push(marker.getLatLng()));
       if (latLngs.length > 1) {
         mapInstance.current!.fitBounds(L.latLngBounds(latLngs), { padding: [50, 50] });
       }
     }, [otherUsers]);
+
+    useEffect(() => {
+      if (!mapInstance.current) return;
+      const map = mapInstance.current;
+      const activeMarkers = customMarkersRef.current;
+      const list = markers || [];
+      const ids = new Set(list.map((item) => item.id));
+
+      Object.keys(activeMarkers).forEach((id) => {
+        if (!ids.has(id)) {
+          activeMarkers[id].off('click');
+          map.removeLayer(activeMarkers[id]);
+          delete activeMarkers[id];
+        }
+      });
+
+      list.forEach((marker) => {
+        const latLng: [number, number] = [marker.lat, marker.lng];
+        const icon = createMarkerIcon(marker.iconUrl, marker.isActive);
+        const existing = activeMarkers[marker.id];
+
+        if (existing) {
+          existing.setLatLng(latLng);
+          existing.setIcon(icon);
+          existing.off('click');
+          existing.unbindTooltip();
+        } else {
+          activeMarkers[marker.id] = L.marker(latLng, { icon }).addTo(map);
+        }
+
+        const current = activeMarkers[marker.id];
+
+        if (marker.title) {
+          current.bindTooltip(marker.title, { direction: 'top', offset: [0, -32] });
+        } else {
+          current.unbindTooltip();
+        }
+
+        if (onMarkerClick) {
+          current.on('click', () => onMarkerClick(marker.id));
+        }
+      });
+
+      const sortedIds = list.map((item) => item.id).sort();
+      const previousIds = markerIdsRef.current;
+      const changed =
+        sortedIds.length !== previousIds.length ||
+        sortedIds.some((id, index) => id !== previousIds[index]);
+      markerIdsRef.current = sortedIds;
+
+      if (changed) {
+        const latLngs: L.LatLngExpression[] = [];
+        if (projectMarkerRef.current) latLngs.push(projectMarkerRef.current.getLatLng());
+        if (userMarkerRef.current) latLngs.push(userMarkerRef.current.getLatLng());
+        Object.values(otherUsersMarkersRef.current).forEach((marker) => latLngs.push(marker.getLatLng()));
+        Object.values(activeMarkers).forEach((marker) => latLngs.push(marker.getLatLng()));
+        if (latLngs.length > 1) {
+          map.fitBounds(L.latLngBounds(latLngs), { padding: [50, 50] });
+        } else if (latLngs.length === 1) {
+          map.setView(latLngs[0], map.getZoom());
+        }
+      }
+
+      return () => {
+        Object.values(activeMarkers).forEach((marker) => marker.off('click'));
+      };
+    }, [markers, onMarkerClick]);
+
+    useEffect(() => {
+      if (!mapInstance.current) return;
+      if (!focusLocation) {
+        lastFocusRef.current = null;
+        return;
+      }
+
+      const key = `${focusLocation.lat.toFixed(6)}:${focusLocation.lng.toFixed(6)}`;
+      if (lastFocusRef.current === key) return;
+      lastFocusRef.current = key;
+
+      const zoom = focusZoom ?? Math.max(mapInstance.current.getZoom(), 13);
+      mapInstance.current.setView([focusLocation.lat, focusLocation.lng], zoom, { animate: true });
+    }, [focusLocation, focusZoom]);
+
+    useEffect(() => {
+      return () => {
+        if (!mapInstance.current) return;
+        Object.values(customMarkersRef.current).forEach((marker) => {
+          marker.off('click');
+          mapInstance.current?.removeLayer(marker);
+        });
+        customMarkersRef.current = {};
+      };
+    }, []);
 
     useEffect(() => {
       if (!mapInstance.current || !isEditable) return;

--- a/frontend/src/shared/ui/marker.css
+++ b/frontend/src/shared/ui/marker.css
@@ -5,6 +5,59 @@
   border: 2px solid white;
 }
 
+.task-marker {
+  position: relative;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: rgba(17, 18, 21, 0.92);
+  border: 2px solid rgba(255, 255, 255, 0.9);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.35);
+  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.task-marker img,
+.task-marker__dot {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.task-marker__dot {
+  background: radial-gradient(circle at 30% 30%, #ffffff 0%, #93c5fd 100%);
+}
+
+.task-marker__pointer {
+  position: absolute;
+  bottom: -11px;
+  left: 50%;
+  width: 18px;
+  height: 18px;
+  transform: translateX(-50%) rotate(45deg);
+  background: rgba(17, 18, 21, 0.92);
+  border-left: 2px solid rgba(255, 255, 255, 0.9);
+  border-bottom: 2px solid rgba(255, 255, 255, 0.9);
+  border-top: none;
+  border-right: none;
+  border-radius: 0 0 4px 0;
+}
+
+.task-marker--active {
+  transform: scale(1.08);
+  border-color: var(--brand, #fa3356);
+  box-shadow: 0 14px 32px rgba(250, 51, 86, 0.38);
+}
+
+.task-marker--active .task-marker__pointer {
+  border-left-color: var(--brand, #fa3356);
+  border-bottom-color: var(--brand, #fa3356);
+}
+
 
 
 


### PR DESCRIPTION
## Summary
- rebuild the mobile tasks experience with a full-screen map backdrop, draggable bottom sheet snap points, and scrolling task list
- wire map markers to task selection and pan-to-task focus via the shared Leaflet map component, including updated marker styling
- refresh drawer styles to support the new overlay, handle, and status cards while preserving quick task creation

## Testing
- npm run lint
- npm run typecheck *(fails: missing optional dependency `recharts` in existing budget chart code)*

------
https://chatgpt.com/codex/tasks/task_e_68daee592e34832496dc1b2fc50647a7