### PR TITLE
Add developer dashboard preview mode

### DIFF
--- a/docs/dev-dashboard-preview.md
+++ b/docs/dev-dashboard-preview.md
@@ -1,0 +1,38 @@
+# Dashboard Preview Mode (Dev Only)
+
+The dashboard can now be loaded without signing in when you are running the
+frontend in Vite's development mode. This is intended purely for layout and UX
+validation – the data shown is static fixture content and no backend requests or
+mutations are performed.
+
+## Enable preview mode
+
+1. Start the frontend with `npm run dev` (or any command that launches Vite in
+   dev mode).
+2. Open the dashboard route with the `preview` query parameter:
+
+   ```text
+   http://localhost:5173/dashboard?preview=1
+   ```
+
+   This flag is stored in `sessionStorage`, so navigating around the app keeps
+   the dashboard unlocked for the current tab.
+
+## Disable preview mode
+
+Use any of the following options:
+
+* Visit any route with `?preview=0` (for example
+  `http://localhost:5173/dashboard?preview=0`).
+* Clear `sessionStorage['dashboardPreviewMode']` in your devtools console.
+* Close the tab (a fresh session starts without preview).
+
+## Notes
+
+* Preview mode is **only** available when `import.meta.env.DEV` is true. It is
+  ignored in production builds.
+* The sample data includes two example projects, a handful of collaborators,
+  and representative inbox/messages activity so that core dashboard widgets
+  render as expected.
+* Actions that would normally persist data (e.g. saving settings) are turned
+  into no-ops – use this mode only to check styling and layout.

