### PR TITLE
Make collaborator project icons circular

### DIFF
--- a/frontend/src/dashboard/home/components/CollaboratorList.tsx
+++ b/frontend/src/dashboard/home/components/CollaboratorList.tsx
@@ -101,6 +101,7 @@ const CollaboratorList: React.FC<CollaboratorListProps> = ({
                               thumb={p.thumbnails && p.thumbnails[0]}
                               name={p.title}
                               className={styles.projectIcon}
+                              shape="circle"
                             />
                           ))}
                           {isMobile && userProjects.length > 3 && (

--- a/frontend/src/dashboard/home/components/Collaborators.module.css
+++ b/frontend/src/dashboard/home/components/Collaborators.module.css
@@ -145,6 +145,8 @@
   width: 24px;
   height: 24px;
   border: 2px solid #0c0c0c;
+  border-radius: 999px;
+  overflow: hidden;
 }
 
 .projectIcons > :not(:first-child) {

--- a/frontend/src/dashboard/home/components/Collaborators.tsx
+++ b/frontend/src/dashboard/home/components/Collaborators.tsx
@@ -821,6 +821,7 @@ interface EditValues {
                             thumb={p.thumbnails && p.thumbnails[0]}
                             name={p.title}
                             className="project-thumb"
+                            shape="circle"
                           />
                           <span className="project-name">{p.title}</span>
                         </label>

--- a/frontend/src/dashboard/home/components/CurrentUserProfile.tsx
+++ b/frontend/src/dashboard/home/components/CurrentUserProfile.tsx
@@ -64,6 +64,7 @@ const CurrentUserProfile: React.FC<CurrentUserProfileProps> = ({
                       thumb={p.thumbnails && p.thumbnails[0]}
                       name={p.title}
                       className={styles.projectIcon}
+                      shape="circle"
                     />
                   ))}
                   {isMobile && userProjects.length > 3 && (

--- a/frontend/src/shared/ui/ProjectAvatar.tsx
+++ b/frontend/src/shared/ui/ProjectAvatar.tsx
@@ -10,6 +10,7 @@ interface ProjectAvatarProps {
   initial?: string;
   className?: string;
   radius?: number;
+  shape?: 'squircle' | 'circle';
 }
 
 const DEFAULT_RADIUS = 10;
@@ -20,24 +21,38 @@ const ProjectAvatar: React.FC<ProjectAvatarProps> = ({
   initial = '',
   className = '',
   radius = DEFAULT_RADIUS,
+  shape = 'squircle',
 }) => {
-  const wrapperClassName = ['project-avatar', className].filter(Boolean).join(' ').trim() || undefined;
+  const wrapperClassName =
+    ['project-avatar', className, shape === 'circle' ? 'project-avatar--circle' : null]
+      .filter(Boolean)
+      .join(' ')
+      .trim() || undefined;
   const displayInitial = (initial || name.charAt(0)).toUpperCase() || '#';
+  const content = thumb ? (
+    <img
+      src={getFileUrl(thumb)}
+      alt={name}
+      className="project-avatar__media"
+    />
+  ) : (
+    <SVGThumbnail
+      initial={displayInitial}
+      className="project-avatar__media"
+    />
+  );
+
+  if (shape === 'circle') {
+    return (
+      <span className={wrapperClassName} aria-hidden={!name && !initial}>
+        {content}
+      </span>
+    );
+  }
 
   return (
     <Squircle as="span" className={wrapperClassName} radius={radius} aria-hidden={!name && !initial}>
-      {thumb ? (
-        <img
-          src={getFileUrl(thumb)}
-          alt={name}
-          className="project-avatar__media"
-        />
-      ) : (
-        <SVGThumbnail
-          initial={displayInitial}
-          className="project-avatar__media"
-        />
-      )}
+      {content}
     </Squircle>
   );
 };

--- a/frontend/src/shared/ui/project-avatar.css
+++ b/frontend/src/shared/ui/project-avatar.css
@@ -6,6 +6,10 @@
   background: var(--bg, #0c0c0c);
 }
 
+.project-avatar--circle {
+  border-radius: 50%;
+}
+
 .project-avatar__media {
   width: 100%;
   height: 100%;


### PR DESCRIPTION
## Summary
- add a circle mode to `ProjectAvatar` with styling support
- update collaborator project icon usage so the coins render as circles
- tweak collaborator module styles to ensure round project icons

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68db0bad90948324bd2bf971155c5d14