### PR TITLE
Restyle gallery preview as fading carousel

### DIFF
--- a/frontend/src/dashboard/project/components/Gallery/GalleryTrigger.tsx
+++ b/frontend/src/dashboard/project/components/Gallery/GalleryTrigger.tsx
@@ -53,10 +53,58 @@ const GalleryTrigger: React.FC<GalleryTriggerProps> = ({
 }) => {
   const isCompact = useCompactGalleryLayout();
   const hasGalleries = galleries.length > 0;
-  const maxVisibleThumbs = isCompact ? 6 : 3;
-  const visibleCount = Math.min(maxVisibleThumbs, galleries.length);
-  const visibleGalleries = galleries.slice(0, visibleCount);
-  const hiddenCount = galleries.length - visibleCount;
+  const carouselRef = React.useRef<HTMLDivElement | null>(null);
+  const [canScrollLeft, setCanScrollLeft] = React.useState(false);
+  const [canScrollRight, setCanScrollRight] = React.useState(false);
+
+  const updateScrollState = React.useCallback(() => {
+    const node = carouselRef.current;
+
+    if (!node) {
+      setCanScrollLeft(false);
+      setCanScrollRight(false);
+      return;
+    }
+
+    const { scrollLeft, scrollWidth, clientWidth } = node;
+    const maxScrollLeft = scrollWidth - clientWidth;
+    setCanScrollLeft(scrollLeft > 2);
+    setCanScrollRight(scrollLeft < maxScrollLeft - 2);
+  }, []);
+
+  React.useEffect(() => {
+    const node = carouselRef.current;
+
+    if (!node) {
+      return undefined;
+    }
+
+    updateScrollState();
+
+    const handleScroll = () => updateScrollState();
+    const handleResize = () => updateScrollState();
+
+    node.addEventListener("scroll", handleScroll, { passive: true });
+    window.addEventListener("resize", handleResize);
+
+    return () => {
+      node.removeEventListener("scroll", handleScroll);
+      window.removeEventListener("resize", handleResize);
+    };
+  }, [galleries.length, updateScrollState]);
+
+  React.useEffect(() => {
+    updateScrollState();
+  }, [galleries.length, updateScrollState]);
+
+  const viewportClassName = [
+    styles.carouselViewport,
+    canScrollLeft ? styles.carouselViewportRevealLeft : "",
+    canScrollRight ? styles.carouselViewportRevealRight : "",
+    isCompact ? styles.carouselViewportCompact : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
 
   return (
     <div
@@ -75,7 +123,7 @@ const GalleryTrigger: React.FC<GalleryTriggerProps> = ({
       <div className={styles.titleColumn}>
         <div className={styles.topRow}>
           <span>Galleries</span>
-         
+
         </div>
         {hasGalleries ? (
           <p className={styles.galleryHelperText}>
@@ -89,55 +137,43 @@ const GalleryTrigger: React.FC<GalleryTriggerProps> = ({
       <div className={styles.thumbsColumn}>
         {hasGalleries ? (
           <div className={styles.carouselSection}>
-            <div
-              className={styles.thumbnailCarousel}
-              aria-label="Gallery preview thumbnails"
-            >
-              {visibleGalleries.map((galleryItem, idx) => {
-                const previewUrl = getPreviewUrl(galleryItem);
-                const galleryName = galleryItem.name?.trim() || `Gallery ${idx + 1}`;
+            <div className={viewportClassName}>
+              <div
+                ref={carouselRef}
+                className={styles.thumbnailCarousel}
+                aria-label="Gallery preview thumbnails"
+              >
+                {galleries.map((galleryItem, idx) => {
+                  const previewUrl = getPreviewUrl(galleryItem);
+                  const galleryName = galleryItem.name?.trim() || `Gallery ${idx + 1}`;
 
-                return (
-                  <button
-                    key={galleryItem.slug || idx}
-                    type="button"
-                    className={styles.thumbnailButton}
-                    aria-label={`Open ${galleryName}`}
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      onOpenModal();
-                    }}
-                  >
-                    {previewUrl ? (
-                      <img
-                        src={getFileUrl(previewUrl)}
-                        alt={galleryName}
-                        loading="lazy"
-                      />
-                    ) : (
-                      <span className={styles.thumbnailPlaceholder}>
-                        <GalleryVerticalEnd size={24} aria-hidden="true" />
-                      </span>
-                    )}
-                  </button>
-                );
-              })}
-              {hiddenCount > 0 && (
-                <button
-                  type="button"
-                  className={`${styles.thumbnailButton} ${styles.moreTile}`}
-                  aria-label={`View ${hiddenCount} more galleries`}
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    onOpenModal();
-                  }}
-                >
-                  +{hiddenCount}
-                </button>
-              )}
+                  return (
+                    <button
+                      key={galleryItem.slug || idx}
+                      type="button"
+                      className={styles.thumbnailButton}
+                      aria-label={`Open ${galleryName}`}
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        onOpenModal();
+                      }}
+                    >
+                      {previewUrl ? (
+                        <img
+                          src={getFileUrl(previewUrl)}
+                          alt={galleryName}
+                          loading="lazy"
+                        />
+                      ) : (
+                        <span className={styles.thumbnailPlaceholder}>
+                          <GalleryVerticalEnd size={24} aria-hidden="true" />
+                        </span>
+                      )}
+                    </button>
+                  );
+                })}
+              </div>
             </div>
-            <span className={`${styles.carouselEdge} ${styles.carouselEdgeLeft}`} aria-hidden="true" />
-            <span className={`${styles.carouselEdge} ${styles.carouselEdgeRight}`} aria-hidden="true" />
           </div>
         ) : (
           <div className={styles.emptyState}>No galleries yet</div>

--- a/frontend/src/dashboard/project/components/Gallery/gallery-component.module.css
+++ b/frontend/src/dashboard/project/components/Gallery/gallery-component.module.css
@@ -9,13 +9,16 @@
   width: 100%;
   flex: 0 1 auto;
   min-height: var(--row-h);
-  transition: transform 0.2s ease;
+  transition: transform 0.25s ease, background 0.35s ease, box-shadow 0.35s ease;
   flex-wrap: nowrap;
   gap: 12px;
   padding: 20px;
   box-sizing: border-box;
-  background-color: rgba(12, 12, 12, 0.75);
-  border-radius: 16px;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.08) 0%, rgba(255, 255, 255, 0.02) 42%, rgba(17, 18, 19, 0.65) 100%);
+  border-radius: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02), 0 24px 48px rgba(0, 0, 0, 0.35);
+  backdrop-filter: blur(16px);
 }
 
 /* Two columns inside the trigger */
@@ -68,22 +71,81 @@
 .carouselSection {
   display: flex;
   flex-direction: column;
-  align-items: flex-end;
-  gap: 10px;
+  align-items: stretch;
+  gap: 12px;
   width: 100%;
   position: relative;
 }
 
+.carouselViewport {
+  --fade-size: 56px;
+  position: relative;
+  width: 100%;
+  overflow: hidden;
+  border-radius: 18px;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.06) 0%, rgba(255, 255, 255, 0.01) 100%);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.22);
+  transition: background 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.carouselViewport::before,
+.carouselViewport::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: var(--fade-size);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.35s ease;
+  background: linear-gradient(90deg, rgba(17, 18, 19, 0.9) 0%, rgba(17, 18, 19, 0) 100%);
+}
+
+.carouselViewport::after {
+  right: 0;
+  left: auto;
+  transform: scaleX(-1);
+}
+
+.carouselViewport::before {
+  left: 0;
+}
+
+.carouselViewportRevealLeft::before {
+  opacity: 1;
+}
+
+.carouselViewportRevealRight::after {
+  opacity: 1;
+}
+
+.carouselViewportCompact {
+  --fade-size: 36px;
+}
+
+.carouselViewportCompact .thumbnailCarousel {
+  padding: 10px 14px;
+  gap: 12px;
+}
+
 .thumbnailCarousel {
   --thumb-column: calc(var(--row-h) * 0.78);
-  display: grid;
-  grid-auto-flow: column;
-  grid-auto-columns: max-content;
-  gap: 12px;
+  display: flex;
+  gap: 14px;
   width: 100%;
-  justify-content: flex-end;
+  justify-content: flex-start;
   align-items: center;
-  padding: 4px 0;
+  padding: 12px 18px;
+  overflow-x: auto;
+  overscroll-behavior-x: contain;
+  scroll-snap-type: x proximity;
+  scroll-behavior: smooth;
+  scrollbar-width: none;
+}
+
+.thumbnailCarousel::-webkit-scrollbar {
+  display: none;
 }
 
 
