### PR TITLE
Fix actual cost aggregation when costs include currency symbols

### DIFF
--- a/frontend/src/dashboard/project/features/budget/components/BudgetStateManager.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetStateManager.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useCallback, useMemo } from "react";
 import { useBudget } from "@/dashboard/project/features/budget/context/BudgetContext";
 import { updateBudgetItem } from "@/shared/utils/api";
+import { parseBudget } from "@/shared/utils/budgetUtils";
 import type { BudgetItem, Project } from "@/shared/utils/api";
 
 type BudgetSnapshot = {
@@ -137,16 +138,22 @@ const BudgetStateManager: React.FC<BudgetStateManagerProps> = ({
     setRedoStack([]);
   }, [budgetItems, budgetHeader]);
 
+  const toMoney = useCallback((value: unknown): number => {
+    if (typeof value === "number" || typeof value === "string") {
+      return parseBudget(value);
+    }
+    return 0;
+  }, []);
+
   const calculateHeaderTotals = useCallback((items: Record<string, unknown>[]) => {
     let budgeted = 0;
     let final = 0;
     let actual = 0;
     items.forEach((it) => {
       const qty = parseFloat(String(it.quantity)) || 0;
-      const budget = parseFloat(String(it.itemBudgetedCost)) || 0;
+      const budget = toMoney(it.itemBudgetedCost);
       const markup = parseFloat(String(it.itemMarkUp)) || 0;
-      const actualUnit =
-        parseFloat(String(it.itemReconciledCost ?? it.itemActualCost)) || 0;
+      const actualUnit = toMoney(it.itemReconciledCost ?? it.itemActualCost);
 
       const hasFinal =
         it.itemFinalCost !== undefined &&
@@ -157,22 +164,17 @@ const BudgetStateManager: React.FC<BudgetStateManagerProps> = ({
       actual += qty * actualUnit;
 
       if (hasFinal) {
-        final += parseFloat(String(it.itemFinalCost)) || 0;
+        final += toMoney(it.itemFinalCost);
       } else {
-        const baseForFinal =
-          parseFloat(
-            String(
-              it.itemReconciledCost ??
-                it.itemActualCost ??
-                it.itemBudgetedCost
-            )
-          ) || 0;
+        const baseForFinal = toMoney(
+          it.itemReconciledCost ?? it.itemActualCost ?? it.itemBudgetedCost
+        );
         final += qty * baseForFinal * (1 + markup);
       }
     });
     const effectiveMarkup = budgeted ? (final - budgeted) / budgeted : 0;
     return { budgeted, final, actual, effectiveMarkup };
-  }, []);
+  }, [toMoney]);
 
   const syncHeaderTotals = useCallback(
     async (items: Record<string, unknown>[]) => {

--- a/frontend/src/dashboard/project/features/budget/components/HeaderStats.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/HeaderStats.tsx
@@ -20,7 +20,7 @@ import BudgetDonut, {
 import { useSocket } from "@/app/contexts/useSocket";
 
 import { updateBudgetItem } from "@/shared/utils/api";
-import { formatUSD } from "@/shared/utils/budgetUtils";
+import { formatUSD, parseBudget } from "@/shared/utils/budgetUtils";
 import {
   CHART_COLORS,
   generateSequentialPalette,
@@ -52,7 +52,7 @@ export interface BudgetItem {
   invoiceGroup?: string;
   category?: string;
 
-  // numeric fields (string or number in data; we coerce with parseFloat)
+  // numeric fields (string or number in data; we coerce with parseBudget)
   itemBudgetedCost?: string | number;
   itemActualCost?: string | number;
   itemReconciledCost?: string | number;
@@ -127,11 +127,8 @@ type ChartState = {
    Helpers
    ========================= */
 
-const toNumber = (v: number | string | undefined | null): number => {
-  if (v === undefined || v === null) return 0;
-  const n = typeof v === "number" ? v : parseFloat(String(v));
-  return Number.isNaN(n) ? 0 : n;
-};
+const toNumber = (v: number | string | undefined | null): number =>
+  parseBudget(v);
 
 /* =========================
    Components
@@ -242,11 +239,7 @@ const BudgetHeader: React.FC<BudgetHeaderProps> = ({
   }, []);
 
   const reconciledTotal = useMemo(
-    () =>
-      budgetItems.reduce(
-        (sum, it) => sum + (parseFloat(String(it.itemReconciledCost ?? 0)) || 0),
-        0
-      ),
+    () => budgetItems.reduce((sum, it) => sum + toNumber(it.itemReconciledCost), 0),
     [budgetItems]
   );
 


### PR DESCRIPTION
## Summary
- normalize money values when deriving budget header totals so that currency-formatted inputs are counted
- parse formatted costs inside the budget header metrics to display accurate actual and reconciled totals

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc7da0d3888324b3ed7d32fd6a29c9