### PR TITLE
Revamp budget toolbar interactions

### DIFF
--- a/frontend/src/dashboard/project/features/budget/components/BudgetToolbar.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetToolbar.tsx
@@ -1,7 +1,8 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { Segmented, Tooltip as AntTooltip } from "antd";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faClone, faTrash, faUndo, faRedo, faPlus } from "@fortawesome/free-solid-svg-icons";
+import { faClone, faTrash, faPlus } from "@fortawesome/free-solid-svg-icons";
+import styles from "./budget-toolbar.module.css";
 
 interface BudgetToolbarProps {
   groupBy: string;
@@ -27,99 +28,112 @@ const BudgetToolbar: React.FC<BudgetToolbarProps> = ({
   handleUndo,
   handleRedo,
   openCreateModal,
-}) => (
-  <div
-    style={{
-      color: "white",
-      width: "100%",
-      display: "flex",
-      justifyContent: "space-between",
-      alignItems: "center",
-    }}
-  >
-    <Segmented
-      size="small"
-      options={[
-        { label: "None", value: "none" },
-        { label: "Area Group", value: "areaGroup" },
-        { label: "Invoice Group", value: "invoiceGroup" },
-        { label: "Category", value: "category" },
-      ]}
-      value={groupBy}
-      onChange={(val) => onGroupChange(val as string)}
-    />
-    <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
-      {selectedRowKeys.length > 0 && (
-        <>
-          <AntTooltip title="Duplicate Selected">
-            <button
-              type="button"
-              className="modal-button secondary"
-              style={{ borderRadius: "10px" }}
-              onClick={handleDuplicateSelected}
-              aria-label="Duplicate selected"
-            >
-              <FontAwesomeIcon icon={faClone} />
-            </button>
-          </AntTooltip>
-          <AntTooltip title="Delete Selected">
-            <button
-              type="button"
-              className="modal-button secondary"
-              style={{ borderRadius: "10px" }}
-              onClick={() => openDeleteModal(selectedRowKeys)}
-              aria-label="Delete selected"
-            >
-              <FontAwesomeIcon icon={faTrash} />
-            </button>
-          </AntTooltip>
-        </>
-      )}
-      <AntTooltip title="Undo">
-        <button
-          type="button"
-          className="modal-button secondary"
-          style={{ borderRadius: "10px" }}
-          onClick={handleUndo}
-          disabled={undoStackLength === 0}
-          aria-label="Undo"
-        >
-          <FontAwesomeIcon icon={faUndo} />
-        </button>
-      </AntTooltip>
-      <AntTooltip title="Redo">
-        <button
-          type="button"
-          className="modal-button secondary"
-          style={{ borderRadius: "10px" }}
-          onClick={handleRedo}
-          disabled={redoStackLength === 0}
-          aria-label="Redo"
-        >
-          <FontAwesomeIcon icon={faRedo} />
-        </button>
-      </AntTooltip>
-      <AntTooltip title="Create Line Item">
-        <button
-          type="button"
-          className="modal-button primary"
-          style={{ borderRadius: "10px" }}
-          onClick={openCreateModal}
-          aria-label="Create line item"
-        >
-          <FontAwesomeIcon icon={faPlus} />
-        </button>
-      </AntTooltip>
+}) => {
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const isMeta = event.metaKey || event.ctrlKey;
+      const key = event.key.toLowerCase();
+
+      if (!isMeta) return;
+
+      if (key === "z" && undoStackLength > 0) {
+        event.preventDefault();
+        handleUndo();
+        return;
+      }
+
+      if (key === "y" && redoStackLength > 0) {
+        event.preventDefault();
+        handleRedo();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [handleUndo, handleRedo, redoStackLength, undoStackLength]);
+
+  return (
+    <div className={styles.container}>
+      <Segmented
+        size="small"
+        className={styles.segmented}
+        options={[
+          { label: "None", value: "none" },
+          { label: "Area Group", value: "areaGroup" },
+          { label: "Invoice Group", value: "invoiceGroup" },
+          { label: "Category", value: "category" },
+        ]}
+        value={groupBy}
+        onChange={(val) => onGroupChange(val as string)}
+      />
+      <div className={styles.actions}>
+        {selectedRowKeys.length > 0 && (
+          <>
+            <AntTooltip title="Duplicate Selected">
+              <button
+                type="button"
+                className={styles.iconButton}
+                onClick={handleDuplicateSelected}
+                aria-label="Duplicate selected"
+              >
+                <FontAwesomeIcon icon={faClone} />
+              </button>
+            </AntTooltip>
+            <AntTooltip title="Delete Selected">
+              <button
+                type="button"
+                className={styles.iconButton}
+                onClick={() => openDeleteModal(selectedRowKeys)}
+                aria-label="Delete selected"
+              >
+                <FontAwesomeIcon icon={faTrash} />
+              </button>
+            </AntTooltip>
+          </>
+        )}
+        <AntTooltip title="Undo (Ctrl+Z)">
+          <button
+            type="button"
+            className={styles.actionButton}
+            onClick={handleUndo}
+            disabled={undoStackLength === 0}
+            aria-label="Undo"
+          >
+            <span>Undo</span>
+            <span className={styles.shortcut}>Ctrl+Z</span>
+          </button>
+        </AntTooltip>
+        <AntTooltip title="Redo (Ctrl+Y)">
+          <button
+            type="button"
+            className={styles.actionButton}
+            onClick={handleRedo}
+            disabled={redoStackLength === 0}
+            aria-label="Redo"
+          >
+            <span>Redo</span>
+            <span className={styles.shortcut}>Ctrl+Y</span>
+          </button>
+        </AntTooltip>
+        <AntTooltip title="Add Line Item">
+          <button
+            type="button"
+            className={styles.addButton}
+            onClick={openCreateModal}
+            aria-label="Add line item"
+          >
+            <span className={styles.addIcon}>
+              <FontAwesomeIcon icon={faPlus} />
+            </span>
+            <span>Add Item</span>
+          </button>
+        </AntTooltip>
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 export default BudgetToolbar;
-
-
-
-
-
-
-
-

--- a/frontend/src/dashboard/project/features/budget/components/budget-toolbar.module.css
+++ b/frontend/src/dashboard/project/features/budget/components/budget-toolbar.module.css
@@ -1,0 +1,144 @@
+.container {
+  color: #f9fafb;
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.segmented {
+  background: rgba(17, 24, 39, 0.6);
+  border-radius: 12px;
+  padding: 4px;
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.iconButton {
+  background: rgba(17, 24, 39, 0.85);
+  color: #f9fafb;
+  border: 1px solid rgba(75, 85, 99, 0.6);
+  border-radius: 12px;
+  width: 36px;
+  height: 36px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.iconButton:hover,
+.iconButton:focus-visible {
+  background: rgba(17, 24, 39, 0.95);
+  border-color: rgba(129, 140, 248, 0.8);
+  transform: translateY(-1px);
+}
+
+.iconButton:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(129, 140, 248, 0.35);
+}
+
+.iconButton:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.actionButton {
+  background: rgba(17, 24, 39, 0.85);
+  color: #f9fafb;
+  border: 1px solid rgba(75, 85, 99, 0.6);
+  border-radius: 12px;
+  padding: 6px 14px;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 500;
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.actionButton:hover,
+.actionButton:focus-visible {
+  background: rgba(17, 24, 39, 0.95);
+  border-color: rgba(129, 140, 248, 0.8);
+  box-shadow: 0 6px 16px rgba(17, 24, 39, 0.45);
+  transform: translateY(-1px);
+}
+
+.actionButton:focus-visible {
+  outline: none;
+}
+
+.actionButton:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.shortcut {
+  font-size: 0.75rem;
+  line-height: 1;
+  letter-spacing: 0.02em;
+  color: rgba(249, 250, 251, 0.75);
+  background: rgba(55, 65, 81, 0.75);
+  padding: 2px 6px;
+  border-radius: 6px;
+}
+
+.addButton {
+  background: linear-gradient(135deg, #6366f1, #8b5cf6);
+  color: #ffffff;
+  border: none;
+  border-radius: 14px;
+  padding: 8px 18px;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  box-shadow: 0 12px 24px rgba(99, 102, 241, 0.35);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
+}
+
+.addButton:hover,
+.addButton:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 32px rgba(99, 102, 241, 0.4);
+  filter: brightness(1.02);
+}
+
+.addButton:focus-visible {
+  outline: none;
+}
+
+.addButton:active {
+  transform: translateY(0);
+}
+
+.addIcon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.2);
+  border-radius: 9999px;
+  width: 28px;
+  height: 28px;
+}
+
+@media (max-width: 768px) {
+  .container {
+    align-items: flex-start;
+  }
+
+  .actions {
+    flex-wrap: wrap;
+  }
+}


### PR DESCRIPTION
## Summary
- replace the undo/redo arrow buttons with text-first controls and wire them up to Ctrl+Z / Ctrl+Y shortcuts
- restyle the budget toolbar, including a modernized "Add Item" button and refreshed icon buttons

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dde78048648324a1b9f59ed8137653