### PR TITLE
Adjust HQ mobile header to reuse welcome header

### DIFF
--- a/frontend/src/hq/components/HQLayout.module.css
+++ b/frontend/src/hq/components/HQLayout.module.css
@@ -82,6 +82,10 @@
   margin: 0 0 16px;
 }
 
+:global(body.hq-hide-marketing-nav header.header .nav-bar) {
+  display: none !important;
+}
+
 .mobilePageHeader {
   display: grid;
   gap: 12px;

--- a/frontend/src/hq/components/HQLayout.module.css
+++ b/frontend/src/hq/components/HQLayout.module.css
@@ -78,6 +78,36 @@
   padding-right: 4px;
 }
 
+.mobileWelcomeHeader {
+  margin: 0 0 16px;
+}
+
+.mobilePageHeader {
+  display: grid;
+  gap: 12px;
+}
+
+.mobilePageTitle {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: #ffffff;
+}
+
+.mobilePageSubtitle {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.72);
+  line-height: 1.5;
+  font-size: 0.95rem;
+}
+
+.mobileActionsRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
 .threadColumn {
   flex: 0 0 auto;
   display: flex;
@@ -152,6 +182,14 @@
   .menuButton {
     display: none;
   }
+
+  .mobileWelcomeHeader {
+    display: none;
+  }
+
+  .mobilePageHeader {
+    display: none;
+  }
 }
 
 @media (max-width: 1023px) {
@@ -180,5 +218,14 @@
 
   .actionsRow {
     margin-left: 0;
+  }
+
+  .mobileWelcomeHeader {
+    margin-bottom: 12px;
+  }
+
+  .mobilePageHeader {
+    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+    padding-bottom: 16px;
   }
 }

--- a/frontend/src/hq/components/HQLayout.tsx
+++ b/frontend/src/hq/components/HQLayout.tsx
@@ -7,7 +7,6 @@ import React, {
   useRef,
   useState,
 } from "react";
-import { Menu } from "lucide-react";
 import DashboardNavPanel from "@/shared/ui/DashboardNavPanel";
 import NavigationDrawer from "@/shared/ui/NavigationDrawer";
 import { useNavCollapsed } from "@/shared/hooks/useNavCollapsed";
@@ -15,6 +14,7 @@ import { useUser } from "@/app/contexts/useUser";
 import ProjectMessagesThread from "@/dashboard/features/messages/ProjectMessagesThread";
 import ChatPanel from "@/dashboard/project/components/Shared/ChatPanel";
 import "@/dashboard/home/pages/dashboard-styles.css";
