### PR TITLE
Show location pin icons for task map markers

### DIFF
--- a/frontend/src/dashboard/project/components/Tasks/TasksComponentMobile.tsx
+++ b/frontend/src/dashboard/project/components/Tasks/TasksComponentMobile.tsx
@@ -218,8 +218,8 @@ function isSameDay(a: Date, b: Date): boolean {
 }
 
 function buildMarkerThumbnail(color?: string) {
-  if (!color) return undefined;
-  const svg = `<?xml version="1.0" encoding="UTF-8"?>\n<svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><circle cx="16" cy="16" r="14" fill="${color}" stroke="white" stroke-width="4"/></svg>`;
+  const fill = color && color.trim() ? color : "#2563eb";
+  const svg = `<?xml version="1.0" encoding="UTF-8"?>\n<svg width="40" height="52" viewBox="0 0 40 52" xmlns="http://www.w3.org/2000/svg"><path d="M20 2C11.163 2 4 9.163 4 18c0 11.046 16 30 16 30s16-18.954 16-30C36 9.163 28.837 2 20 2z" fill="${fill}" stroke="#ffffff" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><circle cx="20" cy="18" r="7" fill="#ffffff"/></svg>`;
   return `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`;
 }
 
@@ -390,6 +390,7 @@ const TasksComponentMobile: React.FC<TasksComponentMobileProps> = ({
         iconUrl: markerThumbnail,
         title: task.title,
         isActive: task.id === activeTaskId,
+        variant: "pin" as const,
       })),
     [mapTasks, markerThumbnail, activeTaskId],
   );

--- a/frontend/src/shared/ui/Map.tsx
+++ b/frontend/src/shared/ui/Map.tsx
@@ -8,6 +8,10 @@ import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 import './marker.css';
 
+const DEFAULT_PIN_ICON = `data:image/svg+xml;utf8,${encodeURIComponent(
+  `<?xml version="1.0" encoding="UTF-8"?>\n<svg width="40" height="52" viewBox="0 0 40 52" xmlns="http://www.w3.org/2000/svg"><path d="M20 2C11.163 2 4 9.163 4 18c0 11.046 16 30 16 30s16-18.954 16-30C36 9.163 28.837 2 20 2z" fill="#2563eb" stroke="#ffffff" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><circle cx="20" cy="18" r="7" fill="#ffffff"/></svg>`,
+)}`;
+
 export interface MapRef {
   locateUser: () => void;
 }
