### PR TITLE
Add budget preview fixtures and enlarge budget donut

### DIFF
--- a/frontend/src/dashboard/home/styles/components/dashboard-cards.css
+++ b/frontend/src/dashboard/home/styles/components/dashboard-cards.css
@@ -99,9 +99,11 @@
   display: flex;
   flex-direction: column;
   align-items: flex-start;
+  justify-content: center;
   flex: 1 1 0%;
   max-width: 50%;
   min-width: 0;
+  gap: 12px;
 }
 
 .budget-overview-header {
@@ -126,7 +128,7 @@
 }
 
 .budget-overview-amount {
-  margin-top: 8px;
+  margin-top: 0;
   display: inline-flex;
   align-items: center;
   gap: 8px;
@@ -144,7 +146,7 @@
 }
 
 .budget-overview-date {
-  margin-top: 8px;
+  margin-top: 0;
 }
 
 /* Make budget card hover match calendar overview card and gallery feel */
@@ -188,11 +190,11 @@
 
 .budget-chart {
   width: 100%;
-  max-width: 280px;
+  max-width: 320px;
   aspect-ratio: 1 / 1;
   position: relative;
   margin-inline: auto;
-  
+
   box-sizing: border-box;
 }
 
@@ -261,13 +263,13 @@
 
   .budget-chart {
     margin-inline: auto;
-    max-width: 240px;
+    max-width: 280px;
   }
 }
 
 @container budget-card (max-width: 760px) {
   .budget-chart {
-    max-width: 200px;
+    max-width: 220px;
   }
 }
 
