### PR TITLE
Improve invoice preview modal mobile responsiveness

### DIFF
--- a/docs/dev-dashboard-preview.md
+++ b/docs/dev-dashboard-preview.md
@@ -34,5 +34,8 @@ Use any of the following options:
 * The sample data includes two example projects, a handful of collaborators,
   and representative inbox/messages activity so that core dashboard widgets
   render as expected.
+* Previewing invoices is supported: open a project budget and launch the
+  **Invoice Preview** modal to review the full sample invoice, including brand
+  and client information, without signing in.
 * Actions that would normally persist data (e.g. saving settings) are turned
   into no-ops – use this mode only to check styling and layout.

--- a/frontend/src/dashboard/project/features/budget/components/InvoicePreviewModal.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/InvoicePreviewModal.tsx
@@ -1110,9 +1110,21 @@ const InvoicePreviewModal: React.FC<InvoicePreviewModalProps> = ({
                       .invoice-header{flex-direction:column;align-items:flex-start;gap:12px;}
                       .company-block{flex-direction:column;align-items:flex-start;gap:8px;width:100%;}
                       .invoice-meta{text-align:left;width:100%;}
-                      .billing-info{flex-direction:column;align-items:flex-start;gap:12px;}
+                      .billing-info{flex-direction:column;align-items:flex-start;gap:12px;font-size:0.82rem;}
                       .invoice-title{margin-left:0;text-align:left;font-size:1.6rem;}
                       .summary{flex-direction:column;gap:12px;}
+                      .items-table th,.items-table td{padding:6px;font-size:0.85rem;}
+                      .bottom-block{margin-bottom:28px;}
+                    }
+                    @media (max-width:480px){
+                      .invoice-page{padding:12px;}
+                      .invoice-header{gap:10px;}
+                      .brand-name{font-size:1.05rem;}
+                      .invoice-title{font-size:1.4rem;}
+                      .company-info,.billing-info{font-size:0.78rem;}
+                      .summary{gap:10px;}
+                      .items-table th,.items-table td{padding:5px;font-size:0.78rem;}
+                      .bottom-block{margin-bottom:24px;}
                     }
                     @media print{
                       .invoice-container{width:210mm;max-width:210mm;padding:20px;}
@@ -1125,6 +1137,7 @@ const InvoicePreviewModal: React.FC<InvoicePreviewModalProps> = ({
                   <div
                     className="invoice-page invoice-container"
                     ref={invoiceRef}
+                    data-preview-role="measure"
                     style={{ position: "absolute", visibility: "hidden", pointerEvents: "none" }}
                   >
                     <div className="invoice-top">
@@ -1427,7 +1440,8 @@ const InvoicePreviewModal: React.FC<InvoicePreviewModalProps> = ({
 
                   {/* Visible paginated preview */}
                   {pages[currentPage] && (
-                    <div className="invoice-page invoice-container">
+                    <div className={styles.previewViewport}>
+                      <div className="invoice-page invoice-container">
                       <div className="invoice-top">
                         <header className="invoice-header">
                           <div
@@ -1725,6 +1739,7 @@ const InvoicePreviewModal: React.FC<InvoicePreviewModalProps> = ({
                           </div>
                         </div>
                       )}
+                      </div>
                     </div>
                   )}
                 </div>

--- a/frontend/src/dashboard/project/features/budget/components/InvoicePreviewModal.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/InvoicePreviewModal.tsx
@@ -1078,17 +1078,17 @@ const InvoicePreviewModal: React.FC<InvoicePreviewModalProps> = ({
                   <style id="invoice-preview-styles">{`
                     @page { margin: 0; }
                     body { margin: 0; }
-                    .invoice-container{background:#fff;color:#000;font-family:Arial,Helvetica,sans-serif;width:210mm;box-sizing:border-box;margin:0 auto;padding:20px;overflow-x:hidden;}
-                    .invoice-page{width:210mm;height:297mm;box-shadow:0 2px 6px rgba(0,0,0,0.15);margin:0 auto 20px;padding:20px;box-sizing:border-box;position:relative;overflow-x:hidden;display:flex;flex-direction:column;}
+                    .invoice-container{background:#fff;color:#000;font-family:Arial,Helvetica,sans-serif;width:min(100%,210mm);max-width:210mm;box-sizing:border-box;margin:0 auto;padding:20px;overflow-x:hidden;}
+                    .invoice-page{width:min(100%,210mm);max-width:210mm;min-height:297mm;box-shadow:0 2px 6px rgba(0,0,0,0.15);margin:0 auto 20px;padding:20px;box-sizing:border-box;position:relative;overflow-x:hidden;display:flex;flex-direction:column;}
                     .invoice-header{display:flex;align-items:flex-start;gap:20px;}
                     .logo-upload{width:100px;height:100px;border:1px dashed #ccc;display:flex;align-items:center;justify-content:center;cursor:pointer;flex-shrink:0;}
                     .logo-upload img{max-width:100%;max-height:100%;}
-                    .company-block{flex:1;display:flex;justify-content:space-between;align-items:flex-start;}
+                    .company-block{flex:1;display:flex;justify-content:space-between;align-items:flex-start;gap:16px;}
                     .company-info{display:flex;flex-direction:column;margin-top:10px;}
                     .brand-name{font-size:1.2rem;font-weight:bold;}
                     .brand-tagline,.brand-address,.brand-phone{font-size:0.7rem;}
                     .invoice-meta{text-align:right;font-size:0.85rem;}
-                    .billing-info{margin-top:20px;display:flex;justify-content:space-between;font-size:0.85rem;}
+                    .billing-info{margin-top:20px;display:flex;justify-content:space-between;gap:20px;font-size:0.85rem;}
                     .invoice-title{font-size:2rem;color:#FA3356;font-weight:bold;text-align:right;margin-left:auto;}
                     .project-title{font-size:1.5rem;font-weight:bold;text-align:center;margin:10px 0;}
                     .summary{display:flex;justify-content:space-between;gap:10px;margin-bottom:10px;}
@@ -1104,8 +1104,19 @@ const InvoicePreviewModal: React.FC<InvoicePreviewModalProps> = ({
                     .notes{margin-top:20px;}
                     .footer{margin-top:40px;font-size:0.9rem;color:#666;}
                     .pageNumber{position:absolute;bottom:10px;left:0;right:0;text-align:center;font-family:'Roboto',Arial,sans-serif;font-size:0.85rem;color:#666;font-weight:normal;pointer-events:none;user-select:none;}
+                    @media (max-width:768px){
+                      .invoice-container{padding:16px;width:100%;}
+                      .invoice-page{padding:16px;width:100%;min-height:auto;}
+                      .invoice-header{flex-direction:column;align-items:flex-start;gap:12px;}
+                      .company-block{flex-direction:column;align-items:flex-start;gap:8px;width:100%;}
+                      .invoice-meta{text-align:left;width:100%;}
+                      .billing-info{flex-direction:column;align-items:flex-start;gap:12px;}
+                      .invoice-title{margin-left:0;text-align:left;font-size:1.6rem;}
+                      .summary{flex-direction:column;gap:12px;}
+                    }
                     @media print{
-                      .invoice-page{box-shadow:none;margin:0;page-break-after:always;}
+                      .invoice-container{width:210mm;max-width:210mm;padding:20px;}
+                      .invoice-page{width:210mm;max-width:210mm;height:297mm;min-height:auto;box-shadow:none;margin:0;page-break-after:always;}
                       .invoice-page:last-child{page-break-after:auto;}
                     }
                   `}</style>

--- a/frontend/src/dashboard/project/features/budget/components/invoice-preview-modal.module.css
+++ b/frontend/src/dashboard/project/features/budget/components/invoice-preview-modal.module.css
@@ -11,6 +11,8 @@
   z-index: 1000;
   opacity: 0;
   transition: opacity 0.3s ease;
+  padding: 20px;
+  overflow: auto;
 }
 .modalOverlayAfterOpen {
   opacity: 1;
@@ -33,6 +35,7 @@
   transition: opacity 0.3s ease, transform 0.3s ease;
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
   font-family: "Helvetica Neue", sans-serif;
+  max-width: 1200px;
 }
 .modalContentAfterOpen {
   opacity: 1;
@@ -224,13 +227,15 @@
   background: #fff;
   color: #000;
   font-family: Arial, Helvetica, sans-serif;
-  width: 210mm;
+  width: min(100%, 210mm);
+  max-width: 210mm;
   box-sizing: border-box;
 }
 
 .invoice-page {
-  width: 210mm;
-  height: 297mm;
+  width: min(100%, 210mm);
+  max-width: 210mm;
+  min-height: 297mm;
   margin: 0 auto 20px;
   padding: 20px;
   box-sizing: border-box;
@@ -238,6 +243,106 @@
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
   display: flex;
   flex-direction: column;
+}
+
+@media (max-width: 1200px) {
+  .modalOverlay {
+    padding: 16px;
+  }
+
+  .modalContent {
+    height: auto;
+    max-height: none;
+  }
+
+  .modalBody {
+    overflow-y: auto;
+    padding-right: 4px;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .contentRow {
+    min-width: 0;
+    overflow-x: visible;
+  }
+
+  .previewWrapper {
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+}
+
+@media (max-width: 900px) {
+  .modalContent {
+    width: 100%;
+    border-radius: 12px;
+    padding: 16px;
+  }
+
+  .contentRow {
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  .previewWrapper {
+    order: 1;
+    width: 100%;
+    padding: 0;
+    background: transparent;
+    overflow: visible;
+  }
+
+  .sidebar {
+    order: 2;
+    width: 100%;
+    max-width: none;
+    background: #121212;
+    padding: 12px 14px;
+    border-radius: 10px;
+    overflow: visible;
+  }
+
+  .invoice-page {
+    min-height: auto;
+  }
+}
+
+@media (max-width: 600px) {
+  .modalOverlay {
+    padding: 0;
+    align-items: flex-start;
+    justify-content: flex-start;
+  }
+
+  .modalContent {
+    border-radius: 0;
+    width: 100vw;
+    min-height: 100vh;
+    height: auto;
+    max-height: none;
+    padding: 16px 14px 24px;
+    border-width: 0;
+  }
+
+  .modalHeader,
+  .currentFileRow {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+  }
+
+  .previewWrapper {
+    align-items: stretch;
+  }
+
+  .invoice-container,
+  .invoice-page {
+    width: 100%;
+  }
+
+  .invoice-page {
+    padding: 16px;
+  }
 }
 
 .items-table-wrapper {
@@ -401,19 +506,4 @@
   background: #ff4b6c;
   border-color: #ff4b6c;
 }
-
-@media (max-width: 768px) {
-  .contentRow {
-    flex-direction: column;
-  }
-  .sidebar {
-    width: 100%;
-    max-width: none;
-  }
-}
-
-
-
-
-
 

--- a/frontend/src/dashboard/project/features/budget/components/invoice-preview-modal.module.css
+++ b/frontend/src/dashboard/project/features/budget/components/invoice-preview-modal.module.css
@@ -165,9 +165,23 @@
   color: #000;
   padding: 10px;
   display: flex;
-  justify-content: flex-start;
+  justify-content: center;
   align-items: center;
   flex-direction: column;
+}
+
+.previewViewport {
+  width: 100%;
+  max-width: 210mm;
+  display: flex;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.previewViewport :global(.invoice-page) {
+  width: 100%;
+  max-width: 210mm;
+  transition: transform 0.2s ease;
 }
 
 .groupSelect,
@@ -270,6 +284,10 @@
     flex: 1 1 auto;
     min-width: 0;
   }
+
+  .previewViewport {
+    max-width: 100%;
+  }
 }
 
 @media (max-width: 900px) {
@@ -290,6 +308,31 @@
     padding: 0;
     background: transparent;
     overflow: visible;
+  }
+
+  .previewViewport {
+    overflow: visible;
+  }
+
+  .previewViewport :global(.invoice-page) {
+    padding: 14px;
+  }
+
+  .previewViewport :global(.invoice-header) {
+    gap: 12px;
+  }
+
+  .previewViewport :global(.invoice-title) {
+    font-size: 1.6rem;
+  }
+
+  .previewViewport :global(.billing-info) {
+    font-size: 0.82rem;
+  }
+
+  .previewViewport :global(.items-table th),
+  .previewViewport :global(.items-table td) {
+    padding: 6px;
   }
 
   .sidebar {
@@ -335,6 +378,41 @@
     align-items: stretch;
   }
 
+  .previewViewport {
+    padding-bottom: 16px;
+  }
+
+  .previewViewport :global(.invoice-page) {
+    padding: 12px;
+  }
+
+  .previewViewport :global(.invoice-header) {
+    gap: 10px;
+  }
+
+  .previewViewport :global(.invoice-title) {
+    font-size: 1.4rem;
+  }
+
+  .previewViewport :global(.company-info),
+  .previewViewport :global(.billing-info) {
+    font-size: 0.78rem;
+  }
+
+  .previewViewport :global(.summary) {
+    gap: 10px;
+  }
+
+  .previewViewport :global(.items-table th),
+  .previewViewport :global(.items-table td) {
+    font-size: 0.78rem;
+    padding: 5px;
+  }
+
+  .previewViewport :global(.bottom-block) {
+    margin-bottom: 24px;
+  }
+
   .invoice-container,
   .invoice-page {
     width: 100%;
@@ -343,6 +421,32 @@
   .invoice-page {
     padding: 16px;
   }
+}
+
+.metaInput {
+  background: #ffffff;
+  border: 1px solid rgba(0, 0, 0, 0.4);
+  border-radius: 6px;
+  color: #0c0c0c;
+  font-size: 0.85rem;
+  min-height: 32px;
+  padding: 4px 8px;
+  box-sizing: border-box;
+  width: auto;
+  min-width: 150px;
+  max-width: 220px;
+  -webkit-appearance: none;
+  appearance: none;
+  color-scheme: light;
+}
+
+.metaInput:focus {
+  outline: 2px solid rgba(78, 161, 255, 0.9);
+  outline-offset: 1px;
+}
+
+.metaInput::-webkit-calendar-picker-indicator {
+  filter: invert(15%);
 }
 
 .items-table-wrapper {

--- a/frontend/src/shared/utils/devPreview.ts
+++ b/frontend/src/shared/utils/devPreview.ts
@@ -1,4 +1,4 @@
-import type { Project, Message, Thread, UserLite } from "@/app/contexts/DataProvider";
+import type { Project, Thread, UserLite } from "@/app/contexts/DataProvider";
 import type { ProjectMessagesMap } from "@/app/contexts/MessagesContextValue";
 
 const PREVIEW_STORAGE_KEY = "dashboardPreviewMode";
@@ -85,8 +85,14 @@ const DEV_PREVIEW_DATA: DevPreviewData = {
       description:
         "A public space refresh with new wayfinding, lighting, and modular seating zones.",
       color: "#0F62FE",
+      invoiceBrandName: "MYLG Lighting Group",
+      invoiceBrandAddress: "145 Dock Street, Suite 400\nWestbridge, NY 11201",
+      invoiceBrandPhone: "+1 (555) 010-0190",
       clientName: "City of Westbridge",
+      clientAddress: "123 Riverwalk Ave, Westbridge, NY 11201",
+      clientPhone: "+1 (555) 020-0110",
       clientEmail: "parks@westbridge.gov",
+      address: "Riverside Park Conservancy HQ\n12 Riverside Dr, Westbridge, NY 11209",
       previewUrl: "project-thumbnails/riverside/main.jpg",
       quickLinks: [
         { id: "brief", title: "Project Brief", url: "https://example.com/brief" },
@@ -125,8 +131,14 @@ const DEV_PREVIEW_DATA: DevPreviewData = {
       description:
         "Seasonal retail pavilion with interactive lighting and vendor stalls.",
       color: "#FF7A45",
+      invoiceBrandName: "Harbor Events Collective",
+      invoiceBrandAddress: "9 Wharfside Road\nHarborport, NY 11221",
+      invoiceBrandPhone: "+1 (555) 010-0215",
       clientName: "Port Authority",
+      clientAddress: "88 Bay Terminal, Harborport, NY 11221",
+      clientPhone: "+1 (555) 020-0225",
       clientEmail: "events@harborport.io",
+      address: "Pier 9 Event Lot\nHarborport, NY 11221",
       previewUrl: "project-thumbnails/harbor/main.jpg",
       quickLinks: [
         { id: "budget", title: "Budget Snapshot", url: "https://example.com/budget" },


### PR DESCRIPTION
## Summary
- adjust the invoice preview modal layout styles so it fills the viewport and scrolls correctly on phones
- update the in-modal inline styles to mirror the responsive CSS so exported HTML keeps the new breakpoints
- extend the dev preview fixtures and docs with invoice brand/client details for the modal

## Testing
- npm run lint *(fails: pre-existing hook/unused variable violations in contexts and tests)*

------
https://chatgpt.com/codex/tasks/task_e_68df0def49e0832484e3c5e9035d3f24