### PR TITLE
Add desktop drawer layout for project tasks map view

### DIFF
--- a/frontend/src/dashboard/project/components/Tasks/TasksComponent.tsx
+++ b/frontend/src/dashboard/project/components/Tasks/TasksComponent.tsx
@@ -54,6 +54,7 @@ const TasksComponent: React.FC<TasksComponentProps> = ({
   const [isDragging, setIsDragging] = useState(false);
   const [dragStartY, setDragStartY] = useState<number | null>(null);
   const [currentDragY, setCurrentDragY] = useState(0);
+  const [isDesktop, setIsDesktop] = useState(false);
   const inlineTaskListRef = useRef<HTMLUListElement | null>(null);
   const drawerTaskListRef = useRef<HTMLUListElement | null>(null);
   const sheetRef = useRef<HTMLDivElement | null>(null);
@@ -247,6 +248,25 @@ const TasksComponent: React.FC<TasksComponentProps> = ({
       body.style.overflow = previousOverflow;
     };
   }, [drawerOpen]);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      setIsDesktop(false);
+      return;
+    }
+
+    const mediaQuery = window.matchMedia("(min-width: 1024px)");
+    const updateMatch = () => setIsDesktop(mediaQuery.matches);
+    updateMatch();
+
+    if (typeof mediaQuery.addEventListener === "function") {
+      mediaQuery.addEventListener("change", updateMatch);
+      return () => mediaQuery.removeEventListener("change", updateMatch);
+    }
+
+    mediaQuery.addListener(updateMatch);
+    return () => mediaQuery.removeListener(updateMatch);
+  }, []);
 
   const sheetHeights = useMemo(() => DRAWER_SNAP_POINTS.map((point) => viewportHeight * point), [viewportHeight]);
   const baseTargetY = viewportHeight ? viewportHeight - sheetHeights[snapIndex] : 0;
