### PR TITLE
feat: add mobile-friendly budget card layout

### DIFF
--- a/frontend/src/dashboard/project/features/budget/components/BudgetStateManager.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetStateManager.tsx
@@ -45,7 +45,7 @@ interface BudgetStateManagerState extends Record<string, unknown> {
   setSortField: (field: string | null) => void;
   setSortOrder: (order: string | null) => void;
   selectedRowKeys: string[];
-  setSelectedRowKeys: (keys: string[]) => void;
+  setSelectedRowKeys: React.Dispatch<React.SetStateAction<string[]>>;
   
   // Edit/Create state
   editItem: BudgetItem | null;

--- a/frontend/src/dashboard/project/features/budget/components/BudgetTable.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetTable.tsx
@@ -1,9 +1,13 @@
-import React from "react";
-import { Table } from "antd";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { Pagination, Table } from "antd";
 import type { ColumnsType, TableProps } from "antd/es/table";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faClone, faClock, faTrash } from "@fortawesome/free-solid-svg-icons";
 import styles from "@/dashboard/project/features/budget/pages/budget-page.module.css";
+import { formatUSD } from "@/shared/utils/budgetUtils";
 
 const TABLE_HEADER_FOOTER = 110;
+const MOBILE_BREAKPOINT = 768;
 
 type BudgetItem = Record<string, unknown> & {
   budgetItemId: string;
@@ -14,10 +18,14 @@ interface BudgetItemsTableProps {
   dataSource: BudgetItem[];
   columns: ColumnsType<BudgetItem>;
   selectedRowKeys: string[];
+  setSelectedRowKeys: (keys: string[] | ((prev: string[]) => string[])) => void;
   lockedLines: string[];
   handleTableChange: TableProps<BudgetItem>['onChange'];
   openEditModal: (record: BudgetItem) => void;
+  openDuplicateModal: (record: BudgetItem) => void;
   openDeleteModal: (ids: string[]) => void;
+  openEventModal: (record: BudgetItem) => void;
+  eventsByLineItem: Record<string, Record<string, unknown>[]>;
   tableRef: React.RefObject<HTMLDivElement>;
   tableHeight: number;
   pageSize: number;
@@ -31,10 +39,14 @@ const BudgetItemsTable: React.FC<BudgetItemsTableProps> = React.memo(
     dataSource,
     columns,
     selectedRowKeys,
+    setSelectedRowKeys,
     lockedLines,
     handleTableChange,
     openEditModal,
+    openDuplicateModal,
     openDeleteModal,
+    openEventModal,
+    eventsByLineItem,
     tableRef,
     tableHeight,
     pageSize,
@@ -42,61 +54,375 @@ const BudgetItemsTable: React.FC<BudgetItemsTableProps> = React.memo(
     setCurrentPage,
     setPageSize,
   }) => {
-    return (
-      <div ref={tableRef} style={{ width: "100%", fontSize: "10px" }}>
-        <Table<BudgetItem>
-          dataSource={dataSource}
-          columns={columns.map((col) => ({
-            ...col,
-            ellipsis: col.key !== "actions" && col.key !== "events",
-          }))}
-          locale={{
-            emptyText: (
-              <div className={styles.emptyPlaceholder}>No budget items to display</div>
-            ),
-          }}
-          onChange={handleTableChange}
-          rowClassName={(record) =>
-            `${styles.clickableRow}${
-              selectedRowKeys.includes(record.budgetItemId)
-                ? ` ${styles.selectedRow}`
-                : ""
-            }${
-              lockedLines.includes(record.budgetItemId)
-                ? ` ${styles.lockedRow}`
-                : ""
-            }`
+    const [isMobile, setIsMobile] = useState(false);
+
+    useEffect(() => {
+      if (typeof window === "undefined") return;
+      const mediaQuery = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT}px)`);
+      const handleChange = (event: MediaQueryListEvent | MediaQueryList) => {
+        setIsMobile(event.matches);
+      };
+
+      handleChange(mediaQuery);
+
+      const listener = (event: MediaQueryListEvent) => handleChange(event);
+
+      if (typeof mediaQuery.addEventListener === "function") {
+        mediaQuery.addEventListener("change", listener);
+        return () => mediaQuery.removeEventListener("change", listener);
+      }
+
+      mediaQuery.addListener(listener);
+      return () => mediaQuery.removeListener(listener);
+    }, []);
+
+    const costKeys = useMemo(
+      () => [
+        "itemBudgetedCost",
+        "itemActualCost",
+        "itemReconciledCost",
+        "itemFinalCost",
+      ],
+      []
+    );
+
+    const isDefined = useCallback((val: unknown) => {
+      if (val === undefined || val === null) return false;
+      const str = String(val).trim();
+      if (!str) return false;
+      const num = parseFloat(str.replace(/[$,]/g, ""));
+      if (!Number.isNaN(num)) {
+        return num !== 0;
+      }
+      return str !== "0";
+    }, []);
+
+    const getActiveCostKey = useCallback(
+      (item: BudgetItem) => {
+        if (isDefined(item.itemReconciledCost)) return "itemReconciledCost";
+        if (isDefined(item.itemActualCost)) return "itemActualCost";
+        return "itemBudgetedCost";
+      },
+      [isDefined]
+    );
+
+    const mobileMetrics = useMemo(
+      () => [
+        { key: "quantity", label: "Qty" },
+        { key: "unit", label: "U" },
+        { key: "itemBudgetedCost", label: "BC" },
+        { key: "itemActualCost", label: "AC" },
+        { key: "itemReconciledCost", label: "RC" },
+        { key: "itemMarkUp", label: "MK" },
+        { key: "itemFinalCost", label: "FC" },
+      ],
+      []
+    );
+
+    const handleCardKeyDown = useCallback(
+      (event: React.KeyboardEvent<HTMLElement>, record: BudgetItem, isLocked: boolean) => {
+        if (isLocked) return;
+        if (event.key === "Enter") {
+          event.preventDefault();
+          openEditModal(record);
+        } else if (event.key === " ") {
+          event.preventDefault();
+          openDeleteModal([record.budgetItemId]);
+        }
+      },
+      [openDeleteModal, openEditModal]
+    );
+
+    const toggleSelection = useCallback(
+      (record: BudgetItem, checked: boolean) => {
+        const id = String(record.budgetItemId);
+        setSelectedRowKeys((prevKeys) => {
+          const nextKeys = new Set(prevKeys);
+          if (checked) {
+            nextKeys.add(id);
+          } else {
+            nextKeys.delete(id);
           }
-          onRow={(record) => ({
-            onClick: () => openEditModal(record),
-            tabIndex: lockedLines.includes(record.budgetItemId) ? -1 : 0,
-            onKeyDown: (e) => {
-              if (e.key === "Enter") {
-                e.preventDefault();
-                openEditModal(record);
-              } else if (e.key === " ") {
-                e.preventDefault();
-                openDeleteModal([record.budgetItemId]);
-              }
-            },
-          })}
-          pagination={{
-            pageSize,
-            current: currentPage,
-            showSizeChanger: true,
-            pageSizeOptions: ["10", "20", "50", "100"],
-            position: ["bottomRight"],
-            showTotal: (total, range) => `Showing ${range[0]}–${range[1]} of ${total} items`,
-            size: "small",
-            onChange: (page, size) => {
-              setCurrentPage(page);
-              if (size !== pageSize) setPageSize(size);
-            },
-          }}
-          scroll={{ y: Math.max(0, tableHeight - TABLE_HEADER_FOOTER) }}
-          className={styles.tableMinHeight}
-          style={{ height: tableHeight }}
-        />
+          return Array.from(nextKeys);
+        });
+      },
+      [setSelectedRowKeys]
+    );
+
+    const paginatedMobileData = useMemo(() => {
+      if (!isMobile) return [];
+      const startIndex = Math.max(0, (currentPage - 1) * pageSize);
+      return dataSource.slice(startIndex, startIndex + pageSize);
+    }, [isMobile, dataSource, currentPage, pageSize]);
+
+    const formatMetricValue = useCallback(
+      (record: BudgetItem, metricKey: string) => {
+        const value = record[metricKey];
+        if (metricKey === "itemMarkUp") {
+          if (typeof value === "number") {
+            return `${Math.round(value * 100)}%`;
+          }
+          return value ? String(value) : "—";
+        }
+
+        if (costKeys.includes(metricKey)) {
+          if (!isDefined(value)) return "—";
+          if (metricKey === "itemFinalCost") {
+            return formatUSD(Number(value));
+          }
+          const activeKey = getActiveCostKey(record);
+          const formatted = formatUSD(Number(value));
+          return activeKey === metricKey
+            ? formatted
+            : (
+                <span className={styles.dimmed}>{formatted}</span>
+              );
+        }
+
+        if (value === undefined || value === null || value === "") {
+          return "—";
+        }
+
+        return String(value);
+      },
+      [costKeys, getActiveCostKey, isDefined]
+    );
+
+    const renderPaymentStatus = useCallback(
+      (status: unknown) => {
+        if (typeof status !== "string") return null;
+        const cleaned = status.replace(/[·.]+$/, "").trim();
+        if (!cleaned) return null;
+        const normalizedStatus = cleaned.toUpperCase();
+        const colorClass =
+          normalizedStatus === "PAID"
+            ? styles.paid
+            : normalizedStatus === "PARTIAL"
+            ? styles.partial
+            : styles.unpaid;
+        const display =
+          normalizedStatus === "PAID" || normalizedStatus === "PARTIAL"
+            ? cleaned
+            : "UNPAID";
+        return (
+          <span className={styles.paymentStatus}>
+            {display}
+            <span className={`${styles.statusDot} ${colorClass}`} />
+          </span>
+        );
+      },
+      []
+    );
+
+    const handlePaginationChange = useCallback(
+      (page: number, size: number) => {
+        setCurrentPage(page);
+        if (size !== pageSize) {
+          setPageSize(size);
+        }
+      },
+      [pageSize, setCurrentPage, setPageSize]
+    );
+
+    return (
+      <div ref={tableRef} className={styles.tableContainer}>
+        <div className={styles.desktopTable}>
+          <Table<BudgetItem>
+            dataSource={dataSource}
+            columns={columns.map((col) => ({
+              ...col,
+              ellipsis: col.key !== "actions" && col.key !== "events",
+            }))}
+            locale={{
+              emptyText: (
+                <div className={styles.emptyPlaceholder}>No budget items to display</div>
+              ),
+            }}
+            onChange={handleTableChange}
+            rowClassName={(record) =>
+              `${styles.clickableRow}${
+                selectedRowKeys.includes(record.budgetItemId)
+                  ? ` ${styles.selectedRow}`
+                  : ""
+              }${
+                lockedLines.includes(record.budgetItemId)
+                  ? ` ${styles.lockedRow}`
+                  : ""
+              }`
+            }
+            onRow={(record) => ({
+              onClick: () => openEditModal(record),
+              tabIndex: lockedLines.includes(record.budgetItemId) ? -1 : 0,
+              onKeyDown: (e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  openEditModal(record);
+                } else if (e.key === " ") {
+                  e.preventDefault();
+                  openDeleteModal([record.budgetItemId]);
+                }
+              },
+            })}
+            pagination={{
+              pageSize,
+              current: currentPage,
+              showSizeChanger: true,
+              pageSizeOptions: ["10", "20", "50", "100"],
+              position: ["bottomRight"],
+              showTotal: (total, range) => `Showing ${range[0]}–${range[1]} of ${total} items`,
+              size: "small",
+              onChange: (page, size) => {
+                setCurrentPage(page);
+                if (size !== pageSize) setPageSize(size);
+              },
+            }}
+            scroll={{ y: Math.max(0, tableHeight - TABLE_HEADER_FOOTER) }}
+            className={styles.tableMinHeight}
+            style={{ height: tableHeight }}
+          />
+        </div>
+
+        {isMobile && (
+          <div className={styles.mobileCardList}>
+            {paginatedMobileData.length === 0 ? (
+              <div className={styles.emptyPlaceholder}>No budget items to display</div>
+            ) : (
+              <>
+                {paginatedMobileData.map((record) => {
+                  const isSelected = selectedRowKeys.includes(record.budgetItemId);
+                  const isLocked = lockedLines.includes(record.budgetItemId);
+                  const events = eventsByLineItem[record.budgetItemId] || [];
+                  const eventCount = events.length;
+
+                  return (
+                    <article
+                      key={record.key}
+                      className={`${styles.mobileCard}${
+                        isSelected ? ` ${styles.mobileCardSelected}` : ""
+                      }${isLocked ? ` ${styles.mobileCardLocked}` : ""}`}
+                      role="button"
+                      tabIndex={isLocked ? -1 : 0}
+                      aria-pressed={isSelected}
+                      aria-disabled={isLocked}
+                      onClick={() => {
+                        if (!isLocked) {
+                          openEditModal(record);
+                        }
+                      }}
+                      onKeyDown={(event) => handleCardKeyDown(event, record, isLocked)}
+                    >
+                      <header className={styles.mobileCardHeader}>
+                        <div className={styles.mobileCardHeaderLeft}>
+                          <label className={styles.mobileCardCheckbox}>
+                            <input
+                              type="checkbox"
+                              checked={isSelected}
+                              disabled={isLocked}
+                              onChange={(event) => {
+                                event.stopPropagation();
+                                toggleSelection(record, event.target.checked);
+                              }}
+                              onClick={(event) => event.stopPropagation()}
+                              aria-label="Select budget line item"
+                            />
+                          </label>
+                          <div className={styles.mobileCardIdentifiers}>
+                            <span className={styles.mobileCardKey}>
+                              {String(record.elementKey ?? "—")}
+                            </span>
+                            {record.elementId && (
+                              <span className={styles.mobileCardId}>
+                                {String(record.elementId)}
+                              </span>
+                            )}
+                          </div>
+                        </div>
+                        <div className={styles.mobileCardControls}>
+                          <button
+                            className={styles.mobileIconButton}
+                            type="button"
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              openEventModal(record);
+                            }}
+                            aria-label={
+                              eventCount > 0
+                                ? `Manage ${eventCount} scheduled events`
+                                : "Manage events"
+                            }
+                          >
+                            <FontAwesomeIcon icon={faClock} />
+                            {eventCount > 0 && (
+                              <span className={styles.mobileEventBadge}>{eventCount}</span>
+                            )}
+                          </button>
+                          <button
+                            className={styles.mobileIconButton}
+                            type="button"
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              openDuplicateModal(record);
+                            }}
+                            aria-label="Duplicate line item"
+                          >
+                            <FontAwesomeIcon icon={faClone} />
+                          </button>
+                          <button
+                            className={styles.mobileIconButton}
+                            type="button"
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              openDeleteModal([record.budgetItemId]);
+                            }}
+                            aria-label="Delete line item"
+                          >
+                            <FontAwesomeIcon icon={faTrash} />
+                          </button>
+                        </div>
+                      </header>
+
+                      <div className={styles.mobileCardDescription}>
+                        {record.description ? String(record.description) : "No description"}
+                      </div>
+
+                      <div className={styles.mobileCardMetrics}>
+                        {mobileMetrics.map((metric) => (
+                          <div key={metric.key} className={styles.mobileCardMetric}>
+                            <span className={styles.mobileCardMetricLabel}>{metric.label}</span>
+                            <span className={styles.mobileCardMetricValue}>
+                              {formatMetricValue(record, metric.key)}
+                            </span>
+                          </div>
+                        ))}
+                      </div>
+
+                      {record.paymentStatus && (
+                        <footer className={styles.mobileCardFooter}>
+                          <span className={styles.mobileCardFooterLabel}>Payment</span>
+                          <span className={styles.mobileCardFooterValue}>
+                            {renderPaymentStatus(String(record.paymentStatus))}
+                          </span>
+                        </footer>
+                      )}
+                    </article>
+                  );
+                })}
+
+                <Pagination
+                  className={styles.mobilePagination}
+                  current={currentPage}
+                  pageSize={pageSize}
+                  total={dataSource.length}
+                  showSizeChanger
+                  pageSizeOptions={["10", "20", "50", "100"]}
+                  size="small"
+                  onChange={handlePaginationChange}
+                  onShowSizeChange={handlePaginationChange}
+                />
+              </>
+            )}
+          </div>
+        )}
       </div>
     );
   }

--- a/frontend/src/dashboard/project/features/budget/components/BudgetTableLogic.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetTableLogic.tsx
@@ -15,7 +15,7 @@ interface BudgetTableLogicProps {
   sortOrder: string | null;
   selectedRowKeys: string[];
   eventsByLineItem: Record<string, Record<string, unknown>[]>;
-  setSelectedRowKeys: (keys: string[]) => void;
+  setSelectedRowKeys: (keys: string[] | ((prev: string[]) => string[])) => void;
   openDeleteModal: (ids: string[]) => void;
   openDuplicateModal: (item: Record<string, unknown>) => void;
   openEventModal: (item: Record<string, unknown>) => void;

--- a/frontend/src/dashboard/project/features/budget/pages/BudgetPage.tsx
+++ b/frontend/src/dashboard/project/features/budget/pages/BudgetPage.tsx
@@ -656,6 +656,7 @@ const BudgetPageContent = () => {
                                     }
                                     columns={tableConfig.tableColumns}
                                     selectedRowKeys={stateManager.selectedRowKeys}
+                                    setSelectedRowKeys={stateManager.setSelectedRowKeys}
                                     lockedLines={stateManager.lockedLines}
                                     handleTableChange={(_pagination, _filters, sorter) => {
                                       const sortConfig = Array.isArray(sorter) ? sorter[0] : sorter;
@@ -677,7 +678,10 @@ const BudgetPageContent = () => {
                                       stateManager.setSortOrder(null);
                                     }}
                                     openEditModal={eventHandlers.openEditModal}
+                                    openDuplicateModal={eventHandlers.openDuplicateModal}
                                     openDeleteModal={eventHandlers.openDeleteModal}
+                                    openEventModal={eventHandlers.openEventModal}
+                                    eventsByLineItem={eventsByLineItem}
                                     tableRef={tableRef}
                                     tableHeight={tableHeight}
                                     pageSize={stateManager.pageSize}

--- a/frontend/src/dashboard/project/features/budget/pages/budget-page.module.css
+++ b/frontend/src/dashboard/project/features/budget/pages/budget-page.module.css
@@ -135,6 +135,15 @@
   border-right: 1px solid #2a2a2a;
 }
 
+.tableContainer {
+  width: 100%;
+  font-size: 10px;
+}
+
+.desktopTable {
+  display: block;
+}
+
 .tableMinHeight {
   min-height: 100%;
   height: 100%;
@@ -143,6 +152,10 @@
 }
 .clickableRow {
   transition: background-color 0.2s ease;
+}
+
+.selectedRow {
+  background-color: rgba(250, 51, 86, 0.08) !important;
 }
 .tableMinHeight :global(.ant-spin-nested-loading),
 .tableMinHeight :global(.ant-spin-container),
@@ -170,6 +183,254 @@
   align-items: center;
   justify-content: center;
   height: 750px;
+}
+
+.mobileCardList {
+  display: none;
+}
+
+.mobileCard {
+  background: linear-gradient(160deg, rgba(24, 24, 24, 0.95), rgba(9, 9, 9, 0.95));
+  border-radius: 22px;
+  border: 1px solid #2a2a2a;
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.45);
+  transition: box-shadow 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.mobileCard:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.5);
+}
+
+.mobileCardSelected {
+  border-color: #FA3356;
+  box-shadow: 0 0 0 1px #FA3356, 0 20px 36px rgba(250, 51, 86, 0.25);
+}
+
+.mobileCardLocked {
+  opacity: 0.6;
+}
+
+.mobileCardHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.mobileCardHeaderLeft {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.mobileCardCheckbox {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.mobileCardCheckbox input {
+  width: 18px;
+  height: 18px;
+  margin: 0;
+  accent-color: #FA3356;
+}
+
+.mobileCardIdentifiers {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.mobileCardKey {
+  color: #ffffff;
+  font-weight: 600;
+  font-size: 0.95rem;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.mobileCardId {
+  color: #bbbbbb;
+  font-size: 0.85rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.mobileCardControls {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.mobileIconButton {
+  position: relative;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: 1px solid #2a2a2a;
+  background: #131313;
+  color: #eaeaea;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.mobileIconButton:hover,
+.mobileIconButton:focus-visible {
+  background: #FA3356;
+  border-color: #FA3356;
+  color: #ffffff;
+}
+
+.mobileEventBadge {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  min-width: 16px;
+  height: 16px;
+  border-radius: 999px;
+  background: #FA3356;
+  color: #ffffff;
+  font-size: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 4px;
+  line-height: 1;
+}
+
+.mobileCardDescription {
+  color: #e0e0e0;
+  font-size: 0.95rem;
+  line-height: 1.4;
+}
+
+.mobileCardMetrics {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.mobileCardMetric {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.mobileCardMetricLabel {
+  font-size: 0.75rem;
+  color: #888888;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.mobileCardMetricValue {
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: #f5f5f5;
+  min-height: 1.2em;
+}
+
+.mobileCardMetricValue span {
+  color: inherit;
+}
+
+.mobileCardFooter {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-top: 1px solid #232323;
+  padding-top: 10px;
+  margin-top: 2px;
+}
+
+.mobileCardFooterLabel {
+  font-size: 0.8rem;
+  color: #888888;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.mobileCardFooterValue {
+  display: inline-flex;
+  align-items: center;
+}
+
+.mobilePagination {
+  align-self: center;
+  margin-top: 12px;
+}
+
+.mobilePagination :global(.ant-select-selector) {
+  background: transparent !important;
+  border-color: #FA3356 !important;
+  color: #ffffff !important;
+}
+
+.mobilePagination :global(.ant-select-arrow) {
+  color: #ffffff !important;
+}
+
+.mobilePagination :global(.ant-pagination-item a) {
+  color: #ffffff !important;
+}
+
+.mobilePagination :global(.ant-pagination-item-active) {
+  border-color: #FA3356 !important;
+}
+
+.mobilePagination :global(.ant-pagination-item-active a) {
+  color: #FA3356 !important;
+}
+
+@media (max-width: 992px) {
+  .mobileCardMetrics {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 768px) {
+  .desktopTable {
+    display: none;
+  }
+
+  .mobileCardList {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    width: 100%;
+  }
+
+  .mobileCard {
+    border-radius: 26px;
+    padding: 20px;
+  }
+
+  .mobileCardMetrics {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 480px) {
+  .mobileCardMetrics {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 10px;
+  }
+
+  .mobileCard {
+    padding: 18px 16px;
+  }
+
+  .mobileCardControls {
+    gap: 6px;
+  }
 }
 
 .clickableRow:hover {


### PR DESCRIPTION
## Summary
- detect mobile breakpoints and render a card-based budget list with inline actions, pagination, and payment status
- add responsive styling for the new mobile cards while preserving the desktop table layout
- update budget state typings and wiring so selection controls work in both views

## Testing
- npm run typecheck *(fails: existing ApiTask vs Task type mismatch in TasksComponent.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68ddb75784208324b6086af53817dbd7