### PR TITLE
Refine quick task modal sheet interactions

### DIFF
--- a/frontend/src/dashboard/home/components/QuickCreateTaskModal.module.css
+++ b/frontend/src/dashboard/home/components/QuickCreateTaskModal.module.css
@@ -72,8 +72,29 @@
   flex-direction: column;
   gap: 20px;
   overflow-y: auto;
-  padding: max(24px, env(safe-area-inset-top)) max(16px, env(safe-area-inset-right))
-    max(24px, env(safe-area-inset-bottom)) max(16px, env(safe-area-inset-left));
+  padding-top: max(24px, env(safe-area-inset-top));
+  padding-right: max(16px, env(safe-area-inset-right));
+  padding-left: max(16px, env(safe-area-inset-left));
+  padding-bottom: calc(env(safe-area-inset-bottom) + 24px);
+  scrollbar-width: none;
+}
+
+.formBody::-webkit-scrollbar {
+  display: none;
+}
+
+.grabZone {
+  display: flex;
+  justify-content: center;
+  padding-bottom: 8px;
+  touch-action: none;
+}
+
+.grabHandle {
+  width: 64px;
+  height: 4px;
+  border-radius: 999px;
+  background: rgba(246, 247, 251, 0.32);
 }
 
 .fieldGroup {

--- a/frontend/src/dashboard/home/components/QuickCreateTaskModal.tsx
+++ b/frontend/src/dashboard/home/components/QuickCreateTaskModal.tsx
@@ -47,6 +47,8 @@ export type QuickCreateTaskModalProps = {
   scopedProjectId?: string | null;
 };
 
+const GRAB_ZONE_HEIGHT = 48;
+
 const QuickCreateTaskModal: React.FC<QuickCreateTaskModalProps> = ({
   open,
   onClose,
@@ -417,7 +419,21 @@ const QuickCreateTaskModal: React.FC<QuickCreateTaskModalProps> = ({
       return;
     }
 
-    touchStartYRef.current = event.touches[0].clientY;
+    const touch = event.touches[0];
+    const modal = modalRef.current;
+    if (!modal) return;
+
+    const rect = modal.getBoundingClientRect();
+    const distanceFromTop = touch.clientY - rect.top;
+    if (distanceFromTop < 0 || distanceFromTop > GRAB_ZONE_HEIGHT) {
+      touchStartYRef.current = null;
+      isDraggingRef.current = false;
+      lastOffsetRef.current = 0;
+      setIsDragging(false);
+      return;
+    }
+
+    touchStartYRef.current = touch.clientY;
     isDraggingRef.current = true;
     lastOffsetRef.current = 0;
     setIsDragging(true);
@@ -603,6 +619,9 @@ const QuickCreateTaskModal: React.FC<QuickCreateTaskModalProps> = ({
           noValidate
         >
           <div className={styles.formBody}>
+            <div className={styles.grabZone} aria-hidden="true">
+              <span className={styles.grabHandle} />
+            </div>
             <div className={styles.createHeader}>
               <h2 id="quick-task-title">Create a task</h2>
               <p id={descriptionId} className={styles.createDescription}>


### PR DESCRIPTION
## Summary
- add a grab handle and restrict swipe-to-close to the grab zone for the quick task modal
- adjust modal padding so the save button can be fully scrolled into view above the safe area inset
- hide modal scrollbars to present a single clean scrolling sheet

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db5596517883248fe8e5d7c27314a2