### PR TITLE
Update tasks overview to honor completion timestamps

### DIFF
--- a/frontend/src/dashboard/home/hooks/useTasksOverview.test.ts
+++ b/frontend/src/dashboard/home/hooks/useTasksOverview.test.ts
@@ -1,0 +1,73 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, beforeEach, vi } from "vitest";
+
+import { useTasksOverview } from "./useTasksOverview";
+import { useData } from "@/app/contexts/useData";
+import { fetchTasks } from "@/shared/utils/api";
+import type { Project } from "@/app/contexts/DataProvider";
+
+vi.mock("@/app/contexts/useData", () => ({
+  useData: vi.fn(),
+}));
+
+vi.mock("@/shared/utils/api", async () => {
+  const actual = await vi.importActual<typeof import("@/shared/utils/api")>(
+    "@/shared/utils/api",
+  );
+  return {
+    ...actual,
+    fetchTasks: vi.fn(),
+  };
+});
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+  return {
+    ...actual,
+    useNavigate: () => vi.fn(),
+  };
+});
+
+describe("useTasksOverview", () => {
+  const mockUseData = vi.mocked(useData);
+  const mockFetchTasks = vi.mocked(fetchTasks);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("counts tasks completed this week using completion timestamps", async () => {
+    const project: Project = { projectId: "project-1", title: "Project" };
+    mockUseData.mockReturnValue({ projects: [project] } as unknown as ReturnType<typeof useData>);
+
+    const now = new Date();
+    const recentIso = now.toISOString();
+
+    mockFetchTasks.mockResolvedValue([
+      {
+        id: "task-no-due",
+        title: "No due date task",
+        status: "done",
+        completedAt: recentIso,
+      },
+      {
+        id: "task-old-due",
+        title: "Old due task",
+        status: "done",
+        dueDate: "2020-01-01",
+        updatedAt: recentIso,
+      },
+    ]);
+
+    const { result } = renderHook(() => useTasksOverview());
+
+    await waitFor(() => {
+      expect(result.current.completedThisWeek).toHaveLength(2);
+    });
+
+    const titles = result.current.completedThisWeek.map((task) => task.title);
+    expect(titles).toContain("No due date task");
+    expect(titles).toContain("Old due task");
+    expect(result.current.stats.completed).toBe(2);
+  });
+});

--- a/frontend/src/dashboard/home/hooks/useTasksOverview.ts
+++ b/frontend/src/dashboard/home/hooks/useTasksOverview.ts
@@ -43,11 +43,13 @@ type NormalizedTask = {
   title: string;
   status: TaskStatus;
   dueDate: Date | null;
+  completedAt: Date | null;
   projectId: string;
   projectName: string;
   projectColor: string;
   dueKey?: string;
   timeLabel?: string;
+  completedTimeLabel?: string;
   raw: RawTask & { projectId: string };
 };
 
