### PR TITLE
feat: add mobile budget header layout

### DIFF
--- a/frontend/src/dashboard/project/features/budget/components/HeaderStats.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/HeaderStats.tsx
@@ -9,7 +9,7 @@ import {
   faCalculator,
   faPen,
 } from "@fortawesome/free-solid-svg-icons";
-import { Segmented, Switch } from "antd";
+import { Segmented, Switch, Select } from "antd";
 
 import EditBallparkModal from "@/dashboard/project/features/budget/components/EditBallparkModal";
 import ClientInvoicePreviewModal from "@/dashboard/project/features/budget/ClientInvoicePreviewModal";
@@ -29,6 +29,7 @@ import {
 
 import summaryStyles from "./budget-header-summary.module.css";
 import headerStyles from "./header-stats.module.css";
+import mobileStyles from "./budget-header-mobile.module.css";
 
 /* =========================
    Types
@@ -68,6 +69,8 @@ export interface BudgetHeaderData {
   headerBudgetedTotalCost?: number | string;
   headerActualTotalCost?: number | string;
   headerFinalTotalCost?: number | string;
+  clientRevisionId?: number | string | null;
+  createdAt?: string | number | Date | null;
 }
 
 export interface ProjectLike {
@@ -123,6 +126,8 @@ type ChartState = {
   palette: string[];
   signature: string;
 };
+
+const MOBILE_BREAKPOINT = 768;
 
 /* =========================
    Helpers
@@ -195,6 +200,7 @@ const BudgetHeader: React.FC<BudgetHeaderProps> = ({
   onOpenRevisionModal,
 }) => {
   const [selectedMetric, setSelectedMetric] = useState<MetricTitle>("Final Cost");
+  const [isMobile, setIsMobile] = useState(false);
 
   const hasReconciled = useMemo(
     () =>
@@ -211,6 +217,27 @@ const BudgetHeader: React.FC<BudgetHeaderProps> = ({
   const [invoiceRevision, setInvoiceRevision] = useState<BudgetHeaderData | null>(null);
 
   const { ws } = useSocket();
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const mediaQuery = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT}px)`);
+    const handleChange = (event: MediaQueryList | MediaQueryListEvent) => {
+      setIsMobile(event.matches);
+    };
+
+    handleChange(mediaQuery);
+
+    const listener = (event: MediaQueryListEvent) => handleChange(event);
+
+    if (typeof mediaQuery.addEventListener === "function") {
+      mediaQuery.addEventListener("change", listener);
+      return () => mediaQuery.removeEventListener("change", listener);
+    }
+
+    mediaQuery.addListener(listener);
+    return () => mediaQuery.removeListener(listener);
+  }, []);
 
   useEffect(() => {
     if (!hasReconciled) setShowReconciled(false);
@@ -429,6 +456,55 @@ const BudgetHeader: React.FC<BudgetHeaderProps> = ({
     ]
   );
 
+  const metricOptions = useMemo(
+    () =>
+      metrics
+        .filter((metric) => metric.field)
+        .map((metric) => ({
+          label: metric.title,
+          value: metric.title,
+        })),
+    [metrics]
+  );
+
+  const markupOptions = useMemo(
+    () =>
+      (showReconciled
+        ? (["Budgeted", "Actual", "Reconciled"] as MarkupBasis[])
+        : (["Budgeted", "Actual"] as MarkupBasis[])
+      ).map((value) => ({
+        label: value,
+        value,
+      })),
+    [showReconciled]
+  );
+
+  const groupByOptions = useMemo(
+    () =>
+      ([
+        { label: "None", value: "none" },
+        { label: "Area Group", value: "areaGroup" },
+        { label: "Invoice Group", value: "invoiceGroup" },
+        { label: "Category", value: "category" },
+      ] as { label: string; value: GroupBy }[]),
+    []
+  );
+
+  const createdDateLabel = useMemo(() => {
+    if (!budgetHeader?.createdAt) return "No date";
+    const date = new Date(budgetHeader.createdAt);
+    if (Number.isNaN(date.getTime())) return "No date";
+    return date.toLocaleDateString();
+  }, [budgetHeader?.createdAt]);
+
+  const ballparkDisplay = useMemo(
+    () =>
+      budgetHeader
+        ? formatUSD(toNumber(budgetHeader.headerBallPark))
+        : "Not available",
+    [budgetHeader]
+  );
+
   const handleBallparkSave = async (val: number) => {
     if (!activeProject?.projectId || !budgetHeader) {
       setBallparkModalOpen(false);
@@ -636,99 +712,265 @@ const BudgetHeader: React.FC<BudgetHeaderProps> = ({
     []
   );
 
-  return (
-    <div>
-      <div className={summaryStyles.container}>
-        <div className={summaryStyles.cardsColumn}>
-          <div className={summaryStyles.cardsRow}>
-            {metrics.slice(0, 3).map((m) => (
-              <SummaryCard
-                key={m.title}
-                icon={m.icon}
-                color={m.color}
-                title={m.title}
-                tag={m.tag}
-                value={m.value}
-                description={m.description}
-                className={m.sticky ? summaryStyles.stickyCard : ""}
-                onClick={m.field ? () => setSelectedMetric(m.title) : undefined}
-                active={selectedMetric === m.title}
-              >
-                {m.extra}
-              </SummaryCard>
-            ))}
-          </div>
+  const legendPreview = useMemo(
+    () => chartState.slices.slice(0, 4),
+    [chartState.slices]
+  );
 
-          <div className={summaryStyles.cardsRow}>
-            {metrics.slice(3).map((m) => (
-              <SummaryCard
-                key={m.title}
-                icon={m.icon}
-                color={m.color}
-                title={m.title}
-                tag={m.tag}
-                value={m.value}
-                description={m.description}
-                className={m.sticky ? summaryStyles.stickyCard : ""}
-                onClick={m.field ? () => setSelectedMetric(m.title) : undefined}
-                active={selectedMetric === m.title}
-              >
-                {m.extra}
-              </SummaryCard>
-            ))}
-          </div>
+  const hiddenLegendCount = Math.max(
+    0,
+    chartState.slices.length - legendPreview.length
+  );
+
+  const metricSelectId = "budget-mobile-metric-select";
+  const groupSelectId = "budget-mobile-group-select";
+  const markupSelectId = "budget-mobile-markup-select";
+
+  const desktopContent = (
+    <div className={summaryStyles.container}>
+      <div className={summaryStyles.cardsColumn}>
+        <div className={summaryStyles.cardsRow}>
+          {metrics.slice(0, 3).map((m) => (
+            <SummaryCard
+              key={m.title}
+              icon={m.icon}
+              color={m.color}
+              title={m.title}
+              tag={m.tag}
+              value={m.value}
+              description={m.description}
+              className={m.sticky ? summaryStyles.stickyCard : ""}
+              onClick={m.field ? () => setSelectedMetric(m.title) : undefined}
+              active={selectedMetric === m.title}
+            >
+              {m.extra}
+            </SummaryCard>
+          ))}
         </div>
 
-        <div className={summaryStyles.chartColumn}>
-          <div className={summaryStyles.overviewHeader}>
-            <Segmented
-              size="small"
-              options={
-                [
-                  { label: "None", value: "none" },
-                  { label: "Area Group", value: "areaGroup" },
-                  { label: "Invoice Group", value: "invoiceGroup" },
-                  { label: "Category", value: "category" },
-                ] as { label: string; value: GroupBy }[]
-              }
-              value={groupBy}
-              onChange={(val: SegmentedValue) => setGroupBy(val as GroupBy)}
-              style={{ background: "#1a1a1a" }}
-            />
-          </div>
-
-          <div className={summaryStyles.chartAndLegend}>
-            <div className={summaryStyles.chartContainer}>
-              <BudgetDonut
-                data={chartState.slices}
-                total={chartState.total}
-                palette={chartState.palette}
-                formatTooltip={formatTooltip}
-                totalFormatter={totalFormatter}
-              />
-            </div>
-            <ul className={summaryStyles.legend}>
-              {chartState.slices.map((slice, index) => {
-                const palette = chartState.palette;
-                const paletteLength = palette.length;
-                const background =
-                  paletteLength > 0
-                    ? palette[index % paletteLength]
-                    : getColor(`${slice.id}-${index}`);
-                return (
-                  <li className={summaryStyles.legendItem} key={slice.id}>
-                    <span
-                      className={summaryStyles.legendDot}
-                      style={{ background }}
-                    />
-                    {slice.label}
-                  </li>
-                );
-              })}
-            </ul>
-          </div>
+        <div className={summaryStyles.cardsRow}>
+          {metrics.slice(3).map((m) => (
+            <SummaryCard
+              key={m.title}
+              icon={m.icon}
+              color={m.color}
+              title={m.title}
+              tag={m.tag}
+              value={m.value}
+              description={m.description}
+              className={m.sticky ? summaryStyles.stickyCard : ""}
+              onClick={m.field ? () => setSelectedMetric(m.title) : undefined}
+              active={selectedMetric === m.title}
+            >
+              {m.extra}
+            </SummaryCard>
+          ))}
         </div>
       </div>
+
+      <div className={summaryStyles.chartColumn}>
+        <div className={summaryStyles.overviewHeader}>
+          <Segmented
+            size="small"
+            options={groupByOptions}
+            value={groupBy}
+            onChange={(val: SegmentedValue) => setGroupBy(val as GroupBy)}
+            style={{ background: "#1a1a1a" }}
+          />
+        </div>
+
+        <div className={summaryStyles.chartAndLegend}>
+          <div className={summaryStyles.chartContainer}>
+            <BudgetDonut
+              data={chartState.slices}
+              total={chartState.total}
+              palette={chartState.palette}
+              formatTooltip={formatTooltip}
+              totalFormatter={totalFormatter}
+            />
+          </div>
+          <ul className={summaryStyles.legend}>
+            {chartState.slices.map((slice, index) => {
+              const palette = chartState.palette;
+              const paletteLength = palette.length;
+              const background =
+                paletteLength > 0
+                  ? palette[index % paletteLength]
+                  : getColor(`${slice.id}-${index}`);
+              return (
+                <li className={summaryStyles.legendItem} key={slice.id}>
+                  <span
+                    className={summaryStyles.legendDot}
+                    style={{ background }}
+                  />
+                  {slice.label}
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+
+  const mobileContent = (
+    <div className={mobileStyles.card}>
+      <div className={mobileStyles.headerRow}>
+        <div className={mobileStyles.titleGroup}>
+          <span>Budget</span>
+          {budgetHeader?.clientRevisionId != null && budgetHeader.clientRevisionId !== "" && (
+            <span className={mobileStyles.clientRevision}>{`Rev.${budgetHeader.clientRevisionId}`}</span>
+          )}
+        </div>
+        <button
+          type="button"
+          className={mobileStyles.revisionButton}
+          onClick={onOpenRevisionModal}
+          disabled={!budgetHeader}
+        >
+          {`Rev.${budgetHeader?.revision ?? 1}`}
+        </button>
+      </div>
+
+      <div className={mobileStyles.amountRow}>
+        <span className={mobileStyles.amountValue}>{ballparkDisplay}</span>
+        <div className={mobileStyles.amountActions}>
+          <button
+            type="button"
+            className={mobileStyles.iconButton}
+            onClick={() => setBallparkModalOpen(true)}
+            aria-label="Edit Ballpark"
+            disabled={!budgetHeader}
+          >
+            <FontAwesomeIcon icon={faPen} />
+          </button>
+          <button
+            type="button"
+            className={mobileStyles.iconButton}
+            onClick={openInvoicePreview}
+            aria-label="Invoice preview"
+            disabled={!budgetHeader}
+          >
+            <FontAwesomeIcon icon={faFileInvoiceDollar} />
+          </button>
+        </div>
+      </div>
+
+      <div className={mobileStyles.dateRow}>{createdDateLabel}</div>
+
+      <div className={mobileStyles.controls}>
+        <div className={mobileStyles.controlRow}>
+          <div className={mobileStyles.controlSelect}>
+            <label className={mobileStyles.srOnly} htmlFor={metricSelectId}>
+              Select metric
+            </label>
+            <Select<MetricTitle>
+              id={metricSelectId}
+              size="small"
+              value={selectedMetric}
+              onChange={(value: MetricTitle) => setSelectedMetric(value)}
+              options={metricOptions}
+              dropdownMatchSelectWidth={false}
+            />
+          </div>
+        </div>
+        <div className={mobileStyles.controlRow}>
+          <div className={mobileStyles.controlSelect}>
+            <label className={mobileStyles.srOnly} htmlFor={groupSelectId}>
+              Group by
+            </label>
+            <Select<GroupBy>
+              id={groupSelectId}
+              size="small"
+              value={groupBy}
+              onChange={(value: GroupBy) => setGroupBy(value)}
+              options={groupByOptions}
+              dropdownMatchSelectWidth={false}
+            />
+          </div>
+          <div className={mobileStyles.controlSelect}>
+            <label className={mobileStyles.srOnly} htmlFor={markupSelectId}>
+              Markup basis
+            </label>
+            <Select<MarkupBasis>
+              id={markupSelectId}
+              size="small"
+              value={markupBasis}
+              onChange={(value: MarkupBasis) => setMarkupBasis(value)}
+              options={markupOptions}
+              dropdownMatchSelectWidth={false}
+            />
+          </div>
+        </div>
+        {hasReconciled && (
+          <div className={mobileStyles.switchRow}>
+            <span>Show reconciled totals</span>
+            <Switch
+              size="small"
+              checked={showReconciled}
+              onChange={(val) => setShowReconciled(val)}
+            />
+          </div>
+        )}
+      </div>
+
+      <div className={mobileStyles.chartRow}>
+        <div className={mobileStyles.chartContainer}>
+          <BudgetDonut
+            data={chartState.slices}
+            total={chartState.total}
+            palette={chartState.palette}
+            formatTooltip={formatTooltip}
+            totalFormatter={totalFormatter}
+          />
+        </div>
+        <div className={mobileStyles.legend}>
+          {legendPreview.map((slice, index) => {
+            const palette = chartState.palette;
+            const paletteLength = palette.length;
+            const background =
+              paletteLength > 0
+                ? palette[index % paletteLength]
+                : getColor(`${slice.id}-${index}`);
+            return (
+              <div className={mobileStyles.legendItem} key={slice.id}>
+                <span
+                  className={mobileStyles.legendDot}
+                  style={{ background }}
+                />
+                {slice.label}
+              </div>
+            );
+          })}
+          {hiddenLegendCount > 0 && (
+            <span className={mobileStyles.legendMore}>{`+${hiddenLegendCount} more`}</span>
+          )}
+        </div>
+      </div>
+
+      <div className={mobileStyles.metricScroll}>
+        {metrics.map((metric) => (
+          <button
+            key={metric.title}
+            type="button"
+            className={`${mobileStyles.metricChip} ${
+              selectedMetric === metric.title ? mobileStyles.metricChipActive : ""
+            }`}
+            onClick={metric.field ? () => setSelectedMetric(metric.title) : undefined}
+            disabled={!metric.field}
+          >
+            <span className={mobileStyles.metricTag}>{metric.tag}</span>
+            <span className={mobileStyles.metricValue}>{metric.value}</span>
+            <span className={mobileStyles.metricDescription}>{metric.description}</span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+
+  return (
+    <div>
+      {isMobile ? mobileContent : desktopContent}
 
       <EditBallparkModal
         isOpen={isBallparkModalOpen}

--- a/frontend/src/dashboard/project/features/budget/components/budget-header-mobile.module.css
+++ b/frontend/src/dashboard/project/features/budget/components/budget-header-mobile.module.css
@@ -1,0 +1,261 @@
+.card {
+  background: rgba(17, 24, 39, 0.85);
+  border-radius: 16px;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  color: #f9fafb;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.06), 0 12px 28px rgba(15, 23, 42, 0.4);
+}
+
+.headerRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.titleGroup {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.clientRevision {
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 9999px;
+  padding: 2px 8px;
+  font-size: 0.7rem;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.revisionButton {
+  background: rgba(255, 255, 255, 0.08);
+  border: none;
+  border-radius: 9999px;
+  padding: 4px 10px;
+  font-size: 0.75rem;
+  color: inherit;
+  cursor: pointer;
+  transition: background-color 0.2s ease, transform 0.2s ease;
+}
+
+.revisionButton:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.16);
+  transform: translateY(-1px);
+}
+
+.revisionButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.amountRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.amountValue {
+  font-size: 1.6rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+}
+
+.amountActions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.iconButton {
+  background: transparent;
+  border: none;
+  color: inherit;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 9999px;
+  padding: 6px;
+  cursor: pointer;
+  transition: background-color 0.2s ease, transform 0.2s ease;
+}
+
+.iconButton:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.12);
+  transform: scale(1.05);
+}
+
+.iconButton:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.dateRow {
+  font-size: 0.75rem;
+  color: rgba(249, 250, 251, 0.7);
+}
+
+.controls {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.controlRow {
+  display: flex;
+  gap: 8px;
+}
+
+.controlSelect {
+  flex: 1;
+  min-width: 0;
+}
+
+.controlSelect :global(.ant-select) {
+  width: 100%;
+}
+
+.controlSelect :global(.ant-select-selector) {
+  background: rgba(30, 41, 59, 0.9) !important;
+  border-radius: 12px !important;
+  border: 1px solid rgba(255, 255, 255, 0.08) !important;
+  color: #f9fafb !important;
+}
+
+.controlSelect :global(.ant-select-selection-item) {
+  color: inherit !important;
+}
+
+.controlSelect :global(.ant-select-arrow) {
+  color: rgba(249, 250, 251, 0.8);
+}
+
+.switchRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  font-size: 0.75rem;
+  color: rgba(249, 250, 251, 0.8);
+}
+
+.chartRow {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.chartContainer {
+  width: 120px;
+  height: 120px;
+  flex-shrink: 0;
+}
+
+.legend {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  flex: 1;
+  min-width: 0;
+}
+
+.legendItem {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.72rem;
+  color: rgba(249, 250, 251, 0.85);
+}
+
+.legendDot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+}
+
+.legendMore {
+  font-size: 0.7rem;
+  color: rgba(249, 250, 251, 0.65);
+}
+
+.metricScroll {
+  display: flex;
+  gap: 8px;
+  overflow-x: auto;
+  padding-bottom: 4px;
+  margin: 0 -4px;
+  padding-left: 4px;
+}
+
+.metricChip {
+  min-width: 120px;
+  background: rgba(30, 41, 59, 0.85);
+  border-radius: 12px;
+  padding: 8px 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  border: 1px solid transparent;
+  color: inherit;
+  text-align: left;
+  transition: border-color 0.2s ease, transform 0.2s ease;
+}
+
+.metricChip:active:not(.metricChipActive) {
+  transform: scale(0.98);
+}
+
+.metricChip:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.metricChipActive {
+  border-color: rgba(255, 255, 255, 0.8);
+  background: rgba(17, 24, 39, 0.9);
+}
+
+.metricTag {
+  font-size: 0.65rem;
+  color: rgba(249, 250, 251, 0.65);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.metricValue {
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.metricDescription {
+  font-size: 0.65rem;
+  color: rgba(249, 250, 251, 0.55);
+}
+
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 480px) {
+  .chartContainer {
+    width: 100px;
+    height: 100px;
+  }
+
+  .metricChip {
+    min-width: 110px;
+  }
+}


### PR DESCRIPTION
## Summary
- introduce a dedicated mobile layout for the budget header that mirrors the compact dashboard overview card
- keep metric selection, grouping, markup controls, and invoice/ballpark actions accessible in the new mobile view
- add a scoped CSS module to style the mobile header, chart preview, and compact control chips

## Testing
- npm run build *(fails: missing `recharts` dependency required by BudgetDonut)*

------
https://chatgpt.com/codex/tasks/task_e_68ddd011f9d48324ba1b161905fc7ccd