### PR TITLE
Refine mobile project tasks spacing

### DIFF
--- a/frontend/src/dashboard/home/components/MobileTasksOverviewCard.module.css
+++ b/frontend/src/dashboard/home/components/MobileTasksOverviewCard.module.css
@@ -2,10 +2,10 @@
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  height: 100%;
+  height: auto;
   min-height: 0;
-  padding: 13px 15px;
-  gap: 11px;
+  padding: 11px 13px;
+  gap: 9px;
   color: rgba(255, 255, 255, 0.92);
   background:
     radial-gradient(120% 120% at 100% 0%, color-mix(in srgb, var(--brand, #fa3356) 12%, transparent) 0%, transparent 60%),
@@ -25,7 +25,7 @@
 
 .title {
   margin: 0;
-  font-size: 15px;
+  font-size: 14px;
   font-weight: 600;
   letter-spacing: -0.01em;
 }
@@ -52,7 +52,8 @@
 
 .statRow {
   display: flex;
-  gap: 7px;
+  gap: 6px;
+  flex-wrap: wrap;
 }
 
 .stat {
@@ -60,21 +61,21 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
-  gap: 3px;
-  padding: 9px 11px;
-  border-radius: 16px;
+  gap: 2px;
+  padding: 8px 10px;
+  border-radius: 14px;
   background: rgba(255, 255, 255, 0.05);
   border: 1px solid rgba(255, 255, 255, 0.08);
-  min-height: 58px;
+  min-height: 52px;
 }
 
 .statValue {
-  font-size: 17px;
+  font-size: 16px;
   font-weight: 600;
 }
 
 .statLabel {
-  font-size: 11px;
+  font-size: 10.5px;
   text-transform: uppercase;
   letter-spacing: 0.06em;
   color: rgba(255, 255, 255, 0.6);
@@ -97,15 +98,15 @@
 
 .status {
   margin: 0;
-  font-size: 12px;
+  font-size: 11.5px;
   color: rgba(255, 255, 255, 0.65);
   line-height: 1.28;
 }
 
 @media (max-width: 480px) {
   .card {
-    padding: 11px 13px;
-    gap: 9px;
+    padding: 10px 12px;
+    gap: 8px;
   }
 
   .statRow {
@@ -113,8 +114,9 @@
   }
 
   .stat {
-    padding: 9px;
-    border-radius: 15px;
+    padding: 8px 9px;
+    border-radius: 13px;
+    min-height: 48px;
   }
 }
 

--- a/frontend/src/dashboard/home/styles/components/welcome-screen.css
+++ b/frontend/src/dashboard/home/styles/components/welcome-screen.css
@@ -81,8 +81,8 @@
   max-width: 100vw;
   overflow: visible; /* allow children (CTA) to be fully visible */
   align-items: stretch;
- 
-
+  gap: clamp(12px, 3vw, 18px);
+  padding-bottom: clamp(16px, 6vw, 32px);
 }
 
 .mobile-projects-tasks {
@@ -91,7 +91,7 @@
   flex: 1 1 auto;
   min-height: 0;
   overflow: hidden;
-  
+  gap: clamp(12px, 3vw, 18px);
 }
 
 .mobile-projects-section {
@@ -126,6 +126,7 @@
   max-width: 100vw;
   overflow: visible;
   margin-top: auto;
+  padding-bottom: env(safe-area-inset-bottom, 12px);
 }
 
 .dashboard-footer {

--- a/frontend/src/dashboard/project/components/Tasks/TasksComponentMobile.module.css
+++ b/frontend/src/dashboard/project/components/Tasks/TasksComponentMobile.module.css
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: column;
   gap: 12px;
-  padding: 18px 20px;
+  padding: 16px 18px 18px;
   color: rgba(255, 255, 255, 0.92);
   background:
     radial-gradient(120% 120% at 100% 0%, color-mix(in srgb, var(--brand, #fa3356) 12%, transparent) 0%, transparent 60%),
@@ -11,6 +11,7 @@
   border: 1px solid rgba(255, 255, 255, 0.12);
   border-radius: var(--radius-squircle, 20px);
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+  margin-bottom: clamp(18px, env(safe-area-inset-bottom, 0px) + 18px, 36px);
 }
 
 .header {
@@ -144,6 +145,7 @@
 .statRow {
   display: flex;
   gap: 9px;
+  flex-wrap: wrap;
 }
 
 .statCard {
@@ -193,14 +195,37 @@
   line-height: 1.35;
 }
 
+.cardSummary {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.cardStatRow {
+  gap: 8px;
+  row-gap: 8px;
+}
+
+.cardStatRow .statCard {
+  flex: 1 1 120px;
+  min-width: 120px;
+  padding: 9px 11px;
+}
+
+.cardStatus {
+  font-size: 12.5px;
+  color: rgba(255, 255, 255, 0.68);
+  line-height: 1.4;
+}
+
 .status strong {
   color: rgba(255, 255, 255, 0.9);
 }
 
 @media (max-width: 480px) {
   .card {
-    padding: 16px 18px;
-    gap: 14px;
+    padding: 14px 16px 18px;
+    gap: 12px;
   }
 
   .header {
@@ -235,6 +260,21 @@
   .statCard {
     padding: 9px 10px;
     border-radius: 15px;
+  }
+
+  .cardStatRow {
+    gap: 7px;
+    row-gap: 7px;
+  }
+
+  .cardStatRow .statCard {
+    flex: 1 1 104px;
+    min-width: 104px;
+    padding: 8px 10px;
+  }
+
+  .cardStatus {
+    font-size: 12px;
   }
 
   /* Mobile-specific scroll area improvements */

--- a/frontend/src/dashboard/project/components/Tasks/TasksComponentMobile.tsx
+++ b/frontend/src/dashboard/project/components/Tasks/TasksComponentMobile.tsx
@@ -511,7 +511,7 @@ const TasksComponentMobile: React.FC<TasksComponentMobileProps> = ({
   }, [error, loading]);
 
   return (
-    <section className={styles.card} aria-label="Project tasks overview">
+    <section className={`${styles.card} tasks-component`} aria-label="Project tasks overview">
       <header className={styles.header}>
         <div className={styles.headingGroup}>
           <h3 className={styles.title}>Tasks</h3>
@@ -555,7 +555,15 @@ const TasksComponentMobile: React.FC<TasksComponentMobileProps> = ({
         </div>
       </header>
 
-      <TaskSummary stats={stats} formatValue={formatStatValue} statusMessage={statusMessage} />
+      <div className={styles.cardSummary}>
+        <TaskSummary
+          stats={stats}
+          formatValue={formatStatValue}
+          statusMessage={statusMessage}
+          statRowClassName={styles.cardStatRow}
+          statusClassName={`${styles.status} ${styles.cardStatus}`}
+        />
+      </div>
 
       <TaskDrawer
         open={drawerOpen}


### PR DESCRIPTION
## Summary
- add the shared `tasks-component` class and wrap the summary so the mobile project tasks card slots cleanly into the stacked layout
- compact the mobile project task stats row with safe-area spacing, responsive wrapping, and tightened typography so counters stay readable on narrow viewports

## Testing
- npm run lint *(fails: existing warnings in QuickCreateTaskModal.tsx and errors in BudgetStateManager.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68dd8ef023808324b00eb447c6cc84f8