### PR TITLE
Add location search to quick task creator

### DIFF
--- a/frontend/src/dashboard/home/components/QuickCreateTaskModal.module.css
+++ b/frontend/src/dashboard/home/components/QuickCreateTaskModal.module.css
@@ -82,6 +82,53 @@
   resize: vertical;
 }
 
+.locationInputWrapper {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.locationSuggestions {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  background: rgba(13, 14, 16, 0.98);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 12px;
+  box-shadow: 0 18px 32px rgba(0, 0, 0, 0.42);
+  max-height: 200px;
+  overflow-y: auto;
+  padding: 6px;
+  z-index: 10;
+}
+
+.locationSuggestionButton {
+  width: 100%;
+  padding: 10px 12px;
+  border: none;
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  border-radius: 10px;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.locationSuggestionButton:hover,
+.locationSuggestionButton:focus {
+  background: rgba(255, 255, 255, 0.08);
+  outline: none;
+}
+
+.locationSelectedHint {
+  margin-top: 6px;
+  font-size: 0.85rem;
+  color: var(--text-tertiary, rgba(246, 247, 251, 0.65));
+}
+
 .fieldOptional {
   font-size: 0.85rem;
   color: var(--text-tertiary, rgba(246, 247, 251, 0.55));

--- a/frontend/src/dashboard/home/components/QuickCreateTaskModal.tsx
+++ b/frontend/src/dashboard/home/components/QuickCreateTaskModal.tsx
@@ -1,9 +1,21 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { createPortal } from "react-dom";
 
-import { createTask } from "@/shared/utils/api";
+import { NOMINATIM_SEARCH_URL, apiFetch, createTask } from "@/shared/utils/api";
 
 import styles from "./QuickCreateTaskModal.module.css";
+
+type NominatimSuggestion = {
+  place_id: string | number;
+  display_name: string;
+  lat: string;
+  lon: string;
+};
+
+type Coordinates = {
+  lat: number;
+  lng: number;
+};
 
 export type QuickCreateTaskModalProject = {
   id: string;
@@ -27,9 +39,14 @@ const QuickCreateTaskModal: React.FC<QuickCreateTaskModalProps> = ({
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
   const [dueDate, setDueDate] = useState("");
+  const [addressSearch, setAddressSearch] = useState("");
+  const [addressSuggestions, setAddressSuggestions] = useState<NominatimSuggestion[]>([]);
+  const [selectedLocation, setSelectedLocation] = useState<Coordinates | null>(null);
+  const [userLocation, setUserLocation] = useState<Coordinates | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const suggestionsListId = "quick-create-task-location-suggestions";
 
   const projectOptions = useMemo(() => projects ?? [], [projects]);
 
@@ -38,6 +55,9 @@ const QuickCreateTaskModal: React.FC<QuickCreateTaskModalProps> = ({
     setTitle("");
     setDescription("");
     setDueDate("");
+    setAddressSearch("");
+    setAddressSuggestions([]);
+    setSelectedLocation(null);
     setSubmitting(false);
     setErrorMessage(null);
     setSuccessMessage(null);
@@ -87,10 +107,87 @@ const QuickCreateTaskModal: React.FC<QuickCreateTaskModalProps> = ({
 
   const hasProjects = projectOptions.length > 0;
 
+  useEffect(() => {
+    if (!open) return;
+
+    if (typeof window === "undefined" || !("geolocation" in navigator)) {
+      setUserLocation(null);
+      return;
+    }
+
+    let cancelled = false;
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        if (!cancelled) {
+          setUserLocation({ lat: pos.coords.latitude, lng: pos.coords.longitude });
+        }
+      },
+      () => {
+        if (!cancelled) {
+          setUserLocation(null);
+        }
+      }
+    );
+
+    return () => {
+      cancelled = true;
+    };
+  }, [open]);
+
+  const sortSuggestionsByProximity = useCallback(
+    (suggestions: NominatimSuggestion[], origin: Coordinates | null) => {
+      if (!origin) return suggestions;
+      return [...suggestions].sort((a, b) => {
+        const distanceA = Math.hypot(origin.lat - parseFloat(a.lat), origin.lng - parseFloat(a.lon));
+        const distanceB = Math.hypot(origin.lat - parseFloat(b.lat), origin.lng - parseFloat(b.lon));
+        return distanceA - distanceB;
+      });
+    },
+    []
+  );
+
+  useEffect(() => {
+    if (!userLocation) return;
+    setAddressSuggestions((prev) => sortSuggestionsByProximity(prev, userLocation));
+  }, [sortSuggestionsByProximity, userLocation]);
+
+  const fetchAddressSuggestions = useCallback(
+    async (query: string) => {
+      if (!query || query.length < 3) {
+        setAddressSuggestions([]);
+        return;
+      }
+
+      try {
+        const url = `${NOMINATIM_SEARCH_URL}${encodeURIComponent(query)}&addressdetails=1&limit=5`;
+        const results = await apiFetch<NominatimSuggestion[]>(url);
+        setAddressSuggestions(sortSuggestionsByProximity(results ?? [], userLocation));
+      } catch (error) {
+        console.error("Failed to fetch address suggestions", error);
+        setAddressSuggestions([]);
+      }
+    },
+    [sortSuggestionsByProximity, userLocation]
+  );
+
   const handleOverlayMouseDown = (event: React.MouseEvent<HTMLDivElement>) => {
     if (event.target === event.currentTarget && !submitting) {
       onClose();
     }
+  };
+
+  const handleAddressChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value;
+    setAddressSearch(value);
+    setSelectedLocation(null);
+    void fetchAddressSuggestions(value);
+  };
+
+  const handleAddressSuggestionSelect = (suggestion: NominatimSuggestion) => {
+    const coords = { lat: parseFloat(suggestion.lat), lng: parseFloat(suggestion.lon) };
+    setSelectedLocation(coords);
+    setAddressSearch(suggestion.display_name);
+    setAddressSuggestions([]);
   };
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
@@ -118,17 +215,27 @@ const QuickCreateTaskModal: React.FC<QuickCreateTaskModalProps> = ({
     }
 
     try {
+      const trimmedAddress = addressSearch.trim();
+      const locationPayload = selectedLocation
+        ? { lat: selectedLocation.lat, lng: selectedLocation.lng }
+        : undefined;
+
       await createTask({
         projectId: targetProjectId,
         title: trimmedTitle,
         description: description.trim() || undefined,
         dueDate: dueDateIso,
         status: "todo",
+        ...(trimmedAddress ? { address: trimmedAddress } : {}),
+        ...(locationPayload ? { location: locationPayload } : {}),
       });
       setSuccessMessage("Task created. You'll see it in your lists shortly.");
       setTitle("");
       setDescription("");
       setDueDate("");
+      setAddressSearch("");
+      setAddressSuggestions([]);
+      setSelectedLocation(null);
       onCreated();
     } catch (error) {
       console.error("Failed to create task", error);
@@ -182,6 +289,47 @@ const QuickCreateTaskModal: React.FC<QuickCreateTaskModalProps> = ({
               placeholder="What needs to get done?"
               disabled={submitting}
             />
+          </label>
+          <label className={styles.fieldLabel}>
+            Location <span className={styles.fieldOptional}>(optional)</span>
+            <div className={styles.locationInputWrapper}>
+              <input
+                type="text"
+                className={styles.textInput}
+                value={addressSearch}
+                onChange={handleAddressChange}
+                placeholder="Search for an address or venue"
+                disabled={submitting}
+                aria-autocomplete="list"
+                aria-expanded={addressSuggestions.length > 0}
+                aria-controls={addressSuggestions.length > 0 ? suggestionsListId : undefined}
+              />
+              {addressSuggestions.length > 0 ? (
+                <div
+                  className={styles.locationSuggestions}
+                  role="listbox"
+                  id={suggestionsListId}
+                >
+                  {addressSuggestions.map((suggestion) => (
+                    <button
+                      key={suggestion.place_id}
+                      type="button"
+                      className={styles.locationSuggestionButton}
+                      role="option"
+                      onMouseDown={(event) => event.preventDefault()}
+                      onClick={() => handleAddressSuggestionSelect(suggestion)}
+                    >
+                      {suggestion.display_name}
+                    </button>
+                  ))}
+                </div>
+              ) : null}
+            </div>
+            {selectedLocation ? (
+              <span className={styles.locationSelectedHint}>
+                Saved coordinates: {selectedLocation.lat.toFixed(4)}, {selectedLocation.lng.toFixed(4)}
+              </span>
+            ) : null}
           </label>
           <label className={styles.fieldLabel}>
             Due date <span className={styles.fieldOptional}>(optional)</span>


### PR DESCRIPTION
## Summary
- allow the quick-create task modal to search for real addresses via Nominatim suggestions and sort results by proximity when possible
- capture the selected address and coordinates so new tasks save location data alongside their other fields
- add styling for the inline suggestion list and saved-coordinate helper text in the quick-create form

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db0767b8848324b57955a9f18ae605