@@ -57,10 +59,12 @@ export type TasksOverviewListItem = {
   title: string;
   status: TaskStatus;
   dueDate: Date | null;
+  completedAt: Date | null;
   projectId: string;
   projectName: string;
   projectColor: string;
   timeLabel?: string;
+  completedTimeLabel?: string;
   description?: string;
   assigneeId?: string;
   address?: string;
@@ -198,6 +202,18 @@ function pickDue(raw: RawTask): { value: Date | null; key?: string; timeLabel?: 
   return { value: dueDate, key, timeLabel };
 }
 
+function pickCompletion(value: unknown): { value: Date | null; timeLabel?: string } {
+  const date = parseDueDate(value);
+  if (!date) {
+    return { value: null, timeLabel: undefined };
+  }
+
+  const timeLabel =
+    typeof value === "string" && value.includes("T") ? timeFormatter.format(date) : undefined;
+
+  return { value: date, timeLabel };
+}
+
 export function useTasksOverview() {
   const { projects = [] } = useData() as { projects: Project[] };
   const navigate = useNavigate();
@@ -241,33 +257,45 @@ export function useTasksOverview() {
                 try {
                   const raw = await fetchTasks(project.projectId);
                   return (raw || []).map((task: RawTask, idx) => {
-                  const { value: dueDate, key: dueKey, timeLabel } = pickDue(task);
-                  const projectName = project.title || project.projectId;
-                  const projectColor = project.color || getColor(project.projectId);
-                  const id =
-                    (task.taskId as string | undefined) ||
-                    (task.id as string | undefined) ||
-                    `${project.projectId}-${idx}`;
+                    const { value: dueDate, key: dueKey, timeLabel } = pickDue(task);
+                    const projectName = project.title || project.projectId;
+                    const projectColor = project.color || getColor(project.projectId);
+                    const id =
+                      (task.taskId as string | undefined) ||
+                      (task.id as string | undefined) ||
+                      `${project.projectId}-${idx}`;
 
-                  const status = typeof task.status === "string" ? task.status.toLowerCase() : "todo";
-                  const title = normalizeTitle(task.title ?? task.name);
-                  const rawWithProject = { ...task, projectId: project.projectId } as RawTask & {
-                    projectId: string;
-                  };
+                    const status = typeof task.status === "string" ? task.status.toLowerCase() : "todo";
+                    const title = normalizeTitle(task.title ?? task.name);
+                    const completionCandidate =
+                      (task as { completedAt?: unknown }).completedAt ??
+                      (task as { completed_at?: unknown }).completed_at ??
+                      (task as { updatedAt?: unknown }).updatedAt ??
+                      (task as { updated_at?: unknown }).updated_at ??
+                      null;
+                    const { value: completedAt, timeLabel: completedTimeLabel } =
+                      status === "done"
+                        ? pickCompletion(completionCandidate)
+                        : { value: null, timeLabel: undefined };
+                    const rawWithProject = { ...task, projectId: project.projectId } as RawTask & {
+                      projectId: string;
+                    };
 
-                  return {
-                    id,
-                    title,
-                    status,
-                    dueDate,
-                    dueKey,
-                    timeLabel,
-                    projectId: project.projectId,
-                    projectName,
-                    projectColor,
-                    raw: rawWithProject,
-                  } satisfies NormalizedTask;
-                });
+                    return {
+                      id,
+                      title,
+                      status,
+                      dueDate,
+                      completedAt,
+                      dueKey,
+                      timeLabel,
+                      completedTimeLabel,
+                      projectId: project.projectId,
+                      projectName,
+                      projectColor,
+                      raw: rawWithProject,
+                    } satisfies NormalizedTask;
+                  });
                 } catch (err) {
                   console.error("Failed to fetch tasks for project", project.projectId, err);
                   return [] as NormalizedTask[];
@@ -327,10 +355,12 @@ export function useTasksOverview() {
         title: task.title,
         status: task.status,
         dueDate: task.dueDate,
+        completedAt: task.completedAt,
         projectId: task.projectId,
         projectName: task.projectName,
         projectColor: task.projectColor,
         timeLabel: task.timeLabel,
+        completedTimeLabel: task.completedTimeLabel,
         description,
         assigneeId: assignee,
         address,
@@ -372,15 +402,21 @@ export function useTasksOverview() {
     >();
 
     tasks.forEach((task) => {
-      if (!task.dueDate) {
-        return;
-      }
-
       const due = task.dueDate;
       const isDone = task.status === "done";
+      const completionReference = task.completedAt ?? due;
 
-      if (isDone && due >= weekStart && due <= weekEnd) {
+      if (
+        isDone &&
+        completionReference &&
+        completionReference >= weekStart &&
+        completionReference <= weekEnd
+      ) {
         completedCount += 1;
+      }
+
+      if (!due) {
+        return;
       }
 
       if (!isDone) {
@@ -447,11 +483,22 @@ export function useTasksOverview() {
       .map(toListItem);
 
     const completedThisWeek = tasks
-      .filter(
-        (task) =>
-          task.status === "done" && task.dueDate && task.dueDate >= weekStart && task.dueDate <= weekEnd
-      )
-      .sort((a, b) => (a.dueDate && b.dueDate ? b.dueDate.getTime() - a.dueDate.getTime() : 0))
+      .filter((task) => {
+        if (task.status !== "done") {
+          return false;
+        }
+
+        const completedOn = task.completedAt ?? task.dueDate;
+        return Boolean(completedOn && completedOn >= weekStart && completedOn <= weekEnd);
+      })
+      .sort((a, b) => {
+        const aCompleted = a.completedAt ?? a.dueDate;
+        const bCompleted = b.completedAt ?? b.dueDate;
+        if (!aCompleted || !bCompleted) {
+          return 0;
+        }
+        return bCompleted.getTime() - aCompleted.getTime();
+      })
       .map(toListItem);
 
     return {

--- a/frontend/src/dashboard/home/pages/TasksListPage.tsx
+++ b/frontend/src/dashboard/home/pages/TasksListPage.tsx
@@ -25,7 +25,7 @@ const dueFormatter = new Intl.DateTimeFormat(undefined, {
   weekday: "short",
 });
 
-function formatDueDate(date: Date | null | undefined, timeLabel?: string): string {
+function formatDateLabel(date: Date | null | undefined, timeLabel?: string): string {
   if (!date) return "No due date";
   const formatted = dueFormatter.format(date);
   return timeLabel ? `${formatted} · ${timeLabel}` : formatted;
@@ -46,41 +46,48 @@ const TaskList: React.FC<TaskListProps> = ({ tasks, emptyLabel, onStart, showCom
 
   return (
     <ul className={styles.taskList}>
-      {tasks.map((task) => (
-        <li key={task.id} className={styles.taskItem}>
-          <button
-            type="button"
-            className={`${styles.taskMain} ${styles.taskButton}`}
-            onClick={onSelect ? () => onSelect(task) : undefined}
-            disabled={!onSelect}
-          >
-            <span
-              className={styles.projectDot}
-              style={{ backgroundColor: task.projectColor || "var(--brand, #fa3356)" }}
-              aria-hidden="true"
-            />
-            <div className={styles.taskMeta}>
-              <span className={styles.taskTitle} title={task.title}>
-                {task.title}
-              </span>
-              <span className={styles.taskDetails}>
-                {task.projectName}
-                {task.projectName && (task.dueDate || task.timeLabel) ? " · " : ""}
-                {formatDueDate(task.dueDate, task.timeLabel)}
-              </span>
+      {tasks.map((task) => {
+        const displayDate = showCompleted ? task.completedAt ?? task.dueDate : task.dueDate;
+        const displayTimeLabel = showCompleted
+          ? task.completedTimeLabel ?? task.timeLabel
+          : task.timeLabel;
+
+        return (
+          <li key={task.id} className={styles.taskItem}>
+            <button
+              type="button"
+              className={`${styles.taskMain} ${styles.taskButton}`}
+              onClick={onSelect ? () => onSelect(task) : undefined}
+              disabled={!onSelect}
+            >
+              <span
+                className={styles.projectDot}
+                style={{ backgroundColor: task.projectColor || "var(--brand, #fa3356)" }}
+                aria-hidden="true"
+              />
+              <div className={styles.taskMeta}>
+                <span className={styles.taskTitle} title={task.title}>
+                  {task.title}
+                </span>
+                <span className={styles.taskDetails}>
+                  {task.projectName}
+                  {task.projectName && (displayDate || displayTimeLabel) ? " · " : ""}
+                  {formatDateLabel(displayDate, displayTimeLabel)}
+                </span>
+              </div>
+            </button>
+            <div className={styles.taskActions}>
+              {showCompleted ? (
+                <span className={styles.completedTag}>Completed</span>
+              ) : onStart ? (
+                <button type="button" className={styles.startButton} onClick={() => onStart(task)}>
+                  Open project
+                </button>
+              ) : null}
             </div>
-          </button>
-          <div className={styles.taskActions}>
-            {showCompleted ? (
-              <span className={styles.completedTag}>Completed</span>
-            ) : onStart ? (
-              <button type="button" className={styles.startButton} onClick={() => onStart(task)}>
-                Open project
-              </button>
-            ) : null}
-          </div>
-        </li>
-      ))}
+          </li>
+        );
+      })}
     </ul>
   );
 };


### PR DESCRIPTION
## Summary
- track each task's completion timestamp alongside due date information in the dashboard tasks overview
- use completion times to compute weekly completion stats and surface them in the completed list display
- adjust the tasks list UI to show completed dates and add a hook test covering tasks without recent due dates

## Testing
- `npm run test -- useTasksOverview`


------
https://chatgpt.com/codex/tasks/task_e_68deee1c891083248693493c07d202d4