### PR TITLE
Improve mobile ballpark editing

### DIFF
--- a/frontend/src/dashboard/project/features/budget/components/EditBallparkModal.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/EditBallparkModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useEffect, useId, useState } from "react";
 import Modal from "@/shared/ui/ModalWithStack";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faXmark } from "@fortawesome/free-solid-svg-icons";
@@ -24,6 +24,7 @@ const EditBallparkModal: React.FC<EditBallparkModalProps> = ({
   const [value, setValue] = useState<string>(
     initialValue !== undefined && initialValue !== null ? String(initialValue) : ""
   );
+  const inputId = useId();
 
   useEffect(() => {
     setValue(
@@ -66,41 +67,40 @@ const EditBallparkModal: React.FC<EditBallparkModalProps> = ({
         </button>
       </div>
 
-      <form onSubmit={handleSubmit} style={{ width: "100%" }}>
-        <div className="currency-input-wrapper">
-          <span className="currency-prefix">$</span>
-          <input
-            type="number"
-            step="0.01"
-            value={value}
-            onChange={(e) => setValue(e.target.value)}
-            className="modal-input currency-input"
-            autoFocus
-          />
+      <form onSubmit={handleSubmit} className={styles.form}>
+        <div className={styles.fieldGroup}>
+          <label className={styles.inputLabel} htmlFor={inputId}>
+            Estimate amount
+          </label>
+          <div className={styles.currencyInputWrapper}>
+            <span className={styles.currencyPrefix} aria-hidden="true">
+              $
+            </span>
+            <input
+              id={inputId}
+              type="number"
+              inputMode="decimal"
+              step="0.01"
+              min="0"
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              className={styles.input}
+              placeholder="0.00"
+              autoFocus
+            />
+          </div>
         </div>
 
-        <div
-          style={{
-            display: "flex",
-            justifyContent: "flex-end",
-            gap: "10px",
-            marginTop: "20px",
-          }}
-        >
-          <button
-            type="submit"
-            className="modal-button primary"
-            style={{ borderRadius: "5px" }}
-          >
-            Save
-          </button>
+        <div className={styles.actions}>
           <button
             type="button"
-            className="modal-button secondary"
-            style={{ borderRadius: "5px" }}
+            className={styles.secondaryButton}
             onClick={onRequestClose}
           >
             Cancel
+          </button>
+          <button type="submit" className={styles.primaryButton}>
+            Save
           </button>
         </div>
       </form>

--- a/frontend/src/dashboard/project/features/budget/components/HeaderStats.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/HeaderStats.tsx
@@ -781,7 +781,13 @@ const BudgetHeader: React.FC<BudgetHeaderProps> = ({
       mobileStyles.metricChip,
       selectedMetric === metric.title ? mobileStyles.metricChipActive : "",
       isReconciledToggleMetric ? mobileStyles.metricChipWithSwitch : "",
-      isBallparkMetric ? mobileStyles.metricChipWithAction : "",
+    ]
+      .filter(Boolean)
+      .join(" ");
+
+    const tagClassName = [
+      mobileStyles.metricTag,
+      isBallparkMetric ? mobileStyles.metricTagBallpark : "",
     ]
       .filter(Boolean)
       .join(" ");
@@ -791,11 +797,26 @@ const BudgetHeader: React.FC<BudgetHeaderProps> = ({
         <button
           type="button"
           className={chipClassName}
-          onClick={metric.field ? () => setSelectedMetric(metric.title) : undefined}
-          disabled={!metric.field}
+          onClick={() => {
+            if (isBallparkMetric) {
+              setBallparkModalOpen(true);
+              return;
+            }
+            if (metric.field) {
+              setSelectedMetric(metric.title);
+            }
+          }}
+          disabled={!metric.field && !isBallparkMetric}
+          aria-label={
+            isBallparkMetric
+              ? "Edit estimate"
+              : metric.field
+              ? undefined
+              : metric.title
+          }
         >
           <div className={mobileStyles.metricChipHeader}>
-            <span className={mobileStyles.metricTag}>{metric.tag}</span>
+            <span className={tagClassName}>{metric.tag}</span>
           </div>
           <span className={mobileStyles.metricValue}>{metric.value}</span>
           <span className={mobileStyles.metricDescription}>{metric.description}</span>
@@ -808,21 +829,6 @@ const BudgetHeader: React.FC<BudgetHeaderProps> = ({
             className={mobileStyles.metricChipSwitch}
             aria-label="Toggle reconciled totals"
           />
-        )}
-        {isBallparkMetric && (
-          <button
-            type="button"
-            className={mobileStyles.metricChipEdit}
-            onClick={(event) => {
-              event.preventDefault();
-              event.stopPropagation();
-              setBallparkModalOpen(true);
-            }}
-            disabled={!budgetHeader}
-            aria-label="Edit estimate"
-          >
-            <FontAwesomeIcon icon={faPen} />
-          </button>
         )}
       </div>
     );

--- a/frontend/src/dashboard/project/features/budget/components/budget-header-mobile.module.css
+++ b/frontend/src/dashboard/project/features/budget/components/budget-header-mobile.module.css
@@ -226,36 +226,6 @@
   z-index: 1;
 }
 
-.metricChipWithAction {
-  padding-right: 38px;
-}
-
-.metricChipEdit {
-  position: absolute;
-  top: 8px;
-  right: 10px;
-  background: rgba(30, 41, 59, 0.9);
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  border-radius: 9999px;
-  color: inherit;
-  padding: 4px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  transition: background-color 0.2s ease, border-color 0.2s ease;
-}
-
-.metricChipEdit:hover:not(:disabled) {
-  background: rgba(30, 41, 59, 1);
-  border-color: rgba(255, 255, 255, 0.24);
-}
-
-.metricChipEdit:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
 .metricRowTop {
   grid-template-columns: repeat(3, minmax(0, 1fr));
 }
@@ -299,6 +269,13 @@
   color: rgba(249, 250, 251, 0.65);
   text-transform: uppercase;
   letter-spacing: 0.08em;
+}
+
+.metricTagBallpark {
+  color: rgba(249, 250, 251, 0.85);
+  text-transform: none;
+  letter-spacing: 0.02em;
+  font-weight: 600;
 }
 
 .metricValue {

--- a/frontend/src/dashboard/project/features/budget/components/edit-ball-park-modal.module.css
+++ b/frontend/src/dashboard/project/features/budget/components/edit-ball-park-modal.module.css
@@ -1,13 +1,10 @@
 .modalOverlay {
   position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
+  inset: 0;
   display: flex;
   align-items: center;
   justify-content: center;
-  background: rgba(0, 0, 0, 0.75);
+  background: rgba(5, 10, 25, 0.72);
   z-index: 1000;
   box-sizing: border-box;
   opacity: 0;
@@ -23,20 +20,21 @@
 }
 
 .modalContent {
-  background: #0c0c0c;
-  color: white;
-  border: 2px solid #ffffff;
-  border-radius: 16px;
-  padding: 22px;
-  width: 90%;
-  max-width: 400px;
+  background: linear-gradient(155deg, rgba(17, 24, 39, 0.95), rgba(30, 41, 59, 0.88));
+  color: #f9fafb;
+  border: none;
+  border-radius: 24px;
+  padding: 28px 32px;
+  width: min(420px, 92vw);
   display: flex;
   flex-direction: column;
-  align-items: center;
+  gap: 24px;
   opacity: 0;
   transform: translateY(-20px);
   transition: opacity 0.3s ease, transform 0.3s ease;
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 255, 255, 0.05),
+    0 28px 56px rgba(8, 15, 35, 0.55);
   font-family: "Helvetica Neue", "Helvetica Display", sans-serif;
 }
 
@@ -55,32 +53,169 @@
   justify-content: space-between;
   align-items: center;
   width: 100%;
-  margin-bottom: 1rem;
 }
 
 .modalTitle {
-  font-size: 1rem;
+  font-size: 1.1rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
 }
 
 .iconButton {
-  background: transparent;
-  border: none;
-  color: white;
-  padding: 4px;
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: inherit;
+  padding: 6px;
   cursor: pointer;
-  border-radius: 6px;
-  transition: background-color 0.2s ease, transform 0.2s ease;
+  border-radius: 12px;
+  transition: background-color 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
   display: inline-flex;
   align-items: center;
+  justify-content: center;
 }
 
-.iconButton:hover {
-  transform: scale(1.03);
-  background-color: rgba(255, 255, 255, 0.1);
+.iconButton:hover,
+.iconButton:focus-visible {
+  background: rgba(15, 23, 42, 0.85);
+  border-color: rgba(255, 255, 255, 0.2);
+  transform: translateY(-1px);
+  outline: none;
 }
 
+.form {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
 
+.fieldGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
 
+.inputLabel {
+  font-size: 0.85rem;
+  color: rgba(249, 250, 251, 0.75);
+  font-weight: 500;
+}
 
+.currencyInputWrapper {
+  position: relative;
+  width: 100%;
+}
 
+.currencyPrefix {
+  position: absolute;
+  inset: 0 auto 0 18px;
+  display: flex;
+  align-items: center;
+  color: rgba(249, 250, 251, 0.65);
+  pointer-events: none;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
 
+.input {
+  width: 100%;
+  padding: 16px 18px 16px 52px;
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(15, 23, 42, 0.9);
+  color: inherit;
+  font-size: 1.3rem;
+  font-weight: 600;
+  box-sizing: border-box;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+  font-family: inherit;
+  -moz-appearance: textfield;
+}
+
+.input::placeholder {
+  color: rgba(249, 250, 251, 0.35);
+}
+
+.input:focus,
+.input:focus-visible {
+  outline: none;
+  border-color: rgba(250, 51, 86, 0.7);
+  box-shadow: 0 0 0 3px rgba(250, 51, 86, 0.25);
+  background: rgba(15, 23, 42, 0.95);
+}
+
+.input::-webkit-outer-spin-button,
+.input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+.secondaryButton,
+.primaryButton {
+  border-radius: 14px;
+  padding: 12px 22px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease,
+    border-color 0.2s ease;
+  border: 1px solid transparent;
+  background: transparent;
+  color: inherit;
+}
+
+.secondaryButton {
+  border-color: rgba(255, 255, 255, 0.14);
+  background: rgba(15, 23, 42, 0.6);
+}
+
+.secondaryButton:hover,
+.secondaryButton:focus-visible {
+  background: rgba(15, 23, 42, 0.85);
+  border-color: rgba(255, 255, 255, 0.24);
+  outline: none;
+  transform: translateY(-1px);
+}
+
+.primaryButton {
+  background: linear-gradient(135deg, #fa3356, #f43f5e);
+  border-color: transparent;
+  color: #0b0f1a;
+  box-shadow: 0 12px 24px rgba(244, 63, 94, 0.35);
+}
+
+.primaryButton:hover,
+.primaryButton:focus-visible {
+  background: linear-gradient(135deg, #ff4d6b, #fb7185);
+  box-shadow: 0 16px 28px rgba(244, 63, 94, 0.45);
+  transform: translateY(-1px);
+  outline: none;
+}
+
+.primaryButton:active {
+  transform: translateY(0);
+}
+
+@media (max-width: 480px) {
+  .modalContent {
+    padding: 24px 20px;
+    border-radius: 20px;
+  }
+
+  .actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .secondaryButton,
+  .primaryButton {
+    width: 100%;
+    justify-content: center;
+  }
+}


### PR DESCRIPTION
## Summary
- allow the mobile "Estimate" chip to open the ballpark editor directly and refresh its label styling
- restyle the Edit Ballpark modal to match the dashboard card aesthetic and improve the currency field layout

## Testing
- npm run lint *(fails: existing lint errors in unrelated files such as MessagesProvider.tsx, ProjectsProvider.tsx, TasksComponentMobile.tsx, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68df1742b4408324af672d8e330cbefa