### PR TITLE
Refine budget toolbar layout for mobile

### DIFF
--- a/frontend/src/dashboard/project/features/budget/components/BudgetToolbar.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetToolbar.tsx
@@ -41,7 +41,6 @@ const BudgetToolbar: React.FC<BudgetToolbarProps> = ({
         ]}
         value={groupBy}
         onChange={(val) => onGroupChange(val as string)}
-        className={styles.segmentedControl}
       />
     </div>
     <div className={styles.actions}>

--- a/frontend/src/dashboard/project/features/budget/components/BudgetToolbar.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetToolbar.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Segmented, Tooltip as AntTooltip } from "antd";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faClone, faTrash, faUndo, faRedo, faPlus } from "@fortawesome/free-solid-svg-icons";
+import styles from "./budget-toolbar.module.css";
 
 interface BudgetToolbarProps {
   groupBy: string;
@@ -28,34 +29,28 @@ const BudgetToolbar: React.FC<BudgetToolbarProps> = ({
   handleRedo,
   openCreateModal,
 }) => (
-  <div
-    style={{
-      color: "white",
-      width: "100%",
-      display: "flex",
-      justifyContent: "space-between",
-      alignItems: "center",
-    }}
-  >
-    <Segmented
-      size="small"
-      options={[
-        { label: "None", value: "none" },
-        { label: "Area Group", value: "areaGroup" },
-        { label: "Invoice Group", value: "invoiceGroup" },
-        { label: "Category", value: "category" },
-      ]}
-      value={groupBy}
-      onChange={(val) => onGroupChange(val as string)}
-    />
-    <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+  <div className={styles.toolbar}>
+    <div className={styles.groupControl}>
+      <Segmented
+        size="small"
+        options={[
+          { label: "None", value: "none" },
+          { label: "Area Group", value: "areaGroup" },
+          { label: "Invoice Group", value: "invoiceGroup" },
+          { label: "Category", value: "category" },
+        ]}
+        value={groupBy}
+        onChange={(val) => onGroupChange(val as string)}
+        className={styles.segmentedControl}
+      />
+    </div>
+    <div className={styles.actions}>
       {selectedRowKeys.length > 0 && (
-        <>
+        <div className={styles.selectionActions}>
           <AntTooltip title="Duplicate Selected">
             <button
               type="button"
-              className="modal-button secondary"
-              style={{ borderRadius: "10px" }}
+              className={`modal-button secondary ${styles.actionButton}`}
               onClick={handleDuplicateSelected}
               aria-label="Duplicate selected"
             >
@@ -65,21 +60,19 @@ const BudgetToolbar: React.FC<BudgetToolbarProps> = ({
           <AntTooltip title="Delete Selected">
             <button
               type="button"
-              className="modal-button secondary"
-              style={{ borderRadius: "10px" }}
+              className={`modal-button secondary ${styles.actionButton}`}
               onClick={() => openDeleteModal(selectedRowKeys)}
               aria-label="Delete selected"
             >
               <FontAwesomeIcon icon={faTrash} />
             </button>
           </AntTooltip>
-        </>
+        </div>
       )}
       <AntTooltip title="Undo">
         <button
           type="button"
-          className="modal-button secondary"
-          style={{ borderRadius: "10px" }}
+          className={`modal-button secondary ${styles.actionButton}`}
           onClick={handleUndo}
           disabled={undoStackLength === 0}
           aria-label="Undo"
@@ -90,8 +83,7 @@ const BudgetToolbar: React.FC<BudgetToolbarProps> = ({
       <AntTooltip title="Redo">
         <button
           type="button"
-          className="modal-button secondary"
-          style={{ borderRadius: "10px" }}
+          className={`modal-button secondary ${styles.actionButton}`}
           onClick={handleRedo}
           disabled={redoStackLength === 0}
           aria-label="Redo"
@@ -102,8 +94,7 @@ const BudgetToolbar: React.FC<BudgetToolbarProps> = ({
       <AntTooltip title="Create Line Item">
         <button
           type="button"
-          className="modal-button primary"
-          style={{ borderRadius: "10px" }}
+          className={`modal-button primary ${styles.primaryActionButton}`}
           onClick={openCreateModal}
           aria-label="Create line item"
         >

--- a/frontend/src/dashboard/project/features/budget/components/budget-toolbar.module.css
+++ b/frontend/src/dashboard/project/features/budget/components/budget-toolbar.module.css
@@ -1,0 +1,68 @@
+.toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  gap: 16px;
+  color: #ffffff;
+  flex-wrap: wrap;
+}
+
+.groupControl {
+  flex: 1;
+  min-width: 240px;
+}
+
+.segmentedControl {
+  width: 100%;
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-left: auto;
+}
+
+.selectionActions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.actionButton,
+.primaryActionButton {
+  border-radius: 10px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+@media (max-width: 768px) {
+  .toolbar {
+    justify-content: flex-end;
+    gap: 12px;
+  }
+
+  .groupControl {
+    display: none;
+  }
+
+  .actions {
+    width: 100%;
+    justify-content: flex-end;
+    gap: 12px;
+  }
+
+  .selectionActions {
+    display: none;
+  }
+
+  .actionButton,
+  .primaryActionButton {
+    width: 44px;
+    height: 44px;
+    border-radius: 14px;
+    font-size: 1rem;
+  }
+}

--- a/frontend/src/dashboard/project/features/budget/components/budget-toolbar.module.css
+++ b/frontend/src/dashboard/project/features/budget/components/budget-toolbar.module.css
@@ -3,18 +3,13 @@
   align-items: center;
   justify-content: space-between;
   width: 100%;
-  gap: 16px;
   color: #ffffff;
   flex-wrap: wrap;
+  row-gap: 16px;
 }
 
 .groupControl {
-  flex: 1;
-  min-width: 240px;
-}
-
-.segmentedControl {
-  width: 100%;
+  flex: 0 0 auto;
 }
 
 .actions {
@@ -39,11 +34,6 @@
 }
 
 @media (max-width: 768px) {
-  .toolbar {
-    justify-content: flex-end;
-    gap: 12px;
-  }
-
   .groupControl {
     display: none;
   }


### PR DESCRIPTION
## Summary
- move budget toolbar layout styling into a CSS module so the segmented control hides on small screens
- restyle the remaining action buttons and hide selection-only actions on mobile to eliminate horizontal scrolling

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ddd9ad63f483248de7eec18d3a7fb6