### PR TITLE
Fix quantity handling for budget totals

### DIFF
--- a/frontend/src/dashboard/project/features/budget/components/BudgetStateManager.test.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetStateManager.test.tsx
@@ -21,7 +21,7 @@ describe("BudgetStateManager header totals", () => {
     vi.clearAllMocks();
   });
 
-  test("syncHeaderTotals sums stored actual totals without quantity or reconciled influence", async () => {
+  test("syncHeaderTotals multiplies costs by quantity when calculating totals", async () => {
     type Header = {
       budgetItemId: string;
       revision: number;
@@ -76,14 +76,16 @@ describe("BudgetStateManager header totals", () => {
     const items = [
       {
         quantity: 5,
-        itemBudgetedCost: 20,
-        itemActualCost: 100,
-        itemReconciledCost: 999,
+        itemBudgetedCost: "20",
+        itemActualCost: "$18.50",
+        itemReconciledCost: "19",
+        itemMarkUp: "0.1",
       },
       {
         quantity: 3,
         itemBudgetedCost: 40,
         itemActualCost: 50,
+        itemFinalCost: "225",
       },
       {
         quantity: 2,
@@ -93,21 +95,28 @@ describe("BudgetStateManager header totals", () => {
     ];
 
     const totals = capturedState.calculateHeaderTotals(items);
-    expect(totals.actual).toBeCloseTo(150);
+    expect(totals.budgeted).toBeCloseTo(280);
+    expect(totals.actual).toBeCloseTo(242.5);
+    expect(totals.final).toBeCloseTo(479.5);
+    expect(totals.effectiveMarkup).toBeCloseTo(0.7125, 5);
 
     await act(async () => {
       await capturedState.syncHeaderTotals(items);
     });
 
-    expect(mockedUpdateBudgetItem).toHaveBeenCalledWith(
-      "proj-1",
-      "header-1",
-      expect.objectContaining({
-        headerActualTotalCost: 150,
-      })
-    );
+    expect(mockedUpdateBudgetItem).toHaveBeenCalledTimes(1);
+    const [projectId, headerId, payload] = mockedUpdateBudgetItem.mock.calls[0];
+    expect(projectId).toBe("proj-1");
+    expect(headerId).toBe("header-1");
+    expect(payload.headerBudgetedTotalCost).toBeCloseTo(280);
+    expect(payload.headerActualTotalCost).toBeCloseTo(242.5);
+    expect(payload.headerFinalTotalCost).toBeCloseTo(479.5);
+    expect(payload.headerEffectiveMarkup).toBeCloseTo(0.7125, 5);
 
-    expect(header.headerActualTotalCost).toBe(150);
+    expect(header.headerBudgetedTotalCost).toBeCloseTo(280);
+    expect(header.headerActualTotalCost).toBeCloseTo(242.5);
+    expect(header.headerFinalTotalCost).toBeCloseTo(479.5);
+    expect(header.headerEffectiveMarkup).toBeCloseTo(0.7125, 5);
     expect(setBudgetHeader).toHaveBeenCalled();
   });
 });

--- a/frontend/src/dashboard/project/features/budget/components/BudgetStateManager.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetStateManager.tsx
@@ -153,7 +153,7 @@ const BudgetStateManager: React.FC<BudgetStateManagerProps> = ({
       const qty = parseFloat(String(it.quantity)) || 0;
       const budget = toMoney(it.itemBudgetedCost);
       const markup = parseFloat(String(it.itemMarkUp)) || 0;
-      const actualTotal = parseFloat(String(it.itemActualCost)) || 0;
+      const actualCost = toMoney(it.itemActualCost);
 
       const hasFinal =
         it.itemFinalCost !== undefined &&
@@ -161,7 +161,7 @@ const BudgetStateManager: React.FC<BudgetStateManagerProps> = ({
         String(it.itemFinalCost).trim() !== "";
 
       budgeted += qty * budget;
-      actual += actualTotal;
+      actual += qty * actualCost;
 
       if (hasFinal) {
         final += toMoney(it.itemFinalCost);

--- a/frontend/src/dashboard/project/features/budget/components/HeaderStats.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/HeaderStats.tsx
@@ -51,6 +51,7 @@ export interface BudgetItem {
   areaGroup?: string;
   invoiceGroup?: string;
   category?: string;
+  quantity?: string | number;
 
   // numeric fields (string or number in data; we coerce with parseBudget)
   itemBudgetedCost?: string | number;
@@ -129,6 +130,12 @@ type ChartState = {
 
 const toNumber = (v: number | string | undefined | null): number =>
   parseBudget(v);
+
+const toQuantity = (value: unknown): number => {
+  if (value === undefined || value === null || value === "") return 0;
+  const parsed = Number.parseFloat(String(value));
+  return Number.isFinite(parsed) ? parsed : 0;
+};
 
 /* =========================
    Components
@@ -239,7 +246,11 @@ const BudgetHeader: React.FC<BudgetHeaderProps> = ({
   }, []);
 
   const reconciledTotal = useMemo(
-    () => budgetItems.reduce((sum, it) => sum + toNumber(it.itemReconciledCost), 0),
+    () =>
+      budgetItems.reduce(
+        (sum, it) => sum + toQuantity(it.quantity) * toNumber(it.itemReconciledCost),
+        0
+      ),
     [budgetItems]
   );
 
@@ -477,12 +488,13 @@ const BudgetHeader: React.FC<BudgetHeaderProps> = ({
       const rawKey = (item[groupBy] as string) || "Unspecified";
       const key = rawKey && rawKey.trim() !== "" ? rawKey : "Unspecified";
       let val: number;
+      const quantity = toQuantity(item.quantity);
 
       if (field === "markupAmount") {
         const finalCost = toNumber(item.itemFinalCost);
         const budgeted = toNumber(item.itemBudgetedCost);
         const actual = toNumber(item.itemActualCost);
-        const reconciled = toNumber(item.itemReconciledCost);
+        const reconciled = toNumber(item.itemReconciledCost) * quantity;
         const base =
           markupBasis === "Budgeted"
             ? budgeted
@@ -493,7 +505,8 @@ const BudgetHeader: React.FC<BudgetHeaderProps> = ({
       } else if (field === "itemMarkUp") {
         val = toNumber(item[field] as number | string | undefined | null) * 100;
       } else {
-        val = toNumber(item[field] as number | string | undefined | null);
+        const numericValue = toNumber(item[field] as number | string | undefined | null);
+        val = field === "itemReconciledCost" ? numericValue * quantity : numericValue;
       }
 
       const safeValue = Number.isNaN(val) ? 0 : val;


### PR DESCRIPTION
## Summary
- multiply actual totals by quantity when computing budget header metrics
- align reconciled aggregations in header stats with quantity-adjusted totals
- extend BudgetStateManager tests to cover multi-quantity items and updated percentages

## Testing
- npm test -- BudgetStateManager

------
https://chatgpt.com/codex/tasks/task_e_68dca60925708324be9275676cf5674c