+import WelcomeHeader from "@/dashboard/home/components/WelcomeHeader";
 import styles from "./HQLayout.module.css";
 
 type HQLayoutProps = {
@@ -72,7 +72,7 @@ const HQLayout: React.FC<HQLayoutProps> = ({
   actions,
   children,
 }) => {
-  const { isAdmin } = useUser();
+  const { isAdmin, userName } = useUser();
   const [flags, setFlags] = useState<ViewportFlags>(() => getViewportFlags());
   const [isNavCollapsed, setIsNavCollapsed] = useNavCollapsed("hq");
   const [isNavigationOpen, setIsNavigationOpen] = useState(false);
@@ -83,6 +83,7 @@ const HQLayout: React.FC<HQLayoutProps> = ({
   );
   const pageHeaderRef = useRef<HTMLElement | null>(null);
   const [headerOffset, setHeaderOffset] = useState<number>(0);
+  const mobileWelcomeHeaderRef = useRef<HTMLDivElement | null>(null);
   const [floatingThread, setFloatingThread] = useState<boolean>(() => {
     if (typeof window === "undefined") return false;
     try {
@@ -138,7 +139,10 @@ const HQLayout: React.FC<HQLayoutProps> = ({
     const localHeight = pageHeaderRef.current
       ? pageHeaderRef.current.getBoundingClientRect().height
       : 0;
-    setHeaderOffset(globalHeight + localHeight);
+    const welcomeHeight = mobileWelcomeHeaderRef.current
+      ? mobileWelcomeHeaderRef.current.getBoundingClientRect().height
+      : 0;
+    setHeaderOffset(globalHeight + localHeight + welcomeHeight);
   }, []);
 
   useLayoutEffect(() => {
@@ -149,7 +153,15 @@ const HQLayout: React.FC<HQLayoutProps> = ({
 
   useEffect(() => {
     updateHeaderOffset();
-  }, [updateHeaderOffset, flags.isDesktop, isNavCollapsed, title, description, actions]);
+  }, [
+    updateHeaderOffset,
+    flags.isDesktop,
+    isNavCollapsed,
+    title,
+    description,
+    actions,
+    userName,
+  ]);
 
   const handleShowChat = useCallback(() => {
     setIsChatHidden(false);
@@ -168,7 +180,6 @@ const HQLayout: React.FC<HQLayoutProps> = ({
     return () => window.removeEventListener("hq-open-chat", handleOpenChatEvent);
   }, [handleShowChat, isAdmin]);
 
-  const handleOpenNavigation = () => setIsNavigationOpen(true);
   const handleCloseNavigation = () => setIsNavigationOpen(false);
   const handleToggleCollapse = () => setIsNavCollapsed((previous) => !previous);
 
@@ -179,18 +190,6 @@ const HQLayout: React.FC<HQLayoutProps> = ({
   const pageHeader = (
     <header ref={pageHeaderRef} className={styles.pageHeader}>
       <div className={styles.pageHeading}>
-        {!flags.isDesktop ? (
-          <button
-            type="button"
-            className={styles.menuButton}
-            onClick={handleOpenNavigation}
-            aria-label="Open navigation"
-            aria-controls={drawerId}
-            aria-expanded={isNavigationOpen}
-          >
-            <Menu size={20} />
-          </button>
-        ) : null}
         <div className={styles.headingCopy}>
           <h1 className={styles.pageTitle}>{title}</h1>
           {description ? (
@@ -199,6 +198,18 @@ const HQLayout: React.FC<HQLayoutProps> = ({
         </div>
       </div>
       {actions ? <div className={styles.actionsRow}>{actions}</div> : null}
+    </header>
+  );
+
+  const mobilePageHeader = (
+    <header ref={pageHeaderRef} className={styles.mobilePageHeader}>
+      <div className={styles.headingCopy}>
+        <h1 className={styles.mobilePageTitle}>{title}</h1>
+        {description ? (
+          <p className={styles.mobilePageSubtitle}>{description}</p>
+        ) : null}
+      </div>
+      {actions ? <div className={styles.mobileActionsRow}>{actions}</div> : null}
     </header>
   );
 
@@ -219,10 +230,17 @@ const HQLayout: React.FC<HQLayoutProps> = ({
   const shouldRenderFloatingPanel =
     isAdmin && !isChatHidden && (floatingThread || !flags.isDesktop);
 
+  const mobileWelcomeHeader = !flags.isDesktop ? (
+    <div ref={mobileWelcomeHeaderRef} className={styles.mobileWelcomeHeader}>
+      <WelcomeHeader userName={userName} isDesktopLayout />
+    </div>
+  ) : null;
+
   const mainContent = (
     <main className="dashboard-main">
+      {mobileWelcomeHeader}
       <div className={`dashboard-wrapper ${styles.wrapper}`}>
-        {pageHeader}
+        {flags.isDesktop ? pageHeader : mobilePageHeader}
         <div className={styles.contentArea}>
           <div className={styles.content}>{children}</div>
           {shouldRenderDockedThread ? (

--- a/frontend/src/hq/components/HQLayout.tsx
+++ b/frontend/src/hq/components/HQLayout.tsx
@@ -110,6 +110,16 @@ const HQLayout: React.FC<HQLayoutProps> = ({
   }, []);
 
   useEffect(() => {
+    if (typeof document === "undefined") return;
+    const { body } = document;
+    if (!body) return;
+    body.classList.add("hq-hide-marketing-nav");
+    return () => {
+      body.classList.remove("hq-hide-marketing-nav");
+    };
+  }, []);
+
+  useEffect(() => {
     if (typeof window === "undefined") return;
     try {
       localStorage.setItem(
@@ -180,11 +190,16 @@ const HQLayout: React.FC<HQLayoutProps> = ({
     return () => window.removeEventListener("hq-open-chat", handleOpenChatEvent);
   }, [handleShowChat, isAdmin]);
 
+  const handleOpenNavigation = () => setIsNavigationOpen(true);
   const handleCloseNavigation = () => setIsNavigationOpen(false);
   const handleToggleCollapse = () => setIsNavCollapsed((previous) => !previous);
 
   const handleHideChat = useCallback(() => {
     setIsChatHidden(true);
+  }, []);
+
+  const handleSetActiveView = useCallback((view: string) => {
+    void view;
   }, []);
 
   const pageHeader = (
@@ -232,7 +247,14 @@ const HQLayout: React.FC<HQLayoutProps> = ({
 
   const mobileWelcomeHeader = !flags.isDesktop ? (
     <div ref={mobileWelcomeHeaderRef} className={styles.mobileWelcomeHeader}>
-      <WelcomeHeader userName={userName} isDesktopLayout />
+      <WelcomeHeader
+        userName={userName}
+        setActiveView={handleSetActiveView}
+        onToggleNavigation={handleOpenNavigation}
+        isNavigationOpen={isNavigationOpen}
+        navigationDrawerId={drawerId}
+        isDesktopLayout={flags.isDesktop}
+      />
     </div>
   ) : null;
 


### PR DESCRIPTION
## Summary
- render the dashboard welcome header on HQ mobile to replace the marketing-style hero
- add a compact mobile page header so titles, descriptions, and actions remain visible without the hamburger button
- account for the new header height when positioning floating chat panels

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68df17f286688324a4e98d9e84cafc27