### PR TITLE
feat: modernize budget toolbar interactions

### DIFF
--- a/frontend/src/dashboard/project/features/budget/components/BudgetStateManager.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetStateManager.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useMemo } from "react";
+import React, { useState, useCallback, useMemo, useEffect } from "react";
 import { useBudget } from "@/dashboard/project/features/budget/context/BudgetContext";
 import { updateBudgetItem } from "@/shared/utils/api";
 import { parseBudget } from "@/shared/utils/budgetUtils";
@@ -255,6 +255,61 @@ const BudgetStateManager: React.FC<BudgetStateManagerProps> = ({
     setSelectedRowKeys([]);
     await syncHeaderTotals(next.items);
   }, [redoStack, budgetItems, budgetHeader, setBudgetItems, setBudgetHeader, computeGroupsAndClients, syncHeaderTotals]);
+
+  useEffect(() => {
+    const isEditableElement = (element: EventTarget | null): boolean => {
+      if (!(element instanceof HTMLElement)) {
+        return false;
+      }
+
+      if (element.isContentEditable) {
+        return true;
+      }
+
+      const tagName = element.tagName;
+      return tagName === "INPUT" || tagName === "TEXTAREA" || tagName === "SELECT";
+    };
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (!(event.ctrlKey || event.metaKey)) {
+        return;
+      }
+
+      if (event.defaultPrevented) {
+        return;
+      }
+
+      if (isEditableElement(event.target)) {
+        return;
+      }
+
+      const key = event.key.toLowerCase();
+
+      if (key === "z") {
+        event.preventDefault();
+        if (event.shiftKey) {
+          void handleRedo();
+        } else {
+          void handleUndo();
+        }
+        return;
+      }
+
+      if (key === "y" && !event.shiftKey) {
+        event.preventDefault();
+        void handleRedo();
+      }
+    };
+
+    if (typeof window === "undefined") {
+      return undefined;
+    }
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+    };
+  }, [handleUndo, handleRedo]);
 
   const state: BudgetStateManagerState = useMemo(() => ({
     // Undo/Redo state

--- a/frontend/src/dashboard/project/features/budget/components/BudgetToolbar.module.css
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetToolbar.module.css
@@ -1,0 +1,69 @@
+.toolbar {
+  color: var(--text-color);
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.addButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1.25rem;
+  border: none;
+  border-radius: 999px;
+  background: var(--brand);
+  color: var(--color-active);
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  box-shadow: 0 6px 18px var(--brand-20);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+.addButton:hover {
+  background: var(--color-hover);
+  transform: translateY(-1px);
+  box-shadow: 0 12px 28px var(--brand-20);
+}
+
+.addButton:focus-visible {
+  outline: 2px solid var(--color-focus);
+  outline-offset: 3px;
+}
+
+.addIcon {
+  display: grid;
+  place-items: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 999px;
+  background: var(--brand-12);
+  color: var(--color-active);
+  font-size: 1.1rem;
+  font-weight: 600;
+  line-height: 1;
+}
+
+.addLabel {
+  white-space: nowrap;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .addButton {
+    transition: background-color 0.2s ease;
+  }
+
+  .addButton:hover {
+    transform: none;
+  }
+}

--- a/frontend/src/dashboard/project/features/budget/components/BudgetToolbar.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetToolbar.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import { Segmented, Tooltip as AntTooltip } from "antd";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faClone, faTrash, faUndo, faRedo, faPlus } from "@fortawesome/free-solid-svg-icons";
+import { faClone, faTrash } from "@fortawesome/free-solid-svg-icons";
+import styles from "./BudgetToolbar.module.css";
 
 interface BudgetToolbarProps {
   groupBy: string;
@@ -9,10 +10,6 @@ interface BudgetToolbarProps {
   selectedRowKeys: string[];
   handleDuplicateSelected: () => void;
   openDeleteModal: (ids: string[]) => void;
-  undoStackLength: number;
-  redoStackLength: number;
-  handleUndo: () => void;
-  handleRedo: () => void;
   openCreateModal: () => void;
 }
 
@@ -22,21 +19,9 @@ const BudgetToolbar: React.FC<BudgetToolbarProps> = ({
   selectedRowKeys,
   handleDuplicateSelected,
   openDeleteModal,
-  undoStackLength,
-  redoStackLength,
-  handleUndo,
-  handleRedo,
   openCreateModal,
 }) => (
-  <div
-    style={{
-      color: "white",
-      width: "100%",
-      display: "flex",
-      justifyContent: "space-between",
-      alignItems: "center",
-    }}
-  >
+  <div className={styles.toolbar}>
     <Segmented
       size="small"
       options={[
@@ -48,7 +33,7 @@ const BudgetToolbar: React.FC<BudgetToolbarProps> = ({
       value={groupBy}
       onChange={(val) => onGroupChange(val as string)}
     />
-    <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+    <div className={styles.actions}>
       {selectedRowKeys.length > 0 && (
         <>
           <AntTooltip title="Duplicate Selected">
@@ -75,39 +60,17 @@ const BudgetToolbar: React.FC<BudgetToolbarProps> = ({
           </AntTooltip>
         </>
       )}
-      <AntTooltip title="Undo">
-        <button
-          type="button"
-          className="modal-button secondary"
-          style={{ borderRadius: "10px" }}
-          onClick={handleUndo}
-          disabled={undoStackLength === 0}
-          aria-label="Undo"
-        >
-          <FontAwesomeIcon icon={faUndo} />
-        </button>
-      </AntTooltip>
-      <AntTooltip title="Redo">
-        <button
-          type="button"
-          className="modal-button secondary"
-          style={{ borderRadius: "10px" }}
-          onClick={handleRedo}
-          disabled={redoStackLength === 0}
-          aria-label="Redo"
-        >
-          <FontAwesomeIcon icon={faRedo} />
-        </button>
-      </AntTooltip>
       <AntTooltip title="Create Line Item">
         <button
           type="button"
-          className="modal-button primary"
-          style={{ borderRadius: "10px" }}
+          className={styles.addButton}
           onClick={openCreateModal}
-          aria-label="Create line item"
+          aria-label="Add budget line item"
         >
-          <FontAwesomeIcon icon={faPlus} />
+          <span className={styles.addIcon} aria-hidden="true">
+            +
+          </span>
+          <span className={styles.addLabel}>Add Item</span>
         </button>
       </AntTooltip>
     </div>

--- a/frontend/src/dashboard/project/features/budget/pages/BudgetPage.tsx
+++ b/frontend/src/dashboard/project/features/budget/pages/BudgetPage.tsx
@@ -639,10 +639,6 @@ const BudgetPageContent = () => {
                                     selectedRowKeys={stateManager.selectedRowKeys}
                                     handleDuplicateSelected={eventHandlers.handleDuplicateSelected}
                                     openDeleteModal={eventHandlers.openDeleteModal}
-                                    undoStackLength={stateManager.undoStack.length}
-                                    redoStackLength={stateManager.redoStack.length}
-                                    handleUndo={stateManager.handleUndo}
-                                    handleRedo={stateManager.handleRedo}
                                     openCreateModal={eventHandlers.openCreateModal}
                                   />
                                   <BudgetItemsTable


### PR DESCRIPTION
## Summary
- replace the budget toolbar undo/redo buttons with a streamlined layout and refreshed Add Item control that uses design tokens
- add a keyboard listener so users can trigger undo and redo with Ctrl/Cmd+Z and Ctrl/Cmd+Y (or Shift+Cmd/Ctrl+Z)

## Testing
- npm run lint *(fails: existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dde95be23883249b1c5511c6fc06db