### PR TITLE
Cache message thread favicons locally

### DIFF
--- a/frontend/src/dashboard/features/messages/MessageItem.tsx
+++ b/frontend/src/dashboard/features/messages/MessageItem.tsx
@@ -7,6 +7,7 @@ import ReactPlayer from "react-player";
 import { normalizeFileUrl, getFileUrl } from "../../../shared/utils/api";
 import ReactionBar from "@/shared/ui/ReactionBar";
 import { ChatMessage, ChatFile, DMFile } from "@/shared/utils/messageUtils";
+import CachedFavicon from "./components/CachedFavicon";
 
 type Emoji = string;
 
@@ -117,38 +118,15 @@ const MessageItem: React.FC<MessageItemProps> = ({
     } catch {
       domain = "";
     }
-    const defaultIcon =
-      "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Crect width='16' height='16' rx='3' fill='%234ea1f3'/%3E%3Cpath d='M5.75 10.25l4.5-4.5M6.5 5.75h3.75V9.5' fill='none' stroke='white' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E";
-    const fallbackIcon =
-      domain !== ""
-        ? `https://icons.duckduckgo.com/ip3/${domain}.ico`
-        : undefined;
-    const faviconUrl =
-      domain !== ""
-        ? `https://www.google.com/s2/favicons?sz=64&domain=${domain}`
-        : fallbackIcon ?? defaultIcon;
     return (
       <div style={{ maxWidth: "300px" }}>
         <a
           href={url}
           target="_blank"
           rel="noopener noreferrer"
-          style={{ color: "#4ea1f3", display: "flex", alignItems: "center" }}
+          style={{ color: "#4ea1f3", display: "flex", alignItems: "center", gap: 6 }}
         >
-          <img
-            src={faviconUrl}
-            alt=""
-            style={{ width: 16, height: 16, marginRight: 4 }}
-            referrerPolicy="no-referrer"
-            onError={(event) => {
-              if (fallbackIcon && event.currentTarget.src !== fallbackIcon) {
-                event.currentTarget.src = fallbackIcon;
-                return;
-              }
-              event.currentTarget.onerror = null;
-              event.currentTarget.src = defaultIcon;
-            }}
-          />
+          <CachedFavicon domain={domain} />
           {url}
         </a>
       </div>

--- a/frontend/src/dashboard/features/messages/components/CachedFavicon.tsx
+++ b/frontend/src/dashboard/features/messages/components/CachedFavicon.tsx
@@ -4,30 +4,67 @@ const DEFAULT_ICON =
   "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3E%3Crect width='20' height='20' rx='4' fill='%234ea1f3'/%3E%3Cpath d='M4.75 11.25l4.5-4.5m1.5 0l4.5 4.5M6 14h8' fill='none' stroke='%23fff' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E";
 
 const CACHE_NAMESPACE = "mylg:favicon";
-const memoryCache = new Map<string, string>();
-const pendingFetches = new Map<string, Promise<string>>();
+const ICON_TTL_MS = 1000 * 60 * 60 * 24 * 7; // 7 days
+const FALLBACK_TTL_MS = 1000 * 60 * 30; // 30 minutes before retrying a failed fetch
+
+interface CacheEntry {
+  dataUrl: string;
+  timestamp: number;
+  isFallback: boolean;
+}
+
+const memoryCache = new Map<string, CacheEntry>();
+const pendingFetches = new Map<string, Promise<CacheEntry>>();
 
 const getStorageKey = (domain: string) => `${CACHE_NAMESPACE}:${domain}`;
 
 const isBrowser = typeof window !== "undefined";
 
-const readFromStorage = (domain: string): string | null => {
+const readFromStorage = (domain: string): CacheEntry | null => {
   if (!isBrowser) return null;
   try {
     const stored = window.localStorage.getItem(getStorageKey(domain));
-    return stored;
+    if (!stored) return null;
+    const parsed = JSON.parse(stored) as CacheEntry;
+    if (!parsed?.dataUrl || typeof parsed.timestamp !== "number") {
+      return null;
+    }
+    return parsed;
   } catch {
     return null;
   }
 };
 
-const writeToStorage = (domain: string, dataUrl: string) => {
+const writeToStorage = (domain: string, entry: CacheEntry) => {
   if (!isBrowser) return;
   try {
-    window.localStorage.setItem(getStorageKey(domain), dataUrl);
+    window.localStorage.setItem(getStorageKey(domain), JSON.stringify(entry));
   } catch {
     // ignore quota/security errors
   }
+};
+
+const saveEntry = (domain: string, entry: CacheEntry) => {
+  memoryCache.set(domain, entry);
+  writeToStorage(domain, entry);
+};
+
+const isExpired = (entry: CacheEntry) => {
+  const ttl = entry.isFallback ? FALLBACK_TTL_MS : ICON_TTL_MS;
+  return Date.now() - entry.timestamp > ttl;
+};
+
+const getCachedEntry = (domain: string): CacheEntry | null => {
+  const inMemory = memoryCache.get(domain);
+  if (inMemory) {
+    return inMemory;
+  }
+  const stored = readFromStorage(domain);
+  if (stored) {
+    memoryCache.set(domain, stored);
+    return stored;
+  }
+  return null;
 };
 
 const blobToDataUrl = async (blob: Blob) =>
@@ -44,16 +81,15 @@ const blobToDataUrl = async (blob: Blob) =>
     reader.readAsDataURL(blob);
   });
 
-const fetchFavicon = async (domain: string): Promise<string> => {
-  if (!isBrowser || !domain || typeof fetch !== "function") return DEFAULT_ICON;
+const buildCacheEntry = (dataUrl: string, isFallback: boolean): CacheEntry => ({
+  dataUrl,
+  timestamp: Date.now(),
+  isFallback,
+});
 
-  const inMemory = memoryCache.get(domain);
-  if (inMemory) return inMemory;
-
-  const stored = readFromStorage(domain);
-  if (stored) {
-    memoryCache.set(domain, stored);
-    return stored;
+const fetchAndCacheFavicon = async (domain: string): Promise<CacheEntry> => {
+  if (!isBrowser || !domain || typeof fetch !== "function") {
+    return buildCacheEntry(DEFAULT_ICON, true);
   }
 
   if (pendingFetches.has(domain)) {
@@ -77,17 +113,17 @@ const fetchFavicon = async (domain: string): Promise<string> => {
         const blob = await response.blob();
         if (blob.size === 0) continue;
         const dataUrl = await blobToDataUrl(blob);
-        memoryCache.set(domain, dataUrl);
-        writeToStorage(domain, dataUrl);
-        return dataUrl;
+        const entry = buildCacheEntry(dataUrl, false);
+        saveEntry(domain, entry);
+        return entry;
       } catch {
         // try next endpoint
       }
     }
 
-    memoryCache.set(domain, DEFAULT_ICON);
-    writeToStorage(domain, DEFAULT_ICON);
-    return DEFAULT_ICON;
+    const fallbackEntry = buildCacheEntry(DEFAULT_ICON, true);
+    saveEntry(domain, fallbackEntry);
+    return fallbackEntry;
   })().finally(() => {
     pendingFetches.delete(domain);
   });
@@ -116,12 +152,25 @@ const CachedFaviconComponent: React.FC<CachedFaviconProps> = ({ domain }) => {
       };
     }
 
-    setSrc(DEFAULT_ICON);
+    const cached = getCachedEntry(normalizedDomain);
+    const shouldRefresh = !cached || isExpired(cached);
 
-    fetchFavicon(normalizedDomain)
-      .then((dataUrl) => {
+    if (cached) {
+      setSrc(cached.dataUrl || DEFAULT_ICON);
+    } else {
+      setSrc(DEFAULT_ICON);
+    }
+
+    if (!shouldRefresh) {
+      return () => {
+        isMounted = false;
+      };
+    }
+
+    fetchAndCacheFavicon(normalizedDomain)
+      .then((entry) => {
         if (isMounted) {
-          setSrc(dataUrl || DEFAULT_ICON);
+          setSrc(entry.dataUrl || DEFAULT_ICON);
         }
       })
       .catch(() => {

--- a/frontend/src/dashboard/features/messages/components/CachedFavicon.tsx
+++ b/frontend/src/dashboard/features/messages/components/CachedFavicon.tsx
@@ -1,0 +1,176 @@
+import React, { useEffect, useMemo, useState } from "react";
+
+const DEFAULT_ICON =
+  "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3E%3Crect width='20' height='20' rx='4' fill='%234ea1f3'/%3E%3Cpath d='M4.75 11.25l4.5-4.5m1.5 0l4.5 4.5M6 14h8' fill='none' stroke='%23fff' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E";
+
+const CACHE_NAMESPACE = "mylg:favicon";
+const memoryCache = new Map<string, string>();
+const pendingFetches = new Map<string, Promise<string>>();
+
+const getStorageKey = (domain: string) => `${CACHE_NAMESPACE}:${domain}`;
+
+const isBrowser = typeof window !== "undefined";
+
+const readFromStorage = (domain: string): string | null => {
+  if (!isBrowser) return null;
+  try {
+    const stored = window.localStorage.getItem(getStorageKey(domain));
+    return stored;
+  } catch {
+    return null;
+  }
+};
+
+const writeToStorage = (domain: string, dataUrl: string) => {
+  if (!isBrowser) return;
+  try {
+    window.localStorage.setItem(getStorageKey(domain), dataUrl);
+  } catch {
+    // ignore quota/security errors
+  }
+};
+
+const blobToDataUrl = async (blob: Blob) =>
+  new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onloadend = () => {
+      if (typeof reader.result === "string") {
+        resolve(reader.result);
+      } else {
+        reject(new Error("Failed to convert blob"));
+      }
+    };
+    reader.onerror = () => reject(reader.error ?? new Error("Failed to read blob"));
+    reader.readAsDataURL(blob);
+  });
+
+const fetchFavicon = async (domain: string): Promise<string> => {
+  if (!isBrowser || !domain || typeof fetch !== "function") return DEFAULT_ICON;
+
+  const inMemory = memoryCache.get(domain);
+  if (inMemory) return inMemory;
+
+  const stored = readFromStorage(domain);
+  if (stored) {
+    memoryCache.set(domain, stored);
+    return stored;
+  }
+
+  if (pendingFetches.has(domain)) {
+    return pendingFetches.get(domain)!;
+  }
+
+  const fetchPromise = (async () => {
+    const endpoints = [
+      `https://www.google.com/s2/favicons?sz=64&domain=${domain}`,
+      `https://icons.duckduckgo.com/ip3/${domain}.ico`,
+    ];
+
+    for (const endpoint of endpoints) {
+      try {
+        const response = await fetch(endpoint, {
+          mode: "cors",
+          credentials: "omit",
+          cache: "force-cache",
+        });
+        if (!response.ok) continue;
+        const blob = await response.blob();
+        if (blob.size === 0) continue;
+        const dataUrl = await blobToDataUrl(blob);
+        memoryCache.set(domain, dataUrl);
+        writeToStorage(domain, dataUrl);
+        return dataUrl;
+      } catch {
+        // try next endpoint
+      }
+    }
+
+    memoryCache.set(domain, DEFAULT_ICON);
+    writeToStorage(domain, DEFAULT_ICON);
+    return DEFAULT_ICON;
+  })().finally(() => {
+    pendingFetches.delete(domain);
+  });
+
+  pendingFetches.set(domain, fetchPromise);
+
+  return fetchPromise;
+};
+
+interface CachedFaviconProps {
+  domain: string;
+}
+
+const CachedFaviconComponent: React.FC<CachedFaviconProps> = ({ domain }) => {
+  const [src, setSrc] = useState(DEFAULT_ICON);
+
+  const normalizedDomain = useMemo(() => domain.trim().toLowerCase(), [domain]);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    if (!normalizedDomain) {
+      setSrc(DEFAULT_ICON);
+      return () => {
+        isMounted = false;
+      };
+    }
+
+    setSrc(DEFAULT_ICON);
+
+    fetchFavicon(normalizedDomain)
+      .then((dataUrl) => {
+        if (isMounted) {
+          setSrc(dataUrl || DEFAULT_ICON);
+        }
+      })
+      .catch(() => {
+        if (isMounted) {
+          setSrc(DEFAULT_ICON);
+        }
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [normalizedDomain]);
+
+  return (
+    <span
+      aria-hidden="true"
+      style={{
+        width: 20,
+        height: 20,
+        display: "inline-flex",
+        alignItems: "center",
+        justifyContent: "center",
+        flexShrink: 0,
+      }}
+    >
+      <img
+        src={src}
+        alt=""
+        loading="lazy"
+        decoding="async"
+        style={{
+          width: "100%",
+          height: "100%",
+          aspectRatio: "1 / 1",
+          objectFit: "contain",
+          display: "block",
+        }}
+        referrerPolicy="no-referrer"
+      />
+    </span>
+  );
+};
+
+const CachedFavicon = React.memo(
+  CachedFaviconComponent,
+  (prevProps, nextProps) => prevProps.domain === nextProps.domain
+);
+
+CachedFavicon.displayName = "CachedFavicon";
+
+export default CachedFavicon;
+


### PR DESCRIPTION
## Summary
- add a memoized CachedFavicon component that stores fetched icons in localStorage and memory so message links reuse cached copies
- update message link rendering to use the cached favicon with a fixed-size container to prevent layout shifts

## Testing
- npm run test -- MessageItem

------
https://chatgpt.com/codex/tasks/task_e_68dafa8bf25c8324b0c6e58e0522e71b