### PR TITLE
feat: allow assigning collaborators in quick task modal

### DIFF
--- a/frontend/src/dashboard/home/components/QuickCreateTaskModal.tsx
+++ b/frontend/src/dashboard/home/components/QuickCreateTaskModal.tsx
@@ -10,10 +10,16 @@ export type QuickCreateTaskModalProject = {
   name: string;
 };
 
+export type QuickCreateTaskModalAssignee = {
+  id: string;
+  name: string;
+};
+
 export type QuickCreateTaskModalProps = {
   open: boolean;
   onClose: () => void;
   projects: QuickCreateTaskModalProject[];
+  assignees?: QuickCreateTaskModalAssignee[];
   onCreated: () => void;
 };
 
@@ -21,23 +27,27 @@ const QuickCreateTaskModal: React.FC<QuickCreateTaskModalProps> = ({
   open,
   onClose,
   projects,
+  assignees,
   onCreated,
 }) => {
   const [projectId, setProjectId] = useState<string>("");
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
   const [dueDate, setDueDate] = useState("");
+  const [assigneeId, setAssigneeId] = useState<string>("");
   const [submitting, setSubmitting] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
 
   const projectOptions = useMemo(() => projects ?? [], [projects]);
+  const assigneeOptions = useMemo(() => assignees ?? [], [assignees]);
 
   const resetForm = useCallback(() => {
     setProjectId("");
     setTitle("");
     setDescription("");
     setDueDate("");
+    setAssigneeId("");
     setSubmitting(false);
     setErrorMessage(null);
     setSuccessMessage(null);
@@ -64,6 +74,19 @@ const QuickCreateTaskModal: React.FC<QuickCreateTaskModalProps> = ({
       return projectOptions[0].id;
     });
   }, [open, projectOptions, resetForm]);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    setAssigneeId((current) => {
+      if (current && assigneeOptions.some((assignee) => assignee.id === current)) {
+        return current;
+      }
+      return "";
+    });
+  }, [open, assigneeOptions]);
 
   useEffect(() => {
     if (!open) return;
@@ -124,11 +147,13 @@ const QuickCreateTaskModal: React.FC<QuickCreateTaskModalProps> = ({
         description: description.trim() || undefined,
         dueDate: dueDateIso,
         status: "todo",
+        assigneeId: assigneeId || undefined,
       });
       setSuccessMessage("Task created. You'll see it in your lists shortly.");
       setTitle("");
       setDescription("");
       setDueDate("");
+      setAssigneeId("");
       onCreated();
     } catch (error) {
       console.error("Failed to create task", error);
@@ -165,6 +190,22 @@ const QuickCreateTaskModal: React.FC<QuickCreateTaskModalProps> = ({
               {projectOptions.map((project) => (
                 <option key={project.id} value={project.id}>
                   {project.name}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className={styles.fieldLabel}>
+            Assigned to <span className={styles.fieldOptional}>(optional)</span>
+            <select
+              className={styles.selectInput}
+              value={assigneeId}
+              onChange={(event) => setAssigneeId(event.target.value)}
+              disabled={submitting}
+            >
+              <option value="">Unassigned</option>
+              {assigneeOptions.map((assignee) => (
+                <option key={assignee.id} value={assignee.id}>
+                  {assignee.name}
                 </option>
               ))}
             </select>

--- a/frontend/src/dashboard/home/components/TasksOverviewCard.tsx
+++ b/frontend/src/dashboard/home/components/TasksOverviewCard.tsx
@@ -10,7 +10,8 @@ type TasksOverviewCardProps = {
   className?: string;
 };
 const TasksOverviewCard: React.FC<TasksOverviewCardProps> = ({ className }) => {
-  const { loading, error, stats, groups, refreshTasks, projectOptions } = useTasksOverview();
+  const { loading, error, stats, groups, refreshTasks, projectOptions, assigneeOptions } =
+    useTasksOverview();
   const location = useLocation();
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
 
@@ -114,6 +115,7 @@ const TasksOverviewCard: React.FC<TasksOverviewCardProps> = ({ className }) => {
         open={isCreateModalOpen}
         onClose={closeCreateModal}
         projects={projectOptions}
+        assignees={assigneeOptions}
         onCreated={refreshTasks}
       />
     </>

--- a/frontend/src/dashboard/home/hooks/useTasksOverview.ts
+++ b/frontend/src/dashboard/home/hooks/useTasksOverview.ts
@@ -2,12 +2,14 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { useData } from "@/app/contexts/useData";
-import type { Project } from "@/app/contexts/DataProvider";
+import type { Project, UserLite } from "@/app/contexts/DataProvider";
 import { fetchTasks } from "@/shared/utils/api";
 import { getColor } from "@/shared/utils/colorUtils";
 import { getProjectDashboardPath } from "@/shared/utils/projectUrl";
 import pLimit from "@/shared/utils/pLimit";
 import { endOfWeek, startOfWeek } from "@/dashboard/home/utils/dateUtils";
+import type { AppUser } from "@/dashboard/features/messages/types";
+import { getUserDisplayName } from "@/dashboard/features/messages/utils/userHelpers";
 
 const dayFormatter = new Intl.DateTimeFormat(undefined, {
   weekday: "short",
@@ -86,6 +88,11 @@ export type TasksOverviewProjectOption = {
   color?: string;
 };
 
+type TasksOverviewAssigneeOption = {
+  id: string;
+  name: string;
+};
+
 function parseDueDate(value?: unknown): Date | null {
   if (value == null || value === "") return null;
 
@@ -153,7 +160,11 @@ function pickDue(raw: RawTask): { value: Date | null; key?: string; timeLabel?: 
 }
 
 export function useTasksOverview() {
-  const { projects = [] } = useData() as { projects: Project[] };
+  const { projects = [], userData, allUsers } = useData() as {
+    projects: Project[];
+    userData?: UserLite | null;
+    allUsers?: UserLite[];
+  };
   const navigate = useNavigate();
 
   const [tasks, setTasks] = useState<NormalizedTask[]>([]);
@@ -423,6 +434,32 @@ export function useTasksOverview() {
     [projects]
   );
 
+  const assigneeOptions: TasksOverviewAssigneeOption[] = useMemo(() => {
+    const collaboratorIds = Array.isArray(userData?.collaborators)
+      ? userData.collaborators.filter(
+          (id): id is string => typeof id === "string" && id.trim().length > 0
+        )
+      : [];
+
+    if (!collaboratorIds.length) {
+      return [];
+    }
+
+    const collaboratorsSet = new Set(collaboratorIds);
+    const users = Array.isArray(allUsers) ? allUsers : [];
+
+    const options = users
+      .filter((user): user is UserLite & { userId: string } =>
+        Boolean(user?.userId && collaboratorsSet.has(user.userId))
+      )
+      .map((user) => ({
+        id: user.userId,
+        name: getUserDisplayName(user as AppUser),
+      }));
+
+    return options.sort((a, b) => a.name.localeCompare(b.name));
+  }, [allUsers, userData]);
+
   const primaryProjectName = primaryProjectId
     ? projectMap.get(primaryProjectId)?.title ?? primaryProjectId
     : undefined;
@@ -441,6 +478,7 @@ export function useTasksOverview() {
     navigateToProject,
     refreshTasks,
     projectOptions,
+    assigneeOptions,
     primaryProjectId,
     primaryProjectName,
   };

--- a/frontend/src/dashboard/home/pages/TasksListPage.tsx
+++ b/frontend/src/dashboard/home/pages/TasksListPage.tsx
@@ -143,6 +143,7 @@ const TasksListPage: React.FC = () => {
     navigateToProject,
     refreshTasks,
     projectOptions,
+    assigneeOptions,
   } = useTasksOverview();
 
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
@@ -376,6 +377,7 @@ const TasksListPage: React.FC = () => {
         open={isCreateModalOpen}
         onClose={closeCreateModal}
         projects={projectOptions}
+        assignees={assigneeOptions}
         onCreated={refreshTasks}
       />
     </>


### PR DESCRIPTION
## Summary
- surface collaborator assignee options from the tasks overview hook
- add an optional assignee dropdown to the quick create task modal and include the selected value when saving
- wire the dashboard entry points to provide collaborator options to the modal

## Testing
- npm --prefix frontend run lint

------
https://chatgpt.com/codex/tasks/task_e_68db0b8aa1188324a5420cc53d078ee4