### PR TITLE
Integrate project chat thread into HQ layout

### DIFF
--- a/frontend/src/hq/components/HQLayout.module.css
+++ b/frontend/src/hq/components/HQLayout.module.css
@@ -57,11 +57,60 @@
   margin-left: auto;
 }
 
+.contentArea {
+  display: flex;
+  gap: 24px;
+  align-items: stretch;
+  min-height: 0;
+}
+
 .content {
   display: flex;
+  flex: 1 1 auto;
   flex-direction: column;
   gap: 32px;
+  min-width: 0;
   min-height: 0;
+}
+
+.threadColumn {
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+}
+
+.chatReopenButton {
+  position: fixed;
+  right: 32px;
+  bottom: 32px;
+  z-index: 60;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 12px 20px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(250, 51, 86, 0.85);
+  color: #ffffff;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 12px 32px rgba(250, 51, 86, 0.4);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.chatReopenButton:hover,
+.chatReopenButton:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 40px rgba(250, 51, 86, 0.55);
+  background: rgba(250, 51, 86, 0.95);
+}
+
+.chatReopenButton:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.9);
+  outline-offset: 2px;
 }
 
 .menuButton {
@@ -107,6 +156,21 @@
     border-radius: 0;
     padding: 28px 20px 40px;
     box-shadow: none;
+  }
+
+  .contentArea {
+    flex-direction: column;
+  }
+
+  .threadColumn {
+    width: 100%;
+  }
+
+  .chatReopenButton {
+    right: 20px;
+    bottom: 20px;
+    padding: 10px 18px;
+    font-size: 0.9rem;
   }
 
   .actionsRow {

--- a/frontend/src/hq/components/HQLayout.tsx
+++ b/frontend/src/hq/components/HQLayout.tsx
@@ -1,8 +1,19 @@
-import React, { useEffect, useId, useMemo, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { Menu } from "lucide-react";
 import DashboardNavPanel from "@/shared/ui/DashboardNavPanel";
 import NavigationDrawer from "@/shared/ui/NavigationDrawer";
 import { useNavCollapsed } from "@/shared/hooks/useNavCollapsed";
+import { useUser } from "@/app/contexts/useUser";
+import ProjectMessagesThread from "@/dashboard/features/messages/ProjectMessagesThread";
+import ChatPanel from "@/dashboard/project/components/Shared/ChatPanel";
 import "@/dashboard/home/pages/dashboard-styles.css";
 import styles from "./HQLayout.module.css";
 
@@ -13,9 +24,37 @@ type HQLayoutProps = {
   children: React.ReactNode;
 };
 
+type ProjectMessagesThreadProps = {
+  projectId: string;
+  open: boolean;
+  setOpen: (open: boolean | ((prev: boolean) => boolean)) => void;
+  floating: boolean;
+  setFloating: (floating: boolean | ((prev: boolean) => boolean)) => void;
+  startDrag: (event: React.MouseEvent<HTMLDivElement>) => void;
+  headerOffset: number;
+  onCloseChat?: () => void;
+};
+
+type ChatPanelProps = {
+  projectId: string;
+  initialFloating?: boolean;
+  onFloatingChange?: (floating: boolean) => void;
+  openSignal?: number;
+  onCloseChat?: () => void;
+};
+
 type ViewportFlags = {
   isDesktop: boolean;
 };
+
+const HQ_PROJECT_ID = "ed504178-de7a-41b2-899d-dae2232e4139";
+const THREAD_WIDTH = 360;
+const FLOATING_STORAGE_KEY = "hqChatPanelFloating";
+const HIDDEN_STORAGE_KEY = "hqChatPanelHidden";
+
+const _ProjectMessagesThread =
+  ProjectMessagesThread as unknown as React.FC<ProjectMessagesThreadProps>;
+const _ChatPanel = ChatPanel as unknown as React.FC<ChatPanelProps>;
 
 function getViewportFlags(): ViewportFlags {
   if (typeof window === "undefined") {
@@ -33,6 +72,7 @@ const HQLayout: React.FC<HQLayoutProps> = ({
   actions,
   children,
 }) => {
+  const { isAdmin } = useUser();
   const [flags, setFlags] = useState<ViewportFlags>(() => getViewportFlags());
   const [isNavCollapsed, setIsNavCollapsed] = useNavCollapsed("hq");
   const [isNavigationOpen, setIsNavigationOpen] = useState(false);
@@ -41,6 +81,25 @@ const HQLayout: React.FC<HQLayoutProps> = ({
     () => `hq-nav-${rawDrawerId.replace(/[^a-zA-Z0-9_-]/g, "")}`,
     [rawDrawerId]
   );
+  const pageHeaderRef = useRef<HTMLElement | null>(null);
+  const [headerOffset, setHeaderOffset] = useState<number>(0);
+  const [floatingThread, setFloatingThread] = useState<boolean>(() => {
+    if (typeof window === "undefined") return false;
+    try {
+      return localStorage.getItem(FLOATING_STORAGE_KEY) === "true";
+    } catch {
+      return false;
+    }
+  });
+  const [chatOpenSignal, setChatOpenSignal] = useState<number>(0);
+  const [isChatHidden, setIsChatHidden] = useState<boolean>(() => {
+    if (typeof window === "undefined") return false;
+    try {
+      return localStorage.getItem(HIDDEN_STORAGE_KEY) === "true";
+    } catch {
+      return false;
+    }
+  });
 
   useEffect(() => {
     const handleResize = () => setFlags(getViewportFlags());
@@ -49,12 +108,76 @@ const HQLayout: React.FC<HQLayoutProps> = ({
     return () => window.removeEventListener("resize", handleResize);
   }, []);
 
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      localStorage.setItem(
+        FLOATING_STORAGE_KEY,
+        floatingThread ? "true" : "false"
+      );
+    } catch {
+      /* ignore */
+    }
+  }, [floatingThread]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      localStorage.setItem(HIDDEN_STORAGE_KEY, isChatHidden ? "true" : "false");
+    } catch {
+      /* ignore */
+    }
+  }, [isChatHidden]);
+
+  const updateHeaderOffset = useCallback(() => {
+    if (typeof window === "undefined") return;
+    const navBar = document.querySelector(
+      "header.header .nav-bar"
+    ) as HTMLElement | null;
+    const globalHeight = navBar ? navBar.getBoundingClientRect().height : 0;
+    const localHeight = pageHeaderRef.current
+      ? pageHeaderRef.current.getBoundingClientRect().height
+      : 0;
+    setHeaderOffset(globalHeight + localHeight);
+  }, []);
+
+  useLayoutEffect(() => {
+    updateHeaderOffset();
+    window.addEventListener("resize", updateHeaderOffset);
+    return () => window.removeEventListener("resize", updateHeaderOffset);
+  }, [updateHeaderOffset]);
+
+  useEffect(() => {
+    updateHeaderOffset();
+  }, [updateHeaderOffset, flags.isDesktop, isNavCollapsed, title, description, actions]);
+
+  const handleShowChat = useCallback(() => {
+    setIsChatHidden(false);
+    setFloatingThread(true);
+    setChatOpenSignal((prev) => prev + 1);
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const handleOpenChatEvent = () => {
+      if (!isAdmin) return;
+      handleShowChat();
+    };
+
+    window.addEventListener("hq-open-chat", handleOpenChatEvent);
+    return () => window.removeEventListener("hq-open-chat", handleOpenChatEvent);
+  }, [handleShowChat, isAdmin]);
+
   const handleOpenNavigation = () => setIsNavigationOpen(true);
   const handleCloseNavigation = () => setIsNavigationOpen(false);
   const handleToggleCollapse = () => setIsNavCollapsed((previous) => !previous);
 
+  const handleHideChat = useCallback(() => {
+    setIsChatHidden(true);
+  }, []);
+
   const pageHeader = (
-    <header className={styles.pageHeader}>
+    <header ref={pageHeaderRef} className={styles.pageHeader}>
       <div className={styles.pageHeading}>
         {!flags.isDesktop ? (
           <button
@@ -79,11 +202,47 @@ const HQLayout: React.FC<HQLayoutProps> = ({
     </header>
   );
 
+  const noopSetOpen = useCallback(
+    (value: boolean | ((prev: boolean) => boolean)) => {
+      void value;
+    },
+    []
+  );
+
+  const noopStartDrag = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
+    void event;
+  }, []);
+
+  const shouldRenderDockedThread =
+    isAdmin && !isChatHidden && !floatingThread && flags.isDesktop;
+
+  const shouldRenderFloatingPanel =
+    isAdmin && !isChatHidden && (floatingThread || !flags.isDesktop);
+
   const mainContent = (
     <main className="dashboard-main">
       <div className={`dashboard-wrapper ${styles.wrapper}`}>
         {pageHeader}
-        <div className={styles.content}>{children}</div>
+        <div className={styles.contentArea}>
+          <div className={styles.content}>{children}</div>
+          {shouldRenderDockedThread ? (
+            <div
+              className={styles.threadColumn}
+              style={{ width: THREAD_WIDTH, flexBasis: THREAD_WIDTH }}
+            >
+              <_ProjectMessagesThread
+                projectId={HQ_PROJECT_ID}
+                open
+                setOpen={noopSetOpen}
+                floating={false}
+                setFloating={setFloatingThread}
+                startDrag={noopStartDrag}
+                headerOffset={headerOffset}
+                onCloseChat={handleHideChat}
+              />
+            </div>
+          ) : null}
+        </div>
       </div>
     </main>
   );
@@ -104,6 +263,24 @@ const HQLayout: React.FC<HQLayoutProps> = ({
           />
         </aside>
         {mainContent}
+        {shouldRenderFloatingPanel ? (
+          <_ChatPanel
+            projectId={HQ_PROJECT_ID}
+            initialFloating
+            onFloatingChange={setFloatingThread}
+            openSignal={chatOpenSignal}
+            onCloseChat={handleHideChat}
+          />
+        ) : null}
+        {isAdmin && isChatHidden ? (
+          <button
+            type="button"
+            className={styles.chatReopenButton}
+            onClick={handleShowChat}
+          >
+            Open HQ messages
+          </button>
+        ) : null}
       </div>
     );
   }
@@ -117,6 +294,24 @@ const HQLayout: React.FC<HQLayoutProps> = ({
         drawerId={drawerId}
       />
       {mainContent}
+      {shouldRenderFloatingPanel ? (
+        <_ChatPanel
+          projectId={HQ_PROJECT_ID}
+          initialFloating
+          onFloatingChange={setFloatingThread}
+          openSignal={chatOpenSignal}
+          onCloseChat={handleHideChat}
+        />
+      ) : null}
+      {isAdmin && isChatHidden ? (
+        <button
+          type="button"
+          className={styles.chatReopenButton}
+          onClick={handleShowChat}
+        >
+          Open HQ messages
+        </button>
+      ) : null}
     </>
   );
 };


### PR DESCRIPTION
## Summary
- embed the MYLG project message thread inside the HQ layout for admins with floating/docked chat support and persistence
- add a reopen affordance and responsive layout styles so HQ content and the chat column coexist cleanly

## Testing
- npm run lint -- --max-warnings=0 *(fails: pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68df01b3f26883248eedc97f5a723bda