### PR TITLE
Adjust mobile project tasks card spacing

### DIFF
--- a/frontend/src/dashboard/home/components/MobileTasksOverviewCard.module.css
+++ b/frontend/src/dashboard/home/components/MobileTasksOverviewCard.module.css
@@ -1,11 +1,11 @@
 .card {
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
-  height: 100%;
+  justify-content: flex-start;
+  height: auto;
   min-height: 0;
-  padding: 13px 15px;
-  gap: 11px;
+  padding: 12px 14px;
+  gap: 10px;
   color: rgba(255, 255, 255, 0.92);
   background:
     radial-gradient(120% 120% at 100% 0%, color-mix(in srgb, var(--brand, #fa3356) 12%, transparent) 0%, transparent 60%),
@@ -52,7 +52,7 @@
 
 .statRow {
   display: flex;
-  gap: 7px;
+  gap: 6px;
 }
 
 .stat {
@@ -60,21 +60,21 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
-  gap: 3px;
-  padding: 9px 11px;
-  border-radius: 16px;
+  gap: 2px;
+  padding: 8px 10px;
+  border-radius: 15px;
   background: rgba(255, 255, 255, 0.05);
   border: 1px solid rgba(255, 255, 255, 0.08);
-  min-height: 58px;
+  min-height: 54px;
 }
 
 .statValue {
-  font-size: 17px;
+  font-size: 16px;
   font-weight: 600;
 }
 
 .statLabel {
-  font-size: 11px;
+  font-size: 10.5px;
   text-transform: uppercase;
   letter-spacing: 0.06em;
   color: rgba(255, 255, 255, 0.6);
@@ -97,14 +97,14 @@
 
 .status {
   margin: 0;
-  font-size: 12px;
+  font-size: 11.5px;
   color: rgba(255, 255, 255, 0.65);
   line-height: 1.28;
 }
 
 @media (max-width: 480px) {
   .card {
-    padding: 11px 13px;
+    padding: 11px 12px;
     gap: 9px;
   }
 
@@ -113,8 +113,9 @@
   }
 
   .stat {
-    padding: 9px;
-    border-radius: 15px;
+    padding: 7px 9px;
+    border-radius: 14px;
+    min-height: 50px;
   }
 }
 

--- a/frontend/src/dashboard/home/styles/components/welcome-screen.css
+++ b/frontend/src/dashboard/home/styles/components/welcome-screen.css
@@ -90,9 +90,11 @@
   flex-direction: column;
   flex: 1 1 auto;
   min-height: 0;
-  overflow: hidden;
-  
+  overflow: visible;
+  gap: 16px;
+  padding: 0 16px 24px;
 }
+
 
 .mobile-projects-section {
   flex: 1 1 auto;
@@ -106,6 +108,7 @@
   flex-direction: column;
   min-height: 0;
 }
+
 
 .mobile-projects-panel {
   flex: 1 1 auto;
@@ -125,7 +128,8 @@
   width: 100%;
   max-width: 100vw;
   overflow: visible;
-  margin-top: auto;
+  margin-top: 0;
+  padding-bottom: 16px;
 }
 
 .dashboard-footer {

--- a/frontend/src/dashboard/project/components/Tasks/TasksComponentMobile.module.css
+++ b/frontend/src/dashboard/project/components/Tasks/TasksComponentMobile.module.css
@@ -1,8 +1,13 @@
 .card {
   display: flex;
   flex-direction: column;
+  align-items: stretch;
+  justify-content: flex-start;
+  width: 100%;
+  min-height: 0;
   gap: 12px;
-  padding: 18px 20px;
+  padding: 16px 18px;
+  box-sizing: border-box;
   color: rgba(255, 255, 255, 0.92);
   background:
     radial-gradient(120% 120% at 100% 0%, color-mix(in srgb, var(--brand, #fa3356) 12%, transparent) 0%, transparent 60%),
@@ -15,27 +20,30 @@
 
 .header {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   justify-content: space-between;
-  gap: 20px;
-  min-height: 44px;
+  flex-wrap: wrap;
+  gap: 12px;
+  min-height: 0;
 }
 
 .actions {
   display: inline-flex;
   align-items: center;
+  justify-content: flex-end;
   gap: 8px;
   flex-shrink: 0;
   white-space: nowrap;
+  row-gap: 6px;
 }
 
 .headingGroup {
   display: flex;
   flex-direction: column;
   gap: 8px;
-  flex: 1;
+  flex: 1 1 160px;
   min-width: 0;
-  max-width: calc(100% - 140px);
+  max-width: 100%;
   overflow: hidden;
 }
 
@@ -64,12 +72,12 @@
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  padding: 8px 14px;
+  padding: 8px 13px;
   border-radius: 999px;
   border: 1px solid rgba(255, 255, 255, 0.18);
   background: rgba(255, 255, 255, 0.14);
   color: rgba(255, 255, 255, 0.95);
-  font-size: 13px;
+  font-size: 12.5px;
   font-weight: 600;
   line-height: 1;
   cursor: pointer;
@@ -143,7 +151,11 @@
 
 .statRow {
   display: flex;
-  gap: 9px;
+  gap: 8px;
+}
+
+.statRowCompact {
+  gap: 7px;
 }
 
 .statCard {
@@ -152,7 +164,7 @@
   flex-direction: column;
   justify-content: center;
   gap: 4px;
-  padding: 10px 12px;
+  padding: 9px 11px;
   border-radius: 16px;
   background: rgba(255, 255, 255, 0.07);
   border: 1px solid rgba(255, 255, 255, 0.1);
@@ -193,24 +205,30 @@
   line-height: 1.35;
 }
 
+.statusCompact {
+  font-size: 12.5px;
+  color: rgba(255, 255, 255, 0.68);
+  line-height: 1.32;
+}
+
 .status strong {
   color: rgba(255, 255, 255, 0.9);
 }
 
 @media (max-width: 480px) {
   .card {
-    padding: 16px 18px;
-    gap: 14px;
+    padding: 14px 16px;
+    gap: 12px;
   }
 
   .header {
-    gap: 16px;
+    gap: 10px;
     align-items: flex-start;
   }
 
   .headingGroup {
     gap: 8px;
-    max-width: calc(100vw - 140px);
+    max-width: 100%;
   }
 
   .title {
@@ -229,12 +247,20 @@
   }
 
   .statRow {
-    gap: 7px;
+    gap: 6px;
+  }
+
+  .statRowCompact {
+    gap: 5px;
   }
 
   .statCard {
     padding: 9px 10px;
     border-radius: 15px;
+  }
+
+  .statusCompact {
+    font-size: 12px;
   }
 
   /* Mobile-specific scroll area improvements */

--- a/frontend/src/dashboard/project/components/Tasks/TasksComponentMobile.tsx
+++ b/frontend/src/dashboard/project/components/Tasks/TasksComponentMobile.tsx
@@ -511,7 +511,7 @@ const TasksComponentMobile: React.FC<TasksComponentMobileProps> = ({
   }, [error, loading]);
 
   return (
-    <section className={styles.card} aria-label="Project tasks overview">
+    <section className={`${styles.card} tasks-component`} aria-label="Project tasks overview">
       <header className={styles.header}>
         <div className={styles.headingGroup}>
           <h3 className={styles.title}>Tasks</h3>
@@ -555,7 +555,13 @@ const TasksComponentMobile: React.FC<TasksComponentMobileProps> = ({
         </div>
       </header>
 
-      <TaskSummary stats={stats} formatValue={formatStatValue} statusMessage={statusMessage} />
+      <TaskSummary
+        stats={stats}
+        formatValue={formatStatValue}
+        statusMessage={statusMessage}
+        statRowClassName={styles.statRowCompact}
+        statusClassName={styles.statusCompact}
+      />
 
       <TaskDrawer
         open={drawerOpen}


### PR DESCRIPTION
## Summary
- make the mobile project tasks card fill the column naturally instead of behaving like a footer
- tighten the mobile project task stats spacing by using the compact summary styling

## Testing
- npm run lint *(fails: existing lint errors in QuickCreateTaskModal.tsx and BudgetStateManager.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68dd8f6d2a9c8324a137b945d0ed8a60