@@ -32,6 +36,9 @@ interface MapMarker {
   iconUrl?: string;
   title?: string;
   isActive?: boolean;
+  markerColor?: string;
+  borderColor?: string;
+  variant?: 'pin' | 'avatar';
 }
 
 interface MapProps {
@@ -86,17 +93,43 @@ const Map = forwardRef<MapRef, MapProps>(
     const lastFocusRef = useRef<string | null>(null);
     const markerIdsRef = useRef<string[]>([]);
 
-    const createMarkerIcon = (iconUrl?: string, isActive?: boolean) => {
-      const markerClass = `task-marker${isActive ? ' task-marker--active' : ''}`;
-      const inner = iconUrl
-        ? `<img src="${iconUrl}" alt="" />`
-        : '<span class="task-marker__dot"></span>';
+    const createMarkerIcon = (marker: MapMarker) => {
+      const { iconUrl, isActive, markerColor, borderColor, variant } = marker;
+      const mode = variant === 'avatar' ? 'avatar' : 'pin';
+      const markerClasses = ['task-marker', `task-marker--${mode}`];
+      if (isActive) {
+        markerClasses.push('task-marker--active');
+      }
+
+      const styleParts: string[] = [];
+      if (mode === 'avatar') {
+        if (markerColor) {
+          styleParts.push(`--marker-bg:${markerColor}`);
+        }
+        if (borderColor) {
+          styleParts.push(`--marker-border:${borderColor}`);
+        }
+      }
+      const styleAttr = styleParts.length ? ` style="${styleParts.join(';')}"` : '';
+
+      let innerHtml: string;
+      if (mode === 'avatar') {
+        innerHtml = iconUrl
+          ? `<img src="${iconUrl}" alt="" class="task-marker__avatar" />`
+          : '<span class="task-marker__avatar-fallback" aria-hidden="true"></span>';
+      } else {
+        const pinUrl = iconUrl || DEFAULT_PIN_ICON;
+        innerHtml = `<img src="${pinUrl}" alt="" class="task-marker__pin-image" />`;
+      }
+
+      const iconSize: [number, number] = mode === 'pin' ? [40, 52] : [36, 48];
+      const iconAnchor: [number, number] = mode === 'pin' ? [20, 48] : [18, 44];
 
       return L.divIcon({
-        html: `<div class="${markerClass}">${inner}<span class="task-marker__pointer" aria-hidden="true"></span></div>`,
+        html: `<div class="${markerClasses.join(' ')}"${styleAttr}>${innerHtml}</div>`,
         className: '',
-        iconSize: [36, 48],
-        iconAnchor: [18, 44],
+        iconSize,
+        iconAnchor,
       });
     };
 
@@ -398,7 +431,7 @@ const Map = forwardRef<MapRef, MapProps>(
 
       list.forEach((marker) => {
         const latLng: [number, number] = [marker.lat, marker.lng];
-        const icon = createMarkerIcon(marker.iconUrl, marker.isActive);
+        const icon = createMarkerIcon(marker);
         const existing = activeMarkers[marker.id];
 
         if (existing) {

--- a/frontend/src/shared/ui/marker.css
+++ b/frontend/src/shared/ui/marker.css
@@ -12,57 +12,79 @@
 
 .task-marker {
   position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
+}
+
+.task-marker--pin {
+  width: 40px;
+  height: 52px;
+}
+
+.task-marker__pin-image {
+  display: block;
+  width: 100%;
+  height: 100%;
+  filter: drop-shadow(0 12px 24px rgba(0, 0, 0, 0.35));
+}
+
+.task-marker--pin.task-marker--active .task-marker__pin-image {
+  filter: drop-shadow(0 14px 32px rgba(250, 51, 86, 0.38));
+}
+
+.task-marker--avatar {
   width: 36px;
   height: 36px;
   border-radius: 50%;
-  background: rgba(17, 18, 21, 0.92);
-  border: 2px solid rgba(255, 255, 255, 0.9);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  overflow: hidden;
+  background: var(--marker-bg, rgba(17, 18, 21, 0.92));
+  border: 2px solid var(--marker-border, rgba(255, 255, 255, 0.9));
   box-shadow: 0 12px 24px rgba(0, 0, 0, 0.35);
-  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+  overflow: hidden;
 }
 
-.task-marker img,
-.task-marker__dot {
+.task-marker__avatar,
+.task-marker__avatar-fallback {
   width: 100%;
   height: 100%;
   border-radius: 50%;
+  display: block;
   object-fit: cover;
 }
 
-.task-marker__dot {
+.task-marker__avatar-fallback {
   background: radial-gradient(circle at 30% 30%, #ffffff 0%, #93c5fd 100%);
 }
 
-.task-marker__pointer {
+.task-marker--avatar::after {
+  content: "";
   position: absolute;
   bottom: -11px;
   left: 50%;
   width: 18px;
   height: 18px;
   transform: translateX(-50%) rotate(45deg);
-  background: rgba(17, 18, 21, 0.92);
-  border-left: 2px solid rgba(255, 255, 255, 0.9);
-  border-bottom: 2px solid rgba(255, 255, 255, 0.9);
-  border-top: none;
-  border-right: none;
+  background: var(--marker-bg, rgba(17, 18, 21, 0.92));
+  border-left: 2px solid var(--marker-border, rgba(255, 255, 255, 0.9));
+  border-bottom: 2px solid var(--marker-border, rgba(255, 255, 255, 0.9));
   border-radius: 0 0 4px 0;
 }
 
 .task-marker--active {
-  transform: scale(1.08);
+  transform: translateY(-2px);
+}
+
+.task-marker--avatar.task-marker--active {
+  transform: translateY(-2px) scale(1.08);
   border-color: var(--brand, #fa3356);
   box-shadow: 0 14px 32px rgba(250, 51, 86, 0.38);
 }
 
-.task-marker--active .task-marker__pointer {
+.task-marker--avatar.task-marker--active::after {
   border-left-color: var(--brand, #fa3356);
   border-bottom-color: var(--brand, #fa3356);
 }
-
 
 
 


### PR DESCRIPTION
## Summary
- replace the mobile task marker thumbnail with a location-pin SVG that tints to the project color
- update the shared map marker renderer to distinguish pin versus avatar markers and default to the new pin artwork
- restyle marker CSS for the new pin image while keeping avatar styling for future user thumbnails

## Testing
- npm run lint -- --max-warnings=0

------
https://chatgpt.com/codex/tasks/task_e_68db5094640883249ff1a9cd73924b54