### PR TITLE
Add HQ chat panel for MYLG project messages

### DIFF
--- a/frontend/src/hq/components/HQChatPanel.module.css
+++ b/frontend/src/hq/components/HQChatPanel.module.css
@@ -1,0 +1,44 @@
+.chatLauncher {
+  position: fixed;
+  right: 24px;
+  bottom: 24px;
+  z-index: 10000;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 18px;
+  border: none;
+  border-radius: 999px;
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  color: #ffffff;
+  background: var(--accent-strong, #fa3356);
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.25);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.chatLauncher:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 24px 45px rgba(0, 0, 0, 0.3);
+}
+
+.chatLauncher:active {
+  transform: translateY(0);
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.2);
+}
+
+.chatLauncher:focus-visible {
+  outline: 3px solid rgba(255, 255, 255, 0.7);
+  outline-offset: 2px;
+}
+
+@media (max-width: 768px) {
+  .chatLauncher {
+    right: 16px;
+    bottom: 16px;
+    padding: 10px 16px;
+    font-size: 13px;
+  }
+}

--- a/frontend/src/hq/components/HQChatPanel.tsx
+++ b/frontend/src/hq/components/HQChatPanel.tsx
@@ -1,0 +1,91 @@
+import React from "react";
+import ChatPanel from "@/dashboard/project/components/Shared/ChatPanel";
+import styles from "./HQChatPanel.module.css";
+
+const HQ_PROJECT_ID = "ed504178-de7a-41b2-899d-dae2232e4139";
+const HIDDEN_STORAGE_KEY = "hqChatPanelHidden";
+const FLOATING_STORAGE_KEY = "hqChatPanelFloating";
+
+const getStoredBoolean = (key: string, fallback: boolean) => {
+  if (typeof window === "undefined") {
+    return fallback;
+  }
+
+  try {
+    const storedValue = window.localStorage.getItem(key);
+    if (storedValue === null) {
+      return fallback;
+    }
+
+    return storedValue === "true";
+  } catch (error) {
+    console.warn(`Unable to read localStorage key "${key}":`, error);
+    return fallback;
+  }
+};
+
+const setStoredBoolean = (key: string, value: boolean) => {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(key, value ? "true" : "false");
+  } catch (error) {
+    console.warn(`Unable to write localStorage key "${key}":`, error);
+  }
+};
+
+const HQChatPanel: React.FC = () => {
+  const [isHidden, setIsHidden] = React.useState<boolean>(() =>
+    getStoredBoolean(HIDDEN_STORAGE_KEY, false)
+  );
+  const [floatingPreference, setFloatingPreference] = React.useState<boolean>(
+    () => getStoredBoolean(FLOATING_STORAGE_KEY, false)
+  );
+
+  const handleCloseChat = React.useCallback(() => {
+    setIsHidden(true);
+  }, []);
+
+  const handleShowChat = React.useCallback(() => {
+    setIsHidden(false);
+  }, []);
+
+  const handleFloatingChange = React.useCallback((floating: boolean) => {
+    setFloatingPreference(floating);
+  }, []);
+
+  React.useEffect(() => {
+    setStoredBoolean(HIDDEN_STORAGE_KEY, isHidden);
+  }, [isHidden]);
+
+  React.useEffect(() => {
+    setStoredBoolean(FLOATING_STORAGE_KEY, floatingPreference);
+  }, [floatingPreference]);
+
+  if (isHidden) {
+    return (
+      <button
+        type="button"
+        className={styles.chatLauncher}
+        onClick={handleShowChat}
+        aria-label="Open HQ message thread"
+      >
+        Open HQ messages
+      </button>
+    );
+  }
+
+  return (
+    <ChatPanel
+      projectId={HQ_PROJECT_ID}
+      initialFloating={floatingPreference}
+      onFloatingChange={handleFloatingChange}
+      initialOpen
+      onCloseChat={handleCloseChat}
+    />
+  );
+};
+
+export default HQChatPanel;

--- a/frontend/src/hq/components/HQLayout.tsx
+++ b/frontend/src/hq/components/HQLayout.tsx
@@ -5,6 +5,8 @@ import NavigationDrawer from "@/shared/ui/NavigationDrawer";
 import { useNavCollapsed } from "@/shared/hooks/useNavCollapsed";
 import "@/dashboard/home/pages/dashboard-styles.css";
 import styles from "./HQLayout.module.css";
+import { useUser } from "@/app/contexts/useUser";
+import HQChatPanel from "./HQChatPanel";
 
 type HQLayoutProps = {
   title: string;
@@ -41,6 +43,7 @@ const HQLayout: React.FC<HQLayoutProps> = ({
     () => `hq-nav-${rawDrawerId.replace(/[^a-zA-Z0-9_-]/g, "")}`,
     [rawDrawerId]
   );
+  const { isAdmin } = useUser();
 
   useEffect(() => {
     const handleResize = () => setFlags(getViewportFlags());
@@ -88,23 +91,28 @@ const HQLayout: React.FC<HQLayoutProps> = ({
     </main>
   );
 
+  const chatPanel = isAdmin ? <HQChatPanel /> : null;
+
   if (flags.isDesktop) {
     return (
-      <div
-        className={`dashboard-root${
-          isNavCollapsed ? " dashboard-root--nav-collapsed" : ""
-        }`}
-      >
-        <aside>
-          <DashboardNavPanel
-            variant="persistent"
-            setActiveView={noop}
-            isCollapsed={isNavCollapsed}
-            onToggleCollapse={handleToggleCollapse}
-          />
-        </aside>
-        {mainContent}
-      </div>
+      <>
+        <div
+          className={`dashboard-root${
+            isNavCollapsed ? " dashboard-root--nav-collapsed" : ""
+          }`}
+        >
+          <aside>
+            <DashboardNavPanel
+              variant="persistent"
+              setActiveView={noop}
+              isCollapsed={isNavCollapsed}
+              onToggleCollapse={handleToggleCollapse}
+            />
+          </aside>
+          {mainContent}
+        </div>
+        {chatPanel}
+      </>
     );
   }
 
@@ -117,6 +125,7 @@ const HQLayout: React.FC<HQLayoutProps> = ({
         drawerId={drawerId}
       />
       {mainContent}
+      {chatPanel}
     </>
   );
 };


### PR DESCRIPTION
## Summary
- add an HQ chat panel that reuses the project message thread for the MYLG HQ project
- gate the HQ chat panel to admins and mount it within the HQ layout so it can float, dock, and persist state
- style a launcher button that lets admins reopen the HQ chat when it is hidden

## Testing
- npm run lint -- --max-warnings=0 *(fails: existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68deff64d23c8324bb0351d4346a8ab4