### PR TITLE
Adjust project dashboard stacked layout for tall mobile screens

### DIFF
--- a/frontend/src/dashboard/home/styles/components/calendar.css
+++ b/frontend/src/dashboard/home/styles/components/calendar.css
@@ -68,6 +68,49 @@
   flex: none;
 }
 
+.budget-calendar-layout--stacked.budget-calendar-layout--stacked-tall {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+.budget-calendar-layout--stacked.budget-calendar-layout--stacked-tall .budget-column {
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+.budget-calendar-layout--stacked.budget-calendar-layout--stacked-tall .budget-column > * {
+  flex: 1 1 0;
+  min-height: 0;
+}
+
+.budget-calendar-layout--stacked.budget-calendar-layout--stacked-tall .budget-column .budget-overview-card {
+  flex: 0 0 auto;
+  min-height: clamp(220px, 32vh, 360px);
+  max-height: none;
+}
+
+.budget-calendar-layout--stacked.budget-calendar-layout--stacked-tall .budget-calendar-mobile-card {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.budget-calendar-layout--stacked.budget-calendar-layout--stacked-tall .budget-calendar-mobile-card > * {
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+.budget-calendar-layout--stacked.budget-calendar-layout--stacked-tall .budget-column .view-gallery {
+  flex: 1 1 0;
+  min-height: 0;
+}
+
+.budget-calendar-layout--stacked.budget-calendar-layout--stacked-tall + .timeline-location-row {
+  margin-top: auto;
+}
+
 /* Mobile stacked layout height optimization */
 @media (max-width: 768px) {
   .budget-calendar-layout .budget-column,

--- a/frontend/src/dashboard/project/project.tsx
+++ b/frontend/src/dashboard/project/project.tsx
@@ -27,6 +27,7 @@ import Spinner from "@/shared/ui/Spinner";
 
 const MOBILE_LAYOUT_WIDTH = 640;
 const TASKS_MOBILE_WIDTH = 768;
+const TALL_MOBILE_HEIGHT = 780;
 
 interface LocationState {
   flashDate?: string;
@@ -57,6 +58,12 @@ const SingleProject: React.FC = () => {
   const [isMobileTasksLayout, setIsMobileTasksLayout] = useState(() => {
     if (typeof window === "undefined") return false;
     return window.innerWidth <= TASKS_MOBILE_WIDTH;
+  });
+  const [isTallMobileBudgetLayout, setIsTallMobileBudgetLayout] = useState(() => {
+    if (typeof window === "undefined") return false;
+    return (
+      window.innerWidth <= MOBILE_LAYOUT_WIDTH && window.innerHeight >= TALL_MOBILE_HEIGHT
+    );
   });
 
   const projectNameFromPath = useMemo(() => {
@@ -141,8 +148,12 @@ const SingleProject: React.FC = () => {
     if (typeof window === "undefined") return;
     const handleResize = () => {
       const width = window.innerWidth;
-      setIsMobileBudgetLayout(width <= MOBILE_LAYOUT_WIDTH);
+      const height = window.innerHeight;
+      const isMobileWidth = width <= MOBILE_LAYOUT_WIDTH;
+
+      setIsMobileBudgetLayout(isMobileWidth);
       setIsMobileTasksLayout(width <= TASKS_MOBILE_WIDTH);
+      setIsTallMobileBudgetLayout(isMobileWidth && height >= TALL_MOBILE_HEIGHT);
     };
     handleResize();
     window.addEventListener("resize", handleResize);
@@ -381,6 +392,8 @@ const SingleProject: React.FC = () => {
         <div
           className={`dashboard-layout budget-calendar-layout${
             isMobileBudgetLayout ? " budget-calendar-layout--stacked" : ""
+          }${
+            isTallMobileBudgetLayout ? " budget-calendar-layout--stacked-tall" : ""
           }`}
         >
           <div className="budget-column">


### PR DESCRIPTION
## Summary
- mark tall mobile viewports so the stacked budget layout can stretch and keep tasks pinned at the bottom
- update stacked budget layout styles to let the budget card, week widget, and gallery grow to fill available height on taller phones

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de322b718c8324acc0b711ab69c3a9