### PR TITLE
Remove duplicate budget group control

### DIFF
--- a/frontend/src/dashboard/project/features/budget/components/BudgetToolbar.module.css
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetToolbar.module.css
@@ -8,6 +8,59 @@
   padding: 6px;
 }
 
+.groupTabs {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  align-content: flex-end;
+  gap: clamp(6px, 1vw, 12px);
+  margin-right: auto;
+}
+
+.tabButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 14px;
+  font-weight: 600;
+  font-size: clamp(0.78rem, 0.2vw + 0.74rem, 0.88rem);
+  letter-spacing: 0.01em;
+  color: rgba(255, 255, 255, 0.78);
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: rgba(255, 255, 255, 0.06);
+  box-shadow: 0 4px 12px rgba(5, 10, 28, 0.2);
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease,
+    box-shadow 0.2s ease, transform 0.2s ease;
+  cursor: pointer;
+}
+
+.tabButton:hover {
+  background: rgba(255, 255, 255, 0.12);
+  border-color: rgba(255, 255, 255, 0.22);
+  color: rgba(255, 255, 255, 0.92);
+  transform: translateY(-1px);
+}
+
+.tabButton:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.5);
+  outline-offset: 2px;
+}
+
+.tabButton:focus-visible:not(.activeTab) {
+  background: rgba(255, 255, 255, 0.12);
+  border-color: rgba(255, 255, 255, 0.22);
+  color: rgba(255, 255, 255, 0.92);
+  transform: translateY(-1px);
+}
+
+.activeTab {
+  background: rgba(255, 255, 255, 0.98);
+  border-color: transparent;
+  color: #111213;
+  box-shadow: 0 8px 20px rgba(5, 10, 28, 0.32);
+}
+
 .actions {
   display: flex;
   align-items: center;

--- a/frontend/src/dashboard/project/features/budget/components/BudgetToolbar.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetToolbar.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Segmented, Tooltip as AntTooltip } from "antd";
+import { Tooltip as AntTooltip } from "antd";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faClone, faTrash } from "@fortawesome/free-solid-svg-icons";
 import styles from "./BudgetToolbar.module.css";
@@ -13,6 +13,13 @@ interface BudgetToolbarProps {
   openCreateModal: () => void;
 }
 
+const GROUP_BY_OPTIONS = [
+  { label: "None", value: "none" },
+  { label: "Area Group", value: "areaGroup" },
+  { label: "Invoice Group", value: "invoiceGroup" },
+  { label: "Category", value: "category" },
+];
+
 const BudgetToolbar: React.FC<BudgetToolbarProps> = ({
   groupBy,
   onGroupChange,
@@ -22,17 +29,25 @@ const BudgetToolbar: React.FC<BudgetToolbarProps> = ({
   openCreateModal,
 }) => (
   <div className={styles.toolbar}>
-    <Segmented
-      size="small"
-      options={[
-        { label: "None", value: "none" },
-        { label: "Area Group", value: "areaGroup" },
-        { label: "Invoice Group", value: "invoiceGroup" },
-        { label: "Category", value: "category" },
-      ]}
-      value={groupBy}
-      onChange={(val) => onGroupChange(val as string)}
-    />
+    <div className={styles.groupTabs} role="group" aria-label="Group budget items">
+      {GROUP_BY_OPTIONS.map((option) => {
+        const isActive = option.value === groupBy;
+        const className = isActive
+          ? `${styles.tabButton} ${styles.activeTab}`
+          : styles.tabButton;
+        return (
+          <button
+            key={option.value}
+            type="button"
+            aria-pressed={isActive}
+            className={className}
+            onClick={() => onGroupChange(option.value)}
+          >
+            <span>{option.label}</span>
+          </button>
+        );
+      })}
+    </div>
     <div className={styles.actions}>
       {selectedRowKeys.length > 0 && (
         <>

--- a/frontend/src/dashboard/project/features/budget/components/HeaderStats.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/HeaderStats.tsx
@@ -769,16 +769,6 @@ const BudgetHeader: React.FC<BudgetHeaderProps> = ({
       </div>
 
       <div className={summaryStyles.chartColumn}>
-        <div className={summaryStyles.overviewHeader}>
-          <Segmented
-            size="small"
-            options={groupByOptions}
-            value={groupBy}
-            onChange={(val: SegmentedValue) => setGroupBy(val as GroupBy)}
-            style={{ background: "#1a1a1a" }}
-          />
-        </div>
-
         <div className={summaryStyles.chartAndLegend}>
           <div className={summaryStyles.chartContainer}>
             <BudgetDonut


### PR DESCRIPTION
## Summary
- remove the extra group-by segmented control from the budget header donut chart
- restyle the remaining budget toolbar group toggle to match the project header tab styling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ddf58f87208324af25778a25c4aa26