### PR TITLE
Adjust mobile budget header actions

### DIFF
--- a/frontend/src/dashboard/project/features/budget/components/HeaderStats.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/HeaderStats.tsx
@@ -833,9 +833,15 @@ const BudgetHeader: React.FC<BudgetHeaderProps> = ({
       <div className={mobileStyles.headerRow}>
         <div className={mobileStyles.titleGroup}>
           <span>Budget</span>
-          {budgetHeader?.clientRevisionId != null && budgetHeader.clientRevisionId !== "" && (
-            <span className={mobileStyles.clientRevision}>{`Rev.${budgetHeader.clientRevisionId}`}</span>
-          )}
+          <button
+            type="button"
+            className={mobileStyles.iconButton}
+            onClick={openInvoicePreview}
+            aria-label="Invoice preview"
+            disabled={!budgetHeader}
+          >
+            <FontAwesomeIcon icon={faFileInvoiceDollar} />
+          </button>
         </div>
         <button
           type="button"
@@ -851,17 +857,6 @@ const BudgetHeader: React.FC<BudgetHeaderProps> = ({
         <div className={mobileStyles.summaryColumn}>
           <div className={mobileStyles.amountRow}>
             <span className={mobileStyles.amountValue}>{finalDisplay}</span>
-            <div className={mobileStyles.amountActions}>
-              <button
-                type="button"
-                className={mobileStyles.iconButton}
-                onClick={openInvoicePreview}
-                aria-label="Invoice preview"
-                disabled={!budgetHeader}
-              >
-                <FontAwesomeIcon icon={faFileInvoiceDollar} />
-              </button>
-            </div>
           </div>
           <div className={mobileStyles.dateRow}>{createdDateLabel}</div>
         </div>

--- a/frontend/src/dashboard/project/features/budget/components/budget-header-mobile.module.css
+++ b/frontend/src/dashboard/project/features/budget/components/budget-header-mobile.module.css
@@ -24,17 +24,9 @@
 .titleGroup {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 10px;
   font-size: 1rem;
   font-weight: 600;
-}
-
-.clientRevision {
-  background: rgba(255, 255, 255, 0.1);
-  border-radius: 9999px;
-  padding: 2px 8px;
-  font-size: 0.7rem;
-  color: rgba(255, 255, 255, 0.8);
 }
 
 .revisionButton {


### PR DESCRIPTION
## Summary
- move the invoice preview action into the budget title row on the mobile header
- remove the redundant client revision pill so only the top-right revision control remains

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68deed9fb0ec8324b19916bb4d8b53a1