### PR TITLE
Adjust HQ HQ layout width and card sizing

### DIFF
--- a/frontend/src/hq/components/HQCard.module.css
+++ b/frontend/src/hq/components/HQCard.module.css
@@ -1,13 +1,13 @@
 .card {
   background: linear-gradient(160deg, rgba(12, 12, 12, 0.96), rgba(12, 12, 12, 0.88));
   border-radius: 22px;
-  padding: 24px;
+  padding: 22px;
   box-shadow: 0 18px 48px rgba(0, 0, 0, 0.45);
   border: 1px solid rgba(255, 255, 255, 0.05);
   display: flex;
   flex-direction: column;
   gap: 16px;
-  min-height: 180px;
+  min-height: 160px;
   font-family: var(--font-family-helvetica-special, "Helvetica Special", sans-serif);
   color: rgba(255, 255, 255, 0.9);
 }

--- a/frontend/src/hq/components/HQLayout.module.css
+++ b/frontend/src/hq/components/HQLayout.module.css
@@ -4,8 +4,7 @@
   flex-direction: column;
   gap: 32px;
   padding: 32px clamp(20px, 4vw, 48px) 48px;
-  margin: 0 auto;
-  width: min(1200px, 100%);
+  width: 100%;
   color: #f4f5f7;
   background: rgba(12, 12, 12, 0.96);
   border-radius: 32px 32px 0 0;

--- a/frontend/src/hq/pages/HQOverview.module.css
+++ b/frontend/src/hq/pages/HQOverview.module.css
@@ -39,8 +39,14 @@
 
 .cardsGrid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 22px;
+}
+
+@media (max-width: 1199px) {
+  .cardsGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }
 
 .chartBars {


### PR DESCRIPTION
## Summary
- expand the HQ wrapper to fill the dashboard width while keeping styling
- lock the overview grid to three cards per row on wide screens with responsive fallbacks
- shrink card padding and height so the rows fit without overflowing

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68defd19bb5883249ae885de7d52bcd9