@@ -326,13 +328,13 @@
     margin-top: 6px;
   }
   .budget-overview-amount {
-    margin-top: 2px;
+    margin-top: 0;
   }
   .budget-overview-invoice-icon {
     margin-left: 4px;
   }
   .budget-overview-date {
-    margin-top: 4px;
+    margin-top: 0;
   }
   .budget-calendar-mobile-card {
     display: block;

--- a/frontend/src/dashboard/project/features/budget/components/budget-header-mobile.module.css
+++ b/frontend/src/dashboard/project/features/budget/components/budget-header-mobile.module.css
@@ -64,6 +64,7 @@
   gap: 8px;
   flex: 1 1 220px;
   min-width: 0;
+  justify-content: center;
 }
 
 .amountRow {
@@ -156,8 +157,8 @@
 
 .chartContainer {
   flex: 0 0 auto;
-  width: clamp(120px, 35vw, 180px);
-  max-width: 200px;
+  width: clamp(140px, 40vw, 210px);
+  max-width: 230px;
   aspect-ratio: 1 / 1;
   position: relative;
   margin: 0;

--- a/frontend/src/shared/utils/devPreview.ts
+++ b/frontend/src/shared/utils/devPreview.ts
@@ -1,5 +1,22 @@
-import type { Project, Message, Thread, UserLite } from "@/app/contexts/DataProvider";
+import type { Project, Thread, UserLite } from "@/app/contexts/DataProvider";
 import type { ProjectMessagesMap } from "@/app/contexts/MessagesContextValue";
+
+type PreviewBudgetHeader = {
+  budgetItemId: `HEADER-${string}`;
+  projectId: string;
+  budgetId: string;
+  revision: number;
+  clientRevisionId?: number | null;
+  [key: string]: unknown;
+};
+
+type PreviewBudgetLine = {
+  budgetItemId: `LINE-${string}`;
+  projectId: string;
+  budgetId: string;
+  revision: number;
+  [key: string]: unknown;
+};
 
 const PREVIEW_STORAGE_KEY = "dashboardPreviewMode";
 const PREVIEW_EVENT = "dashboard-preview-mode-change";
@@ -20,9 +37,326 @@ export interface DevPreviewData {
   inbox: Thread[];
   projectMessages: ProjectMessagesMap;
   recentActivity: PreviewActivityItem[];
+  budgets: Record<
+    string,
+    {
+      headers: PreviewBudgetHeader[];
+      items: PreviewBudgetLine[];
+    }
+  >;
 }
 
 const PREVIEW_USER_ID = "preview-user";
+
+const PREVIEW_BUDGETS: DevPreviewData["budgets"] = {
+  "preview-riverside": {
+    headers: [
+      {
+        budgetItemId: "HEADER-riverside-2024-rev2",
+        projectId: "preview-riverside",
+        budgetId: "BUDGET-riverside-2024",
+        revision: 2,
+        clientRevisionId: 2,
+        title: "Phase 2 Lighting + Seating",
+        projectTitle: "Riverside Park Redesign",
+        createdAt: "2024-05-20T17:30:00.000Z",
+        startDate: "2024-06-10",
+        endDate: "2024-09-30",
+        headerBallPark: 3960,
+        headerBudgetedTotalCost: 4125,
+        headerActualTotalCost: 3580,
+        headerFinalTotalCost: 3960,
+        headerEffectiveMarkup: 0.22,
+        clients: ["City of Westbridge Parks Dept."],
+        invoiceBrandName: "MYLG Fabrication",
+        invoiceBrandAddress: "401 Market Street, Westbridge, OR 97204",
+        invoiceBrandPhone: "(555) 210-7788",
+      },
+      {
+        budgetItemId: "HEADER-riverside-2024-rev1",
+        projectId: "preview-riverside",
+        budgetId: "BUDGET-riverside-2024",
+        revision: 1,
+        clientRevisionId: 2,
+        title: "Initial scope draft",
+        projectTitle: "Riverside Park Redesign",
+        createdAt: "2024-04-28T15:10:00.000Z",
+        startDate: "2024-05-20",
+        endDate: "2024-08-15",
+        headerBallPark: 3820,
+        headerBudgetedTotalCost: 3900,
+        headerActualTotalCost: 0,
+        headerFinalTotalCost: 0,
+        headerEffectiveMarkup: 0.18,
+        clients: ["City of Westbridge Parks Dept."],
+      },
+    ],
+    items: [
+      {
+        budgetItemId: "LINE-riverside-lighting",
+        projectId: "preview-riverside",
+        budgetId: "BUDGET-riverside-2024",
+        revision: 2,
+        elementId: "EL-201",
+        invoiceGroup: "Lighting",
+        areaGroup: "Promenade",
+        itemName: "Interactive promenade lighting",
+        itemDescription: "RGBW fixtures with DMX playback for the east promenade railing",
+        quantity: 12,
+        unit: "ea",
+        unitCost: 120,
+        itemBudgetedCost: 1500,
+        itemActualCost: 1425,
+        itemFinalCost: 1460,
+        itemMarkUp: 0.22,
+        paymentStatus: "Partial",
+        status: "Approved",
+        client: "City of Westbridge Parks Dept.",
+        startDate: "2024-07-01",
+        endDate: "2024-07-20",
+        dates: "Jul 1 – Jul 20",
+        owner: "Preview User",
+      },
+      {
+        budgetItemId: "LINE-riverside-seating",
+        projectId: "preview-riverside",
+        budgetId: "BUDGET-riverside-2024",
+        revision: 2,
+        elementId: "EL-218",
+        invoiceGroup: "Fabrication",
+        areaGroup: "Terraces",
+        itemName: "Modular seating platforms",
+        itemDescription: "Powder-coated aluminum platforms with integrated planters",
+        quantity: 8,
+        unit: "kit",
+        unitCost: 160,
+        itemBudgetedCost: 1200,
+        itemActualCost: 1180,
+        itemFinalCost: 1280,
+        itemMarkUp: 0.2,
+        paymentStatus: "Pending",
+        status: "In Progress",
+        client: "City of Westbridge Parks Dept.",
+        startDate: "2024-07-08",
+        endDate: "2024-08-05",
+        dates: "Jul 8 – Aug 5",
+        owner: "Avery Harper",
+      },
+      {
+        budgetItemId: "LINE-riverside-install",
+        projectId: "preview-riverside",
+        budgetId: "BUDGET-riverside-2024",
+        revision: 2,
+        elementId: "EL-233",
+        invoiceGroup: "Installation",
+        areaGroup: "Promenade",
+        itemName: "Night install labor",
+        itemDescription: "Nightly crew for lighting + seating placement",
+        quantity: 6,
+        unit: "shift",
+        unitCost: 110,
+        itemBudgetedCost: 780,
+        itemActualCost: 760,
+        itemFinalCost: 780,
+        itemMarkUp: 0.12,
+        paymentStatus: "Scheduled",
+        status: "Scheduled",
+        client: "City of Westbridge Parks Dept.",
+        startDate: "2024-08-01",
+        endDate: "2024-08-14",
+        dates: "Aug 1 – Aug 14",
+        owner: "Max Ramirez",
+      },
+      {
+        budgetItemId: "LINE-riverside-power",
+        projectId: "preview-riverside",
+        budgetId: "BUDGET-riverside-2024",
+        revision: 2,
+        elementId: "EL-245",
+        invoiceGroup: "Electrical",
+        areaGroup: "Promenade",
+        itemName: "Power redistribution",
+        itemDescription: "Rework of site power drops to support lighting",
+        quantity: 1,
+        unit: "lot",
+        unitCost: 320,
+        itemBudgetedCost: 320,
+        itemActualCost: 300,
+        itemFinalCost: 340,
+        itemMarkUp: 0.15,
+        paymentStatus: "Approved",
+        status: "Approved",
+        client: "City of Westbridge Parks Dept.",
+        startDate: "2024-07-18",
+        endDate: "2024-07-25",
+        dates: "Jul 18 – Jul 25",
+        owner: "Preview User",
+      },
+      {
+        budgetItemId: "LINE-riverside-permits",
+        projectId: "preview-riverside",
+        budgetId: "BUDGET-riverside-2024",
+        revision: 2,
+        elementId: "EL-250",
+        invoiceGroup: "Fees",
+        areaGroup: "Permitting",
+        itemName: "Parks permit fees",
+        itemDescription: "City permit and inspection coordination",
+        quantity: 1,
+        unit: "allow",
+        unitCost: 100,
+        itemBudgetedCost: 100,
+        itemActualCost: 90,
+        itemFinalCost: 100,
+        itemMarkUp: 0.1,
+        paymentStatus: "Paid",
+        status: "Closed",
+        client: "City of Westbridge Parks Dept.",
+        startDate: "2024-06-28",
+        endDate: "2024-07-02",
+        dates: "Jun 28 – Jul 2",
+        owner: "Devon Wells",
+      },
+      {
+        budgetItemId: "LINE-riverside-lighting-r1",
+        projectId: "preview-riverside",
+        budgetId: "BUDGET-riverside-2024",
+        revision: 1,
+        elementId: "EL-201",
+        invoiceGroup: "Lighting",
+        areaGroup: "Promenade",
+        itemName: "Interactive promenade lighting",
+        itemDescription: "Earlier draft scope for lighting",
+        quantity: 10,
+        unit: "ea",
+        unitCost: 120,
+        itemBudgetedCost: 1200,
+        itemActualCost: 0,
+        itemFinalCost: 0,
+        itemMarkUp: 0.15,
+        paymentStatus: "Pending",
+        status: "Draft",
+        client: "City of Westbridge Parks Dept.",
+      },
+    ],
+  },
+  "preview-harbor": {
+    headers: [
+      {
+        budgetItemId: "HEADER-harbor-2024-rev1",
+        projectId: "preview-harbor",
+        budgetId: "BUDGET-harbor-pop-up",
+        revision: 1,
+        clientRevisionId: 1,
+        title: "Pop-up pavilion concept",
+        projectTitle: "Harbor Pavilion Pop-up",
+        createdAt: "2024-05-18T19:05:00.000Z",
+        startDate: "2024-07-05",
+        endDate: "2024-09-15",
+        headerBallPark: 2860,
+        headerBudgetedTotalCost: 2985,
+        headerActualTotalCost: 1895,
+        headerFinalTotalCost: 2620,
+        headerEffectiveMarkup: 0.18,
+        clients: ["Port Authority Events"],
+        invoiceBrandName: "MYLG Studio",
+        invoiceBrandAddress: "24 Harbor Way, Suite 200, Westbridge, OR 97204",
+        invoiceBrandPhone: "(555) 482-1100",
+      },
+    ],
+    items: [
+      {
+        budgetItemId: "LINE-harbor-structure",
+        projectId: "preview-harbor",
+        budgetId: "BUDGET-harbor-pop-up",
+        revision: 1,
+        elementId: "HP-101",
+        invoiceGroup: "Structure",
+        areaGroup: "Deck",
+        itemName: "Modular pavilion framing",
+        itemDescription: "Aluminum tube framing kit with powder coat",
+        quantity: 6,
+        unit: "kit",
+        unitCost: 210,
+        itemBudgetedCost: 1260,
+        itemActualCost: 1180,
+        itemFinalCost: 1320,
+        itemMarkUp: 0.18,
+        paymentStatus: "Partial",
+        status: "Approved",
+        client: "Port Authority Events",
+        startDate: "2024-07-12",
+        endDate: "2024-08-02",
+        dates: "Jul 12 – Aug 2",
+        owner: "Preview User",
+      },
+      {
+        budgetItemId: "LINE-harbor-lighting",
+        projectId: "preview-harbor",
+        budgetId: "BUDGET-harbor-pop-up",
+        revision: 1,
+        elementId: "HP-118",
+        invoiceGroup: "Lighting",
+        areaGroup: "Canopy",
+        itemName: "Interactive canopy lighting",
+        itemDescription: "Wireless DMX fixtures with show controller",
+        quantity: 14,
+        unit: "ea",
+        unitCost: 85,
+        itemBudgetedCost: 980,
+        itemActualCost: 920,
+        itemFinalCost: 980,
+        itemMarkUp: 0.16,
+        paymentStatus: "Pending",
+        status: "In Review",
+        client: "Port Authority Events",
+        startDate: "2024-07-18",
+        endDate: "2024-08-18",
+        dates: "Jul 18 – Aug 18",
+        owner: "Avery Harper",
+      },
+      {
+        budgetItemId: "LINE-harbor-activation",
+        projectId: "preview-harbor",
+        budgetId: "BUDGET-harbor-pop-up",
+        revision: 1,
+        elementId: "HP-140",
+        invoiceGroup: "Programming",
+        areaGroup: "Experience",
+        itemName: "Lighting activation & programming",
+        itemDescription: "Interactive lighting content + onsite programming",
+        quantity: 5,
+        unit: "day",
+        unitCost: 64,
+        itemBudgetedCost: 320,
+        itemActualCost: 295,
+        itemFinalCost: 320,
+        itemMarkUp: 0.14,
+        paymentStatus: "Scheduled",
+        status: "Scheduled",
+        client: "Port Authority Events",
+        startDate: "2024-08-22",
+        endDate: "2024-09-05",
+        dates: "Aug 22 – Sep 5",
+        owner: "Max Ramirez",
+      },
+    ],
+  },
+};
+
+const PREVIEW_BUDGET_LOOKUP = new Map<
+  string,
+  {
+    projectId: string;
+    data: { headers: PreviewBudgetHeader[]; items: PreviewBudgetLine[] };
+  }
+>();
+
+Object.entries(PREVIEW_BUDGETS).forEach(([projectId, data]) => {
+  data.headers.forEach((header) => {
+    PREVIEW_BUDGET_LOOKUP.set(header.budgetId, { projectId, data });
+  });
+});
 
 const DEV_PREVIEW_DATA: DevPreviewData = {
   user: {
@@ -208,6 +542,106 @@ const DEV_PREVIEW_DATA: DevPreviewData = {
       timestamp: "2024-05-20T22:45:00.000Z",
     },
   ],
+  budgets: PREVIEW_BUDGETS,
+};
+
+const deepClone = <T,>(value: T): T => JSON.parse(JSON.stringify(value)) as T;
+
+const createJsonResponse = (payload: unknown): Response =>
+  new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+
+const resolveRequestUrl = (input: RequestInfo | URL): string | null => {
+  if (typeof input === "string") return input;
+  if (input instanceof URL) return input.toString();
+  if (typeof Request !== "undefined" && input instanceof Request) {
+    return input.url;
+  }
+  if (typeof input === "object" && input !== null && "url" in input) {
+    const candidate = (input as { url?: unknown }).url;
+    if (typeof candidate === "string") {
+      return candidate;
+    }
+  }
+  return null;
+};
+
+const handlePreviewBudgetRequest = (rawUrl: string): Response | null => {
+  let parsed: URL;
+  try {
+    parsed = new URL(
+      rawUrl,
+      typeof window !== "undefined" ? window.location.origin : "http://localhost"
+    );
+  } catch {
+    return null;
+  }
+
+  const headerMatch = parsed.pathname.match(/\/projects\/([^/]+)\/budget$/);
+  if (headerMatch && parsed.searchParams.get("headers") === "true") {
+    const projectId = decodeURIComponent(headerMatch[1]);
+    const dataset = PREVIEW_BUDGETS[projectId];
+    if (dataset) {
+      const headers = dataset.headers.map((header) => deepClone(header));
+      return createJsonResponse({ Items: headers });
+    }
+  }
+
+  const itemsMatch = parsed.pathname.match(/\/budgets\/byBudgetId\/([^/]+)$/);
+  if (itemsMatch) {
+    const budgetId = decodeURIComponent(itemsMatch[1]);
+    const entry = PREVIEW_BUDGET_LOOKUP.get(budgetId);
+    if (entry) {
+      const revisionParam = parsed.searchParams.get("revision");
+      const revision = revisionParam != null ? Number(revisionParam) : null;
+      const items = entry.data.items.filter((item) => {
+        if (item.budgetId !== budgetId) return false;
+        if (revision == null) return true;
+        const itemRevision = Number((item as { revision?: number }).revision ?? 0);
+        return Number.isNaN(itemRevision) ? false : itemRevision === revision;
+      });
+      return createJsonResponse({ Items: items.map((item) => deepClone(item)) });
+    }
+  }
+
+  return null;
+};
+
+let restorePreviewFetch: (() => void) | null = null;
+
+const installPreviewFetchMock = (): void => {
+  if (
+    restorePreviewFetch ||
+    typeof window === "undefined" ||
+    typeof window.fetch !== "function"
+  ) {
+    return;
+  }
+
+  const originalFetch = window.fetch.bind(window);
+  window.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = resolveRequestUrl(input);
+    if (url && isPreviewModeEnabled()) {
+      const response = handlePreviewBudgetRequest(url);
+      if (response) {
+        return response;
+      }
+    }
+    return originalFetch(input as RequestInfo, init);
+  }) as typeof window.fetch;
+
+  restorePreviewFetch = () => {
+    window.fetch = originalFetch;
+    restorePreviewFetch = null;
+  };
+};
+
+const removePreviewFetchMock = (): void => {
+  if (restorePreviewFetch) {
+    restorePreviewFetch();
+  }
 };
 
 const noop = () => undefined;
