### PR TITLE
Capture task creator metadata when creating tasks

### DIFF
--- a/backend/projects/router.mjs
+++ b/backend/projects/router.mjs
@@ -57,6 +57,39 @@ const epochNow = () => Math.floor(Date.now() / 1000);
 
 const makeEventId = (ts = Date.now()) => `E#${String(ts).padStart(13, "0")}#${uuidv4()}`;
 
+function getUserFromEvent(e) {
+  const claims = e?.requestContext?.authorizer?.jwt?.claims || {};
+  const rawUserId = claims["custom:userId"] || claims.sub;
+  const userId = typeof rawUserId === "string" && rawUserId.trim() ? rawUserId.trim() : null;
+
+  const usernameCandidates = [
+    claims["cognito:username"],
+    claims.preferred_username,
+    claims.username,
+  ];
+  const username = usernameCandidates.find((value) => typeof value === "string" && value.trim()) || null;
+
+  const givenName = typeof claims.given_name === "string" ? claims.given_name.trim() : "";
+  const familyName = typeof claims.family_name === "string" ? claims.family_name.trim() : "";
+  const fullNameFromParts = [givenName, familyName].filter(Boolean).join(" ");
+  const displayNameCandidates = [
+    typeof claims.name === "string" ? claims.name.trim() : "",
+    fullNameFromParts.trim(),
+    username || "",
+    typeof claims.email === "string" ? claims.email.trim() : "",
+  ];
+  const displayName = displayNameCandidates.find((value) => typeof value === "string" && value.length) || null;
+
+  const email = typeof claims.email === "string" && claims.email.trim() ? claims.email.trim() : null;
+
+  return {
+    userId,
+    username,
+    displayName,
+    email,
+  };
+}
+
 function buildUpdate(obj) {
   const Names = {}, Values = {}, sets = [];
   let i = 0;
@@ -577,19 +610,36 @@ const listTasks = async (_e, C, { projectId }) => {
 
 const createTask = async (e, C, { projectId }) => {
   const b = B(e);
+  const { userId, username, displayName, email } = getUserFromEvent(e);
+  const body = { ...(b || {}) };
+  delete body.createdAt;
+  delete body.updatedAt;
+  delete body.statusDueDateTaskId;
+  delete body.createdBy;
+  delete body.createdById;
+  delete body.createdByName;
+  delete body.createdByUsername;
+  delete body.createdByEmail;
   const taskId = b.taskId || `T-${uuidv4()}`;
   const ts = nowISO();
   const item = {
+    ...body,
     projectId,
     taskId,
-    title: b.title || "",
-    status: b.status || "todo",
-    assigneeId: b.assigneeId,
-    dueAt: b.dueAt,
     createdAt: ts,
     updatedAt: ts,
-    ...b,
   };
+  item.title = typeof item.title === "string" ? item.title : "";
+  item.status = typeof item.status === "string" && item.status ? item.status : "todo";
+  item.projectId = projectId;
+  item.taskId = taskId;
+  if (userId) {
+    item.createdBy = userId;
+    item.createdById = userId;
+  }
+  if (displayName) item.createdByName = displayName;
+  if (username) item.createdByUsername = username;
+  if (email) item.createdByEmail = email;
   const dueDate = item.dueAt ? String(item.dueAt).slice(0, 10) : "";
   item.statusDueDateTaskId = `${item.status}#${dueDate}#${taskId}`;
   await ddb.put({
@@ -607,6 +657,16 @@ const getTask = async (_e, C, { projectId, taskId }) => {
 
 const patchTask = async (e, C, { projectId, taskId }) => {
   const b = B(e);
+  if (b && typeof b === "object") {
+    delete b.createdAt;
+    delete b.createdBy;
+    delete b.createdById;
+    delete b.createdByName;
+    delete b.createdByUsername;
+    delete b.createdByEmail;
+    delete b.statusDueDateTaskId;
+    delete b.updatedAt;
+  }
   if (b.status !== undefined || b.dueAt !== undefined) {
     const curr = await ddb.get({
       TableName: TASKS_TABLE,

--- a/frontend/src/dashboard/project/components/Tasks/components/taskTypes.ts
+++ b/frontend/src/dashboard/project/components/Tasks/components/taskTypes.ts
@@ -17,6 +17,11 @@ export type RawTask = {
   assignedTo?: string;
   location?: unknown;
   address?: string;
+  createdBy?: string;
+  createdById?: string;
+  createdByName?: string;
+  createdByUsername?: string;
+  createdByEmail?: string;
   [key: string]: unknown;
 };
 

--- a/frontend/src/dashboard/project/components/Tasks/types.ts
+++ b/frontend/src/dashboard/project/components/Tasks/types.ts
@@ -48,6 +48,11 @@ export interface Task {
   status: Status;
   location?: TaskLocation;
   address?: string;
+  createdBy?: string;
+  createdById?: string;
+  createdByName?: string;
+  createdByUsername?: string;
+  createdByEmail?: string;
 }
 
 export interface NominatimSuggestion {

--- a/frontend/src/shared/utils/api.ts
+++ b/frontend/src/shared/utils/api.ts
@@ -73,6 +73,11 @@ export interface Task extends JsonRecord {
   status?: 'todo' | 'in_progress' | 'done';
   assigneeId?: string;
   dueDate?: string; // ISO
+  createdBy?: string;
+  createdById?: string;
+  createdByName?: string;
+  createdByUsername?: string;
+  createdByEmail?: string;
 }
 
 export interface TimelineEvent extends JsonRecord {


### PR DESCRIPTION
## Summary
- extract the authenticated user's identity from the request when creating tasks and persist it as creator metadata
- prevent task updates from overwriting creator information while keeping the status index logic intact
- expose the new creator metadata fields on shared task types so the dashboard can consume them

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68deeb58cc0083248690082153777be9