@@ -463,6 +483,7 @@ const TasksComponent: React.FC<TasksComponentProps> = ({
 
       <TaskDrawer
         open={drawerOpen}
+        isDesktop={isDesktop}
         viewportHeight={viewportHeight}
         targetY={targetY}
         projectName={projectName}

--- a/frontend/src/dashboard/project/components/Tasks/TasksComponentMobile.module.css
+++ b/frontend/src/dashboard/project/components/Tasks/TasksComponentMobile.module.css
@@ -501,6 +501,18 @@
   color: var(--text-secondary, rgba(246, 247, 251, 0.74));
 }
 
+.desktopDrawerHeader {
+  display: none;
+}
+
+.desktopDrawerSummary {
+  display: none;
+}
+
+.desktopDrawerScrollArea {
+  padding: 0 1.5rem calc(3.5rem + env(safe-area-inset-bottom, 0px));
+}
+
 .sheetDismiss,
 .sheetCreate {
   position: absolute;
@@ -887,4 +899,151 @@
 
 .mapCanvas :global(.leaflet-map-pane) {
   z-index: inherit;
+}
+
+@media (min-width: 1024px) {
+  .desktopOverlay {
+    --drawer-width: clamp(360px, 32vw, 440px);
+    background: #050607;
+  }
+
+  .desktopSheet {
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: auto;
+    width: var(--drawer-width);
+    height: 100vh;
+    margin: 0;
+    max-height: none;
+    border-radius: 0 24px 24px 0;
+    border-left: none;
+    border-right: 1px solid rgba(255, 255, 255, 0.14);
+    box-shadow: 32px 0 64px rgba(0, 0, 0, 0.52);
+  }
+
+  .desktopDrawerHeader {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1.25rem;
+    padding: 1.5rem 1.75rem 1.25rem;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  }
+
+  .desktopDrawerActions {
+    display: inline-flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+  }
+
+  .desktopDrawerButton {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.6rem 1.1rem;
+    border-radius: 999px;
+    border: 1px solid rgba(255, 255, 255, 0.18);
+    background: rgba(255, 255, 255, 0.08);
+    color: rgba(255, 255, 255, 0.95);
+    font-size: 0.85rem;
+    font-weight: 600;
+    line-height: 1;
+    cursor: pointer;
+    transition: background 0.2s ease, transform 0.2s ease;
+  }
+
+  .desktopDrawerButton svg {
+    width: 16px;
+    height: 16px;
+  }
+
+  .desktopDrawerButton:focus-visible {
+    outline: 2px solid var(--brand, #fa3356);
+    outline-offset: 2px;
+  }
+
+  .desktopDrawerButton:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+  }
+
+  .desktopDrawerButton:not(:disabled):hover,
+  .desktopDrawerButton:not(:disabled):focus-visible {
+    transform: translateY(-1px);
+  }
+
+  .desktopDrawerGhostButton {
+    background: rgba(255, 255, 255, 0.1);
+  }
+
+  .desktopDrawerGhostButton:not(:disabled):hover,
+  .desktopDrawerGhostButton:not(:disabled):focus-visible {
+    background: rgba(255, 255, 255, 0.18);
+  }
+
+  .desktopDrawerPrimaryButton {
+    background: rgba(255, 255, 255, 0.22);
+    border-color: rgba(255, 255, 255, 0.26);
+  }
+
+  .desktopDrawerPrimaryButton:not(:disabled):hover,
+  .desktopDrawerPrimaryButton:not(:disabled):focus-visible {
+    background: rgba(255, 255, 255, 0.3);
+  }
+
+  .desktopDrawerSummary {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    padding: 1.35rem 1.75rem 1.6rem;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+    margin-bottom: 0;
+  }
+
+  .desktopDrawerMapStatus {
+    margin: 0;
+    font-size: 0.85rem;
+    color: rgba(246, 247, 251, 0.72);
+  }
+
+  .desktopDrawerScrollArea {
+    padding: 1.75rem 1.75rem 2.75rem;
+  }
+
+  .desktopOverlay .sheetSection {
+    background: rgba(12, 13, 16, 0.78);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    padding: 1.2rem 1.25rem 1.4rem;
+  }
+
+  .desktopOverlay .mapGradient {
+    top: 0;
+    bottom: 0;
+    left: var(--drawer-width);
+    right: auto;
+    height: 100%;
+    width: min(420px, calc(100vw - var(--drawer-width)));
+    background: linear-gradient(90deg, rgba(5, 6, 7, 0.96) 0%, rgba(5, 6, 7, 0.55) 45%, rgba(5, 6, 7, 0) 100%);
+  }
+
+  .desktopOverlay .mapActiveCard {
+    top: 24px;
+    left: calc(var(--drawer-width) + 24px);
+    right: auto;
+    width: min(360px, calc(100vw - var(--drawer-width) - 48px));
+    max-width: min(360px, calc(100vw - var(--drawer-width) - 48px));
+  }
+
+  .desktopOverlay .mapEmptyBanner {
+    left: calc(var(--drawer-width) + (100vw - var(--drawer-width)) / 2);
+    max-width: min(420px, calc(100vw - var(--drawer-width) - 64px));
+  }
+
+  .desktopOverlay .sheetDismiss,
+  .desktopOverlay .sheetCreate {
+    display: none;
+  }
 }

--- a/frontend/src/dashboard/project/components/Tasks/components/TaskDrawer.tsx
+++ b/frontend/src/dashboard/project/components/Tasks/components/TaskDrawer.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { createPortal } from "react-dom";
-import { Calendar, ChevronDown, MapPin, Plus, User } from "lucide-react";
+import { Calendar, ChevronDown, MapPin, Plus, User, X } from "lucide-react";
 import { motion } from "framer-motion";
 
 import Map from "@/shared/ui/Map";
@@ -12,6 +12,7 @@ import type { QuickTask, TaskMapMarker, TaskStats } from "./taskTypes";
 
 type TaskDrawerProps = {
   open: boolean;
+  isDesktop: boolean;
   viewportHeight: number;
   targetY: number;
   projectName?: string;
@@ -45,6 +46,7 @@ type TaskDrawerProps = {
 
 const TaskDrawer: React.FC<TaskDrawerProps> = ({
   open,
+  isDesktop,
   viewportHeight,
   targetY,
   projectName,
@@ -80,9 +82,18 @@ const TaskDrawer: React.FC<TaskDrawerProps> = ({
   }
 
   const hasMapMarkers = mapMarkers.length > 0;
+  const overlayClassName = isDesktop
+    ? `${styles.sheetOverlay} ${styles.desktopOverlay}`
+    : styles.sheetOverlay;
+  const sheetClassName = isDesktop ? `${styles.sheet} ${styles.desktopSheet}` : styles.sheet;
+  const drawerInitial = isDesktop ? { x: "-100%" } : { y: viewportHeight };
+  const drawerAnimate = isDesktop ? { x: 0 } : { y: targetY };
+  const drawerTransition = isDesktop
+    ? { type: "spring", stiffness: 380, damping: 38, mass: 0.9 }
+    : { type: "spring", stiffness: 360, damping: 42, mass: 0.9 };
 
   return createPortal(
-    <div className={styles.sheetOverlay} role="presentation">
+    <div className={overlayClassName} role="presentation">
       <div className={styles.mapLayer}>
         <div className={styles.mapCanvas}>
           <Map
@@ -121,61 +132,106 @@ const TaskDrawer: React.FC<TaskDrawerProps> = ({
           </div>
         ) : null}
       </div>
-      <button type="button" className={styles.sheetDismiss} onClick={onClose} aria-label="Close tasks drawer">
-        <ChevronDown size={20} strokeWidth={2.5} />
-      </button>
-      <button
-        type="button"
-        className={styles.sheetCreate}
-        onClick={onOpenQuickCreate}
-        aria-label="Quick create a task"
-        disabled={loading || !hasQuickCreateProject}
-      >
-        <Plus size={20} strokeWidth={2.5} />
-      </button>
+      {!isDesktop ? (
+        <>
+          <button
+            type="button"
+            className={styles.sheetDismiss}
+            onClick={onClose}
+            aria-label="Close tasks drawer"
+          >
+            <ChevronDown size={20} strokeWidth={2.5} />
+          </button>
+          <button
+            type="button"
+            className={styles.sheetCreate}
+            onClick={onOpenQuickCreate}
+            aria-label="Quick create a task"
+            disabled={loading || !hasQuickCreateProject}
+          >
+            <Plus size={20} strokeWidth={2.5} />
+          </button>
+        </>
+      ) : null}
       <motion.div
         ref={sheetRef}
-        className={styles.sheet}
+        className={sheetClassName}
         role="dialog"
         aria-modal="true"
         aria-label="Project tasks quick view"
         drag={false}
-        initial={{ y: viewportHeight }}
-        animate={{ y: targetY }}
-        transition={{ type: "spring", stiffness: 360, damping: 42, mass: 0.9 }}
+        initial={drawerInitial}
+        animate={drawerAnimate}
+        transition={drawerTransition}
       >
-        <div
-          className={styles.sheetDragArea}
-          role="button"
-          tabIndex={0}
-          aria-label="Toggle tasks drawer size"
-          onClick={onHandleClick}
-          onTouchStart={onTouchStart}
-          onTouchMove={onTouchMove}
-          onTouchEnd={onTouchEnd}
-          onKeyDown={(event) => {
-            if (event.key === "Enter" || event.key === " ") {
-              event.preventDefault();
-              onHandleClick();
-            }
-          }}
-        >
-          <div className={styles.sheetHandle}>
-            <span className={styles.sheetHandleBar} aria-hidden="true" />
-          </div>
-          <header className={styles.sheetHeader}>
-            <div className={styles.sheetTitleGroup}>
-              <span className={styles.sheetTitle}>Project tasks</span>
-              <span className={styles.sheetSubtitle}>
-                {projectName ? `Everything happening in ${projectName}` : "Keep work on track"}
-              </span>
+        {isDesktop ? (
+          <>
+            <header className={styles.desktopDrawerHeader}>
+              <div className={styles.sheetTitleGroup}>
+                <span className={styles.sheetTitle}>Project tasks</span>
+                <span className={styles.sheetSubtitle}>
+                  {projectName ? `Everything happening in ${projectName}` : "Keep work on track"}
+                </span>
+              </div>
+              <div className={styles.desktopDrawerActions}>
+                <button
+                  type="button"
+                  className={`${styles.desktopDrawerButton} ${styles.desktopDrawerGhostButton}`}
+                  onClick={onClose}
+                >
+                  <X size={16} strokeWidth={2.25} aria-hidden="true" /> Close map
+                </button>
+                <button
+                  type="button"
+                  className={`${styles.desktopDrawerButton} ${styles.desktopDrawerPrimaryButton}`}
+                  onClick={onOpenQuickCreate}
+                  disabled={loading || !hasQuickCreateProject}
+                >
+                  <Plus size={16} strokeWidth={2.25} aria-hidden="true" /> New task
+                </button>
+              </div>
+            </header>
+            <div className={`${styles.sheetSummary} ${styles.desktopDrawerSummary}`}>
+              <TaskSummary stats={stats} formatValue={formatValue} statusMessage={statusMessage} />
+              <p className={styles.desktopDrawerMapStatus}>{mapStatusMessage}</p>
             </div>
-          </header>
-        </div>
-        <div className={styles.sheetSummary}>
-          <TaskSummary stats={stats} formatValue={formatValue} statusMessage={statusMessage} />
-        </div>
-        <div className={styles.sheetScrollArea}>
+          </>
+        ) : (
+          <>
+            <div
+              className={styles.sheetDragArea}
+              role="button"
+              tabIndex={0}
+              aria-label="Toggle tasks drawer size"
+              onClick={onHandleClick}
+              onTouchStart={onTouchStart}
+              onTouchMove={onTouchMove}
+              onTouchEnd={onTouchEnd}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" || event.key === " ") {
+                  event.preventDefault();
+                  onHandleClick();
+                }
+              }}
+            >
+              <div className={styles.sheetHandle}>
+                <span className={styles.sheetHandleBar} aria-hidden="true" />
+              </div>
+              <header className={styles.sheetHeader}>
+                <div className={styles.sheetTitleGroup}>
+                  <span className={styles.sheetTitle}>Project tasks</span>
+                  <span className={styles.sheetSubtitle}>
+                    {projectName ? `Everything happening in ${projectName}` : "Keep work on track"}
+                  </span>
+                </div>
+              </header>
+            </div>
+            <div className={styles.sheetSummary}>
+              <TaskSummary stats={stats} formatValue={formatValue} statusMessage={statusMessage} />
+            </div>
+          </>
+        )}
+        <div className={`${styles.sheetScrollArea} ${isDesktop ? styles.desktopDrawerScrollArea : ""}`}>
           <section className={styles.sheetSection} aria-label="All project tasks">
             <h3 className={styles.sectionHeading}>Task list</h3>
             {error ? (


### PR DESCRIPTION
## Summary
- detect desktop viewports so the tasks map drawer can switch layouts
- implement a left-aligned desktop drawer with dedicated controls while keeping the mobile bottom sheet
- update shared styling to support the desktop drawer and surface map context messaging

## Testing
- pnpm test -- src/dashboard/project/components/Tasks/TasksComponent.test.tsx *(fails: existing unrelated suite failures; run aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68dddd888f1883248567b679ca0c4c63