### PR TITLE
Make invoice preview modal responsive on mobile

### DIFF
--- a/frontend/src/dashboard/project/features/budget/components/InvoicePreviewModal.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/InvoicePreviewModal.tsx
@@ -924,7 +924,7 @@ const InvoicePreviewModal: React.FC<InvoicePreviewModalProps> = ({
 
               <div
                 className={styles.contentRow}
-                style={showSidebar ? undefined : { minWidth: "850px" }}
+                data-has-sidebar={showSidebar ? "true" : "false"}
               >
                 {showSidebar && (
                   <div className={styles.sidebar}>

--- a/frontend/src/dashboard/project/features/budget/components/invoice-preview-modal.module.css
+++ b/frontend/src/dashboard/project/features/budget/components/invoice-preview-modal.module.css
@@ -11,6 +11,8 @@
   z-index: 1000;
   opacity: 0;
   transition: opacity 0.3s ease;
+  padding: 16px;
+  box-sizing: border-box;
 }
 .modalOverlayAfterOpen {
   opacity: 1;
@@ -33,6 +35,8 @@
   transition: opacity 0.3s ease, transform 0.3s ease;
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
   font-family: "Helvetica Neue", sans-serif;
+  max-height: 100%;
+  box-sizing: border-box;
 }
 .modalContentAfterOpen {
   opacity: 1;
@@ -101,6 +105,7 @@
   gap: 10px;
   overflow: hidden;
   margin-top: 0.5rem;
+  min-height: 0;
 }
 
 .contentRow {
@@ -109,7 +114,12 @@
   gap: 10px;
   overflow-x: auto;
   overflow-y: hidden;
-  min-width: calc(850px + 280px + 10px);
+  min-width: 0;
+  justify-content: flex-start;
+}
+
+.contentRow[data-has-sidebar="false"] {
+  justify-content: center;
 }
 .sidebar {
   width: 280px;
@@ -123,6 +133,8 @@
   display: flex;
   flex-direction: column;
   gap: 10px;
+  max-height: 100%;
+  box-sizing: border-box;
 }
 .sidebar select {
   height: 32px;
@@ -134,10 +146,17 @@
 }
 .navControls {
   display: grid;
-  grid-template-columns: 1fr auto 1fr;
+  grid-template-columns: minmax(0, auto) 1fr minmax(0, auto);
   align-items: center;
   justify-items: center;
   gap: 10px;
+  width: fit-content;
+  margin-inline: auto;
+}
+
+.navControls span {
+  text-align: center;
+  width: 100%;
 }
 
 .navButton {
@@ -156,8 +175,9 @@
 }
 .previewWrapper {
   overflow: auto;
-  flex: 1 0 850px;
-  min-width: 850px;
+  flex: 1 1 auto;
+  min-width: 0;
+  width: 100%;
   background: #fff;
   color: #000;
   padding: 10px;
@@ -165,6 +185,8 @@
   justify-content: flex-start;
   align-items: center;
   flex-direction: column;
+  border-radius: 6px;
+  box-sizing: border-box;
 }
 
 .groupSelect,
@@ -224,13 +246,16 @@
   background: #fff;
   color: #000;
   font-family: Arial, Helvetica, sans-serif;
-  width: 210mm;
+  width: min(100%, 210mm);
+  max-width: 210mm;
   box-sizing: border-box;
 }
 
 .invoice-page {
-  width: 210mm;
-  height: 297mm;
+  width: min(100%, 210mm);
+  max-width: 210mm;
+  height: auto;
+  min-height: 297mm;
   margin: 0 auto 20px;
   padding: 20px;
   box-sizing: border-box;
@@ -402,13 +427,91 @@
   border-color: #ff4b6c;
 }
 
+@media (max-width: 1024px) {
+  .modalOverlay {
+    padding: 12px;
+  }
+
+  .modalContent {
+    width: 100%;
+    height: min(100vh, 1100px);
+    max-height: none;
+  }
+
+  .contentRow {
+    overflow-x: hidden;
+  }
+}
+
 @media (max-width: 768px) {
+  .modalOverlay {
+    align-items: stretch;
+    justify-content: stretch;
+    padding: 0;
+  }
+
+  .modalContent {
+    border-radius: 0;
+    width: 100vw;
+    height: 100vh;
+    max-height: none;
+    padding: 16px 12px;
+    border-width: 0;
+  }
+
+  .modalBody {
+    overflow: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
   .contentRow {
     flex-direction: column;
+    gap: 16px;
+    overflow: visible;
   }
+
   .sidebar {
     width: 100%;
     max-width: none;
+    order: 1;
+    max-height: none;
+  }
+
+  .previewWrapper {
+    order: 2;
+    border-radius: 12px;
+  }
+
+  .groupSelect,
+  .pageSelect {
+    max-height: 220px;
+  }
+
+  .navControls {
+    width: 100%;
+  }
+
+  .invoice-page {
+    min-height: auto;
+  }
+}
+
+@media (max-width: 600px) {
+  .modalContent {
+    padding: 12px 10px;
+  }
+
+  .invoice-page {
+    padding: 16px;
+  }
+
+  .items-table th,
+  .items-table td {
+    padding: 6px;
+  }
+
+  .navButton {
+    padding: 6px;
   }
 }
 


### PR DESCRIPTION
## Summary
- update the invoice preview modal layout to remove the fixed desktop-only widths
- restyle the modal container, preview pane, and invoice page so they scale on narrow screens
- add responsive behaviors for navigation controls and stacked sidebar to improve phone usability

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68def1605e4083249734afa2c3f0f486