### PR TITLE
feat: align quick create task desktop UI with tasks list

### DIFF
--- a/frontend/src/dashboard/home/components/QuickCreateTaskModal.module.css
+++ b/frontend/src/dashboard/home/components/QuickCreateTaskModal.module.css
@@ -122,11 +122,62 @@
   line-height: 1.5;
 }
 
+.desktopHeaderRow {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin-bottom: 20px;
+}
+
+.desktopCloseButton {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 999px;
+  border: none;
+  background: transparent;
+  color: var(--text-secondary, rgba(246, 247, 251, 0.72));
+  cursor: pointer;
+  transition: transform 0.2s ease, color 0.2s ease;
+}
+
+.desktopCloseButton svg {
+  width: 20px;
+  height: 20px;
+}
+
+.desktopCloseButton:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.3);
+}
+
+.desktopCloseButton:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+@media (hover: hover) {
+  .desktopCloseButton:not(:disabled):hover {
+    transform: translateY(-1px);
+    color: var(--text-primary, #f6f7fb);
+  }
+}
+
 .fieldGroup {
   display: flex;
   flex-direction: column;
   gap: 10px;
   margin-bottom: 16px;
+}
+
+.fieldGroupHalf {
+  /* Intentionally empty - used for responsive grid placement */
+}
+
+.fieldGroupFull {
+  /* Intentionally empty - used for responsive grid placement */
 }
 
 .fieldHeader {
@@ -155,6 +206,10 @@
   font-size: 0.85rem;
   color: var(--text-tertiary, rgba(246, 247, 251, 0.65));
   margin-top: -8px;
+}
+
+.helperTextFull {
+  /* Intentionally empty - used for responsive grid placement */
 }
 
 .selectInput,
@@ -295,6 +350,97 @@
   background: rgba(250, 51, 86, 0.18);
   color: var(--text-primary, #f6f7fb);
   border-color: rgba(250, 51, 86, 0.65);
+}
+
+@media (min-width: 1024px) {
+  .createOverlay {
+    align-items: center;
+    padding: 32px;
+  }
+
+  .createModal {
+    width: min(1040px, calc(100% - 64px));
+    margin: 0;
+    border-radius: 28px;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    background: var(--dashboard-bg, var(--bg1, #050607));
+    box-shadow: 0 -18px 48px rgba(0, 0, 0, 0.45);
+    max-height: calc(100vh - 64px);
+  }
+
+  .grabZone {
+    display: none;
+  }
+
+  .createForm {
+    padding: 8px 24px 24px;
+  }
+
+  .formBody {
+    padding: 32px;
+    background: rgba(17, 18, 19, 0.92);
+    border-radius: 24px;
+    border: 1px solid rgba(255, 255, 255, 0.07);
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02), 0 18px 48px rgba(0, 0, 0, 0.35);
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 24px 32px;
+  }
+
+  .createHeader {
+    margin-bottom: 0;
+  }
+
+  .desktopHeaderRow {
+    grid-column: 1 / -1;
+    flex-direction: row;
+    align-items: flex-start;
+    justify-content: space-between;
+    margin-bottom: 8px;
+  }
+
+  .desktopCloseButton {
+    display: inline-flex;
+  }
+
+  .fieldGroup {
+    margin-bottom: 0;
+  }
+
+  .fieldGroupHalf {
+    grid-column: span 1;
+  }
+
+  .fieldGroupFull {
+    grid-column: 1 / -1;
+  }
+
+  .helperTextFull {
+    grid-column: 1 / -1;
+    margin-bottom: 0;
+  }
+
+  .feedbackRegion {
+    grid-column: 1 / -1;
+  }
+
+  .actionBar {
+    grid-column: 1 / -1;
+    flex-direction: row;
+    justify-content: flex-end;
+    gap: 16px;
+    margin-top: 8px;
+  }
+
+  .deleteButton,
+  .submitButton {
+    width: auto;
+  }
+
+  .quickChips {
+    flex-wrap: wrap;
+    row-gap: 8px;
+  }
 }
 
 .actionBar {

--- a/frontend/src/dashboard/home/components/QuickCreateTaskModal.tsx
+++ b/frontend/src/dashboard/home/components/QuickCreateTaskModal.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
+import { X } from "lucide-react";
 
 import type { Task } from "@/shared/utils/api";
 import { NOMINATIM_SEARCH_URL, apiFetch, createTask, deleteTask, updateTask } from "@/shared/utils/api";
@@ -866,14 +867,25 @@ const QuickCreateTaskModal: React.FC<QuickCreateTaskModalProps> = ({
           noValidate
         >
           <div className={styles.formBody} onClick={handleFormBodyClick}>
-            <div className={styles.createHeader}>
-              <h2 id="quick-task-title">{modalTitle}</h2>
-              <p id={descriptionId} className={styles.createDescription}>
-                {modalDescription}
-              </p>
+            <div className={styles.desktopHeaderRow}>
+              <div className={styles.createHeader}>
+                <h2 id="quick-task-title">{modalTitle}</h2>
+                <p id={descriptionId} className={styles.createDescription}>
+                  {modalDescription}
+                </p>
+              </div>
+              <button
+                type="button"
+                className={styles.desktopCloseButton}
+                onClick={onClose}
+                aria-label="Close quick create task"
+                disabled={isBusy}
+              >
+                <X size={20} strokeWidth={2.5} aria-hidden="true" />
+              </button>
             </div>
             {showProjectSelect ? (
-              <div className={styles.fieldGroup}>
+              <div className={`${styles.fieldGroup} ${styles.fieldGroupFull}`}>
                 <label className={styles.fieldLabel} htmlFor={projectFieldId}>
                   <span className={styles.fieldLabelText}>Project</span>
                 </label>
@@ -900,9 +912,11 @@ const QuickCreateTaskModal: React.FC<QuickCreateTaskModalProps> = ({
               </div>
             ) : null}
             {!hasProjects && !scopedProjectId ? (
-              <p className={styles.helperText}>Add a project to start creating tasks.</p>
+              <p className={`${styles.helperText} ${styles.helperTextFull}`}>
+                Add a project to start creating tasks.
+              </p>
             ) : null}
-            <div className={styles.fieldGroup}>
+            <div className={`${styles.fieldGroup} ${styles.fieldGroupHalf}`}>
               <div className={styles.fieldHeader}>
                 <label className={styles.fieldLabel} htmlFor={statusFieldId}>
                   <span className={styles.fieldLabelText}>Status</span>
@@ -921,7 +935,7 @@ const QuickCreateTaskModal: React.FC<QuickCreateTaskModalProps> = ({
                 <option value="done">Done</option>
               </select>
             </div>
-            <div className={styles.fieldGroup}>
+            <div className={`${styles.fieldGroup} ${styles.fieldGroupHalf}`}>
               <div className={styles.fieldHeader}>
                 <label className={styles.fieldLabel} htmlFor={assigneeFieldId}>
                   <span className={styles.fieldLabelText}>Assign to</span>
@@ -945,9 +959,11 @@ const QuickCreateTaskModal: React.FC<QuickCreateTaskModalProps> = ({
               </select>
             </div>
             {!hasCollaborators ? (
-              <p className={styles.helperText}>Invite collaborators to assign tasks.</p>
+              <p className={`${styles.helperText} ${styles.helperTextFull}`}>
+                Invite collaborators to assign tasks.
+              </p>
             ) : null}
-            <div className={styles.fieldGroup}>
+            <div className={`${styles.fieldGroup} ${styles.fieldGroupFull}`}>
               <label className={styles.fieldLabel} htmlFor={taskNameFieldId}>
                 <span className={styles.fieldLabelText}>Task name</span>
               </label>
@@ -976,7 +992,7 @@ const QuickCreateTaskModal: React.FC<QuickCreateTaskModalProps> = ({
                 </p>
               ) : null}
             </div>
-            <div className={styles.fieldGroup}>
+            <div className={`${styles.fieldGroup} ${styles.fieldGroupFull}`}>
               <div className={styles.fieldHeader}>
                 <label className={styles.fieldLabel} htmlFor={locationFieldId}>
                   <span className={styles.fieldLabelText}>Location</span>
@@ -1021,7 +1037,7 @@ const QuickCreateTaskModal: React.FC<QuickCreateTaskModalProps> = ({
                 </span>
               ) : null}
             </div>
-            <div className={styles.fieldGroup}>
+            <div className={`${styles.fieldGroup} ${styles.fieldGroupHalf}`}>
               <div className={styles.fieldHeader}>
                 <label className={styles.fieldLabel} htmlFor={dueDateFieldId}>
                   <span className={styles.fieldLabelText}>Due date</span>
@@ -1064,7 +1080,7 @@ const QuickCreateTaskModal: React.FC<QuickCreateTaskModalProps> = ({
                 </button>
               </div>
             </div>
-            <div className={styles.fieldGroup}>
+            <div className={`${styles.fieldGroup} ${styles.fieldGroupFull}`}>
               <div className={styles.fieldHeader}>
                 <label className={styles.fieldLabel} htmlFor={notesFieldId}>
                   <span className={styles.fieldLabelText}>Notes</span>
@@ -1083,7 +1099,11 @@ const QuickCreateTaskModal: React.FC<QuickCreateTaskModalProps> = ({
                 ref={notesRef}
               />
             </div>
-            <div id={feedbackRegionId} className={styles.feedbackRegion} aria-live="polite">
+            <div
+              id={feedbackRegionId}
+              className={`${styles.feedbackRegion} ${styles.fieldGroupFull}`}
+              aria-live="polite"
+            >
               {errorMessage ? (
                 <div className={`${styles.feedback} ${styles.feedbackError}`}>{errorMessage}</div>
               ) : null}
@@ -1091,7 +1111,7 @@ const QuickCreateTaskModal: React.FC<QuickCreateTaskModalProps> = ({
                 <div className={`${styles.feedback} ${styles.feedbackSuccess}`}>{successMessage}</div>
               ) : null}
             </div>
-            <div className={styles.actionBar}>
+            <div className={`${styles.actionBar} ${styles.fieldGroupFull}`}>
               {isEditing ? (
                 <button
                   type="button"


### PR DESCRIPTION
## Summary
- restyle the quick create task drawer on desktop to mirror the Tasks List overlay aesthetics
- introduce a desktop close control and responsive grid layout for form fields
- tweak supporting helper text, chips, and action bar spacing for the wider layout

## Testing
- npm run lint *(fails: existing lint errors in BudgetStateManager.test.tsx and useEffect dependency warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68ddd1231df8832486a5f4c35e5f27e9