### PR TITLE
Add color-coded task status badges

### DIFF
--- a/frontend/src/dashboard/project/components/Tasks/TasksComponentMobile.module.css
+++ b/frontend/src/dashboard/project/components/Tasks/TasksComponentMobile.module.css
@@ -892,6 +892,45 @@
   color: rgba(246, 247, 251, 0.95);
 }
 
+.statusBadgeSuccess {
+  background: color-mix(in srgb, var(--color-success, #4caf50) 28%, transparent);
+  border-color: color-mix(in srgb, var(--color-success, #4caf50) 46%, transparent);
+  color: color-mix(in srgb, #ffffff 88%, var(--color-success, #4caf50) 12%);
+}
+
+.statusBadgeDanger {
+  background: color-mix(in srgb, var(--color-error, #ef5350) 28%, transparent);
+  border-color: color-mix(in srgb, var(--color-error, #ef5350) 48%, transparent);
+  color: color-mix(in srgb, #ffffff 90%, var(--color-error, #ef5350) 10%);
+}
+
+.statusBadgeWarning {
+  background: color-mix(in srgb, var(--color-warning, #ff9800) 28%, transparent);
+  border-color: color-mix(in srgb, var(--color-warning, #ff9800) 46%, transparent);
+  color: color-mix(in srgb, #1f1200 22%, #ffffff 78%);
+}
+
+.statusBadgeNeutral {
+  background: rgba(255, 255, 255, 0.12);
+  border-color: rgba(255, 255, 255, 0.2);
+  color: rgba(246, 247, 251, 0.9);
+}
+
+.modalStatusLabelRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.modalStatusLabel {
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-tertiary, rgba(246, 247, 251, 0.6));
+}
+
 /* Ensure Leaflet controls don't interfere with sheet interactions */
 .sheetOverlay :global(.leaflet-control-container) {
   pointer-events: none;

--- a/frontend/src/dashboard/project/components/Tasks/components/TaskEditModal.tsx
+++ b/frontend/src/dashboard/project/components/Tasks/components/TaskEditModal.tsx
@@ -2,8 +2,23 @@ import React from "react";
 import { AutoComplete, Form, Input, Modal, Select } from "antd";
 import type { FormInstance } from "antd/es/form";
 
-import type { NominatimSuggestion } from "../types";
+import styles from "../TasksComponentMobile.module.css";
+import { STATUS_OPTIONS, parseDueDate } from "../utils";
+import type { NominatimSuggestion, Status } from "../types";
+import {
+  createTaskStatusContext,
+  getTaskStatusBadge,
+  getTaskStatusTone,
+  type TaskStatusTone,
+} from "./quickTaskUtils";
 import LocationSearchInput from "./LocationSearchInput";
+
+const BADGE_CLASS_BY_TONE: Record<TaskStatusTone, string> = {
+  success: "statusBadgeSuccess",
+  danger: "statusBadgeDanger",
+  warning: "statusBadgeWarning",
+  neutral: "statusBadgeNeutral",
+};
 
 type TaskEditModalProps = {
   open: boolean;
@@ -37,67 +52,95 @@ const TaskEditModal: React.FC<TaskEditModalProps> = ({
   onLocationSuggestionSelect,
   onOk,
   onCancel,
-}) => (
-  <Modal
-    title={isEditing ? "Edit Task" : "Add Task"}
-    open={open}
-    onOk={onOk}
-    onCancel={onCancel}
-    centered
-    okButtonProps={{ style: { background: "#FA3356", borderColor: "#FA3356" } }}
-    forceRender
-  >
-    <Form layout="vertical" form={form} preserve={false}>
-      <Form.Item
-        label="Task"
-        name="name"
-        rules={[{ required: true, message: "Task name required" }]}
-      >
-        <AutoComplete
-          options={taskNameOptions}
-          listHeight={160}
-          placeholder="Enter or select task"
-          filterOption={(inputValue, option) =>
-            (option?.value as string)?.toUpperCase().includes(inputValue.toUpperCase())
+}) => {
+  const statusValue = Form.useWatch<Status | undefined>("status", form);
+  const dueDateValue = Form.useWatch<string | number | Date | null | undefined>("dueDate", form);
+  const dueDate = parseDueDate(dueDateValue ?? null);
+  const { category, label } = getTaskStatusBadge(
+    statusValue ?? "todo",
+    dueDate,
+    createTaskStatusContext(),
+  );
+  const tone = getTaskStatusTone(category);
+  const badgeClassKey = BADGE_CLASS_BY_TONE[tone];
+  const badgeToneClass = badgeClassKey ? styles[badgeClassKey as keyof typeof styles] : undefined;
+  const badgeClassName = [styles.statusBadge, badgeToneClass].filter(Boolean).join(" ");
+
+  return (
+    <Modal
+      title={isEditing ? "Edit Task" : "Add Task"}
+      open={open}
+      onOk={onOk}
+      onCancel={onCancel}
+      centered
+      okButtonProps={{ style: { background: "#FA3356", borderColor: "#FA3356" } }}
+      forceRender
+    >
+      <Form layout="vertical" form={form} preserve={false}>
+        <Form.Item
+          label="Task"
+          name="name"
+          rules={[{ required: true, message: "Task name required" }]}
+        >
+          <AutoComplete
+            options={taskNameOptions}
+            listHeight={160}
+            placeholder="Enter or select task"
+            filterOption={(inputValue, option) =>
+              (option?.value as string)?.toUpperCase().includes(inputValue.toUpperCase())
+            }
+          />
+        </Form.Item>
+
+        <Form.Item
+          label={
+            <div className={styles.modalStatusLabelRow}>
+              <span className={styles.modalStatusLabel}>Status</span>
+              <span className={badgeClassName}>{label}</span>
+            </div>
           }
-        />
-      </Form.Item>
+          name="status"
+          initialValue="todo"
+        >
+          <Select size="small" options={STATUS_OPTIONS} />
+        </Form.Item>
 
-      <Form.Item label="Assignee" name="assignedTo">
-        <Select size="small" options={assigneeOptions} />
-      </Form.Item>
+        <Form.Item label="Assignee" name="assignedTo">
+          <Select size="small" options={assigneeOptions} />
+        </Form.Item>
 
-      <Form.Item label="Due Date" name="dueDate">
-        <Input type="date" />
-      </Form.Item>
+        <Form.Item label="Due Date" name="dueDate">
+          <Input type="date" />
+        </Form.Item>
 
-      <Form.Item label="Priority" name="priority">
-        <Input />
-      </Form.Item>
+        <Form.Item label="Priority" name="priority">
+          <Input />
+        </Form.Item>
 
-      <Form.Item label="Budget Code" name="budgetItemId">
-        <Select options={budgetOptions} />
-      </Form.Item>
+        <Form.Item label="Budget Code" name="budgetItemId">
+          <Select options={budgetOptions} />
+        </Form.Item>
 
-      <Form.Item label="Event ID" name="eventId">
-        <Input />
-      </Form.Item>
+        <Form.Item label="Event ID" name="eventId">
+          <Input />
+        </Form.Item>
 
-      <Form.Item label="Location" name="location">
-        <Input placeholder="{lat, lng}" value={locationDisplay} readOnly />
-      </Form.Item>
+        <Form.Item label="Location" name="location">
+          <Input placeholder="{lat, lng}" value={locationDisplay} readOnly />
+        </Form.Item>
 
-      <Form.Item label="Address" name="address">
-        <LocationSearchInput
-          value={locationSearch}
-          suggestions={locationSuggestions}
-          selectedAddress={selectedAddress}
-          onChange={onLocationSearchChange}
-          onSelect={onLocationSuggestionSelect}
-        />
-      </Form.Item>
-    </Form>
-  </Modal>
-);
+        <Form.Item label="Address" name="address">
+          <LocationSearchInput
+            value={locationSearch}
+            suggestions={locationSuggestions}
+            selectedAddress={selectedAddress}
+            onChange={onLocationSearchChange}
+            onSelect={onLocationSuggestionSelect}
+          />
+        </Form.Item>
+      </Form>
+    </Modal>
+  );
+};
 
 export default TaskEditModal;

--- a/frontend/src/dashboard/project/components/Tasks/components/TaskList.tsx
+++ b/frontend/src/dashboard/project/components/Tasks/components/TaskList.tsx
@@ -3,6 +3,12 @@ import { Calendar, MapPin, User } from "lucide-react";
 
 import styles from "../TasksComponentMobile.module.css";
 import { buildDirectionsLinks, formatAssigneeDisplay } from "../utils";
+import {
+  createTaskStatusContext,
+  getTaskStatusBadge,
+  getTaskStatusTone,
+  type TaskStatusTone,
+} from "./quickTaskUtils";
 import type { QuickTask } from "./taskTypes";
 
 type TaskListProps = {
@@ -13,97 +19,111 @@ type TaskListProps = {
   taskListRef: React.RefObject<HTMLUListElement>;
 };
 
+const BADGE_CLASS_BY_TONE: Record<TaskStatusTone, string> = {
+  success: "statusBadgeSuccess",
+  danger: "statusBadgeDanger",
+  warning: "statusBadgeWarning",
+  neutral: "statusBadgeNeutral",
+};
+
 const TaskList: React.FC<TaskListProps> = ({
   tasks,
   activeTaskId,
   onTaskSelect,
   formatDueLabel,
   taskListRef,
-}) => (
-  <ul className={styles.taskList} ref={taskListRef}>
-    {tasks.map((task) => {
-      const isActive = task.id === activeTaskId;
-      const assigneeLabel = formatAssigneeDisplay(task.assignedTo);
-      const listItemClassName = `${styles.taskItem}${isActive ? ` ${styles.taskItemActive}` : ""}`;
+}) => {
+  const statusContext = createTaskStatusContext();
 
-      const directionsLinks = buildDirectionsLinks(task.address);
+  return (
+    <ul className={styles.taskList} ref={taskListRef}>
+      {tasks.map((task) => {
+        const isActive = task.id === activeTaskId;
+        const assigneeLabel = formatAssigneeDisplay(task.assignedTo);
+        const listItemClassName = `${styles.taskItem}${isActive ? ` ${styles.taskItemActive}` : ""}`;
 
-      return (
-        <li key={task.id} data-task-id={task.id} className={listItemClassName}>
-          <div
-            role="button"
-            tabIndex={0}
-            className={styles.taskButton}
-            onClick={() => onTaskSelect(task.id)}
-            onKeyDown={(event) => {
-              if (event.key === "Enter" || event.key === " ") {
-                event.preventDefault();
-                onTaskSelect(task.id);
-              }
-            }}
-          >
-            <div className={styles.taskTitleRow}>
-              <span className={styles.taskTitle}>{task.title}</span>
-              <span className={styles.statusBadge}>
-                {task.status === "done" ? "Completed" : task.status.replace(/_/g, " ")}
-              </span>
-            </div>
-            <div className={styles.taskMeta}>
-              <span className={styles.metaLine}>
-                <Calendar size={14} aria-hidden="true" /> {formatDueLabel(task)}
-              </span>
-              {task.address ? (
-                <span className={`${styles.metaLine} ${styles.metaLineAddress}`}>
-                  <MapPin size={14} aria-hidden="true" />
-                  <span className={styles.addressDetails}>
-                    <span className={styles.addressText}>{task.address}</span>
-                    {directionsLinks ? (
-                      <span className={styles.addressActions}>
-                        <a
-                          href={directionsLinks.appleMaps}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className={styles.addressLink}
-                          onClick={(event) => event.stopPropagation()}
-                        >
-                          Open in Maps
-                        </a>
-                        <span className={styles.addressLinkSeparator} aria-hidden="true">
-                          •
-                        </span>
-                        <a
-                          href={directionsLinks.googleMaps}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className={styles.addressLink}
-                          onClick={(event) => event.stopPropagation()}
-                        >
-                          Open in Google Maps
-                        </a>
-                      </span>
-                    ) : null}
-                  </span>
-                </span>
-              ) : (
-                <span className={`${styles.metaLine} ${styles.metaLineMuted}`}>
-                  <MapPin size={14} aria-hidden="true" /> No location
-                </span>
-              )}
-              {assigneeLabel ? (
+        const directionsLinks = buildDirectionsLinks(task.address);
+        const { category, label } = getTaskStatusBadge(task.status, task.dueDate, statusContext);
+        const tone = getTaskStatusTone(category);
+        const badgeClassKey = BADGE_CLASS_BY_TONE[tone];
+        const badgeToneClass = badgeClassKey ? styles[badgeClassKey as keyof typeof styles] : undefined;
+        const badgeClassName = [styles.statusBadge, badgeToneClass].filter(Boolean).join(" ");
+
+        return (
+          <li key={task.id} data-task-id={task.id} className={listItemClassName}>
+            <div
+              role="button"
+              tabIndex={0}
+              className={styles.taskButton}
+              onClick={() => onTaskSelect(task.id)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" || event.key === " ") {
+                  event.preventDefault();
+                  onTaskSelect(task.id);
+                }
+              }}
+            >
+              <div className={styles.taskTitleRow}>
+                <span className={styles.taskTitle}>{task.title}</span>
+                <span className={badgeClassName}>{label}</span>
+              </div>
+              <div className={styles.taskMeta}>
                 <span className={styles.metaLine}>
-                  <User size={14} aria-hidden="true" /> Assigned to : {assigneeLabel}
+                  <Calendar size={14} aria-hidden="true" /> {formatDueLabel(task)}
                 </span>
-              ) : (
-                <span className={`${styles.metaLine} ${styles.metaLineMuted}`}>
-                  <User size={14} aria-hidden="true" /> No assignee
-                </span>
-              )}
+                {task.address ? (
+                  <span className={`${styles.metaLine} ${styles.metaLineAddress}`}>
+                    <MapPin size={14} aria-hidden="true" />
+                    <span className={styles.addressDetails}>
+                      <span className={styles.addressText}>{task.address}</span>
+                      {directionsLinks ? (
+                        <span className={styles.addressActions}>
+                          <a
+                            href={directionsLinks.appleMaps}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className={styles.addressLink}
+                            onClick={(event) => event.stopPropagation()}
+                          >
+                            Open in Maps
+                          </a>
+                          <span className={styles.addressLinkSeparator} aria-hidden="true">
+                            •
+                          </span>
+                          <a
+                            href={directionsLinks.googleMaps}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className={styles.addressLink}
+                            onClick={(event) => event.stopPropagation()}
+                          >
+                            Open in Google Maps
+                          </a>
+                        </span>
+                      ) : null}
+                    </span>
+                  </span>
+                ) : (
+                  <span className={`${styles.metaLine} ${styles.metaLineMuted}`}>
+                    <MapPin size={14} aria-hidden="true" /> No location
+                  </span>
+                )}
+                {assigneeLabel ? (
+                  <span className={styles.metaLine}>
+                    <User size={14} aria-hidden="true" /> Assigned to : {assigneeLabel}
+                  </span>
+                ) : (
+                  <span className={`${styles.metaLine} ${styles.metaLineMuted}`}>
+                    <User size={14} aria-hidden="true" /> No assignee
+                  </span>
+                )}
+              </div>
             </div>
-          </div>
-        </li>
-      );
-    })}
-  </ul>
-);
+          </li>
+        );
+      })}
+    </ul>
+  );
+};
 
 export default TaskList;

--- a/frontend/src/dashboard/project/components/Tasks/components/quickTaskUtils.ts
+++ b/frontend/src/dashboard/project/components/Tasks/components/quickTaskUtils.ts
@@ -4,6 +4,89 @@ import type { QuickTask, RawTask, TaskMapMarker, TaskStats } from "./taskTypes";
 
 export type { QuickTask, RawTask, TaskStats };
 
+const DAY_IN_MS = 24 * 60 * 60 * 1000;
+
+export type TaskStatusCategory = "completed" | "overdue" | "dueSoon" | "scheduled" | "unscheduled";
+
+export type TaskStatusContext = {
+  startOfToday: Date;
+  upcomingThreshold: Date;
+};
+
+export function createTaskStatusContext(baseDate: Date = new Date()): TaskStatusContext {
+  const startOfToday = new Date(baseDate.getFullYear(), baseDate.getMonth(), baseDate.getDate());
+  const upcomingThreshold = new Date(startOfToday.getTime() + 7 * DAY_IN_MS);
+
+  return { startOfToday, upcomingThreshold };
+}
+
+export function formatStatusLabel(status: Status): string {
+  const normalized = status.replace(/_/g, " ").trim();
+  if (!normalized) {
+    return "To do";
+  }
+
+  return normalized.replace(/\b\w/g, (character) => character.toUpperCase());
+}
+
+export function getTaskStatusCategory(
+  status: Status,
+  dueDate: Date | null,
+  context: TaskStatusContext = createTaskStatusContext(),
+): TaskStatusCategory {
+  if (status === "done") {
+    return "completed";
+  }
+
+  if (!dueDate || Number.isNaN(dueDate.getTime())) {
+    return "unscheduled";
+  }
+
+  if (dueDate < context.startOfToday) {
+    return "overdue";
+  }
+
+  if (dueDate <= context.upcomingThreshold) {
+    return "dueSoon";
+  }
+
+  return "scheduled";
+}
+
+export function getTaskStatusBadge(
+  status: Status,
+  dueDate: Date | null,
+  context?: TaskStatusContext,
+): { label: string; category: TaskStatusCategory } {
+  const category = getTaskStatusCategory(status, dueDate, context);
+
+  switch (category) {
+    case "completed":
+      return { category, label: "Completed" };
+    case "overdue":
+      return { category, label: "Overdue" };
+    case "dueSoon":
+      return { category, label: "Due soon" };
+    default:
+      return { category, label: formatStatusLabel(status) };
+  }
+}
+
+export type TaskStatusTone = "success" | "danger" | "warning" | "neutral";
+
+export function getTaskStatusTone(category: TaskStatusCategory): TaskStatusTone {
+  switch (category) {
+    case "completed":
+      return "success";
+    case "overdue":
+      return "danger";
+    case "dueSoon":
+      return "warning";
+    default:
+      return "neutral";
+  }
+}
+
 export const DRAWER_SNAP_POINTS = [0.1, 0.45, 0.9] as const;
 export type SnapIndex = 0 | 1 | 2;
 
@@ -111,27 +194,20 @@ export function normalizeTask(raw: RawTask): QuickTask | null {
 }
 
 export function computeStats(tasks: QuickTask[]): TaskStats {
-  const now = new Date();
-  const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-  const inSevenDays = new Date(startOfToday.getTime() + 7 * 24 * 60 * 60 * 1000);
+  const context = createTaskStatusContext();
 
   let completed = 0;
   let overdue = 0;
   let dueSoon = 0;
 
   tasks.forEach((task) => {
-    if (task.status === "done") {
+    const { category } = getTaskStatusBadge(task.status, task.dueDate, context);
+
+    if (category === "completed") {
       completed += 1;
-      return;
-    }
-
-    if (!task.dueDate) {
-      return;
-    }
-
-    if (task.dueDate < startOfToday) {
+    } else if (category === "overdue") {
       overdue += 1;
-    } else if (task.dueDate <= inSevenDays) {
+    } else if (category === "dueSoon") {
       dueSoon += 1;
     }
   });


### PR DESCRIPTION
## Summary
- share helpers to categorize task urgency and format status labels across the tasks UI
- color code task status pills in the project task list with success, warning, and danger tones
- surface the same badge styling inside the edit task modal alongside a status selector

## Testing
- npm run lint *(fails: existing lint errors in MessagesProvider.tsx and related files)*

------
https://chatgpt.com/codex/tasks/task_e_68df0e2c67648324af423e72f695cee7