### PR TITLE
Add quick create modal trigger to project tasks mobile card

### DIFF
--- a/frontend/src/dashboard/project/components/Tasks/TasksComponentMobile.module.css
+++ b/frontend/src/dashboard/project/components/Tasks/TasksComponentMobile.module.css
@@ -26,6 +26,12 @@
   gap: 4px;
 }
 
+.actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
 .title {
   margin: 0;
   font-size: 16px;
@@ -70,6 +76,47 @@
 .primaryButton:focus-visible {
   outline: 2px solid var(--color-focus, var(--brand, #fa3356));
   outline-offset: 2px;
+}
+
+.iconButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: rgba(255, 255, 255, 0.1);
+  color: rgba(255, 255, 255, 0.92);
+  cursor: pointer;
+  transition: background 160ms ease, border-color 160ms ease, transform 160ms ease;
+}
+
+.iconButton:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.iconButton:not(:disabled):hover,
+.iconButton:not(:disabled):focus-visible {
+  background: rgba(255, 255, 255, 0.18);
+  transform: translateY(-1px);
+}
+
+.iconButton:focus-visible {
+  outline: 2px solid var(--color-focus, var(--brand, #fa3356));
+  outline-offset: 2px;
+}
+
+.iconButtonPrimary {
+  border-color: color-mix(in srgb, var(--brand, #fa3356) 42%, transparent);
+  background: color-mix(in srgb, var(--brand, #fa3356) 18%, transparent);
+  color: color-mix(in srgb, var(--brand, #fa3356) 82%, white 18%);
+}
+
+.iconButtonPrimary:not(:disabled):hover,
+.iconButtonPrimary:not(:disabled):focus-visible {
+  background: color-mix(in srgb, var(--brand, #fa3356) 26%, transparent);
 }
 
 .statRow {

--- a/frontend/src/dashboard/project/components/Tasks/TasksComponentMobile.tsx
+++ b/frontend/src/dashboard/project/components/Tasks/TasksComponentMobile.tsx
@@ -5,6 +5,9 @@ import { motion } from "framer-motion";
 
 import Map from "@/shared/ui/Map";
 import { createTask, fetchTasks } from "@/shared/utils/api";
+import QuickCreateTaskModal, {
+  QuickCreateTaskModalProject,
+} from "@/dashboard/home/components/QuickCreateTaskModal";
 
 import styles from "./TasksComponentMobile.module.css";
 
@@ -216,9 +219,23 @@ const TasksComponentMobile: React.FC<TasksComponentMobileProps> = ({
   const [viewportHeight, setViewportHeight] = useState(() => getViewportHeight());
   const [activeTaskId, setActiveTaskId] = useState<string | null>(null);
   const [mapFocus, setMapFocus] = useState<{ lat: number; lng: number } | null>(null);
+  const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
   const sheetRef = useRef<HTMLDivElement | null>(null);
   const taskListRef = useRef<HTMLUListElement | null>(null);
   const initialScrollDoneRef = useRef(false);
+
+  const quickCreateProjects = useMemo<QuickCreateTaskModalProject[]>(() => {
+    if (!projectId) {
+      return [];
+    }
+
+    return [
+      {
+        id: projectId,
+        name: projectName?.trim() || "This project",
+      },
+    ];
+  }, [projectId, projectName]);
 
   const handleOpenDrawer = useCallback(() => {
     setDrawerOpen(true);
@@ -237,6 +254,15 @@ const TasksComponentMobile: React.FC<TasksComponentMobileProps> = ({
     setActiveTaskId(null);
     setMapFocus(null);
     initialScrollDoneRef.current = false;
+  }, []);
+
+  const openQuickCreateModal = useCallback(() => {
+    if (!quickCreateProjects.length) return;
+    setIsCreateModalOpen(true);
+  }, [quickCreateProjects]);
+
+  const closeQuickCreateModal = useCallback(() => {
+    setIsCreateModalOpen(false);
   }, []);
 
   const refreshTasks = useCallback(async () => {
@@ -730,46 +756,65 @@ const TasksComponentMobile: React.FC<TasksComponentMobileProps> = ({
   };
 
   return (
-    <section className={styles.card} aria-label="Project tasks overview">
-      <header className={styles.header}>
-        <div className={styles.headingGroup}>
-          <h3 className={styles.title}>Tasks</h3>
-          <p className={styles.subtitle}>
-            {projectName
-              ? `Keep ${projectName} moving forward.`
-              : "Keep this project moving forward."}
-          </p>
-        </div>
-        <button
-          type="button"
-          className={styles.primaryButton}
-          onClick={handleOpenDrawer}
-          disabled={loading}
-        >
-          <Plus size={16} strokeWidth={2.25} />
-          Open tasks
-        </button>
-      </header>
+    <>
+      <section className={styles.card} aria-label="Project tasks overview">
+        <header className={styles.header}>
+          <div className={styles.headingGroup}>
+            <h3 className={styles.title}>Tasks</h3>
+            <p className={styles.subtitle}>
+              {projectName
+                ? `Keep ${projectName} moving forward.`
+                : "Keep this project moving forward."}
+            </p>
+          </div>
+          <div className={styles.actions}>
+            <button
+              type="button"
+              className={`${styles.iconButton} ${styles.iconButtonPrimary}`}
+              onClick={openQuickCreateModal}
+              aria-label="Create a quick task"
+              disabled={!quickCreateProjects.length || loading}
+            >
+              <Plus size={16} strokeWidth={2.25} />
+            </button>
+            <button
+              type="button"
+              className={styles.primaryButton}
+              onClick={handleOpenDrawer}
+              disabled={loading}
+            >
+              <ChevronDown size={16} strokeWidth={2.25} />
+              Open tasks
+            </button>
+          </div>
+        </header>
 
-      <div className={styles.statRow} aria-label="Task summary">
-        <div className={`${styles.statCard} ${styles.statOk}`}>
-          <span className={styles.statValue}>{formatStatValue(stats.completed)}</span>
-          <span className={styles.statLabel}>Done</span>
+        <div className={styles.statRow} aria-label="Task summary">
+          <div className={`${styles.statCard} ${styles.statOk}`}>
+            <span className={styles.statValue}>{formatStatValue(stats.completed)}</span>
+            <span className={styles.statLabel}>Done</span>
+          </div>
+          <div className={`${styles.statCard} ${styles.statDanger}`}>
+            <span className={styles.statValue}>{formatStatValue(stats.overdue)}</span>
+            <span className={styles.statLabel}>Overdue</span>
+          </div>
+          <div className={`${styles.statCard} ${styles.statWarn}`}>
+            <span className={styles.statValue}>{formatStatValue(stats.dueSoon)}</span>
+            <span className={styles.statLabel}>Due soon</span>
+          </div>
         </div>
-        <div className={`${styles.statCard} ${styles.statDanger}`}>
-          <span className={styles.statValue}>{formatStatValue(stats.overdue)}</span>
-          <span className={styles.statLabel}>Overdue</span>
-        </div>
-        <div className={`${styles.statCard} ${styles.statWarn}`}>
-          <span className={styles.statValue}>{formatStatValue(stats.dueSoon)}</span>
-          <span className={styles.statLabel}>Due soon</span>
-        </div>
-      </div>
 
-      <p className={styles.status}>{statusMessage}</p>
+        <p className={styles.status}>{statusMessage}</p>
 
-      {renderDrawer()}
-    </section>
+        {renderDrawer()}
+      </section>
+      <QuickCreateTaskModal
+        open={isCreateModalOpen}
+        onClose={closeQuickCreateModal}
+        projects={quickCreateProjects}
+        onCreated={refreshTasks}
+      />
+    </>
   );
 };
 


### PR DESCRIPTION
## Summary
- add a dedicated quick-create button to the mobile project tasks card
- integrate the shared QuickCreateTaskModal with the project view so new tasks refresh the list
- style the mobile header to accommodate the new icon action

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68db172958508324acf92834c02d39b8