--- a/frontend/src/app/contexts/AuthContext.tsx
+++ b/frontend/src/app/contexts/AuthContext.tsx
@@ -15,19 +15,36 @@ import {
 import { secureWebSocketAuth } from "../../shared/utils/secureWebSocketAuth";
 import { csrfProtection, logSecurityEvent } from "../../shared/utils/securityUtils";
 import { AuthContext, AuthContextValue, AuthStatus, Role, CognitoUser } from "./AuthContextValue";
+import { getDevPreviewData, isPreviewModeEnabled, subscribeToPreviewMode } from "@/shared/utils/devPreview";
 
 export const AuthProvider: React.FC<PropsWithChildren> = ({ children }) => {
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [authStatus, setAuthStatus] = useState<AuthStatus>("signedOut");
   const [cognitoUser, setCognitoUser] = useState<CognitoUser | null>(null);
   const [loading, setLoading] = useState(true);
+  const [previewMode, setPreviewMode] = useState<boolean>(() => isPreviewModeEnabled());
+
+  useEffect(() => {
+    if (!import.meta.env.DEV) return;
+    return subscribeToPreviewMode(() => {
+      setPreviewMode(isPreviewModeEnabled());
+    });
+  }, []);
 
   // Debug (keep while migrating; remove later)
   useEffect(() => {
-    console.log("[AuthContext]", { isAuthenticated, authStatus, cognitoUser, loading });
-  }, [isAuthenticated, authStatus, cognitoUser, loading]);
+    console.log("[AuthContext]", { isAuthenticated, authStatus, cognitoUser, loading, previewMode });
+  }, [isAuthenticated, authStatus, cognitoUser, loading, previewMode]);
 
   const validateAndSetUserSession = useCallback(async (label = "default") => {
+    if (previewMode) {
+      const previewUser = getDevPreviewData().user;
+      setIsAuthenticated(true);
+      setAuthStatus("signedIn");
+      setCognitoUser({ userId: previewUser.userId, role: previewUser.role as Role | undefined });
+      return;
+    }
+
     try {
       const session = await fetchAuthSession();
       const { accessToken, idToken } = session.tokens ?? {};
@@ -65,7 +82,7 @@ export const AuthProvider: React.FC<PropsWithChildren> = ({ children }) => {
       setIsAuthenticated(false);
       setCognitoUser(null);
     }
-  }, []);
+  }, [previewMode]);
 
   const getAuthTokens = useCallback(async () => {
     try {
@@ -94,10 +111,14 @@ export const AuthProvider: React.FC<PropsWithChildren> = ({ children }) => {
 
   // periodic check
   useEffect(() => {
+    if (previewMode) {
+      validateAndSetUserSession();
+      return;
+    }
     validateAndSetUserSession();
     const id = setInterval(validateAndSetUserSession, 1000 * 60 * 45);
     return () => clearInterval(id);
-  }, [validateAndSetUserSession]);
+  }, [validateAndSetUserSession, previewMode]);
 
   // initial
   useEffect(() => {

--- a/frontend/src/app/contexts/MessagesProvider.tsx
+++ b/frontend/src/app/contexts/MessagesProvider.tsx
@@ -12,9 +12,81 @@ import { getWithTTL, setWithTTL, DEFAULT_TTL } from "../../shared/utils/storageW
 import { MessagesContext } from "./MessagesContext";
 import type { MessagesValue, ProjectMessagesMap } from "./MessagesContextValue";
 import type { Thread, Message } from "./DataProvider";
+import { getDevPreviewData, isPreviewModeEnabled, subscribeToPreviewMode } from "@/shared/utils/devPreview";
+
+const PreviewMessagesProvider: React.FC<PropsWithChildren> = ({ children }) => {
+  const preview = getDevPreviewData();
+  const [projectMessages, setProjectMessages] = useState<ProjectMessagesMap>(preview.projectMessages);
+  const [inbox, setInbox] = useState<Thread[]>(preview.inbox);
+  const deletedMessageIds = useRef<Set<string>>(new Set());
+
+  const markMessageDeleted = (id?: string) => {
+    if (id) deletedMessageIds.current.add(id);
+  };
+
+  const clearDeletedMessageId = (id?: string) => {
+    if (id) deletedMessageIds.current.delete(id);
+  };
+
+  const toggleReaction = (
+    msgId: string,
+    emoji: string,
+    reactorId: string,
+    _conversationId: string,
+    _conversationType: "dm" | "project",
+    _ws?: WebSocket,
+  ) => {
+    if (!msgId || !emoji || !reactorId) return;
+
+    setProjectMessages((prev) => {
+      const updated: ProjectMessagesMap = {};
+      Object.entries(prev).forEach(([projectId, messages]) => {
+        updated[projectId] = messages.map((message) => {
+          if ((message.messageId || message.optimisticId) !== msgId) return message;
+          const reactions = { ...(message.reactions || {}) };
+          const users = new Set(reactions[emoji] || []);
+          if (users.has(reactorId)) {
+            users.delete(reactorId);
+          } else {
+            users.add(reactorId);
+          }
+          reactions[emoji] = Array.from(users);
+          return { ...message, reactions };
+        });
+      });
+      return updated;
+    });
+  };
+
+  const value: MessagesValue = {
+    inbox,
+    setInbox,
+    projectMessages,
+    setProjectMessages,
+    deletedMessageIds: deletedMessageIds.current,
+    markMessageDeleted,
+    clearDeletedMessageId,
+    toggleReaction,
+  };
+
+  return <MessagesContext.Provider value={value}>{children}</MessagesContext.Provider>;
+};
 
 export const MessagesProvider: React.FC<PropsWithChildren> = ({ children }) => {
   const { userId } = useAuth();
+
+  const [previewMode, setPreviewMode] = useState<boolean>(() => isPreviewModeEnabled());
+
+  useEffect(() => {
+    if (!import.meta.env.DEV) return;
+    return subscribeToPreviewMode(() => {
+      setPreviewMode(isPreviewModeEnabled());
+    });
+  }, []);
+
+  if (previewMode) {
+    return <PreviewMessagesProvider>{children}</PreviewMessagesProvider>;
+  }
 
   const [projectMessages, setProjectMessages] = useState<ProjectMessagesMap>({});
   const [inbox, setInbox] = useState<Thread[]>(() => {

--- a/frontend/src/app/contexts/ProjectsProvider.tsx
+++ b/frontend/src/app/contexts/ProjectsProvider.tsx
@@ -23,6 +23,89 @@ import { getWithTTL, setWithTTL, DEFAULT_TTL } from "../../shared/utils/storageW
 import { ProjectsContext } from "./ProjectsContext";
 import type { ProjectsValue, DMReadStatusMap } from "./ProjectsContextValue";
 import type { Project, TimelineEvent, Message } from "./DataProvider";
+import { getDevPreviewData, isPreviewModeEnabled, subscribeToPreviewMode } from "@/shared/utils/devPreview";
+
+const PreviewProjectsProvider: React.FC<PropsWithChildren> = ({ children }) => {
+  const preview = getDevPreviewData();
+  const [projects, setProjects] = useState<Project[]>(preview.projects);
+  const [userProjects, setUserProjects] = useState<Project[]>(preview.projects);
+  const [activeProject, setActiveProject] = useState<Project | null>(preview.projects[0] ?? null);
+  const [selectedProjects, setSelectedProjects] = useState<string[]>([]);
+  const [opacity, setOpacity] = useState(1);
+  const [settingsUpdated, setSettingsUpdated] = useState(false);
+  const [dmReadStatus, setDmReadStatus] = useState<DMReadStatusMap>({});
+  const [projectsError] = useState(false);
+  const toggleSettingsUpdated = () => setSettingsUpdated((prev) => !prev);
+
+  const fetchProjectDetails = async (projectId: string): Promise<boolean> => {
+    const project = preview.projects.find((p) => p.projectId === projectId) ?? null;
+    setActiveProject(project);
+    return Boolean(project);
+  };
+
+  const fetchProjects = async () => {
+    setProjects(preview.projects);
+    setUserProjects(preview.projects);
+  };
+
+  const fetchUserProfile = async () => undefined;
+
+  const fetchRecentActivity = async () => preview.recentActivity;
+
+  const updateTimelineEvents = async (projectId: string, events: TimelineEvent[]): Promise<void> => {
+    setProjects((prevState) =>
+      prevState.map((project) =>
+        project.projectId === projectId ? { ...project, timelineEvents: events } : project
+      )
+    );
+    setUserProjects((prevState) =>
+      prevState.map((project) =>
+        project.projectId === projectId ? { ...project, timelineEvents: events } : project
+      )
+    );
+  };
+
+  const updateProjectFields = async (projectId: string, fields: Partial<Project>): Promise<void> => {
+    setProjects((prevState) =>
+      prevState.map((project) =>
+        project.projectId === projectId ? { ...project, ...fields } : project
+      )
+    );
+    setUserProjects((prevState) =>
+      prevState.map((project) =>
+        project.projectId === projectId ? { ...project, ...fields } : project
+      )
+    );
+  };
+
+  const value: ProjectsValue = {
+    projects,
+    setProjects,
+    setUserProjects,
+    isLoading: false,
+    setIsLoading: () => undefined,
+    loadingProfile: false,
+    activeProject,
+    setActiveProject,
+    selectedProjects,
+    setSelectedProjects,
+    fetchProjectDetails,
+    fetchProjects,
+    fetchUserProfile,
+    fetchRecentActivity,
+    opacity,
+    setOpacity,
+    settingsUpdated,
+    toggleSettingsUpdated,
+    dmReadStatus,
+    setDmReadStatus,
+    projectsError,
+    updateTimelineEvents,
+    updateProjectFields,
+  };
+
+  return <ProjectsContext.Provider value={value}>{children}</ProjectsContext.Provider>;
+};
 
 const mergeProjectWithFallback = (
   primary: Project,
@@ -59,7 +142,7 @@ const mergeProjectWithFallback = (
 const projectNeedsDetailHydration = (project: Project | null | undefined): project is Project =>
   Boolean(project) && (project.description === undefined || project.customFolders === undefined);
 
-export const ProjectsProvider: React.FC<PropsWithChildren> = ({ children }) => {
+const RegularProjectsProvider: React.FC<PropsWithChildren> = ({ children }) => {
   const { userId } = useAuth();
 
   const [userProjects, setUserProjects] = useState<Project[]>([]);
@@ -587,4 +670,21 @@ export const ProjectsProvider: React.FC<PropsWithChildren> = ({ children }) => {
       {children}
     </ProjectsContext.Provider>
   );
+};
+
+export const ProjectsProvider: React.FC<PropsWithChildren> = ({ children }) => {
+  const [previewMode, setPreviewMode] = useState<boolean>(() => isPreviewModeEnabled());
+
+  useEffect(() => {
+    if (!import.meta.env.DEV) return;
+    return subscribeToPreviewMode(() => {
+      setPreviewMode(isPreviewModeEnabled());
+    });
+  }, []);
+
+  if (previewMode) {
+    return <PreviewProjectsProvider>{children}</PreviewProjectsProvider>;
+  }
+
+  return <RegularProjectsProvider>{children}</RegularProjectsProvider>;
 };

--- a/frontend/src/app/contexts/ProtectedRoute.tsx
+++ b/frontend/src/app/contexts/ProtectedRoute.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
-import { Navigate } from 'react-router-dom';
+import React, { useEffect, useState } from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
 import { useAuth } from '@/app/contexts/useAuth';
+import { isPreviewModeEnabled, subscribeToPreviewMode, syncPreviewModeFromSearch } from '@/shared/utils/devPreview';
 
 interface ProtectedRouteProps {
   children: React.ReactElement;
@@ -8,12 +9,27 @@ interface ProtectedRouteProps {
 
 export default function ProtectedRoute({ children }: ProtectedRouteProps) {
   const { loading, authStatus } = useAuth();
+  const location = useLocation();
+  const [previewMode, setPreviewMode] = useState<boolean>(() => isPreviewModeEnabled());
+
+  useEffect(() => {
+    if (!import.meta.env.DEV) return;
+    syncPreviewModeFromSearch(location.search);
+    setPreviewMode(isPreviewModeEnabled());
+  }, [location.search]);
+
+  useEffect(() => {
+    if (!import.meta.env.DEV) return;
+    return subscribeToPreviewMode(() => {
+      setPreviewMode(isPreviewModeEnabled());
+    });
+  }, []);
 
   if (loading) {
     return <div style={{ padding: 24 }}>Checking session…</div>;
   }
 
-  if (authStatus !== 'signedIn' && authStatus !== 'incompleteProfile') {
+  if (!previewMode && authStatus !== 'signedIn' && authStatus !== 'incompleteProfile') {
     return <Navigate to="/login" replace />;
   }
 

--- a/frontend/src/app/contexts/UserProvider.tsx
+++ b/frontend/src/app/contexts/UserProvider.tsx
@@ -16,6 +16,7 @@ import { resolveStoredFileUrl } from "@/shared/utils/media";
 import { UserContext } from "./UserContext";
 import type { UserContextValue } from "./UserContextValue";
 import type { UserLite } from "./DataProvider";
+import { getDevPreviewData, isPreviewModeEnabled, subscribeToPreviewMode } from "@/shared/utils/devPreview";
 
 const mapUserLite = (user: UserLite): UserLite => {
   const thumbnailUrl = resolveStoredFileUrl(user.thumbnail as string | undefined);
@@ -29,8 +30,32 @@ const mapUserLite = (user: UserLite): UserLite => {
 export const UserProvider: React.FC<PropsWithChildren> = ({ children }) => {
   const { userId } = useAuth();
 
-  const [user, setUser] = useState<UserLite | null>(null);
-  const [allUsers, setAllUsers] = useState<UserLite[]>([]);
+  const [previewMode, setPreviewMode] = useState<boolean>(() => isPreviewModeEnabled());
+  const [user, setUser] = useState<UserLite | null>(() =>
+    previewMode ? getDevPreviewData().user : null
+  );
+  const [allUsers, setAllUsers] = useState<UserLite[]>(() =>
+    previewMode ? getDevPreviewData().allUsers : []
+  );
+
+  useEffect(() => {
+    if (!import.meta.env.DEV) return;
+    return subscribeToPreviewMode(() => {
+      const enabled = isPreviewModeEnabled();
+      setPreviewMode(enabled);
+    });
+  }, []);
+
+  useEffect(() => {
+    if (previewMode) {
+      const preview = getDevPreviewData();
+      setUser(preview.user);
+      setAllUsers(preview.allUsers);
+    } else {
+      setUser(null);
+      setAllUsers([]);
+    }
+  }, [previewMode]);
 
   // Load all users
   useEffect(() => {
@@ -45,12 +70,20 @@ export const UserProvider: React.FC<PropsWithChildren> = ({ children }) => {
         console.error("Error fetching users:", error);
       }
     };
+    if (previewMode || !userId) {
+      return;
+    }
     if (userId) {
       loadUsers();
     }
-  }, [userId]);
+  }, [userId, previewMode]);
 
   const refreshUsers = async () => {
+    if (previewMode) {
+      const preview = getDevPreviewData();
+      setAllUsers(preview.allUsers);
+      return;
+    }
     try {
       const users = await fetchAllUsers();
       const mapped = Array.isArray(users)
@@ -64,6 +97,11 @@ export const UserProvider: React.FC<PropsWithChildren> = ({ children }) => {
 
   // Load user profile
   const fetchUserProfile = useCallback(async () => {
+    if (previewMode) {
+      const preview = getDevPreviewData();
+      setUser({ ...preview.user });
+      return;
+    }
     if (!userId) {
       setUser(null);
       return;
@@ -82,13 +120,18 @@ export const UserProvider: React.FC<PropsWithChildren> = ({ children }) => {
     } catch (error) {
       console.error("Error fetching user profile:", error);
     }
-  }, [userId]);
+  }, [userId, previewMode]);
 
   useEffect(() => {
+    if (previewMode) {
+      const preview = getDevPreviewData();
+      setUser({ ...preview.user });
+      return;
+    }
     if (userId) {
       fetchUserProfile();
     }
-  }, [userId, fetchUserProfile]);
+  }, [userId, fetchUserProfile, previewMode]);
 
   // Derived role checks based on user profile
   const userData = useMemo<UserLite | null>(() => {
@@ -115,6 +158,22 @@ export const UserProvider: React.FC<PropsWithChildren> = ({ children }) => {
   const setUserData = setUser; // alias for backward compatibility
   const refreshUser = fetchUserProfile; // alias for backward compatibility
 
+  const handleUpdateUserProfile = useCallback(
+    async (profile: Parameters<typeof updateUserProfile>[0]) => {
+      if (previewMode) {
+        const preview = getDevPreviewData();
+        const updated = { ...preview.user, ...profile } as UserLite;
+        setUser(updated);
+        setAllUsers((prev) =>
+          prev.map((u) => (u.userId === updated.userId ? updated : u))
+        );
+        return updated as Awaited<ReturnType<typeof updateUserProfile>>;
+      }
+      return updateUserProfile(profile);
+    },
+    [previewMode]
+  );
+
   const value = useMemo<UserContextValue>(
     () => ({
       user,
@@ -126,7 +185,7 @@ export const UserProvider: React.FC<PropsWithChildren> = ({ children }) => {
       setUser,
       refreshUsers,
       refreshUser,
-      updateUserProfile,
+      updateUserProfile: handleUpdateUserProfile,
       fetchUserProfile,
       isAdmin,
       isDesigner,
@@ -148,6 +207,7 @@ export const UserProvider: React.FC<PropsWithChildren> = ({ children }) => {
       isBuilder,
       isVendor,
       isClient,
+      handleUpdateUserProfile,
     ]
   );
 

--- a/frontend/src/shared/utils/devPreview.ts
+++ b/frontend/src/shared/utils/devPreview.ts
@@ -1,0 +1,279 @@
+import type { Project, Message, Thread, UserLite } from "@/app/contexts/DataProvider";
+import type { ProjectMessagesMap } from "@/app/contexts/MessagesContextValue";
+
+const PREVIEW_STORAGE_KEY = "dashboardPreviewMode";
+const PREVIEW_EVENT = "dashboard-preview-mode-change";
+
+export interface PreviewActivityItem {
+  id: string;
+  type: "project" | "message";
+  projectId: string;
+  projectTitle: string;
+  text: string;
+  timestamp: string;
+}
+
+export interface DevPreviewData {
+  user: UserLite;
+  allUsers: UserLite[];
+  projects: Project[];
+  inbox: Thread[];
+  projectMessages: ProjectMessagesMap;
+  recentActivity: PreviewActivityItem[];
+}
+
+const PREVIEW_USER_ID = "preview-user";
+
+const DEV_PREVIEW_DATA: DevPreviewData = {
+  user: {
+    userId: PREVIEW_USER_ID,
+    firstName: "Preview",
+    lastName: "User",
+    email: "preview.user@example.com",
+    role: "admin",
+    occupation: "Design Lead",
+    phoneNumber: "+1 (555) 010-0101",
+    company: "MYLG Labs",
+    collaborators: ["avery-harper", "max-ramirez"],
+    projects: ["preview-riverside", "preview-harbor"],
+    thumbnailUrl: "https://avatars.githubusercontent.com/u/000?v=4",
+    messages: [],
+  },
+  allUsers: [
+    {
+      userId: PREVIEW_USER_ID,
+      firstName: "Preview",
+      lastName: "User",
+      email: "preview.user@example.com",
+      role: "admin",
+      occupation: "Design Lead",
+      phoneNumber: "+1 (555) 010-0101",
+    },
+    {
+      userId: "avery-harper",
+      firstName: "Avery",
+      lastName: "Harper",
+      email: "avery@mylg.dev",
+      role: "designer",
+      occupation: "UX Designer",
+      phoneNumber: "+1 (555) 010-0102",
+    },
+    {
+      userId: "max-ramirez",
+      firstName: "Max",
+      lastName: "Ramirez",
+      email: "max@mylg.dev",
+      role: "builder",
+      occupation: "Site Lead",
+      phoneNumber: "+1 (555) 010-0103",
+    },
+    {
+      userId: "devon-wells",
+      firstName: "Devon",
+      lastName: "Wells",
+      email: "devon@mylg.dev",
+      role: "vendor",
+      occupation: "Lighting Vendor",
+      phoneNumber: "+1 (555) 010-0104",
+    },
+  ],
+  projects: [
+    {
+      projectId: "preview-riverside",
+      title: "Riverside Park Redesign",
+      status: "In Progress",
+      description:
+        "A public space refresh with new wayfinding, lighting, and modular seating zones.",
+      color: "#0F62FE",
+      clientName: "City of Westbridge",
+      clientEmail: "parks@westbridge.gov",
+      previewUrl: "project-thumbnails/riverside/main.jpg",
+      quickLinks: [
+        { id: "brief", title: "Project Brief", url: "https://example.com/brief" },
+        { id: "site-plan", title: "Site Plan", url: "https://example.com/site-plan" },
+      ],
+      timelineEvents: [
+        {
+          id: "event-kickoff",
+          title: "Kickoff workshop",
+          date: "2024-04-04",
+          description: "Stakeholder alignment session with Parks & Rec.",
+        },
+        {
+          id: "event-fabrication",
+          title: "Fabrication lock",
+          date: "2024-06-12",
+          description: "Sign-off on lighting fixture order and bench fabrication.",
+        },
+        {
+          id: "event-install",
+          title: "Install week",
+          date: "2024-07-22",
+          description: "Nightly install for new lighting grid and furniture.",
+        },
+      ],
+      team: [
+        { userId: PREVIEW_USER_ID, role: "admin" },
+        { userId: "avery-harper", role: "designer" },
+        { userId: "max-ramirez", role: "builder" },
+      ],
+    },
+    {
+      projectId: "preview-harbor",
+      title: "Harbor Pavilion Pop-up",
+      status: "Planning",
+      description:
+        "Seasonal retail pavilion with interactive lighting and vendor stalls.",
+      color: "#FF7A45",
+      clientName: "Port Authority",
+      clientEmail: "events@harborport.io",
+      previewUrl: "project-thumbnails/harbor/main.jpg",
+      quickLinks: [
+        { id: "budget", title: "Budget Snapshot", url: "https://example.com/budget" },
+        { id: "deck", title: "Concept Deck", url: "https://example.com/deck" },
+      ],
+      timelineEvents: [
+        {
+          id: "event-scoping",
+          title: "Scoping walk",
+          date: "2024-05-10",
+          description: "Harbor site walk + vendor orientation.",
+        },
+        {
+          id: "event-permits",
+          title: "Permits submitted",
+          date: "2024-05-24",
+          description: "Permitting packet delivered to Port Authority.",
+        },
+      ],
+      team: [
+        { userId: PREVIEW_USER_ID, role: "admin" },
+        { userId: "devon-wells", role: "vendor" },
+      ],
+    },
+  ],
+  inbox: [
+    {
+      conversationId: "thread-avery",
+      otherUserId: "avery-harper",
+      lastMsgTs: "2024-05-21T15:30:00.000Z",
+      snippet: "Moodboard feedback looks great — I dropped comments.",
+      read: false,
+    },
+    {
+      conversationId: "thread-max",
+      otherUserId: "max-ramirez",
+      lastMsgTs: "2024-05-20T20:45:00.000Z",
+      snippet: "Confirmed overnight install crew for July 22 start.",
+      read: true,
+    },
+  ],
+  projectMessages: {
+    "preview-riverside": [
+      {
+        messageId: "riverside-1",
+        body: "Uploaded revised site plan with adjusted lighting grid.",
+        timestamp: "2024-05-21T14:10:00.000Z",
+        reactions: { "👍": [PREVIEW_USER_ID, "avery-harper"] },
+      },
+      {
+        messageId: "riverside-2",
+        body: "Reminder: fabrication lock is June 12 — review fixtures.",
+        timestamp: "2024-05-20T09:00:00.000Z",
+      },
+    ],
+    "preview-harbor": [
+      {
+        messageId: "harbor-1",
+        body: "Permitting packet submitted to Port Authority today.",
+        timestamp: "2024-05-19T18:25:00.000Z",
+      },
+    ],
+  },
+  recentActivity: [
+    {
+      id: "activity-1",
+      type: "project",
+      projectId: "preview-riverside",
+      projectTitle: "Riverside Park Redesign",
+      text: "Avery Harper uploaded a new lighting concept.",
+      timestamp: "2024-05-21T16:10:00.000Z",
+    },
+    {
+      id: "activity-2",
+      type: "message",
+      projectId: "preview-harbor",
+      projectTitle: "Harbor Pavilion Pop-up",
+      text: "Max Ramirez added install notes in Messages.",
+      timestamp: "2024-05-20T22:45:00.000Z",
+    },
+  ],
+};
+
+const noop = () => undefined;
+
+export const isPreviewModeSupported = (): boolean => Boolean(import.meta.env.DEV);
+
+export const isPreviewModeEnabled = (): boolean => {
+  if (!isPreviewModeSupported() || typeof window === "undefined") return false;
+  try {
+    return (
+      window.sessionStorage.getItem(PREVIEW_STORAGE_KEY) === "on" ||
+      window.localStorage.getItem(PREVIEW_STORAGE_KEY) === "on"
+    );
+  } catch {
+    return false;
+  }
+};
+
+export const setPreviewModeEnabled = (enabled: boolean): void => {
+  if (!isPreviewModeSupported() || typeof window === "undefined") return;
+  try {
+    if (enabled) {
+      window.sessionStorage.setItem(PREVIEW_STORAGE_KEY, "on");
+    } else {
+      window.sessionStorage.removeItem(PREVIEW_STORAGE_KEY);
+      window.localStorage.removeItem(PREVIEW_STORAGE_KEY);
+    }
+  } catch {
+    /* ignore storage errors in dev */
+  }
+  try {
+    window.dispatchEvent(new CustomEvent(PREVIEW_EVENT));
+  } catch {
+    noop();
+  }
+};
+
+export const syncPreviewModeFromSearch = (search: string): boolean => {
+  if (!isPreviewModeSupported() || typeof window === "undefined") return false;
+  let handled = false;
+  try {
+    const params = new URLSearchParams(search);
+    const value = params.get("preview");
+    if (value !== null) {
+      const enable = !["0", "false", "off"].includes(value.toLowerCase());
+      setPreviewModeEnabled(enable);
+      handled = true;
+    }
+  } catch {
+    noop();
+  }
+  return handled;
+};
+
+export const subscribeToPreviewMode = (callback: () => void): (() => void) => {
+  if (!isPreviewModeSupported() || typeof window === "undefined") {
+    return () => undefined;
+  }
+  const handler = () => callback();
+  window.addEventListener(PREVIEW_EVENT, handler);
+  window.addEventListener("storage", handler);
+  return () => {
+    window.removeEventListener(PREVIEW_EVENT, handler);
+    window.removeEventListener("storage", handler);
+  };
+};
+
+export const getDevPreviewData = (): DevPreviewData => DEV_PREVIEW_DATA;
+


### PR DESCRIPTION
## Summary
- add a dev-only preview utility with fixture data to unlock the dashboard without Cognito
- wire preview mode through auth, projects, messages, and user providers plus the protected route
- document how to launch and disable preview mode for local testing

## Testing
- npm run typecheck *(fails: tasks module is missing TaskMapMarker export and TaskDrawer requires isDesktop)*

------
https://chatgpt.com/codex/tasks/task_e_68defdab18408324bfbe04885ea10545