### PR TITLE
Improve budget data caching refresh

### DIFF
--- a/frontend/src/dashboard/project/features/budget/context/useBudget.test.ts
+++ b/frontend/src/dashboard/project/features/budget/context/useBudget.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+
+const apiMocks = vi.hoisted(() => ({
+  fetchBudgetHeader: vi.fn(),
+  fetchBudgetItems: vi.fn(),
+}));
+
+vi.mock("@/shared/utils/api", () => ({
+  fetchBudgetHeader: apiMocks.fetchBudgetHeader,
+  fetchBudgetItems: apiMocks.fetchBudgetItems,
+}));
+
+describe("useBudgetData", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    apiMocks.fetchBudgetHeader.mockReset();
+    apiMocks.fetchBudgetItems.mockReset();
+  });
+
+  it("updates cached project data when backend responses change", async () => {
+    const headerV1 = { budgetId: "b1", revision: 1, total: 100 };
+    const headerV2 = { budgetId: "b1", revision: 2, total: 250 };
+
+    apiMocks.fetchBudgetHeader.mockResolvedValueOnce(headerV1);
+    apiMocks.fetchBudgetItems.mockResolvedValue([]);
+
+    const { default: useBudgetData } = await import("./useBudget");
+
+    const firstRender = renderHook(() => useBudgetData("project-1"));
+
+    await waitFor(() => {
+      expect(firstRender.result.current.budgetHeader).toEqual(headerV1);
+      expect(firstRender.result.current.loading).toBe(false);
+    });
+
+    firstRender.unmount();
+
+    apiMocks.fetchBudgetHeader.mockResolvedValueOnce(headerV2);
+    apiMocks.fetchBudgetItems.mockResolvedValue([]);
+
+    const secondRender = renderHook(() => useBudgetData("project-1"));
+
+    // Hydrates from cache immediately
+    expect(secondRender.result.current.budgetHeader).toEqual(headerV1);
+
+    await waitFor(() => {
+      expect(secondRender.result.current.budgetHeader).toEqual(headerV2);
+      expect(secondRender.result.current.loading).toBe(false);
+    });
+
+    expect(apiMocks.fetchBudgetHeader).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/src/dashboard/project/features/budget/context/useBudget.ts
+++ b/frontend/src/dashboard/project/features/budget/context/useBudget.ts
@@ -36,13 +36,25 @@ interface BudgetData {
 
 // In-memory cache and in-flight trackers keyed by projectId
 const budgetCache = new Map<string, BudgetData>();
+const cacheTimestamps = new Map<string, number>();
 const inflight = new Map<string, Promise<BudgetData>>();
+
+const CACHE_TTL = 30_000; // 30 seconds
+
+function isCacheFresh(projectId: string): boolean {
+  const cachedAt = cacheTimestamps.get(projectId);
+  if (!cachedAt) return false;
+  return Date.now() - cachedAt < CACHE_TTL;
+}
 
 async function fetchData(projectId: string, force = false): Promise<BudgetData> {
   if (!projectId) return { header: null, items: [] };
 
-  if (!force && budgetCache.has(projectId)) {
-    return budgetCache.get(projectId)!;
+  const cached = budgetCache.get(projectId) || null;
+  const fresh = cached && !force && isCacheFresh(projectId);
+
+  if (fresh) {
+    return cached;
   }
 
   if (inflight.has(projectId)) {
@@ -63,6 +75,7 @@ async function fetchData(projectId: string, force = false): Promise<BudgetData> 
         }
         const result: BudgetData = { header, items };
         budgetCache.set(projectId, result);
+        cacheTimestamps.set(projectId, Date.now());
         return result;
       } catch (err: unknown) {
         const msg = String((err as { message?: string })?.message || "");
@@ -91,7 +104,8 @@ async function fetchData(projectId: string, force = false): Promise<BudgetData> 
  * immediately with cached data.
  */
 export async function prefetchBudgetData(projectId: string): Promise<void> {
-  if (!projectId || budgetCache.has(projectId)) return;
+  if (!projectId) return;
+  if (budgetCache.has(projectId) && isCacheFresh(projectId)) return;
   try {
     await fetchData(projectId);
   } catch (err) {
@@ -119,7 +133,11 @@ export default function useBudgetData(projectId: string | undefined) {
         return;
       }
 
-      setLoading(true);
+      const hasCached = budgetCache.has(projectId);
+      const cacheFresh = hasCached && isCacheFresh(projectId);
+      setLoading(!cacheFresh);
+
+      let shouldForceRefresh = false;
       try {
         const { header, items } = await fetchData(projectId);
         if (!ignore) {
@@ -130,16 +148,39 @@ export default function useBudgetData(projectId: string | undefined) {
             shallowEqualArrays(prev, items) ? prev : items,
           );
         }
+        shouldForceRefresh = hasCached && cacheFresh;
       } catch (err) {
         console.error("Error fetching budget data", err);
         if (!ignore) {
           setBudgetHeader(null);
           setBudgetItemsState([]);
+          setLoading(false);
         }
-      } finally {
-        if (!ignore) setLoading(false);
+        return;
+      }
+
+      if (shouldForceRefresh) {
+        try {
+          if (!ignore) setLoading(true);
+          const { header, items } = await fetchData(projectId, true);
+          if (!ignore) {
+            setBudgetHeader((prev) =>
+              shallowEqualObjects(prev, header) ? prev : header,
+            );
+            setBudgetItemsState((prev) =>
+              shallowEqualArrays(prev, items) ? prev : items,
+            );
+          }
+        } catch (err) {
+          console.error("Error refreshing budget data", err);
+        } finally {
+          if (!ignore) setLoading(false);
+        }
+      } else if (!ignore) {
+        setLoading(false);
       }
     };
+
     load();
     return () => {
       ignore = true;
@@ -177,6 +218,7 @@ export default function useBudgetData(projectId: string | undefined) {
         items: [] as BudgetItem[],
       };
       budgetCache.set(projectId, { header: cached.header, items });
+      cacheTimestamps.set(projectId, Date.now());
     },
     [projectId],
   );
@@ -195,6 +237,7 @@ export default function useBudgetData(projectId: string | undefined) {
           items: [] as BudgetItem[],
         };
         budgetCache.set(projectId, { header: next, items: cached.items });
+        cacheTimestamps.set(projectId, Date.now());
         return next;
       });
     },

--- a/frontend/src/dashboard/project/features/budget/context/useBudget.ts
+++ b/frontend/src/dashboard/project/features/budget/context/useBudget.ts
@@ -39,7 +39,7 @@ const budgetCache = new Map<string, BudgetData>();
 const cacheTimestamps = new Map<string, number>();
 const inflight = new Map<string, Promise<BudgetData>>();
 
-const CACHE_TTL = 30_000; // 30 seconds
+const CACHE_TTL = 10_000; // 10 seconds
 
 function isCacheFresh(projectId: string): boolean {
   const cachedAt = cacheTimestamps.get(projectId);
@@ -54,6 +54,11 @@ async function fetchData(projectId: string, force = false): Promise<BudgetData> 
   const fresh = cached && !force && isCacheFresh(projectId);
 
   if (fresh) {
+    if (!inflight.has(projectId)) {
+      void fetchData(projectId, true).catch((err) => {
+        console.error("Background budget refresh failed", err);
+      });
+    }
     return cached;
   }
 


### PR DESCRIPTION
## Summary
- add a TTL-backed cache invalidation helper for budget requests and record refresh timestamps
- trigger a forced refresh after hydrating cached budget data so header totals stay current
- cover the cached-refresh flow with a dedicated useBudgetData unit test

## Testing
- npm test -- useBudget

------
https://chatgpt.com/codex/tasks/task_e_68dc96a0ee4c8324bf054b31c1718d53