### PR TITLE
Align quick create desktop modal with tasks list styling

### DIFF
--- a/frontend/src/dashboard/home/components/QuickCreateTaskModal.module.css
+++ b/frontend/src/dashboard/home/components/QuickCreateTaskModal.module.css
@@ -17,6 +17,12 @@
   }
 }
 
+@media (min-width: 960px) {
+  .createOverlay {
+    padding: 32px 16px;
+  }
+}
+
 .createModal {
   width: min(540px, 100%);
   max-height: 90vh;
@@ -46,6 +52,19 @@
   }
 }
 
+@media (min-width: 960px) {
+  .createModal {
+    width: min(520px, 100%);
+    max-height: min(720px, calc(100vh - 48px));
+    margin: 0;
+    border-radius: 24px;
+    padding: 28px;
+    gap: 24px;
+    box-shadow: 0 24px 60px rgba(0, 0, 0, 0.45);
+    background: rgba(13, 14, 16, 0.95);
+  }
+}
+
 .grabZone {
   display: flex;
   justify-content: center;
@@ -62,6 +81,12 @@
 .grabZone:active {
   cursor: grabbing;
   opacity: 0.6;
+}
+
+@media (min-width: 960px) {
+  .grabZone {
+    display: none;
+  }
 }
 
 .grabHandle {
@@ -88,6 +113,13 @@
   display: none;
 }
 
+@media (min-width: 960px) {
+  .createForm {
+    gap: 24px;
+    overflow: visible;
+  }
+}
+
 .formBody {
   flex: 1 1 auto;
   overflow-y: auto;
@@ -102,11 +134,29 @@
   display: none;
 }
 
+@media (min-width: 960px) {
+  .formBody {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    padding: 0;
+    overflow-y: auto;
+    max-height: none;
+  }
+}
+
 .createHeader {
   display: flex;
   flex-direction: column;
   gap: 8px;
   margin-bottom: 20px;
+}
+
+@media (min-width: 960px) {
+  .createHeader {
+    margin-bottom: 12px;
+    gap: 10px;
+  }
 }
 
 .createHeader h2 {
@@ -127,6 +177,12 @@
   flex-direction: column;
   gap: 10px;
   margin-bottom: 16px;
+}
+
+@media (min-width: 960px) {
+  .fieldGroup {
+    margin-bottom: 0;
+  }
 }
 
 .fieldHeader {
@@ -304,6 +360,16 @@
   margin-top: 20px;
 }
 
+@media (min-width: 960px) {
+  .actionBar {
+    flex-direction: row;
+    justify-content: flex-end;
+    align-items: center;
+    gap: 12px;
+    margin-top: 12px;
+  }
+}
+
 .deleteButton {
   width: 100%;
   border-radius: 14px;
@@ -328,6 +394,14 @@
 .deleteButton:disabled {
   opacity: 0.55;
   cursor: not-allowed;
+}
+
+@media (min-width: 960px) {
+  .deleteButton {
+    width: auto;
+    padding: 10px 18px;
+    border-radius: 999px;
+  }
 }
 
 .submitButton {
@@ -358,6 +432,15 @@
   cursor: not-allowed;
   box-shadow: none;
   transform: none;
+}
+
+@media (min-width: 960px) {
+  .submitButton {
+    width: auto;
+    padding: 10px 20px;
+    border-radius: 999px;
+    min-height: 48px;
+  }
 }
 
 .spinner {


### PR DESCRIPTION
## Summary
- adjust the quick create task modal desktop styles to mirror the Tasks List page drawer appearance
- update button layout and spacing for desktop to match the tasks list experience

## Testing
- not run (CSS-only change)

------
https://chatgpt.com/codex/tasks/task_e_68ddd6c3ad6c83249b961bb866521cec