### PR TITLE
Adjust mobile welcome layout spacing on tall phones

### DIFF
--- a/frontend/src/dashboard/home/styles/components/welcome-screen.css
+++ b/frontend/src/dashboard/home/styles/components/welcome-screen.css
@@ -81,21 +81,18 @@
   max-width: 100vw;
   overflow: visible; /* allow children (CTA) to be fully visible */
   align-items: stretch;
- 
-
 }
 
 .mobile-projects-tasks {
   display: flex;
   flex-direction: column;
-  flex: 1 1 auto;
+  flex: 1 1 0;
   min-height: 0;
   overflow: hidden;
-  
 }
 
 .mobile-projects-section {
-  flex: 1 1 auto;
+  flex: 1 1 0;
   max-height: none;
   overflow: hidden;
   padding: 0; /* remove outer grey wrapper */
@@ -126,6 +123,7 @@
   max-width: 100vw;
   overflow: visible;
   margin-top: auto;
+  padding-bottom: max(12px, env(safe-area-inset-bottom, 0px));
 }
 
 .dashboard-footer {
@@ -133,9 +131,9 @@
 }
 
 .mobile-calendar-section {
-  flex: 0 0 auto;
+  flex: 1 1 0;
   min-height: 0;
-  overflow: auto;
+  overflow: hidden;
 
   border-radius: 8px;
   padding: 0px;
@@ -151,6 +149,17 @@
 .mobile-calendar-section > * {
   width: 100%;
   max-width: 100vw;
+}
+
+.mobile-calendar-section > * {
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+.mobile-projects-panel > * {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: auto;
 }
 
 /* Ensure projects header is more compact on mobile */


### PR DESCRIPTION
## Summary
- let the mobile welcome layout calendar and projects sections flex to occupy extra vertical space on taller devices
- keep the mobile tasks card anchored as a footer with safe-area padding so the layout fills the screen
- ensure the embedded widgets can grow or scroll within their containers without clipping

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68de31fce014832483b2fd9a75342abf