### PR TITLE
Refactor project tasks components into modular units

### DIFF
--- a/frontend/src/dashboard/project/components/Tasks/TasksComponent.tsx
+++ b/frontend/src/dashboard/project/components/Tasks/TasksComponent.tsx
@@ -1,28 +1,9 @@
 import React, { useEffect, useState } from "react";
-import {
-  Table,
-  Select,
-  Button,
-  Dropdown,
-  Modal,
-  Form,
-  Input,
-  Tooltip,
-  DatePicker,
-  AutoComplete,
-  ConfigProvider,
-  theme,
-  message,
-} from "antd";
+import { Button, ConfigProvider, Dropdown, Form, Select, Tooltip, message, theme } from "antd";
 import type { ColumnsType } from "antd/es/table";
 import type { MenuProps } from "antd";
 import type { Dayjs } from "dayjs";
-import {
-  EditOutlined,
-  DeleteOutlined,
-  MessageOutlined,
-  DownOutlined,
-} from "@ant-design/icons";
+import { DeleteOutlined, DownOutlined, EditOutlined, MessageOutlined } from "@ant-design/icons";
 import { v4 as uuidv4 } from "uuid";
 
 import {
@@ -35,88 +16,36 @@ import {
   fetchUserProfilesBatch,
 } from "@/shared/utils/api";
 import { useBudget } from "@/dashboard/project/features/budget/context/BudgetContext";
+import AssignTaskForm from "./components/AssignTaskForm";
+import CommentModal from "./components/CommentModal";
+import TaskEditModal from "./components/TaskEditModal";
+import TaskTable from "./components/TaskTable";
+import type {
+  ApiTask,
+  NominatimSuggestion,
+  Status,
+  Task,
+  TaskLocation,
+  TeamMember,
+} from "./types";
+import {
+  STATUS_OPTIONS,
+  buildAssigneeOptions,
+  buildBudgetOptions,
+  buildTaskNameOptions,
+  formatAssigneeDisplay,
+  mapApiTaskToTask,
+  sortByProximity,
+} from "./utils";
 import "./task-table.css";
 
-/* =========================
-   Types
-   ========================= */
-type Status = "todo" | "in_progress" | "done";
-
-interface TeamMember {
-  userId: string;
-  firstName?: string;
-  lastName?: string;
-  displayName?: string;
-  username?: string;
-  email?: string;
-}
-
-interface TaskLocation {
-  lat: number | string;
-  lng: number | string;
-}
-
-interface ApiTask {
-  taskId?: string;
-  id?: string;
-  projectId: string;
-  title?: string;
-  name?: string;
-  description?: string;
-  comments?: string;
-  budgetItemId?: string | null;
-  status?: 'todo' | 'in_progress' | 'done';
-  assigneeId?: string;
-  assignedTo?: string;
-  dueDate?: string;
-}
-
-interface Task {
-  id: string; // table row key
-  taskId?: string;
-  projectId: string;
-  name: string;
-  assigneeId?: string;
-  assignedTo?: string;
-  dueDate?: string;
-  priority?: string;
-  budgetItemId?: string;
-  eventId?: string;
-  description?: string;
-  status: Status;
-  location?: TaskLocation;
-  address?: string;
-}
-
-interface NominatimSuggestion {
-  place_id: string | number;
-  display_name: string;
-  lat: string;
-  lon: string;
-}
-
-interface TasksComponentProps {
+type TasksComponentProps = {
   projectId?: string;
   userId?: string;
   team?: TeamMember[];
-}
+};
 
-/* =========================
-   Constants
-   ========================= */
-const statusOptions = [
-  { value: "todo", label: "To Do" },
-  { value: "in_progress", label: "In Progress" },
-  { value: "done", label: "Done" },
-];
-
-/* =========================
-   Component
-   ========================= */
-const TasksComponent: React.FC<TasksComponentProps> = ({
-  projectId = "",
-  team = [],
-}) => {
+const TasksComponent: React.FC<TasksComponentProps> = ({ projectId = "", team = [] }) => {
   const [tasks, setTasks] = useState<Task[]>([]);
   const [isTaskModalOpen, setIsTaskModalOpen] = useState(false);
   const [editingTask, setEditingTask] = useState<Task | null>(null);
@@ -127,96 +56,59 @@ const TasksComponent: React.FC<TasksComponentProps> = ({
 
   const [assignForm] = Form.useForm();
   const [assignLocationSearch, setAssignLocationSearch] = useState("");
-  const [assignLocationSuggestions, setAssignLocationSuggestions] = useState<
-    NominatimSuggestion[]
-  >([]);
-  const [assignTaskLocation, setAssignTaskLocation] = useState<TaskLocation>({
-    lat: "",
-    lng: "",
-  });
+  const [assignLocationSuggestions, setAssignLocationSuggestions] = useState<NominatimSuggestion[]>([]);
+  const [assignTaskLocation, setAssignTaskLocation] = useState<TaskLocation>({ lat: "", lng: "" });
   const [assignTaskAddress, setAssignTaskAddress] = useState("");
 
-  const [userLocation, setUserLocation] = useState<{
-    lat: number;
-    lng: number;
-  } | null>(null);
+  const [userLocation, setUserLocation] = useState<{ lat: number; lng: number } | null>(null);
 
-  // Get user's current location
   useEffect(() => {
-    if (navigator.geolocation) {
-      navigator.geolocation.getCurrentPosition(
-        (pos) =>
-          setUserLocation({
-            lat: pos.coords.latitude,
-            lng: pos.coords.longitude,
-          }),
-        () => setUserLocation(null)
-      );
-    }
+    if (!navigator.geolocation) return;
+    navigator.geolocation.getCurrentPosition(
+      (pos) =>
+        setUserLocation({
+          lat: pos.coords.latitude,
+          lng: pos.coords.longitude,
+        }),
+      () => setUserLocation(null)
+    );
   }, []);
-
-  // Sort suggestions by proximity to userLocation if available
-  const sortByProximity = (
-    suggestions: NominatimSuggestion[],
-    userLoc: { lat: number; lng: number } | null
-  ) => {
-    if (!userLoc) return suggestions;
-    return [...suggestions].sort((a, b) => {
-      const distA = Math.hypot(
-        userLoc.lat - parseFloat(a.lat),
-        userLoc.lng - parseFloat(a.lon)
-      );
-      const distB = Math.hypot(
-        userLoc.lat - parseFloat(b.lat),
-        userLoc.lng - parseFloat(b.lon)
-      );
-      return distA - distB;
-    });
-  };
 
   const fetchAssignLocationSuggestions = async (query: string) => {
     if (!query || query.length < 3) {
       setAssignLocationSuggestions([]);
       return;
     }
+
     try {
-      const url = `${NOMINATIM_SEARCH_URL}${encodeURIComponent(
-        query
-      )}&addressdetails=1&limit=5`;
+      const url = `${NOMINATIM_SEARCH_URL}${encodeURIComponent(query)}&addressdetails=1&limit=5`;
       const response = await apiFetch(url);
-      let results: NominatimSuggestion[] = response as NominatimSuggestion[];
-      results = sortByProximity(results, userLocation);
+      const results = sortByProximity((response as NominatimSuggestion[]) || [], userLocation);
       setAssignLocationSuggestions(results);
     } catch {
       setAssignLocationSuggestions([]);
     }
   };
 
-  const handleAssignLocationSearchChange = (
-    e: React.ChangeEvent<HTMLInputElement>
-  ) => {
-    setAssignLocationSearch(e.target.value);
-    fetchAssignLocationSuggestions(e.target.value);
+  const handleAssignLocationSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value;
+    setAssignLocationSearch(value);
+    fetchAssignLocationSuggestions(value);
   };
 
-  const handleAssignLocationSuggestionSelect = (s: NominatimSuggestion) => {
-    const loc = { lat: parseFloat(s.lat), lng: parseFloat(s.lon) };
-    setAssignTaskLocation(loc);
-    setAssignTaskAddress(s.display_name);
-    setAssignLocationSearch(s.display_name);
+  const handleAssignLocationSuggestionSelect = (suggestion: NominatimSuggestion) => {
+    const location = { lat: parseFloat(suggestion.lat), lng: parseFloat(suggestion.lon) };
+    setAssignTaskLocation(location);
+    setAssignTaskAddress(suggestion.display_name);
+    setAssignLocationSearch(suggestion.display_name);
     setAssignLocationSuggestions([]);
-    assignForm.setFieldsValue({ location: loc, address: s.display_name });
+    assignForm.setFieldsValue({ location, address: suggestion.display_name });
   };
 
   const [editForm] = Form.useForm();
   const [locationSearch, setLocationSearch] = useState("");
-  const [locationSuggestions, setLocationSuggestions] = useState<
-    NominatimSuggestion[]
-  >([]);
-  const [taskLocation, setTaskLocation] = useState<TaskLocation>({
-    lat: "",
-    lng: "",
-  });
+  const [locationSuggestions, setLocationSuggestions] = useState<NominatimSuggestion[]>([]);
+  const [taskLocation, setTaskLocation] = useState<TaskLocation>({ lat: "", lng: "" });
   const [taskAddress, setTaskAddress] = useState("");
 
   const fetchLocationSuggestions = async (query: string) => {
@@ -224,118 +116,71 @@ const TasksComponent: React.FC<TasksComponentProps> = ({
       setLocationSuggestions([]);
       return;
     }
+
     try {
-      const url = `${NOMINATIM_SEARCH_URL}${encodeURIComponent(
-        query
-      )}&addressdetails=1&limit=5`;
+      const url = `${NOMINATIM_SEARCH_URL}${encodeURIComponent(query)}&addressdetails=1&limit=5`;
       const response = await apiFetch(url);
-      const results: NominatimSuggestion[] = response as NominatimSuggestion[];
-      setLocationSuggestions(results);
+      setLocationSuggestions((response as NominatimSuggestion[]) || []);
     } catch {
       setLocationSuggestions([]);
     }
   };
 
-  const handleLocationSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setLocationSearch(e.target.value);
-    fetchLocationSuggestions(e.target.value);
+  const handleLocationSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value;
+    setLocationSearch(value);
+    fetchLocationSuggestions(value);
   };
 
-  const handleLocationSuggestionSelect = (s: NominatimSuggestion) => {
-    const loc = { lat: parseFloat(s.lat), lng: parseFloat(s.lon) };
-    setTaskLocation(loc);
-    setTaskAddress(s.display_name);
-    setLocationSearch(s.display_name);
+  const handleLocationSuggestionSelect = (suggestion: NominatimSuggestion) => {
+    const location = { lat: parseFloat(suggestion.lat), lng: parseFloat(suggestion.lon) };
+    setTaskLocation(location);
+    setTaskAddress(suggestion.display_name);
+    setLocationSearch(suggestion.display_name);
     setLocationSuggestions([]);
-    editForm.setFieldsValue({ location: loc, address: s.display_name });
+    editForm.setFieldsValue({ location, address: suggestion.display_name });
   };
 
   const { budgetItems } = useBudget();
   const [teamProfiles, setTeamProfiles] = useState<TeamMember[]>([]);
 
-  // Fetch user profiles for team userIds
   useEffect(() => {
     const fetchProfiles = async () => {
-      if (Array.isArray(team) && team.length > 0) {
-        const userIds = team.map((m) => m.userId).filter(Boolean);
-        const profiles = await fetchUserProfilesBatch(userIds);
-        setTeamProfiles(profiles || []);
-      } else {
+      if (!Array.isArray(team) || team.length === 0) {
         setTeamProfiles([]);
+        return;
       }
+
+      const userIds = team.map((member) => member.userId).filter(Boolean);
+      const profiles = await fetchUserProfilesBatch(userIds);
+      setTeamProfiles(profiles || []);
     };
+
     fetchProfiles();
   }, [team]);
 
-  // Load tasks
   useEffect(() => {
     const loadTasks = async () => {
       try {
         const data = await fetchTasks(projectId);
-        const mapped: Task[] = (data || []).map((t: ApiTask) => ({
-          ...t,
-          id: t.taskId || t.id,
-          projectId: t.projectId,
-          name: (t.title || t.name || "").toUpperCase(),
-          status: t.status || "todo",
-          assigneeId: t.assigneeId || t.assignedTo,
-          assignedTo: t.assigneeId || t.assignedTo,
-          description: t.description || t.comments,
-        }));
+        const mapped: Task[] = (data || []).map((task: ApiTask) => mapApiTaskToTask(task));
         setTasks(mapped);
-      } catch (err) {
-        console.error("Failed to fetch tasks", err);
+      } catch (error) {
+        console.error("Failed to fetch tasks", error);
         setTasks([]);
       }
     };
+
     loadTasks();
   }, [projectId]);
 
-  // Helpers
-  const getDisplayName = (m: Partial<TeamMember> = {}) => {
-    const first = m.firstName || "";
-    const last = m.lastName || "";
-    const name = `${first} ${last}`.trim();
-    return name || m.displayName || m.username || m.userId || "";
-  };
+  const assigneeOptions = buildAssigneeOptions(teamProfiles);
+  const budgetArray = Array.isArray(budgetItems)
+    ? (budgetItems as Record<string, unknown>[])
+    : ([] as Record<string, unknown>[]);
+  const budgetOptions = buildBudgetOptions(budgetArray);
+  const taskNameOptions = buildTaskNameOptions(budgetArray);
 
-  const assigneeOptions =
-    Array.isArray(teamProfiles) && teamProfiles.length > 0
-      ? teamProfiles.map((p) => ({
-          value: `${(p.firstName || "")}${(p.lastName || "")}__${p.userId}`,
-          label: getDisplayName(p) || p.userId!,
-        }))
-      : [];
-
-  const budgetOptions = budgetItems.map((it: Record<string, unknown>) => {
-    const desc = (it.descriptionShort || it.description || "").toString().slice(0, 50);
-    return {
-      value: (it.budgetItemId as string) || "",
-      label: `${(it.elementId as string) || ""} (${desc})`,
-      elementId: (it.elementId as string) || "",
-    };
-  });
-
-  const taskNameOptions = budgetItems.map((it: Record<string, unknown>) => {
-    const labelBase = ((it.descriptionShort || it.description || "") as string)
-      .split(" ")
-      .slice(0, 6)
-      .join(" ");
-    return { label: labelBase, value: labelBase, elementId: (it.elementId as string) || "" };
-  });
-
-  // Deduplicate by value (task name)
-  const uniqueTaskNameOptions = Array.from(
-    taskNameOptions.reduce<Map<string, (typeof taskNameOptions)[number]>>(
-      (map, opt) => {
-        if (!map.has(opt.value)) map.set(opt.value, opt);
-        return map;
-      },
-      new Map()
-    ).values()
-  );
-
-  // Actions
   const handleAssignTask = async () => {
     try {
       const values = await assignForm.validateFields();
@@ -343,7 +188,7 @@ const TasksComponent: React.FC<TasksComponentProps> = ({
       const normalizedName = (values.name || "").toUpperCase();
       const due: Dayjs | string | undefined = values.dueDate;
 
-      const payload = {
+      const payload: ApiTask = {
         projectId,
         taskId: id,
         assigneeId: values.assignedTo || "",
@@ -355,59 +200,56 @@ const TasksComponent: React.FC<TasksComponentProps> = ({
             : (due as string) || "",
         title: normalizedName,
         priority: values.priority || "",
-        status: "todo" as Status,
+        status: "todo",
         location: values.location || assignTaskLocation,
         address: values.address || assignTaskAddress,
       };
 
       const saved = await createTask(payload);
+      const combined = mapApiTaskToTask({ ...payload, ...saved }, id);
       const savedAssignee =
-        saved.assigneeId || (saved as ApiTask).assignedTo || payload.assigneeId || "";
-      const mapped: Task = {
-        ...saved,
-        id: saved.taskId || id,
-        projectId: saved.projectId,
-        name: saved.title || '',
-        status: saved.status || "todo",
-        assigneeId: savedAssignee,
-        assignedTo: savedAssignee,
-      };
-      setTasks((prev) => [...prev, mapped]);
+        (saved.assigneeId || (saved as ApiTask).assignedTo || combined.assigneeId || "") as string;
+      const mappedTask: Task = { ...combined, assigneeId: savedAssignee, assignedTo: savedAssignee };
+
+      setTasks((previous) => [...previous, mappedTask]);
 
       assignForm.resetFields();
       setAssignTaskLocation({ lat: "", lng: "" });
       setAssignTaskAddress("");
       setAssignLocationSearch("");
       setAssignLocationSuggestions([]);
-    } catch (err) {
-      console.error("Failed to assign task", err);
+    } catch (error) {
+      console.error("Failed to assign task", error);
       message.error("Failed to assign task");
     }
   };
 
   const openTaskModal = (task?: Task) => {
-    const t = task || null;
-    setEditingTask(t);
+    const targetTask = task || null;
+    setEditingTask(targetTask);
     setIsTaskModalOpen(true);
 
-    editForm.setFieldsValue(
-      t
-        ? { ...t, assignedTo: t.assignedTo || t.assigneeId || "" }
-        : {
-          name: "",
-          assignedTo: "",
-          dueDate: "",
-          priority: "",
-          budgetItemId: "",
-          eventId: "",
-          location: { lat: "", lng: "" },
-          address: "",
-        }
-    );
+    if (targetTask) {
+      editForm.setFieldsValue({ ...targetTask, assignedTo: targetTask.assignedTo || targetTask.assigneeId || "" });
+      setTaskLocation(targetTask.location || { lat: "", lng: "" });
+      setTaskAddress(targetTask.address || "");
+      setLocationSearch(targetTask.address || "");
+    } else {
+      editForm.setFieldsValue({
+        name: "",
+        assignedTo: "",
+        dueDate: "",
+        priority: "",
+        budgetItemId: "",
+        eventId: "",
+        location: { lat: "", lng: "" },
+        address: "",
+      });
+      setTaskLocation({ lat: "", lng: "" });
+      setTaskAddress("");
+      setLocationSearch("");
+    }
 
-    setTaskLocation(t?.location || { lat: "", lng: "" });
-    setTaskAddress(t?.address || "");
-    setLocationSearch(t?.address || "");
     setLocationSuggestions([]);
   };
 
@@ -418,7 +260,7 @@ const TasksComponent: React.FC<TasksComponentProps> = ({
       const normalizedName = (values.name || "").toUpperCase();
       const due: Dayjs | string | undefined = values.dueDate;
 
-      const payload = {
+      const payload: ApiTask = {
         projectId,
         taskId: id,
         assigneeId: values.assignedTo || editingTask?.assigneeId || "",
@@ -433,26 +275,20 @@ const TasksComponent: React.FC<TasksComponentProps> = ({
         status: (editingTask?.status || "todo") as Status,
         location: values.location || taskLocation,
         address: values.address || taskAddress,
+        eventId: values.eventId || editingTask?.eventId,
       };
 
       const saved = editingTask ? await updateTask(payload) : await createTask(payload);
+      const merged = mapApiTaskToTask({ ...editingTask, ...payload, ...saved }, id);
       const savedAssignee =
-        saved.assigneeId || (saved as ApiTask).assignedTo || payload.assigneeId || "";
-      const mapped: Task = {
-        ...saved,
-        id: saved.taskId || id,
-        projectId: saved.projectId,
-        name: saved.title || '',
-        status: saved.status || "todo",
-        assigneeId: savedAssignee,
-        assignedTo: savedAssignee,
-      };
+        (saved.assigneeId || (saved as ApiTask).assignedTo || merged.assigneeId || "") as string;
+      const mappedTask: Task = { ...merged, assigneeId: savedAssignee, assignedTo: savedAssignee };
 
-      setTasks((prev) => {
-        const exists = prev.find((t) => t.id === mapped.id);
+      setTasks((previous) => {
+        const exists = previous.some((taskItem) => taskItem.id === mappedTask.id);
         return exists
-          ? prev.map((t) => (t.id === mapped.id ? mapped : t))
-          : [...prev, mapped];
+          ? previous.map((taskItem) => (taskItem.id === mappedTask.id ? mappedTask : taskItem))
+          : [...previous, mappedTask];
       });
 
       setIsTaskModalOpen(false);
@@ -462,15 +298,15 @@ const TasksComponent: React.FC<TasksComponentProps> = ({
       setTaskAddress("");
       setLocationSearch("");
       setLocationSuggestions([]);
-    } catch (err) {
-      console.error("Failed to save task", err);
+    } catch (error) {
+      console.error("Failed to save task", error);
       message.error("Failed to save task");
     }
   };
 
   const handleStatusChange = (id: string, status: string) => {
     const normalized = (status || "todo").toLowerCase().replace(/\s+/g, "_") as Status;
-    setTasks((prev) => prev.map((t) => (t.id === id ? { ...t, status: normalized } : t)));
+    setTasks((previous) => previous.map((task) => (task.id === id ? { ...task, status: normalized } : task)));
   };
 
   const openCommentModal = (task: Task) => {
@@ -481,37 +317,33 @@ const TasksComponent: React.FC<TasksComponentProps> = ({
 
   const saveComment = () => {
     if (!commentTask) return;
-    setTasks((prev) =>
-      prev.map((t) => (t.id === commentTask.id ? { ...t, description: commentText } : t))
+    setTasks((previous) =>
+      previous.map((task) => (task.id === commentTask.id ? { ...task, description: commentText } : task))
     );
     setIsCommentModalOpen(false);
     setCommentTask(null);
   };
 
-  const handleMenuClick =
-    (task: Task): MenuProps["onClick"] =>
+  const handleMenuClick = (task: Task): MenuProps["onClick"] =>
     async ({ key }) => {
       if (key === "edit") {
         openTaskModal(task);
         return;
       }
+
       if (key === "delete") {
         const previousTasks = tasks;
-        setTasks((prev) => prev.filter((t) => t.id !== task.id));
+        setTasks((current) => current.filter((item) => item.id !== task.id));
         try {
-          await deleteTask({
-            projectId: task.projectId,
-            taskId: task.taskId || task.id,
-          });
-        } catch (err) {
-          console.error("Failed to delete task", err);
+          await deleteTask({ projectId: task.projectId, taskId: task.taskId || task.id });
+        } catch (error) {
+          console.error("Failed to delete task", error);
           setTasks(previousTasks);
           message.error("Failed to delete task");
         }
       }
     };
 
-  /* Columns */
   const columns: ColumnsType<Task> = [
     {
       title: "Task",
@@ -527,13 +359,7 @@ const TasksComponent: React.FC<TasksComponentProps> = ({
       key: "assignedTo",
       width: 120,
       ellipsis: true,
-      render: (text?: string) => {
-        if (text && text.includes("__")) {
-          const [name] = text.split("__");
-          return name.replace(/([a-z])([A-Z])/g, "$1 $2");
-        }
-        return text;
-      },
+      render: (text?: string) => formatAssigneeDisplay(text) || text,
     },
     {
       title: "Due Date",
@@ -563,7 +389,7 @@ const TasksComponent: React.FC<TasksComponentProps> = ({
           size="small"
           style={{ width: "100%", minWidth: 120 }}
           onChange={(value) => handleStatusChange(record.id, value)}
-          options={statusOptions}
+          options={STATUS_OPTIONS}
         />
       ),
     },
@@ -613,318 +439,52 @@ const TasksComponent: React.FC<TasksComponentProps> = ({
     },
   ];
 
-  /* Render */
+  const locationDisplay =
+    taskLocation.lat && taskLocation.lng ? `${taskLocation.lat}, ${taskLocation.lng}` : "";
+
   return (
     <ConfigProvider theme={{ algorithm: theme.darkAlgorithm }}>
       <div className="tasks-component">
         <div className="tasks-card">
-          <Form form={assignForm} layout="vertical" className="assign-task-form">
-            <h3>Assign Task</h3>
+          <AssignTaskForm
+            form={assignForm}
+            taskNameOptions={taskNameOptions}
+            assigneeOptions={assigneeOptions}
+            budgetOptions={budgetOptions}
+            locationSearch={assignLocationSearch}
+            locationSuggestions={assignLocationSuggestions}
+            selectedAddress={assignTaskAddress}
+            onLocationSearchChange={handleAssignLocationSearchChange}
+            onLocationSuggestionSelect={handleAssignLocationSuggestionSelect}
+            onSubmit={handleAssignTask}
+          />
 
-            <div className="form-row">
-              <Form.Item
-                label="Task Name"
-                name="name"
-                rules={[{ required: true, message: "Task name required" }]}
-              >
-                <AutoComplete
-                  size="small"
-                  options={uniqueTaskNameOptions}
-                  listHeight={160}
-                  placeholder="Enter or select task"
-                  filterOption={(inputValue, option) =>
-                    (option?.value as string)
-                      ?.toUpperCase()
-                      .includes(inputValue.toUpperCase())
-                  }
-                />
-              </Form.Item>
+          <TaskTable columns={columns} data={tasks} />
 
-              <Form.Item label="Assigned To" name="assignedTo">
-                <Select size="small" options={assigneeOptions} />
-              </Form.Item>
-
-              <Form.Item label="Due Date" name="dueDate">
-                <DatePicker size="small" format="YYYY-MM-DD" />
-              </Form.Item>
-            </div>
-
-            <div className="form-row">
-              <Form.Item label="Priority" name="priority">
-                <Select size="small" options={["Low", "Medium", "High"].map((p) => ({ value: p, label: p }))} />
-              </Form.Item>
-
-              <Form.Item label="Budget Element Id" name="budgetCode">
-                <Select
-                  size="small"
-                  options={budgetOptions}
-                  showSearch
-                  filterOption={(input, option) =>
-                    (option?.label as string).toLowerCase().includes(input.toLowerCase())
-                  }
-                  optionLabelProp="elementId"
-                  getPopupContainer={(trigger) => trigger.parentNode as HTMLElement}
-                  value={assignForm.getFieldValue("budgetCode")}
-                  onChange={(value) => assignForm.setFieldsValue({ budgetCode: value })}
-                  popupRender={(menu) => menu}
-                />
-              </Form.Item>
-
-              <Form.Item label="Address" name="address">
-                <div>
-                  <Input
-                    placeholder="Search address"
-                    value={assignLocationSearch}
-                    onChange={handleAssignLocationSearchChange}
-                    autoComplete="off"
-                  />
-                  {assignLocationSuggestions.length > 0 && (
-                    <div
-                      className="suggestions-list"
-                      style={{
-                        position: "absolute",
-                        zIndex: 10,
-                        background: "#222",
-                        border: "1px solid #444",
-                        borderRadius: 4,
-                        width: "100%",
-                      }}
-                    >
-                      {assignLocationSuggestions.map((s, idx) => (
-                        <div
-                          key={s.place_id}
-                          onClick={() => handleAssignLocationSuggestionSelect(s)}
-                          style={{
-                            padding: "6px 10px",
-                            cursor: "pointer",
-                            borderBottom:
-                              idx < assignLocationSuggestions.length - 1
-                                ? "1px solid #333"
-                                : "none",
-                            background: "inherit",
-                          }}
-                          onMouseEnter={(e) => {
-                            e.currentTarget.style.background = "#eee";
-                            (e.currentTarget.firstChild as HTMLElement).style.color = "#222";
-                          }}
-                          onMouseLeave={(e) => {
-                            e.currentTarget.style.background = "inherit";
-                            (e.currentTarget.firstChild as HTMLElement).style.color = "#fff";
-                          }}
-                        >
-                          <span
-                            style={{
-                              fontWeight: idx === 0 ? "bold" : "normal",
-                              color: "#fff",
-                            }}
-                          >
-                            {s.display_name}
-                          </span>
-                        </div>
-                      ))}
-                    </div>
-                  )}
-
-                  {assignTaskAddress && (
-                    <div style={{ marginTop: 4, fontSize: 12, color: "#888" }}>
-                      {assignTaskAddress}
-                    </div>
-                  )}
-                </div>
-              </Form.Item>
-            </div>
-
-            <div className="form-row actions">
-              <Button
-                type="primary"
-                size="small"
-                className="modal-submit-button"
-                onClick={handleAssignTask}
-                style={{ background: "#FA3356", borderColor: "#FA3356" }}
-              >
-                Save
-              </Button>
-            </div>
-          </Form>
-
-          <div
-            className="tasks-table-wrapper"
-            style={{ maxHeight: 400, overflow: "auto", position: "relative", paddingBottom: 0 }}
-          >
-            <Table<Task>
-              rowKey="id"
-              columns={columns}
-              dataSource={tasks}
-              pagination={false}
-              size="small"
-              tableLayout="fixed"
-              className="tasks-table custom-sticky-scrollbar"
-              scroll={{ x: "max-content", y: 340 }}
-              locale={{ emptyText: "No tasks yet!" }}
-              sticky={{ offsetHeader: 0, offsetScroll: 0 }}
-              style={{ fontSize: "11px" }}
-            />
-          </div>
-
-          <Modal
-            title={editingTask ? "Edit Task" : "Add Task"}
+          <TaskEditModal
             open={isTaskModalOpen}
+            isEditing={Boolean(editingTask)}
+            form={editForm}
+            taskNameOptions={taskNameOptions}
+            assigneeOptions={assigneeOptions}
+            budgetOptions={budgetOptions}
+            locationSearch={locationSearch}
+            locationSuggestions={locationSuggestions}
+            locationDisplay={locationDisplay}
+            selectedAddress={taskAddress}
+            onLocationSearchChange={handleLocationSearchChange}
+            onLocationSuggestionSelect={handleLocationSuggestionSelect}
             onOk={saveTask}
             onCancel={() => setIsTaskModalOpen(false)}
-            centered
-            okButtonProps={{ style: { background: "#FA3356", borderColor: "#FA3356" } }}
-            forceRender
-          >
-            <Form layout="vertical" form={editForm} preserve={false}>
-              <Form.Item
-                label="Task"
-                name="name"
-                rules={[{ required: true, message: "Task name required" }]}
-              >
-                <AutoComplete
-                  options={taskNameOptions}
-                  listHeight={160}
-                  placeholder="Enter or select task"
-                  filterOption={(inputValue, option) =>
-                    (option?.value as string)
-                      ?.toUpperCase()
-                      .includes(inputValue.toUpperCase())
-                  }
-                />
-              </Form.Item>
+          />
 
-              <Form.Item label="Assignee" name="assignedTo">
-                <Select size="small" options={assigneeOptions} />
-              </Form.Item>
-
-              <Form.Item label="Due Date" name="dueDate">
-                <Input type="date" />
-              </Form.Item>
-
-              <Form.Item label="Priority" name="priority">
-                <Input />
-              </Form.Item>
-
-              <Form.Item label="Budget Code" name="budgetItemId">
-                <div>
-                  <Select options={budgetOptions} />
-                  <Input />
-                </div>
-              </Form.Item>
-
-              <Form.Item label="Event ID" name="eventId">
-                <Input />
-              </Form.Item>
-
-              <Form.Item label="Location" name="location">
-                <div>
-                  <Input
-                    placeholder="{lat, lng}"
-                    value={
-                      taskLocation.lat && taskLocation.lng
-                        ? `${taskLocation.lat}, ${taskLocation.lng}`
-                        : ""
-                    }
-                    readOnly
-                  />
-                  <Input
-                    placeholder="Search address"
-                    value={locationSearch}
-                    onChange={handleLocationSearchChange}
-                  />
-                  {locationSuggestions.length > 0 && (
-                    <div className="suggestions-list">
-                      {locationSuggestions.map((s) => (
-                        <div
-                          key={s.place_id}
-                          onClick={() => handleLocationSuggestionSelect(s)}
-                        >
-                          {s.display_name}
-                        </div>
-                      ))}
-                    </div>
-                  )}
-                </div>
-              </Form.Item>
-
-              <Form.Item label="Address" name="address">
-                <div>
-                  <Input
-                    placeholder="Search address"
-                    value={locationSearch}
-                    onChange={handleLocationSearchChange}
-                    autoComplete="off"
-                  />
-                  {locationSuggestions.length > 0 && (
-                    <div
-                      className="suggestions-list"
-                      style={{
-                        position: "absolute",
-                        zIndex: 10,
-                        background: "#222",
-                        border: "1px solid #444",
-                        borderRadius: 4,
-                        width: "100%",
-                      }}
-                    >
-                      {locationSuggestions.map((s, idx) => (
-                        <div
-                          key={s.place_id}
-                          onClick={() => handleLocationSuggestionSelect(s)}
-                          style={{
-                            padding: "6px 10px",
-                            cursor: "pointer",
-                            borderBottom:
-                              idx < locationSuggestions.length - 1
-                                ? "1px solid #333"
-                                : "none",
-                            background: "inherit",
-                          }}
-                          onMouseEnter={(e) => {
-                            e.currentTarget.style.background = "#eee";
-                            (e.currentTarget.firstChild as HTMLElement).style.color = "#222";
-                          }}
-                          onMouseLeave={(e) => {
-                            e.currentTarget.style.background = "inherit";
-                            (e.currentTarget.firstChild as HTMLElement).style.color = "#fff";
-                          }}
-                        >
-                          <span
-                            style={{
-                              fontWeight: idx === 0 ? "bold" : "normal",
-                              color: "#fff",
-                            }}
-                          >
-                            {s.display_name}
-                          </span>
-                        </div>
-                      ))}
-                    </div>
-                  )}
-                  {taskAddress && (
-                    <div style={{ marginTop: 4, fontSize: 12, color: "#888" }}>
-                      {taskAddress}
-                    </div>
-                  )}
-                </div>
-              </Form.Item>
-            </Form>
-          </Modal>
-
-          <Modal
-            title="Edit Comment"
+          <CommentModal
             open={isCommentModalOpen}
-            onOk={saveComment}
+            value={commentText}
+            onChange={(event) => setCommentText(event.target.value)}
+            onSave={saveComment}
             onCancel={() => setIsCommentModalOpen(false)}
-            centered
-            okButtonProps={{ style: { background: "#FA3356", borderColor: "#FA3356" } }}
-          >
-            <Input.TextArea
-              value={commentText}
-              onChange={(e) => setCommentText(e.target.value)}
-              rows={4}
-            />
-          </Modal>
+          />
         </div>
       </div>
     </ConfigProvider>
@@ -932,14 +492,3 @@ const TasksComponent: React.FC<TasksComponentProps> = ({
 };
 
 export default TasksComponent;
-
-
-
-
-
-
-
-
-
-
-

--- a/frontend/src/dashboard/project/components/Tasks/TasksComponentMobile.tsx
+++ b/frontend/src/dashboard/project/components/Tasks/TasksComponentMobile.tsx
@@ -10,8 +10,8 @@ import QuickCreateTaskModal, {
 } from "@/dashboard/home/components/QuickCreateTaskModal";
 
 import styles from "./TasksComponentMobile.module.css";
-
-type Status = "todo" | "in_progress" | "done" | string;
+import type { Status } from "./types";
+import { formatAssigneeDisplay, parseDueDate, parseLocation } from "./utils";
 
 type RawTask = {
   taskId?: string;
@@ -65,80 +65,6 @@ function getViewportHeight(): number {
   return window.visualViewport?.height ?? window.innerHeight;
 }
 
-function parseDueDate(value?: unknown): Date | null {
-  if (value == null || value === "") return null;
-
-  if (value instanceof Date) {
-    const copy = new Date(value.getTime());
-    return Number.isNaN(copy.getTime()) ? null : copy;
-  }
-
-  if (typeof value === "number") {
-    const byNumber = new Date(value);
-    return Number.isNaN(byNumber.getTime()) ? null : byNumber;
-  }
-
-  if (typeof value === "string") {
-    const trimmed = value.trim();
-    if (!trimmed) return null;
-
-    const direct = new Date(trimmed);
-    if (!Number.isNaN(direct.getTime())) {
-      return direct;
-    }
-
-    if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
-      const iso = new Date(`${trimmed}T00:00:00`);
-      return Number.isNaN(iso.getTime()) ? null : iso;
-    }
-  }
-
-  return null;
-}
-
-function parseLocation(value: unknown): { lat: number; lng: number } | null {
-  if (!value) return null;
-  if (Array.isArray(value) && value.length >= 2) {
-    const [latRaw, lngRaw] = value;
-    const lat = Number(latRaw);
-    const lng = Number(lngRaw);
-    if (!Number.isNaN(lat) && !Number.isNaN(lng)) {
-      return { lat, lng };
-    }
-  }
-
-  if (typeof value === "object") {
-    const latCandidate = (value as Record<string, unknown>).lat ??
-      (value as Record<string, unknown>).latitude ??
-      (value as Record<string, unknown>).y;
-    const lngCandidate = (value as Record<string, unknown>).lng ??
-      (value as Record<string, unknown>).lon ??
-      (value as Record<string, unknown>).longitude ??
-      (value as Record<string, unknown>).x;
-    const lat = Number(latCandidate);
-    const lng = Number(lngCandidate);
-    if (!Number.isNaN(lat) && !Number.isNaN(lng)) {
-      return { lat, lng };
-    }
-  }
-
-  if (typeof value === "string") {
-    try {
-      const parsed = JSON.parse(value);
-      return parseLocation(parsed);
-    } catch {
-      const [latPart, lngPart] = value.split(/[,\s]+/);
-      const lat = Number(latPart);
-      const lng = Number(lngPart);
-      if (!Number.isNaN(lat) && !Number.isNaN(lng)) {
-        return { lat, lng };
-      }
-    }
-  }
-
-  return null;
-}
-
 function normalizeTask(raw: RawTask): QuickTask | null {
   const id = raw.taskId || raw.id;
   const title = (raw.title || raw.name || "").toString().trim();
@@ -166,20 +92,6 @@ function normalizeTask(raw: RawTask): QuickTask | null {
 function formatDueLabel(task: QuickTask): string {
   if (!task.dueDate) return "No due date";
   return dueFormatter.format(task.dueDate);
-}
-
-function formatAssigneeDisplay(value?: string): string | undefined {
-  if (!value) return undefined;
-
-  const trimmed = value.trim();
-  if (!trimmed) return undefined;
-
-  const doubleUnderscoreIndex = trimmed.indexOf("__");
-  const base =
-    doubleUnderscoreIndex >= 0 ? trimmed.slice(0, doubleUnderscoreIndex) : trimmed;
-
-  const formatted = base.replace(/([a-z])([A-Z])/g, "$1 $2").trim();
-  return formatted || undefined;
 }
 
 function computeStats(tasks: QuickTask[]) {

--- a/frontend/src/dashboard/project/components/Tasks/components/AssignTaskForm.tsx
+++ b/frontend/src/dashboard/project/components/Tasks/components/AssignTaskForm.tsx
@@ -1,0 +1,115 @@
+import React from "react";
+import { AutoComplete, Button, DatePicker, Form, Select } from "antd";
+import type { FormInstance } from "antd/es/form";
+
+import type { NominatimSuggestion } from "../types";
+import LocationSearchInput from "./LocationSearchInput";
+
+const priorityOptions = ["Low", "Medium", "High"].map((priority) => ({
+  value: priority,
+  label: priority,
+}));
+
+type AssignTaskFormProps = {
+  form: FormInstance;
+  taskNameOptions: { label: string; value: string }[];
+  assigneeOptions: { value: string; label: string }[];
+  budgetOptions: { value: string; label: string; elementId: string }[];
+  locationSearch: string;
+  locationSuggestions: NominatimSuggestion[];
+  selectedAddress: string;
+  onLocationSearchChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  onLocationSuggestionSelect: (suggestion: NominatimSuggestion) => void;
+  onSubmit: () => void;
+};
+
+const AssignTaskForm: React.FC<AssignTaskFormProps> = ({
+  form,
+  taskNameOptions,
+  assigneeOptions,
+  budgetOptions,
+  locationSearch,
+  locationSuggestions,
+  selectedAddress,
+  onLocationSearchChange,
+  onLocationSuggestionSelect,
+  onSubmit,
+}) => (
+  <Form form={form} layout="vertical" className="assign-task-form">
+    <h3>Assign Task</h3>
+
+    <div className="form-row">
+      <Form.Item
+        label="Task Name"
+        name="name"
+        rules={[{ required: true, message: "Task name required" }]}
+      >
+        <AutoComplete
+          size="small"
+          options={taskNameOptions}
+          listHeight={160}
+          placeholder="Enter or select task"
+          filterOption={(inputValue, option) =>
+            (option?.value as string)?.toUpperCase().includes(inputValue.toUpperCase())
+          }
+        />
+      </Form.Item>
+
+      <Form.Item label="Assigned To" name="assignedTo">
+        <Select size="small" options={assigneeOptions} />
+      </Form.Item>
+
+      <Form.Item label="Due Date" name="dueDate">
+        <DatePicker size="small" format="YYYY-MM-DD" />
+      </Form.Item>
+    </div>
+
+    <Form.Item name="location" hidden>
+      <input type="hidden" />
+    </Form.Item>
+
+    <div className="form-row">
+      <Form.Item label="Priority" name="priority">
+        <Select size="small" options={priorityOptions} />
+      </Form.Item>
+
+      <Form.Item label="Budget Element Id" name="budgetCode">
+        <Select
+          size="small"
+          options={budgetOptions}
+          showSearch
+          optionLabelProp="elementId"
+          filterOption={(input, option) =>
+            (option?.label as string).toLowerCase().includes(input.toLowerCase())
+          }
+          getPopupContainer={(trigger) => trigger.parentNode as HTMLElement}
+          popupRender={(menu) => menu}
+        />
+      </Form.Item>
+
+      <Form.Item label="Address" name="address">
+        <LocationSearchInput
+          value={locationSearch}
+          suggestions={locationSuggestions}
+          selectedAddress={selectedAddress}
+          onChange={onLocationSearchChange}
+          onSelect={onLocationSuggestionSelect}
+        />
+      </Form.Item>
+    </div>
+
+    <div className="form-row actions">
+      <Button
+        type="primary"
+        size="small"
+        className="modal-submit-button"
+        onClick={onSubmit}
+        style={{ background: "#FA3356", borderColor: "#FA3356" }}
+      >
+        Save
+      </Button>
+    </div>
+  </Form>
+);
+
+export default AssignTaskForm;

--- a/frontend/src/dashboard/project/components/Tasks/components/CommentModal.tsx
+++ b/frontend/src/dashboard/project/components/Tasks/components/CommentModal.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { Input, Modal } from "antd";
+
+interface CommentModalProps {
+  open: boolean;
+  value: string;
+  onChange: (event: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  onSave: () => void;
+  onCancel: () => void;
+}
+
+const CommentModal: React.FC<CommentModalProps> = ({ open, value, onChange, onSave, onCancel }) => (
+  <Modal
+    title="Edit Comment"
+    open={open}
+    onOk={onSave}
+    onCancel={onCancel}
+    centered
+    okButtonProps={{ style: { background: "#FA3356", borderColor: "#FA3356" } }}
+  >
+    <Input.TextArea value={value} onChange={onChange} rows={4} />
+  </Modal>
+);
+
+export default CommentModal;

--- a/frontend/src/dashboard/project/components/Tasks/components/LocationSearchInput.tsx
+++ b/frontend/src/dashboard/project/components/Tasks/components/LocationSearchInput.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { Input } from "antd";
+
+import type { NominatimSuggestion } from "../types";
+import LocationSuggestions from "./LocationSuggestions";
+
+type LocationSearchInputProps = {
+  value: string;
+  suggestions: NominatimSuggestion[];
+  selectedAddress?: string;
+  placeholder?: string;
+  autoComplete?: string;
+  onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  onSelect: (suggestion: NominatimSuggestion) => void;
+};
+
+const LocationSearchInput: React.FC<LocationSearchInputProps> = ({
+  value,
+  suggestions,
+  selectedAddress,
+  placeholder = "Search address",
+  autoComplete = "off",
+  onChange,
+  onSelect,
+}) => (
+  <div>
+    <Input
+      placeholder={placeholder}
+      value={value}
+      onChange={onChange}
+      autoComplete={autoComplete}
+    />
+    <LocationSuggestions suggestions={suggestions} onSelect={onSelect} />
+    {selectedAddress && (
+      <div style={{ marginTop: 4, fontSize: 12, color: "#888" }}>{selectedAddress}</div>
+    )}
+  </div>
+);
+
+export default LocationSearchInput;

--- a/frontend/src/dashboard/project/components/Tasks/components/LocationSuggestions.tsx
+++ b/frontend/src/dashboard/project/components/Tasks/components/LocationSuggestions.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+
+import type { NominatimSuggestion } from "../types";
+
+type LocationSuggestionsProps = {
+  suggestions: NominatimSuggestion[];
+  onSelect: (suggestion: NominatimSuggestion) => void;
+};
+
+const baseContainerStyle: React.CSSProperties = {
+  position: "absolute",
+  zIndex: 10,
+  background: "#222",
+  border: "1px solid #444",
+  borderRadius: 4,
+  width: "100%",
+};
+
+const suggestionStyle: React.CSSProperties = {
+  padding: "6px 10px",
+  cursor: "pointer",
+  background: "inherit",
+};
+
+const highlightStyle: React.CSSProperties = {
+  fontWeight: "bold",
+  color: "#fff",
+};
+
+const LocationSuggestions: React.FC<LocationSuggestionsProps> = ({ suggestions, onSelect }) => {
+  if (suggestions.length === 0) return null;
+
+  return (
+    <div className="suggestions-list" style={baseContainerStyle}>
+      {suggestions.map((suggestion, index) => (
+        <div
+          key={suggestion.place_id}
+          onClick={() => onSelect(suggestion)}
+          style={{
+            ...suggestionStyle,
+            borderBottom: index < suggestions.length - 1 ? "1px solid #333" : "none",
+          }}
+          onMouseEnter={(event) => {
+            event.currentTarget.style.background = "#eee";
+            (event.currentTarget.firstChild as HTMLElement).style.color = "#222";
+          }}
+          onMouseLeave={(event) => {
+            event.currentTarget.style.background = "inherit";
+            (event.currentTarget.firstChild as HTMLElement).style.color = "#fff";
+          }}
+        >
+          <span style={highlightStyle}>{suggestion.display_name}</span>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default LocationSuggestions;

--- a/frontend/src/dashboard/project/components/Tasks/components/TaskEditModal.tsx
+++ b/frontend/src/dashboard/project/components/Tasks/components/TaskEditModal.tsx
@@ -1,0 +1,103 @@
+import React from "react";
+import { AutoComplete, Form, Input, Modal, Select } from "antd";
+import type { FormInstance } from "antd/es/form";
+
+import type { NominatimSuggestion } from "../types";
+import LocationSearchInput from "./LocationSearchInput";
+
+type TaskEditModalProps = {
+  open: boolean;
+  isEditing: boolean;
+  form: FormInstance;
+  taskNameOptions: { label: string; value: string }[];
+  assigneeOptions: { value: string; label: string }[];
+  budgetOptions: { value: string; label: string; elementId: string }[];
+  locationSearch: string;
+  locationSuggestions: NominatimSuggestion[];
+  locationDisplay: string;
+  selectedAddress: string;
+  onLocationSearchChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  onLocationSuggestionSelect: (suggestion: NominatimSuggestion) => void;
+  onOk: () => void;
+  onCancel: () => void;
+};
+
+const TaskEditModal: React.FC<TaskEditModalProps> = ({
+  open,
+  isEditing,
+  form,
+  taskNameOptions,
+  assigneeOptions,
+  budgetOptions,
+  locationSearch,
+  locationSuggestions,
+  locationDisplay,
+  selectedAddress,
+  onLocationSearchChange,
+  onLocationSuggestionSelect,
+  onOk,
+  onCancel,
+}) => (
+  <Modal
+    title={isEditing ? "Edit Task" : "Add Task"}
+    open={open}
+    onOk={onOk}
+    onCancel={onCancel}
+    centered
+    okButtonProps={{ style: { background: "#FA3356", borderColor: "#FA3356" } }}
+    forceRender
+  >
+    <Form layout="vertical" form={form} preserve={false}>
+      <Form.Item
+        label="Task"
+        name="name"
+        rules={[{ required: true, message: "Task name required" }]}
+      >
+        <AutoComplete
+          options={taskNameOptions}
+          listHeight={160}
+          placeholder="Enter or select task"
+          filterOption={(inputValue, option) =>
+            (option?.value as string)?.toUpperCase().includes(inputValue.toUpperCase())
+          }
+        />
+      </Form.Item>
+
+      <Form.Item label="Assignee" name="assignedTo">
+        <Select size="small" options={assigneeOptions} />
+      </Form.Item>
+
+      <Form.Item label="Due Date" name="dueDate">
+        <Input type="date" />
+      </Form.Item>
+
+      <Form.Item label="Priority" name="priority">
+        <Input />
+      </Form.Item>
+
+      <Form.Item label="Budget Code" name="budgetItemId">
+        <Select options={budgetOptions} />
+      </Form.Item>
+
+      <Form.Item label="Event ID" name="eventId">
+        <Input />
+      </Form.Item>
+
+      <Form.Item label="Location" name="location">
+        <Input placeholder="{lat, lng}" value={locationDisplay} readOnly />
+      </Form.Item>
+
+      <Form.Item label="Address" name="address">
+        <LocationSearchInput
+          value={locationSearch}
+          suggestions={locationSuggestions}
+          selectedAddress={selectedAddress}
+          onChange={onLocationSearchChange}
+          onSelect={onLocationSuggestionSelect}
+        />
+      </Form.Item>
+    </Form>
+  </Modal>
+);
+
+export default TaskEditModal;

--- a/frontend/src/dashboard/project/components/Tasks/components/TaskTable.tsx
+++ b/frontend/src/dashboard/project/components/Tasks/components/TaskTable.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { Table } from "antd";
+import type { ColumnsType } from "antd/es/table";
+
+import type { Task } from "../types";
+
+type TaskTableProps = {
+  columns: ColumnsType<Task>;
+  data: Task[];
+};
+
+const TaskTable: React.FC<TaskTableProps> = ({ columns, data }) => (
+  <div
+    className="tasks-table-wrapper"
+    style={{ maxHeight: 400, overflow: "auto", position: "relative", paddingBottom: 0 }}
+  >
+    <Table<Task>
+      rowKey="id"
+      columns={columns}
+      dataSource={data}
+      pagination={false}
+      size="small"
+      tableLayout="fixed"
+      className="tasks-table custom-sticky-scrollbar"
+      scroll={{ x: "max-content", y: 340 }}
+      locale={{ emptyText: "No tasks yet!" }}
+      sticky={{ offsetHeader: 0, offsetScroll: 0 }}
+      style={{ fontSize: "11px" }}
+    />
+  </div>
+);
+
+export default TaskTable;

--- a/frontend/src/dashboard/project/components/Tasks/types.ts
+++ b/frontend/src/dashboard/project/components/Tasks/types.ts
@@ -1,0 +1,58 @@
+export type Status = "todo" | "in_progress" | "done" | string;
+
+export interface TeamMember {
+  userId: string;
+  firstName?: string;
+  lastName?: string;
+  displayName?: string;
+  username?: string;
+  email?: string;
+}
+
+export interface TaskLocation {
+  lat: number | string;
+  lng: number | string;
+}
+
+export interface ApiTask {
+  taskId?: string;
+  id?: string;
+  projectId: string;
+  title?: string;
+  name?: string;
+  description?: string;
+  comments?: string;
+  budgetItemId?: string | null;
+  status?: Status;
+  assigneeId?: string;
+  assignedTo?: string;
+  dueDate?: string;
+  priority?: string;
+  eventId?: string;
+  location?: TaskLocation;
+  address?: string;
+}
+
+export interface Task {
+  id: string;
+  taskId?: string;
+  projectId: string;
+  name: string;
+  assigneeId?: string;
+  assignedTo?: string;
+  dueDate?: string;
+  priority?: string;
+  budgetItemId?: string;
+  eventId?: string;
+  description?: string;
+  status: Status;
+  location?: TaskLocation;
+  address?: string;
+}
+
+export interface NominatimSuggestion {
+  place_id: string | number;
+  display_name: string;
+  lat: string;
+  lon: string;
+}

--- a/frontend/src/dashboard/project/components/Tasks/utils.ts
+++ b/frontend/src/dashboard/project/components/Tasks/utils.ts
@@ -1,0 +1,185 @@
+import type { ApiTask, NominatimSuggestion, Status, Task, TeamMember } from "./types";
+
+export const STATUS_OPTIONS: { value: Status; label: string }[] = [
+  { value: "todo", label: "To Do" },
+  { value: "in_progress", label: "In Progress" },
+  { value: "done", label: "Done" },
+];
+
+export function getDisplayName(member: Partial<TeamMember> = {}): string {
+  const first = member.firstName || "";
+  const last = member.lastName || "";
+  const name = `${first} ${last}`.trim();
+  return name || member.displayName || member.username || member.userId || "";
+}
+
+export function buildAssigneeOptions(teamProfiles: TeamMember[]): { value: string; label: string }[] {
+  if (!Array.isArray(teamProfiles) || teamProfiles.length === 0) {
+    return [];
+  }
+
+  return teamProfiles.map((profile) => ({
+    value: `${profile.firstName || ""}${profile.lastName || ""}__${profile.userId}`,
+    label: getDisplayName(profile) || profile.userId,
+  }));
+}
+
+export function buildBudgetOptions(
+  budgetItems: Record<string, unknown>[]
+): { value: string; label: string; elementId: string }[] {
+  return budgetItems.map((item) => {
+    const description = (item.descriptionShort || item.description || "")
+      .toString()
+      .slice(0, 50);
+
+    return {
+      value: (item.budgetItemId as string) || "",
+      label: `${(item.elementId as string) || ""} (${description})`,
+      elementId: (item.elementId as string) || "",
+    };
+  });
+}
+
+export function buildTaskNameOptions(
+  budgetItems: Record<string, unknown>[]
+): { label: string; value: string; elementId: string }[] {
+  const options = budgetItems.map((item) => {
+    const labelBase = ((item.descriptionShort || item.description || "") as string)
+      .split(" ")
+      .slice(0, 6)
+      .join(" ");
+
+    return {
+      label: labelBase,
+      value: labelBase,
+      elementId: (item.elementId as string) || "",
+    };
+  });
+
+  const dedupedMap = options.reduce<Map<string, (typeof options)[number]>>((map, option) => {
+    if (!map.has(option.value)) {
+      map.set(option.value, option);
+    }
+    return map;
+  }, new Map());
+
+  return Array.from(dedupedMap.values());
+}
+
+export function sortByProximity(
+  suggestions: NominatimSuggestion[],
+  userLocation: { lat: number; lng: number } | null
+): NominatimSuggestion[] {
+  if (!userLocation) return suggestions;
+
+  return [...suggestions].sort((a, b) => {
+    const distA = Math.hypot(userLocation.lat - parseFloat(a.lat), userLocation.lng - parseFloat(a.lon));
+    const distB = Math.hypot(userLocation.lat - parseFloat(b.lat), userLocation.lng - parseFloat(b.lon));
+    return distA - distB;
+  });
+}
+
+export function mapApiTaskToTask(task: ApiTask, fallbackId?: string): Task {
+  const id = task.taskId || task.id || fallbackId || "";
+
+  return {
+    id,
+    taskId: task.taskId,
+    projectId: task.projectId,
+    name: (task.title || task.name || "").toUpperCase(),
+    assigneeId: task.assigneeId || task.assignedTo,
+    assignedTo: task.assigneeId || task.assignedTo,
+    dueDate: task.dueDate,
+    priority: task.priority,
+    budgetItemId: task.budgetItemId || undefined,
+    eventId: task.eventId,
+    description: task.description || task.comments,
+    status: (task.status as Status) || "todo",
+    location: task.location,
+    address: task.address,
+  };
+}
+
+export function formatAssigneeDisplay(value?: string): string | undefined {
+  if (!value) return undefined;
+
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+
+  const doubleUnderscoreIndex = trimmed.indexOf("__");
+  const base = doubleUnderscoreIndex >= 0 ? trimmed.slice(0, doubleUnderscoreIndex) : trimmed;
+  const formatted = base.replace(/([a-z])([A-Z])/g, "$1 $2").trim();
+
+  return formatted || undefined;
+}
+
+export function parseDueDate(value: unknown): Date | null {
+  if (value == null || value === "") return null;
+
+  if (value instanceof Date) {
+    const copy = new Date(value.getTime());
+    return Number.isNaN(copy.getTime()) ? null : copy;
+  }
+
+  if (typeof value === "number") {
+    const byNumber = new Date(value);
+    return Number.isNaN(byNumber.getTime()) ? null : byNumber;
+  }
+
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+
+    const direct = new Date(trimmed);
+    if (!Number.isNaN(direct.getTime())) {
+      return direct;
+    }
+
+    if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
+      const iso = new Date(`${trimmed}T00:00:00`);
+      return Number.isNaN(iso.getTime()) ? null : iso;
+    }
+  }
+
+  return null;
+}
+
+export function parseLocation(value: unknown): { lat: number; lng: number } | null {
+  if (!value) return null;
+
+  if (Array.isArray(value) && value.length >= 2) {
+    const [latRaw, lngRaw] = value;
+    const lat = Number(latRaw);
+    const lng = Number(lngRaw);
+    if (!Number.isNaN(lat) && !Number.isNaN(lng)) {
+      return { lat, lng };
+    }
+  }
+
+  if (typeof value === "object") {
+    const candidate = value as Record<string, unknown>;
+    const latCandidate = candidate.lat ?? candidate.latitude ?? candidate.y;
+    const lngCandidate = candidate.lng ?? candidate.lon ?? candidate.longitude ?? candidate.x;
+    const lat = Number(latCandidate);
+    const lng = Number(lngCandidate);
+    if (!Number.isNaN(lat) && !Number.isNaN(lng)) {
+      return { lat, lng };
+    }
+  }
+
+  if (typeof value === "string") {
+    try {
+      const parsed = JSON.parse(value);
+      return parseLocation(parsed);
+    } catch {
+      const [latPart, lngPart] = value.split(/[,\s]+/);
+      const lat = Number(latPart);
+      const lng = Number(lngPart);
+      if (!Number.isNaN(lat) && !Number.isNaN(lng)) {
+        return { lat, lng };
+      }
+    }
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- modularized the dashboard tasks UI into dedicated subcomponents for the form, modal, table, and comment editing
- introduced shared task types and helpers to normalize API data, build option lists, and reuse formatting logic across views
- updated the mobile tasks view to consume the shared utilities instead of maintaining duplicate parsing code

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc4df41e2483249b547e81206b0b48