### PR TITLE
Fix PDF.js worker source to comply with CSP

### DIFF
--- a/frontend/src/dashboard/project/components/Shared/PDFPreview.tsx
+++ b/frontend/src/dashboard/project/components/Shared/PDFPreview.tsx
@@ -1,10 +1,10 @@
 // PDFPreview.tsx
 import React, { useEffect, useRef } from 'react';
 import * as pdfjsLib from 'pdfjs-dist/legacy/build/pdf';
+import pdfWorkerSrc from 'pdfjs-dist/build/pdf.worker.min.js?url';
 
 // Set the worker (required by pdf.js)
-pdfjsLib.GlobalWorkerOptions.workerSrc =
-  'https://d2qb21tb4meex0.cloudfront.net/pdfWorker/pdf.worker.js';
+pdfjsLib.GlobalWorkerOptions.workerSrc = pdfWorkerSrc;
 
 type PDFPreviewProps = {
   url: string;

--- a/frontend/src/dashboard/project/features/gallery/GalleryPage.tsx
+++ b/frontend/src/dashboard/project/features/gallery/GalleryPage.tsx
@@ -17,6 +17,7 @@ import { slugify } from "@/shared/utils/slug";
 import { fetchGalleries, fileUrlsToKeys, getFileUrl } from "@/shared/utils/api";
 import Preloader from "@/shared/ui/Preloader";
 import * as pdfjsLibLocal from "pdfjs-dist/legacy/build/pdf";
+import pdfWorkerSrc from "pdfjs-dist/build/pdf.worker.min.js?url";
 import GalleryMasonry from "./GalleryMasonry";
 
 // Simple types for PDF.js
@@ -345,8 +346,7 @@ const GalleryPage: FC<GalleryPageProps> = ({ projectId: propProjectId }) => {
       } else {
         if (!pdfjsLib) {
           pdfjsLib = pdfjsLibLocal as PDFLib;
-          pdfjsLib.GlobalWorkerOptions.workerSrc =
-            "https://d2qb21tb4meex0.cloudfront.net/pdfWorker/pdf.worker.js";
+          pdfjsLib.GlobalWorkerOptions.workerSrc = pdfWorkerSrc;
         }
         setLoading(true);
         const pdfUrl = normalizedUpdatedPdfUrl || normalizedOriginalPdfUrl;

--- a/frontend/src/types/index.d.ts
+++ b/frontend/src/types/index.d.ts
@@ -114,6 +114,11 @@ declare module 'pdfjs-dist/build/pdf.worker.entry' {
   export default url;
 }
 
+declare module 'pdfjs-dist/build/pdf.worker.min.js?url' {
+  const url: string;
+  export default url;
+}
+
 declare module './app/contexts/AuthContext' {
   interface AuthContextType {
     isAuthenticated: boolean;


### PR DESCRIPTION
## Summary
- configure the PDF.js worker to load from a locally bundled asset so previews work within the existing CSP
- update the gallery PDF renderer to share the same worker configuration
- add TypeScript declarations for the new worker URL import

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ddf374d81883249e523f1d49b7cc3e