### PR TITLE
Improve task modal success feedback

### DIFF
--- a/frontend/src/dashboard/home/components/QuickCreateTaskModal.module.css
+++ b/frontend/src/dashboard/home/components/QuickCreateTaskModal.module.css
@@ -279,8 +279,27 @@
 
 .feedbackSuccess {
   background: rgba(34, 197, 94, 0.16);
-  color: #a6f4c5;
+  color: #d1fae5;
   border: 1px solid rgba(34, 197, 94, 0.35);
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-weight: 600;
+  box-shadow: 0 0 0 1px rgba(34, 197, 94, 0.2), 0 12px 24px rgba(17, 94, 50, 0.35);
+}
+
+.feedbackSuccess::before {
+  content: "✓";
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, rgba(34, 197, 94, 0.85), rgba(16, 185, 129, 0.9));
+  color: rgba(4, 47, 46, 0.95);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.95rem;
+  box-shadow: inset 0 0 0 1px rgba(20, 184, 166, 0.4);
 }
 
 .quickChips {

--- a/frontend/src/dashboard/home/components/QuickCreateTaskModal.tsx
+++ b/frontend/src/dashboard/home/components/QuickCreateTaskModal.tsx
@@ -187,6 +187,8 @@ const QuickCreateTaskModal: React.FC<QuickCreateTaskModalProps> = ({
   const formRef = useRef<HTMLFormElement | null>(null);
   const titleInputRef = useRef<HTMLInputElement | null>(null);
   const notesRef = useRef<HTMLTextAreaElement | null>(null);
+  const lastAppliedTaskRef = useRef<string | null>(null);
+  const successMessageRef = useRef<string | null>(null);
   const descriptionId = useId();
   const projectFieldId = useId();
   const assigneeFieldId = useId();
@@ -323,6 +325,10 @@ const QuickCreateTaskModal: React.FC<QuickCreateTaskModalProps> = ({
   const canSubmit = Boolean(effectiveProjectId && trimmedTitle);
   const isBusy = submitting || deleting;
 
+  useEffect(() => {
+    successMessageRef.current = successMessage;
+  }, [successMessage]);
+
   const sortSuggestionsByProximity = useCallback(
     (suggestions: NominatimSuggestion[], origin: Coordinates | null) => {
       if (!origin) return suggestions;
@@ -374,7 +380,13 @@ const QuickCreateTaskModal: React.FC<QuickCreateTaskModalProps> = ({
   }, []);
 
   const applyTaskToForm = useCallback(
-    (taskData: QuickCreateTaskModalTask) => {
+    (
+      taskData: QuickCreateTaskModalTask,
+      options?: {
+        preserveFeedback?: boolean;
+      },
+    ) => {
+      const preserveFeedback = Boolean(options?.preserveFeedback);
       const nextProjectId = typeof taskData.projectId === "string" ? taskData.projectId.trim() : "";
       setProjectId(nextProjectId);
       const nextTaskId =
@@ -390,8 +402,10 @@ const QuickCreateTaskModal: React.FC<QuickCreateTaskModalProps> = ({
       setAddressSearch(typeof taskData.address === "string" ? taskData.address : "");
       setAddressSuggestions([]);
       setSelectedLocation(normalizeLocation(taskData.location));
-      setSuccessMessage(null);
-      setErrorMessage(null);
+      if (!preserveFeedback) {
+        setSuccessMessage(null);
+        setErrorMessage(null);
+      }
       setTitleError(null);
       setProjectError(null);
     },
@@ -406,6 +420,7 @@ const QuickCreateTaskModal: React.FC<QuickCreateTaskModalProps> = ({
       isDraggingRef.current = false;
       touchStartYRef.current = null;
       lastOffsetRef.current = 0;
+      lastAppliedTaskRef.current = null;
       return;
     }
 
@@ -413,13 +428,12 @@ const QuickCreateTaskModal: React.FC<QuickCreateTaskModalProps> = ({
     setSuccessMessage(null);
     setTitleError(null);
     setProjectError(null);
+  }, [open, resetForm]);
 
-    if (task) {
-      applyTaskToForm(task);
+  useEffect(() => {
+    if (!open || task) {
       return;
     }
-
-    resetForm();
 
     if (scopedProjectId) {
       setProjectId(scopedProjectId);
@@ -432,11 +446,18 @@ const QuickCreateTaskModal: React.FC<QuickCreateTaskModalProps> = ({
     }
 
     setProjectId(projectOptions[0].id);
-  }, [open, projectOptions, resetForm, scopedProjectId, task, applyTaskToForm]);
+  }, [open, projectOptions, scopedProjectId, task]);
 
   useEffect(() => {
     if (!open || !task) return;
-    applyTaskToForm(task);
+    const taskKey =
+      (typeof task.taskId === "string" && task.taskId.trim()) ||
+      (typeof task.id === "string" && task.id.trim()) ||
+      null;
+    const shouldPreserveFeedback =
+      Boolean(successMessageRef.current) && taskKey !== null && taskKey === lastAppliedTaskRef.current;
+    applyTaskToForm(task, { preserveFeedback: shouldPreserveFeedback });
+    lastAppliedTaskRef.current = taskKey;
   }, [open, task, applyTaskToForm]);
 
   useEffect(() => {
@@ -794,7 +815,7 @@ const QuickCreateTaskModal: React.FC<QuickCreateTaskModalProps> = ({
 
       if (isEditing && taskId) {
         await updateTask({ ...payload, taskId });
-        setSuccessMessage("Task updated.");
+        setSuccessMessage("Task updated. Changes saved.");
         onUpdated?.();
       } else {
         await createTask(payload);


### PR DESCRIPTION
## Summary
- keep task edit success feedback visible when the task data refreshes after saving
- prevent the modal from clearing success/error state unnecessarily while still syncing the latest task values
- restyle the success banner with a clear checkmark indicator so saves feel confirmed

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68deeadc7a8083249e80fdbc92f0eef7