### PR TITLE
Add quick map links to task addresses

### DIFF
--- a/frontend/src/dashboard/project/components/Tasks/TasksComponentMobile.module.css
+++ b/frontend/src/dashboard/project/components/Tasks/TasksComponentMobile.module.css
@@ -833,6 +833,50 @@
   gap: 0.35rem;
 }
 
+.metaLineAddress {
+  align-items: flex-start;
+}
+
+.addressDetails {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.addressText {
+  color: inherit;
+  word-break: break-word;
+}
+
+.addressActions {
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.45rem;
+  font-size: 0.75rem;
+  color: rgba(246, 247, 251, 0.8);
+}
+
+.addressLink {
+  color: var(--brand, #fa3356);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.addressLink:hover,
+.addressLink:focus-visible {
+  text-decoration: underline;
+}
+
+.addressLink:focus-visible {
+  outline: 2px solid var(--brand, #fa3356);
+  outline-offset: 2px;
+}
+
+.addressLinkSeparator {
+  color: rgba(246, 247, 251, 0.55);
+}
+
 .statusBadge {
   display: inline-flex;
   align-items: center;

--- a/frontend/src/dashboard/project/components/Tasks/components/TaskDrawer.tsx
+++ b/frontend/src/dashboard/project/components/Tasks/components/TaskDrawer.tsx
@@ -9,6 +9,7 @@ import styles from "../TasksComponentMobile.module.css";
 import TaskList from "./TaskList";
 import TaskSummary from "./TaskSummary";
 import type { QuickTask, TaskMapMarker, TaskStats } from "./taskTypes";
+import { buildDirectionsLinks } from "../utils";
 
 type TaskDrawerProps = {
   open: boolean;
@@ -91,6 +92,7 @@ const TaskDrawer: React.FC<TaskDrawerProps> = ({
   const drawerTransition = isDesktop
     ? { type: "spring", stiffness: 380, damping: 38, mass: 0.9 }
     : { type: "spring", stiffness: 360, damping: 42, mass: 0.9 };
+  const selectedTaskDirections = selectedTask?.address ? buildDirectionsLinks(selectedTask.address) : null;
 
   return createPortal(
     <div className={overlayClassName} role="presentation">
@@ -119,8 +121,34 @@ const TaskDrawer: React.FC<TaskDrawerProps> = ({
                 <Calendar size={14} aria-hidden="true" /> {formatDueLabel(selectedTask)}
               </span>
               {selectedTask.address ? (
-                <span className={styles.metaLine}>
-                  <MapPin size={14} aria-hidden="true" /> {selectedTask.address}
+                <span className={`${styles.metaLine} ${styles.metaLineAddress}`}>
+                  <MapPin size={14} aria-hidden="true" />
+                  <span className={styles.addressDetails}>
+                    <span className={styles.addressText}>{selectedTask.address}</span>
+                    {selectedTaskDirections ? (
+                      <span className={styles.addressActions}>
+                        <a
+                          href={selectedTaskDirections.appleMaps}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className={styles.addressLink}
+                        >
+                          Open in Maps
+                        </a>
+                        <span className={styles.addressLinkSeparator} aria-hidden="true">
+                          •
+                        </span>
+                        <a
+                          href={selectedTaskDirections.googleMaps}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className={styles.addressLink}
+                        >
+                          Open in Google Maps
+                        </a>
+                      </span>
+                    ) : null}
+                  </span>
                 </span>
               ) : null}
               {selectedAssigneeName ? (

--- a/frontend/src/dashboard/project/components/Tasks/components/TaskList.tsx
+++ b/frontend/src/dashboard/project/components/Tasks/components/TaskList.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Calendar, MapPin, User } from "lucide-react";
 
 import styles from "../TasksComponentMobile.module.css";
-import { formatAssigneeDisplay } from "../utils";
+import { buildDirectionsLinks, formatAssigneeDisplay } from "../utils";
 import type { QuickTask } from "./taskTypes";
 
 type TaskListProps = {
@@ -26,9 +26,22 @@ const TaskList: React.FC<TaskListProps> = ({
       const assigneeLabel = formatAssigneeDisplay(task.assignedTo);
       const listItemClassName = `${styles.taskItem}${isActive ? ` ${styles.taskItemActive}` : ""}`;
 
+      const directionsLinks = buildDirectionsLinks(task.address);
+
       return (
         <li key={task.id} data-task-id={task.id} className={listItemClassName}>
-          <button type="button" className={styles.taskButton} onClick={() => onTaskSelect(task.id)}>
+          <div
+            role="button"
+            tabIndex={0}
+            className={styles.taskButton}
+            onClick={() => onTaskSelect(task.id)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter" || event.key === " ") {
+                event.preventDefault();
+                onTaskSelect(task.id);
+              }
+            }}
+          >
             <div className={styles.taskTitleRow}>
               <span className={styles.taskTitle}>{task.title}</span>
               <span className={styles.statusBadge}>
@@ -40,8 +53,36 @@ const TaskList: React.FC<TaskListProps> = ({
                 <Calendar size={14} aria-hidden="true" /> {formatDueLabel(task)}
               </span>
               {task.address ? (
-                <span className={styles.metaLine}>
-                  <MapPin size={14} aria-hidden="true" /> {task.address}
+                <span className={`${styles.metaLine} ${styles.metaLineAddress}`}>
+                  <MapPin size={14} aria-hidden="true" />
+                  <span className={styles.addressDetails}>
+                    <span className={styles.addressText}>{task.address}</span>
+                    {directionsLinks ? (
+                      <span className={styles.addressActions}>
+                        <a
+                          href={directionsLinks.appleMaps}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className={styles.addressLink}
+                          onClick={(event) => event.stopPropagation()}
+                        >
+                          Open in Maps
+                        </a>
+                        <span className={styles.addressLinkSeparator} aria-hidden="true">
+                          •
+                        </span>
+                        <a
+                          href={directionsLinks.googleMaps}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className={styles.addressLink}
+                          onClick={(event) => event.stopPropagation()}
+                        >
+                          Open in Google Maps
+                        </a>
+                      </span>
+                    ) : null}
+                  </span>
                 </span>
               ) : (
                 <span className={`${styles.metaLine} ${styles.metaLineMuted}`}>
@@ -58,7 +99,7 @@ const TaskList: React.FC<TaskListProps> = ({
                 </span>
               )}
             </div>
-          </button>
+          </div>
         </li>
       );
     })}

--- a/frontend/src/dashboard/project/components/Tasks/utils.ts
+++ b/frontend/src/dashboard/project/components/Tasks/utils.ts
@@ -66,6 +66,22 @@ export function buildTaskNameOptions(
   return Array.from(dedupedMap.values());
 }
 
+export function buildDirectionsLinks(
+  address?: string | null,
+): { appleMaps: string; googleMaps: string } | null {
+  if (!address) return null;
+
+  const trimmed = address.trim();
+  if (!trimmed) return null;
+
+  const encoded = encodeURIComponent(trimmed);
+
+  return {
+    appleMaps: `https://maps.apple.com/?q=${encoded}`,
+    googleMaps: `https://www.google.com/maps/search/?api=1&query=${encoded}`,
+  };
+}
+
 export function sortByProximity(
   suggestions: NominatimSuggestion[],
   userLocation: { lat: number; lng: number } | null


### PR DESCRIPTION
## Summary
- add a utility for generating Apple Maps and Google Maps URLs from task addresses
- update the task list and map drawer to surface clickable map direction links alongside each address
- style the new address link actions to match the existing drawer aesthetics

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68de2f5f1d688324ae9e4322d1e0f50a