### PR TITLE
Fix gallery thumbnail aspect ratio

### DIFF
--- a/frontend/src/dashboard/project/components/Gallery/gallery-component.module.css
+++ b/frontend/src/dashboard/project/components/Gallery/gallery-component.module.css
@@ -113,8 +113,10 @@
 .thumbnailButton img {
   width: 100%;
   height: 100%;
-  object-fit: cover;
+  object-fit: contain;
+  object-position: center;
   display: block;
+  background-color: rgba(12, 12, 12, 0.65);
 }
 
 .thumbnailButton:focus-visible {


### PR DESCRIPTION
## Summary
- ensure gallery thumbnail images use `object-fit: contain` so previews respect their original aspect ratio
- center contained imagery and provide a neutral background for letterboxed space

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dafb058a4c8324aa9f7a6640fec6d1