### PR TITLE
Update mobile budget header to emphasize final cost

### DIFF
--- a/frontend/src/dashboard/project/features/budget/components/HeaderStats.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/HeaderStats.tsx
@@ -505,6 +505,14 @@ const BudgetHeader: React.FC<BudgetHeaderProps> = ({
     [budgetHeader]
   );
 
+  const finalCostDisplay = useMemo(
+    () =>
+      budgetHeader
+        ? formatUSD(toNumber(budgetHeader.headerFinalTotalCost))
+        : "Not available",
+    [budgetHeader]
+  );
+
   const handleBallparkSave = async (val: number) => {
     if (!activeProject?.projectId || !budgetHeader) {
       setBallparkModalOpen(false);
@@ -805,48 +813,95 @@ const BudgetHeader: React.FC<BudgetHeaderProps> = ({
 
   const mobileContent = (
     <div className={mobileStyles.card}>
-      <div className={mobileStyles.headerRow}>
-        <div className={mobileStyles.titleGroup}>
-          <span>Budget</span>
-          {budgetHeader?.clientRevisionId != null && budgetHeader.clientRevisionId !== "" && (
-            <span className={mobileStyles.clientRevision}>{`Rev.${budgetHeader.clientRevisionId}`}</span>
-          )}
+      <div className={mobileStyles.summaryRow}>
+        <div className={mobileStyles.summaryDetails}>
+          <div className={mobileStyles.headerRow}>
+            <div className={mobileStyles.titleGroup}>
+              <span>Budget</span>
+              {budgetHeader?.clientRevisionId != null && budgetHeader.clientRevisionId !== "" && (
+                <span className={mobileStyles.clientRevision}>{`Rev.${budgetHeader.clientRevisionId}`}</span>
+              )}
+            </div>
+            <button
+              type="button"
+              className={mobileStyles.revisionButton}
+              onClick={onOpenRevisionModal}
+              disabled={!budgetHeader}
+            >
+              {`Rev.${budgetHeader?.revision ?? 1}`}
+            </button>
+          </div>
+
+          <div className={mobileStyles.finalRow}>
+            <span className={mobileStyles.finalLabel}>Final Cost</span>
+            <span className={mobileStyles.finalValue}>{finalCostDisplay}</span>
+          </div>
+
+          <div className={mobileStyles.estimateRow}>
+            <div className={mobileStyles.estimateCopy}>
+              <span className={mobileStyles.estimateLabel}>Estimate</span>
+              <span className={mobileStyles.estimateValue}>{ballparkDisplay}</span>
+            </div>
+            <div className={mobileStyles.amountActions}>
+              <button
+                type="button"
+                className={mobileStyles.iconButton}
+                onClick={() => setBallparkModalOpen(true)}
+                aria-label="Edit Ballpark"
+                disabled={!budgetHeader}
+              >
+                <FontAwesomeIcon icon={faPen} />
+              </button>
+              <button
+                type="button"
+                className={mobileStyles.iconButton}
+                onClick={openInvoicePreview}
+                aria-label="Invoice preview"
+                disabled={!budgetHeader}
+              >
+                <FontAwesomeIcon icon={faFileInvoiceDollar} />
+              </button>
+            </div>
+          </div>
+
+          <div className={mobileStyles.dateRow}>{createdDateLabel}</div>
         </div>
-        <button
-          type="button"
-          className={mobileStyles.revisionButton}
-          onClick={onOpenRevisionModal}
-          disabled={!budgetHeader}
-        >
-          {`Rev.${budgetHeader?.revision ?? 1}`}
-        </button>
+
+        <div className={mobileStyles.summaryChart}>
+          <div className={mobileStyles.chartContainer}>
+            <BudgetDonut
+              data={chartState.slices}
+              total={chartState.total}
+              palette={chartState.palette}
+              formatTooltip={formatTooltip}
+              totalFormatter={totalFormatter}
+            />
+          </div>
+        </div>
       </div>
 
-      <div className={mobileStyles.amountRow}>
-        <span className={mobileStyles.amountValue}>{ballparkDisplay}</span>
-        <div className={mobileStyles.amountActions}>
-          <button
-            type="button"
-            className={mobileStyles.iconButton}
-            onClick={() => setBallparkModalOpen(true)}
-            aria-label="Edit Ballpark"
-            disabled={!budgetHeader}
-          >
-            <FontAwesomeIcon icon={faPen} />
-          </button>
-          <button
-            type="button"
-            className={mobileStyles.iconButton}
-            onClick={openInvoicePreview}
-            aria-label="Invoice preview"
-            disabled={!budgetHeader}
-          >
-            <FontAwesomeIcon icon={faFileInvoiceDollar} />
-          </button>
-        </div>
+      <div className={mobileStyles.legend}>
+        {legendPreview.map((slice, index) => {
+          const palette = chartState.palette;
+          const paletteLength = palette.length;
+          const background =
+            paletteLength > 0
+              ? palette[index % paletteLength]
+              : getColor(`${slice.id}-${index}`);
+          return (
+            <div className={mobileStyles.legendItem} key={slice.id}>
+              <span
+                className={mobileStyles.legendDot}
+                style={{ background }}
+              />
+              {slice.label}
+            </div>
+          );
+        })}
+        {hiddenLegendCount > 0 && (
+          <span className={mobileStyles.legendMore}>{`+${hiddenLegendCount} more`}</span>
+        )}
       </div>
-
-      <div className={mobileStyles.dateRow}>{createdDateLabel}</div>
 
       <div className={mobileStyles.controls}>
         <div className={mobileStyles.controlRow}>
@@ -902,40 +957,6 @@ const BudgetHeader: React.FC<BudgetHeaderProps> = ({
             />
           </div>
         )}
-      </div>
-
-      <div className={mobileStyles.chartRow}>
-        <div className={mobileStyles.chartContainer}>
-          <BudgetDonut
-            data={chartState.slices}
-            total={chartState.total}
-            palette={chartState.palette}
-            formatTooltip={formatTooltip}
-            totalFormatter={totalFormatter}
-          />
-        </div>
-        <div className={mobileStyles.legend}>
-          {legendPreview.map((slice, index) => {
-            const palette = chartState.palette;
-            const paletteLength = palette.length;
-            const background =
-              paletteLength > 0
-                ? palette[index % paletteLength]
-                : getColor(`${slice.id}-${index}`);
-            return (
-              <div className={mobileStyles.legendItem} key={slice.id}>
-                <span
-                  className={mobileStyles.legendDot}
-                  style={{ background }}
-                />
-                {slice.label}
-              </div>
-            );
-          })}
-          {hiddenLegendCount > 0 && (
-            <span className={mobileStyles.legendMore}>{`+${hiddenLegendCount} more`}</span>
-          )}
-        </div>
       </div>
 
       <div className={mobileStyles.metricScroll}>

--- a/frontend/src/dashboard/project/features/budget/components/budget-header-mobile.module.css
+++ b/frontend/src/dashboard/project/features/budget/components/budget-header-mobile.module.css
@@ -9,6 +9,21 @@
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.06), 0 12px 28px rgba(15, 23, 42, 0.4);
 }
 
+.summaryRow {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.summaryDetails {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  flex: 1;
+  min-width: 0;
+}
+
 .headerRow {
   display: flex;
   align-items: center;
@@ -53,17 +68,50 @@
   cursor: not-allowed;
 }
 
-.amountRow {
+
+.finalRow {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.finalLabel {
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(249, 250, 251, 0.6);
+}
+
+.finalValue {
+  font-size: 1.75rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+}
+
+.estimateRow {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 12px;
 }
 
-.amountValue {
-  font-size: 1.6rem;
-  font-weight: 700;
-  letter-spacing: 0.01em;
+.estimateCopy {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.estimateLabel {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(249, 250, 251, 0.5);
+}
+
+.estimateValue {
+  font-size: 1rem;
+  font-weight: 600;
+  color: rgba(249, 250, 251, 0.85);
 }
 
 .amountActions {
@@ -144,15 +192,16 @@
   color: rgba(249, 250, 251, 0.8);
 }
 
-.chartRow {
+.summaryChart {
   display: flex;
-  gap: 12px;
   align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
 }
 
 .chartContainer {
-  width: 120px;
-  height: 120px;
+  width: 140px;
+  height: 140px;
   flex-shrink: 0;
 }
 
@@ -160,8 +209,6 @@
   display: flex;
   flex-direction: column;
   gap: 6px;
-  flex: 1;
-  min-width: 0;
 }
 
 .legendItem {


### PR DESCRIPTION
## Summary
- highlight the active revision's final cost at the top of the mobile budget header alongside the donut chart
- restyle the mobile budget layout so the estimate appears as supporting information and enlarge the donut visualization

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68de10b8c428832484b880bb3231fd5d