### PR TITLE
Improve budget parsing robustness

### DIFF
--- a/frontend/src/dashboard/project/features/budget/components/BudgetStateManager.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetStateManager.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useCallback, useMemo } from "react";
 import { useBudget } from "@/dashboard/project/features/budget/context/BudgetContext";
 import { updateBudgetItem } from "@/shared/utils/api";
+import { parseBudget } from "@/shared/utils/budgetUtils";
 import type { BudgetItem, Project } from "@/shared/utils/api";
 
 type BudgetSnapshot = {
@@ -143,10 +144,11 @@ const BudgetStateManager: React.FC<BudgetStateManagerProps> = ({
     let actual = 0;
     items.forEach((it) => {
       const qty = parseFloat(String(it.quantity)) || 0;
-      const budget = parseFloat(String(it.itemBudgetedCost)) || 0;
+      const budget = parseBudget(it.itemBudgetedCost as string | number | undefined);
       const markup = parseFloat(String(it.itemMarkUp)) || 0;
-      const actualUnit =
-        parseFloat(String(it.itemReconciledCost ?? it.itemActualCost)) || 0;
+      const actualUnit = parseBudget(
+        (it.itemReconciledCost ?? it.itemActualCost) as string | number | undefined
+      );
 
       const hasFinal =
         it.itemFinalCost !== undefined &&
@@ -157,16 +159,14 @@ const BudgetStateManager: React.FC<BudgetStateManagerProps> = ({
       actual += qty * actualUnit;
 
       if (hasFinal) {
-        final += parseFloat(String(it.itemFinalCost)) || 0;
+        final += parseBudget(it.itemFinalCost as string | number | undefined);
       } else {
-        const baseForFinal =
-          parseFloat(
-            String(
-              it.itemReconciledCost ??
-                it.itemActualCost ??
-                it.itemBudgetedCost
-            )
-          ) || 0;
+        const baseForFinal = parseBudget(
+          (it.itemReconciledCost ?? it.itemActualCost ?? it.itemBudgetedCost) as
+            | string
+            | number
+            | undefined
+        );
         final += qty * baseForFinal * (1 + markup);
       }
     });

--- a/frontend/src/shared/utils/budgetUtils.test.ts
+++ b/frontend/src/shared/utils/budgetUtils.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { parseBudget } from "./budgetUtils";
+
+describe("parseBudget", () => {
+  it("returns numeric input unchanged", () => {
+    expect(parseBudget(1250)).toBe(1250);
+  });
+
+  it("parses formatted currency strings", () => {
+    expect(parseBudget("$1,234.50")).toBeCloseTo(1234.5);
+  });
+
+  it("parses currency codes and accounting negatives", () => {
+    expect(parseBudget("USD ($2,500.75)")).toBeCloseTo(-2500.75);
+  });
+
+  it("handles magnitude suffixes", () => {
+    expect(parseBudget("1.5k")).toBeCloseTo(1500);
+    expect(parseBudget("2m")).toBeCloseTo(2_000_000);
+  });
+
+  it("strips non-numeric characters", () => {
+    expect(parseBudget("€ 3 200")).toBeCloseTo(3200);
+    expect(parseBudget("approx. $987")).toBeCloseTo(987);
+  });
+});

--- a/frontend/src/shared/utils/budgetUtils.ts
+++ b/frontend/src/shared/utils/budgetUtils.ts
@@ -1,25 +1,50 @@
 export function parseBudget(input: string | number | undefined | null): number {
   if (input === undefined || input === null) return 0;
-  if (typeof input === 'number') return input;
-  
-  let str = String(input).trim().toLowerCase();
-  if (!str) return 0;
-  
-  // remove dollar signs and commas
-  str = str.replace(/\$/g, '').replace(/,/g, '');
-  
-  let multiplier = 1;
-  if (str.endsWith('k')) {
-    multiplier = 1000;
-    str = str.slice(0, -1);
-  } else if (str.endsWith('m')) {
-    multiplier = 1000000;
-    str = str.slice(0, -1);
+  if (typeof input === "number") {
+    return Number.isFinite(input) ? input : 0;
   }
-  
-  const value = parseFloat(str);
-  if (isNaN(value)) return 0;
-  return value * multiplier;
+
+  let str = String(input).trim();
+  if (!str) return 0;
+
+  // Normalize common dash variants that may precede negative numbers
+  str = str.replace(/[\u2012-\u2015]/g, "-");
+
+  // Replace common currency symbols or unsupported characters with spaces so
+  // they do not interfere with pattern matching below.
+  str = str.replace(/[^0-9a-zA-Z+\-.,()\s]/g, " ");
+
+  const hasParens = str.includes("(") && str.includes(")");
+  if (hasParens) {
+    str = str.replace(/[()]/g, " ");
+  }
+
+  const match = str.match(/[-+]?(?:\d[\d\s.,]*|\.\d+)(?:[kKmM])?/);
+  if (!match) return 0;
+
+  let numeric = match[0].replace(/\s+/g, "");
+  if (!numeric) return 0;
+
+  let multiplier = 1;
+  const suffix = numeric.slice(-1).toLowerCase();
+  if (suffix === "k" || suffix === "m") {
+    multiplier = suffix === "k" ? 1_000 : 1_000_000;
+    numeric = numeric.slice(0, -1);
+  }
+
+  let sign = hasParens ? -1 : 1;
+  if (numeric.startsWith("+") || numeric.startsWith("-")) {
+    sign *= numeric.startsWith("-") ? -1 : 1;
+    numeric = numeric.slice(1);
+  }
+
+  numeric = numeric.replace(/,/g, "");
+  if (!numeric) return 0;
+
+  const value = Number(numeric);
+  if (!Number.isFinite(value)) return 0;
+
+  return sign * value * multiplier;
 }
 
 export function formatUSD(value: string | number): string {


### PR DESCRIPTION
## Summary
- harden the shared parseBudget helper to handle currency symbols, accounting parentheses, and magnitude suffixes when deriving numeric totals
- add targeted unit coverage for the new parsing scenarios to prevent regressions

## Testing
- npm test -- --run src/shared/utils/budgetUtils.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dc7955f6888324a881aef06e470581