@@ -231,9 +665,11 @@ export const setPreviewModeEnabled = (enabled: boolean): void => {
   try {
     if (enabled) {
       window.sessionStorage.setItem(PREVIEW_STORAGE_KEY, "on");
+      installPreviewFetchMock();
     } else {
       window.sessionStorage.removeItem(PREVIEW_STORAGE_KEY);
       window.localStorage.removeItem(PREVIEW_STORAGE_KEY);
+      removePreviewFetchMock();
     }
   } catch {
     /* ignore storage errors in dev */
@@ -275,5 +711,43 @@ export const subscribeToPreviewMode = (callback: () => void): (() => void) => {
   };
 };
 
+if (isPreviewModeSupported() && typeof window !== "undefined" && isPreviewModeEnabled()) {
+  installPreviewFetchMock();
+}
+
+export const getPreviewBudgetData = (
+  projectId: string
+): { headers: PreviewBudgetHeader[]; items: PreviewBudgetLine[] } | null => {
+  const dataset = PREVIEW_BUDGETS[projectId];
+  if (!dataset) return null;
+  return {
+    headers: dataset.headers.map((header) => deepClone(header)),
+    items: dataset.items.map((item) => deepClone(item)),
+  };
+};
+
+export const getPreviewBudgetHeaders = (projectId: string): PreviewBudgetHeader[] => {
+  const dataset = PREVIEW_BUDGETS[projectId];
+  return dataset ? dataset.headers.map((header) => deepClone(header)) : [];
+};
+
+export const getPreviewBudgetItems = (
+  budgetId: string,
+  revision?: number
+): PreviewBudgetLine[] => {
+  const entry = PREVIEW_BUDGET_LOOKUP.get(budgetId);
+  if (!entry) return [];
+  return entry.data.items
+    .filter((item) => {
+      if (item.budgetId !== budgetId) return false;
+      if (revision == null) return true;
+      const itemRevision = Number((item as { revision?: number }).revision ?? 0);
+      return Number.isNaN(itemRevision) ? false : itemRevision === revision;
+    })
+    .map((item) => deepClone(item));
+};
+
 export const getDevPreviewData = (): DevPreviewData => DEV_PREVIEW_DATA;
+
+export type { PreviewBudgetHeader, PreviewBudgetLine };
 


### PR DESCRIPTION
## Summary
- add realistic budget headers and line items to dev preview data and intercept budget API calls when preview mode is enabled
- enlarge the budget donut and vertically center the summary content on dashboard budget cards
- scale up the mobile budget header donut so it matches the desktop experience

## Testing
- npm run lint *(fails: existing lint violations in contexts and tests)*

------
https://chatgpt.com/codex/tasks/task_e_68df1707501c8324a126de5714ab6961