@@ -93,22 +155,24 @@
   justify-content: center;
   position: relative;
   overflow: hidden;
-  border: none;
-  padding: 6px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  padding: 8px;
   margin: 0;
-  border-radius: 14px;
-  background: transparent;
-  color: rgba(255, 255, 255, 0.65);
+  border-radius: 16px;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.16) 0%, rgba(255, 255, 255, 0.05) 100%);
+  color: rgba(255, 255, 255, 0.82);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  transition: transform 0.2s ease, border-color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+  transition: transform 0.25s ease, border-color 0.25s ease, background 0.25s ease, box-shadow 0.25s ease;
   height: var(--thumb-column);
   min-width: calc(var(--thumb-column) * 0.66);
   max-width: calc(var(--thumb-column) * 1.6);
   isolation: isolate;
   background-clip: padding-box;
   cursor: pointer;
+  scroll-snap-align: center;
+  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.35);
 }
 
 .thumbnailButton img {
@@ -129,8 +193,10 @@
 
 .thumbnailButton:hover {
   transform: translateY(-2px);
-  background: rgba(250, 51, 86, 0.12);
+  background: linear-gradient(135deg, rgba(250, 51, 86, 0.28) 0%, rgba(250, 51, 86, 0.12) 100%);
+  border-color: rgba(250, 51, 86, 0.35);
   color: #FA3356;
+  box-shadow: 0 20px 42px rgba(250, 51, 86, 0.25);
 }
 
 .thumbnailPlaceholder {
@@ -139,37 +205,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background: rgba(12, 12, 12, 0.65);
-  color: rgba(255, 255, 255, 0.65);
-}
-
-.moreTile {
-  background: rgba(250, 51, 86, 0.15);
-  color: #FA3356;
-}
-
-.moreTile:hover {
-  background: rgba(250, 51, 86, 0.22);
-}
-
-.carouselEdge {
-  position: absolute;
-  inset-block: 4px;
-  width: 32px;
-  pointer-events: none;
-  opacity: 0;
-  transition: opacity 0.2s ease;
-  display: none;
-}
-
-.carouselEdgeLeft {
-  left: 0;
-  background: linear-gradient(90deg, rgba(12, 12, 12, 0.95) 0%, rgba(12, 12, 12, 0) 100%);
-}
-
-.carouselEdgeRight {
-  right: 0;
-  background: linear-gradient(270deg, rgba(12, 12, 12, 0.95) 0%, rgba(12, 12, 12, 0) 100%);
+  background: rgba(17, 18, 19, 0.6);
+  color: rgba(255, 255, 255, 0.72);
 }
 
 .viewAllButton {
@@ -269,33 +306,14 @@
 
 @media (max-width: 480px) {
   .thumbnailCarousel {
-    overflow-x: auto;
-    overscroll-behavior-x: contain;
+    padding: 10px 14px;
+    margin: 0 -10px;
+    gap: 10px;
     scroll-snap-type: x mandatory;
-    padding: 6px 12px;
-    margin: 0 -12px;
   }
 
-  .thumbnailCarousel::-webkit-scrollbar {
-    height: 6px;
-  }
-
-  .thumbnailCarousel::-webkit-scrollbar-thumb {
-    background: rgba(255, 255, 255, 0.18);
-    border-radius: 999px;
-  }
-
-  .thumbnailCarousel::-webkit-scrollbar-track {
-    background: transparent;
-  }
-
-  .thumbnailButton {
-    scroll-snap-align: center;
-  }
-
-  .carouselEdge {
-    display: block;
-    opacity: 1;
+  .carouselViewport {
+    --fade-size: 28px;
   }
 }
 


### PR DESCRIPTION
## Summary
- turn the gallery preview row into a horizontally scrolling carousel with smooth edge fades
- refresh the gallery trigger styling so the row blends into the surrounding card and updates thumbnail treatments

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68db83d6c5508324acbbcf9cc372713b