### PR TITLE
Add dashboard preview mode for local development

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -51,6 +51,17 @@ Improved rendering workflows for 2D/3D assets
 
 ## 📖 Technical Documentation
 
+### 🧪 Dashboard Preview Mode (Dev Only)
+When running the frontend locally (`npm run dev`), you can load the dashboard layout without authenticating. Append one of the following query parameters to any `/dashboard` URL:
+
+- `?dashboardPreview` (implicit on)
+- `?dashboardPreview=off` (turns it off for the current tab)
+- `?preview=dashboard` (alternate shorthand)
+
+Example: `http://localhost:5173/dashboard?dashboardPreview`
+
+The flag is stored in `sessionStorage`, so the preview stays enabled for the current tab until you close it or explicitly disable it. The mode is ignored in production builds and is intended strictly for layout/UX verification—data that normally requires authentication will not load.
+
 ### Lexical Editor System
 For detailed technical information about the real-time collaborative editor:
 

--- a/frontend/docs/DASHBOARD_PREVIEW_MODE.md
+++ b/frontend/docs/DASHBOARD_PREVIEW_MODE.md
@@ -1,0 +1,29 @@
+# Dashboard Preview Mode (Dev Only)
+
+The dashboard can now be rendered without logging into Cognito so that designers and developers can validate layout and UX work in isolation. This mode is only available while running the Vite dev server (`npm run dev`).
+
+## Enabling preview mode
+
+1. Start the frontend locally: `npm run dev`.
+2. Open any dashboard URL in the same tab and append one of the flags below:
+   - `?dashboardPreview`
+   - `?preview=dashboard`
+
+Example: <http://localhost:5173/dashboard?dashboardPreview>
+
+When the flag is detected the guard that normally enforces authentication is bypassed and the dashboard renders immediately.
+
+## Turning preview mode off
+
+Append one of the following to any dashboard URL to disable the feature in the current tab:
+
+- `?dashboardPreview=off`
+- `?preview=off`
+
+The preference is stored in `sessionStorage`, so the override persists while the browser tab stays open. Close the tab (or disable it explicitly) to return to the normal authentication flow.
+
+## Notes
+
+- Preview mode is ignored in production builds; it only activates when `import.meta.env.DEV` is true.
+- Because no Cognito session is created, data that normally depends on an authenticated user may appear empty or with placeholder values. This is expected for layout-only validation.
+- A `data-dashboard-preview="true"` attribute is added to the `<body>` tag while preview mode is active. This can be used for optional dev-only styling cues.

--- a/frontend/src/app/contexts/ProtectedRoute.tsx
+++ b/frontend/src/app/contexts/ProtectedRoute.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { Navigate } from 'react-router-dom';
+import { Navigate, useLocation } from 'react-router-dom';
 import { useAuth } from '@/app/contexts/useAuth';
+import { useDashboardPreview } from '@/shared/utils/dashboardPreview';
 
 interface ProtectedRouteProps {
   children: React.ReactElement;
@@ -8,6 +9,12 @@ interface ProtectedRouteProps {
 
 export default function ProtectedRoute({ children }: ProtectedRouteProps) {
   const { loading, authStatus } = useAuth();
+  const location = useLocation();
+  const previewEnabled = useDashboardPreview(location.search);
+
+  if (previewEnabled) {
+    return children;
+  }
 
   if (loading) {
     return <div style={{ padding: 24 }}>Checking session…</div>;

--- a/frontend/src/shared/utils/dashboardPreview.ts
+++ b/frontend/src/shared/utils/dashboardPreview.ts
@@ -1,0 +1,120 @@
+import { useEffect, useState } from "react";
+
+const STORAGE_KEY = "mylg.dashboardPreview";
+const DISABLE_VALUES = new Set(["0", "false", "off", "no", "disable", "disabled", "none"]);
+const ENABLE_VALUES = new Set(["", "1", "true", "on", "yes", "enable", "enabled", "dashboard"]);
+
+function shouldUsePreview(search: string): boolean {
+  if (!import.meta.env.DEV) {
+    return false;
+  }
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  const params = new URLSearchParams(search);
+
+  const explicitDashboardPreview = params.has("dashboardPreview")
+    ? parsePreviewParam(params.get("dashboardPreview"))
+    : null;
+
+  const previewParam = params.has("preview")
+    ? parseAliasParam(params.get("preview"))
+    : null;
+
+  const explicit = explicitDashboardPreview ?? previewParam;
+
+  if (explicit !== null) {
+    persistPreviewChoice(explicit);
+    return explicit;
+  }
+
+  return readStoredPreview();
+}
+
+function parsePreviewParam(raw: string | null): boolean {
+  if (raw == null) {
+    return true;
+  }
+  const value = raw.trim().toLowerCase();
+  if (DISABLE_VALUES.has(value)) {
+    return false;
+  }
+  if (ENABLE_VALUES.has(value)) {
+    return true;
+  }
+  return true;
+}
+
+function parseAliasParam(raw: string | null): boolean | null {
+  if (raw == null) {
+    return null;
+  }
+  const value = raw.trim().toLowerCase();
+  if (value === "dashboard") {
+    return true;
+  }
+  if (DISABLE_VALUES.has(value)) {
+    return false;
+  }
+  if (ENABLE_VALUES.has(value)) {
+    return true;
+  }
+  return null;
+}
+
+function persistPreviewChoice(enabled: boolean) {
+  if (typeof window === "undefined") {
+    return;
+  }
+  try {
+    if (enabled) {
+      window.sessionStorage.setItem(STORAGE_KEY, "1");
+    } else {
+      window.sessionStorage.removeItem(STORAGE_KEY);
+    }
+  } catch (error) {
+    if (import.meta.env.DEV) {
+      console.warn("Unable to persist dashboard preview flag", error);
+    }
+  }
+}
+
+function readStoredPreview(): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+  try {
+    return window.sessionStorage.getItem(STORAGE_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function useDashboardPreview(search: string): boolean {
+  const [enabled, setEnabled] = useState(() => shouldUsePreview(search));
+
+  useEffect(() => {
+    setEnabled(shouldUsePreview(search));
+  }, [search]);
+
+  useEffect(() => {
+    if (typeof document === "undefined") {
+      return;
+    }
+    if (enabled) {
+      document.body.dataset.dashboardPreview = "true";
+    } else {
+      delete document.body.dataset.dashboardPreview;
+    }
+  }, [enabled]);
+
+  return enabled;
+}
+
+export function isDashboardPreviewEnabled(): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+  return shouldUsePreview(window.location.search);
+}


### PR DESCRIPTION
## Summary
- add a reusable hook that enables a dev-only dashboard preview flag and persists it per tab
- allow the dashboard route guard to bypass authentication when the preview flag is active
- document how to enable and disable the preview mode for local UX/layout reviews

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68defa032e888324bf68cdf013dc6a04