### PR TITLE
Add budget toolbar add item button component

### DIFF
--- a/frontend/src/components/ui/budget-add-item-button.css
+++ b/frontend/src/components/ui/budget-add-item-button.css
@@ -1,0 +1,50 @@
+.budget-add-item-button {
+  align-items: center;
+  background-color: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 16px;
+  color: #ffffff;
+  cursor: pointer;
+  display: inline-flex;
+  font-size: 0.875rem;
+  font-weight: 500;
+  gap: 8px;
+  line-height: 1;
+  padding: 8px 16px;
+  position: relative;
+  transition: background-color 120ms ease, border-color 120ms ease, transform 80ms ease,
+    box-shadow 120ms ease;
+  user-select: none;
+}
+
+.budget-add-item-button:hover {
+  background-color: rgba(255, 255, 255, 0.04);
+  border-color: rgba(255, 255, 255, 0.25);
+}
+
+.budget-add-item-button:focus {
+  outline: none;
+}
+
+.budget-add-item-button:focus-visible {
+  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.7), 0 0 0 4px rgba(0, 0, 0, 0.6);
+}
+
+.budget-add-item-button:active {
+  transform: scale(0.98);
+}
+
+.budget-add-item-button__icon {
+  flex-shrink: 0;
+  height: 16px;
+  width: 16px;
+}
+
+.budget-add-item-button__label {
+  white-space: nowrap;
+}
+
+.budget-add-item-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}

--- a/frontend/src/components/ui/budget-add-item-button.tsx
+++ b/frontend/src/components/ui/budget-add-item-button.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { Plus } from "lucide-react";
+import { cn } from "./utils";
+import "./budget-add-item-button.css";
+
+export interface BudgetAddItemButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  label?: string;
+}
+
+export const BudgetAddItemButton = React.forwardRef<
+  HTMLButtonElement,
+  BudgetAddItemButtonProps
+>(({ className, label = "Add item", "aria-label": ariaLabel, type = "button", ...props }, ref) => {
+  const computedAriaLabel = ariaLabel ?? label;
+
+  return (
+    <button
+      ref={ref}
+      type={type}
+      className={cn("budget-add-item-button", className)}
+      aria-label={computedAriaLabel}
+      {...props}
+    >
+      <Plus aria-hidden size={16} strokeWidth={2} className="budget-add-item-button__icon" />
+      <span className="budget-add-item-button__label">{label}</span>
+    </button>
+  );
+});
+
+BudgetAddItemButton.displayName = "BudgetAddItemButton";

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -1,4 +1,5 @@
 export * from "./avatar";
 export * from "./badge";
 export * from "./button";
+export * from "./budget-add-item-button";
 export * from "./popover";


### PR DESCRIPTION
## Summary
- add a reusable budget add item button component with accessible defaults and icon
- style the button for neutral dark-toolbar use including focus and active treatments
- export the component through the shared ui index for easy reuse

## Testing
- npm run lint *(fails due to pre-existing issues in unrelated dashboard files)*

------
https://chatgpt.com/codex/tasks/task_e_68ddf2de8e4c8324906df828f958494e