### PR TITLE
Add dev preview budget fixtures and refine mobile budget header

### DIFF
--- a/frontend/src/dashboard/project/features/budget/components/budget-header-mobile.module.css
+++ b/frontend/src/dashboard/project/features/budget/components/budget-header-mobile.module.css
@@ -52,7 +52,7 @@
 
 .summaryLayout {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   justify-content: space-between;
   gap: 16px;
   flex-wrap: wrap;
@@ -64,6 +64,8 @@
   gap: 8px;
   flex: 1 1 220px;
   min-width: 0;
+  justify-content: center;
+  align-items: flex-start;
 }
 
 .amountRow {
@@ -156,8 +158,8 @@
 
 .chartContainer {
   flex: 0 0 auto;
-  width: clamp(120px, 35vw, 180px);
-  max-width: 200px;
+  width: clamp(138px, 40vw, 216px);
+  max-width: 220px;
   aspect-ratio: 1 / 1;
   position: relative;
   margin: 0;
@@ -306,7 +308,7 @@
   }
 
   .chartContainer {
-    width: 110px;
+    width: 130px;
   }
 
   .metricChip {

--- a/frontend/src/shared/utils/api.ts
+++ b/frontend/src/shared/utils/api.ts
@@ -1,6 +1,12 @@
 // api.ts
 import { waitForAuthReady } from './waitForAuthReady';
 import { csrfProtection, rateLimiter, logSecurityEvent } from './securityUtils';
+import {
+  getPreviewBudgetHeader,
+  getPreviewBudgetHeaders,
+  getPreviewBudgetItems,
+  isPreviewModeEnabled,
+} from './devPreview';
 
 // ───────────────────────────────────────────────────────────────────────────────
 // Types
@@ -355,6 +361,14 @@ function extractItem<T>(data: MaybeItem<T> | JsonRecord): T | null {
   if ('Item' in (data as Record<string, unknown>)) return ((data as Record<string, unknown>).Item ?? null) as T | null;
   return (data as T) ?? null;
 }
+
+const clone = <T,>(value: T): T => {
+  const structured = (globalThis as { structuredClone?: <U>(val: U) => U }).structuredClone;
+  if (typeof structured === 'function') {
+    return structured(value);
+  }
+  return JSON.parse(JSON.stringify(value)) as T;
+};
 
 const userProfilesCache = new Map<string, UserProfile>();
 
@@ -836,6 +850,10 @@ export async function deleteNotification(userId: string, timestampUuid: string):
 
 export async function fetchBudgetHeader(projectId: string): Promise<BudgetHeader | null> {
   if (!projectId) return null;
+  if (isPreviewModeEnabled()) {
+    const preview = getPreviewBudgetHeader(projectId);
+    return preview ? (clone(preview) as BudgetHeader) : null;
+  }
   const url = `${PROJECTS_SERVICE_URL}/projects/${encodeURIComponent(projectId)}/budget?headers=true`;
   const data = await apiFetch<MaybeItems<BudgetItem>>(url);
   const items = extractItems<BudgetItem>(data);
@@ -859,6 +877,9 @@ export async function fetchBudgetHeader(projectId: string): Promise<BudgetHeader
 
 export async function fetchBudgetHeaders(projectId: string): Promise<BudgetHeader[]> {
   if (!projectId) return [];
+  if (isPreviewModeEnabled()) {
+    return getPreviewBudgetHeaders(projectId).map((header) => clone(header) as BudgetHeader);
+  }
   const url = `${PROJECTS_SERVICE_URL}/projects/${encodeURIComponent(projectId)}/budget?headers=true`;
   const data = await apiFetch<MaybeItems<BudgetItem>>(url);
   const items = extractItems<BudgetItem>(data);
@@ -881,6 +902,9 @@ export async function fetchBudgetHeaders(projectId: string): Promise<BudgetHeade
 
 export async function fetchBudgetItems(budgetId: string, revision?: number): Promise<BudgetLine[]> {
   if (!budgetId) return [];
+  if (isPreviewModeEnabled()) {
+    return getPreviewBudgetItems(budgetId, revision).map((item) => clone(item) as BudgetLine);
+  }
   const url = `${PROJECTS_SERVICE_URL}/budgets/byBudgetId/${encodeURIComponent(budgetId)}`;
   const data = await apiFetch<MaybeItems<BudgetItem>>(url);
   const items = extractItems<BudgetItem>(data);

--- a/frontend/src/shared/utils/devPreview.ts
+++ b/frontend/src/shared/utils/devPreview.ts
@@ -1,6 +1,52 @@
 import type { Project, Message, Thread, UserLite } from "@/app/contexts/DataProvider";
 import type { ProjectMessagesMap } from "@/app/contexts/MessagesContextValue";
 
+type PreviewNumber = number | string;
+
+export interface PreviewBudgetHeader {
+  budgetItemId: string;
+  projectId: string;
+  budgetId: string;
+  revision: number;
+  clientRevisionId?: number | null;
+  createdAt?: string;
+  projectTitle?: string;
+  headerBallPark?: PreviewNumber;
+  headerBudgetedTotalCost?: PreviewNumber;
+  headerActualTotalCost?: PreviewNumber;
+  headerFinalTotalCost?: PreviewNumber;
+  headerEffectiveMarkup?: PreviewNumber;
+  [key: string]: unknown;
+}
+
+export interface PreviewBudgetLine {
+  budgetItemId: string;
+  projectId: string;
+  budgetId: string;
+  revision: number;
+  invoiceGroup?: string;
+  elementId?: string;
+  elementKey?: string;
+  itemBudgetedCost?: PreviewNumber;
+  itemActualCost?: PreviewNumber;
+  itemFinalCost?: PreviewNumber;
+  description?: string;
+  [key: string]: unknown;
+}
+
+interface PreviewBudgetRevision {
+  header: PreviewBudgetHeader;
+  items: PreviewBudgetLine[];
+}
+
+interface PreviewBudgetProject {
+  revisions: PreviewBudgetRevision[];
+}
+
+export interface PreviewBudgetData {
+  projects: Record<string, PreviewBudgetProject>;
+}
+
 const PREVIEW_STORAGE_KEY = "dashboardPreviewMode";
 const PREVIEW_EVENT = "dashboard-preview-mode-change";
 
@@ -20,6 +66,7 @@ export interface DevPreviewData {
   inbox: Thread[];
   projectMessages: ProjectMessagesMap;
   recentActivity: PreviewActivityItem[];
+  budget: PreviewBudgetData;
 }
 
 const PREVIEW_USER_ID = "preview-user";
@@ -208,6 +255,287 @@ const DEV_PREVIEW_DATA: DevPreviewData = {
       timestamp: "2024-05-20T22:45:00.000Z",
     },
   ],
+  budget: {
+    projects: {
+      "preview-riverside": {
+        revisions: [
+          {
+            header: {
+              budgetItemId: "HEADER-preview-riverside",
+              budgetId: "budget-preview-riverside",
+              projectId: "preview-riverside",
+              projectTitle: "Riverside Park Redesign",
+              revision: 3,
+              clientRevisionId: 3,
+              createdAt: "2024-05-18T17:45:00.000Z",
+              headerBallPark: 4200,
+              headerBudgetedTotalCost: 3960,
+              headerActualTotalCost: 3120,
+              headerFinalTotalCost: 3960,
+              headerEffectiveMarkup: 0.18,
+            },
+            items: [
+              {
+                budgetItemId: "LINE-preview-riverside-lighting",
+                budgetId: "budget-preview-riverside",
+                projectId: "preview-riverside",
+                revision: 3,
+                invoiceGroup: "Lighting",
+                elementId: "LG-101",
+                elementKey: "lighting-grid",
+                description: "Architectural lighting grid",
+                itemBudgetedCost: 1520,
+                itemActualCost: 1295,
+                itemFinalCost: 1520,
+              },
+              {
+                budgetItemId: "LINE-preview-riverside-furniture",
+                budgetId: "budget-preview-riverside",
+                projectId: "preview-riverside",
+                revision: 3,
+                invoiceGroup: "Furniture",
+                elementId: "FN-207",
+                elementKey: "modular-seating",
+                description: "Modular seating clusters",
+                itemBudgetedCost: 980,
+                itemActualCost: 760,
+                itemFinalCost: 980,
+              },
+              {
+                budgetItemId: "LINE-preview-riverside-wayfinding",
+                budgetId: "budget-preview-riverside",
+                projectId: "preview-riverside",
+                revision: 3,
+                invoiceGroup: "Wayfinding",
+                elementId: "WF-118",
+                elementKey: "wayfinding-kit",
+                description: "Directional signage kit",
+                itemBudgetedCost: 820,
+                itemActualCost: 640,
+                itemFinalCost: 820,
+              },
+              {
+                budgetItemId: "LINE-preview-riverside-electrical",
+                budgetId: "budget-preview-riverside",
+                projectId: "preview-riverside",
+                revision: 3,
+                invoiceGroup: "Electrical",
+                elementId: "EL-302",
+                elementKey: "power-upgrade",
+                description: "Temporary power upgrades",
+                itemBudgetedCost: 640,
+                itemActualCost: 425,
+                itemFinalCost: 640,
+              },
+            ],
+          },
+          {
+            header: {
+              budgetItemId: "HEADER-preview-riverside-r2",
+              budgetId: "budget-preview-riverside",
+              projectId: "preview-riverside",
+              projectTitle: "Riverside Park Redesign",
+              revision: 2,
+              clientRevisionId: 3,
+              createdAt: "2024-04-28T10:15:00.000Z",
+              headerBallPark: 3900,
+              headerBudgetedTotalCost: 3720,
+              headerActualTotalCost: 2900,
+              headerFinalTotalCost: 3720,
+              headerEffectiveMarkup: 0.16,
+            },
+            items: [
+              {
+                budgetItemId: "LINE-preview-riverside-lighting-r2",
+                budgetId: "budget-preview-riverside",
+                projectId: "preview-riverside",
+                revision: 2,
+                invoiceGroup: "Lighting",
+                elementId: "LG-101",
+                elementKey: "lighting-grid",
+                description: "Architectural lighting grid",
+                itemBudgetedCost: 1400,
+                itemActualCost: 1180,
+                itemFinalCost: 1400,
+              },
+              {
+                budgetItemId: "LINE-preview-riverside-furniture-r2",
+                budgetId: "budget-preview-riverside",
+                projectId: "preview-riverside",
+                revision: 2,
+                invoiceGroup: "Furniture",
+                elementId: "FN-207",
+                elementKey: "modular-seating",
+                description: "Modular seating clusters",
+                itemBudgetedCost: 920,
+                itemActualCost: 740,
+                itemFinalCost: 920,
+              },
+              {
+                budgetItemId: "LINE-preview-riverside-wayfinding-r2",
+                budgetId: "budget-preview-riverside",
+                projectId: "preview-riverside",
+                revision: 2,
+                invoiceGroup: "Wayfinding",
+                elementId: "WF-118",
+                elementKey: "wayfinding-kit",
+                description: "Directional signage kit",
+                itemBudgetedCost: 780,
+                itemActualCost: 610,
+                itemFinalCost: 780,
+              },
+              {
+                budgetItemId: "LINE-preview-riverside-electrical-r2",
+                budgetId: "budget-preview-riverside",
+                projectId: "preview-riverside",
+                revision: 2,
+                invoiceGroup: "Electrical",
+                elementId: "EL-302",
+                elementKey: "power-upgrade",
+                description: "Temporary power upgrades",
+                itemBudgetedCost: 620,
+                itemActualCost: 470,
+                itemFinalCost: 620,
+              },
+            ],
+          },
+        ],
+      },
+      "preview-harbor": {
+        revisions: [
+          {
+            header: {
+              budgetItemId: "HEADER-preview-harbor",
+              budgetId: "budget-preview-harbor",
+              projectId: "preview-harbor",
+              projectTitle: "Harbor Pavilion Pop-up",
+              revision: 1,
+              clientRevisionId: 1,
+              createdAt: "2024-05-12T13:20:00.000Z",
+              headerBallPark: 52000,
+              headerBudgetedTotalCost: 48750,
+              headerActualTotalCost: 31200,
+              headerFinalTotalCost: 50210,
+              headerEffectiveMarkup: 0.22,
+            },
+            items: [
+              {
+                budgetItemId: "LINE-preview-harbor-structure",
+                budgetId: "budget-preview-harbor",
+                projectId: "preview-harbor",
+                revision: 1,
+                invoiceGroup: "Structure",
+                elementId: "ST-410",
+                elementKey: "pavilion-structure",
+                description: "Modular pavilion structure",
+                itemBudgetedCost: 17800,
+                itemActualCost: 13200,
+                itemFinalCost: 18450,
+              },
+              {
+                budgetItemId: "LINE-preview-harbor-lighting",
+                budgetId: "budget-preview-harbor",
+                projectId: "preview-harbor",
+                revision: 1,
+                invoiceGroup: "Lighting",
+                elementId: "LG-265",
+                elementKey: "interactive-lighting",
+                description: "Interactive lighting ribbon",
+                itemBudgetedCost: 12400,
+                itemActualCost: 8600,
+                itemFinalCost: 12680,
+              },
+              {
+                budgetItemId: "LINE-preview-harbor-vendors",
+                budgetId: "budget-preview-harbor",
+                projectId: "preview-harbor",
+                revision: 1,
+                invoiceGroup: "Vendor Ops",
+                elementId: "VN-502",
+                elementKey: "vendor-program",
+                description: "Vendor onboarding & ops",
+                itemBudgetedCost: 9600,
+                itemActualCost: 5800,
+                itemFinalCost: 10180,
+              },
+              {
+                budgetItemId: "LINE-preview-harbor-graphics",
+                budgetId: "budget-preview-harbor",
+                projectId: "preview-harbor",
+                revision: 1,
+                invoiceGroup: "Branding",
+                elementId: "BR-144",
+                elementKey: "graphics",
+                description: "Seasonal graphics + signage",
+                itemBudgetedCost: 8960,
+                itemActualCost: 6600,
+                itemFinalCost: 8900,
+              },
+            ],
+          },
+        ],
+      },
+    },
+  },
+};
+
+const clone = <T,>(value: T): T => {
+  const structured = (globalThis as { structuredClone?: <U>(val: U) => U }).structuredClone;
+  if (typeof structured === "function") {
+    return structured(value);
+  }
+  return JSON.parse(JSON.stringify(value)) as T;
+};
+
+interface BudgetRevisionIndexEntry extends PreviewBudgetRevision {
+  projectId: string;
+}
+
+const PREVIEW_BUDGET_INDEX = new Map<string, BudgetRevisionIndexEntry>();
+const PREVIEW_HEADERS_BY_PROJECT = new Map<string, PreviewBudgetHeader[]>();
+
+for (const [projectId, projectBudget] of Object.entries(DEV_PREVIEW_DATA.budget.projects)) {
+  const sorted = [...projectBudget.revisions].sort(
+    (a, b) => (b.header.revision ?? 0) - (a.header.revision ?? 0)
+  );
+  PREVIEW_HEADERS_BY_PROJECT.set(projectId, sorted.map((rev) => clone(rev.header)));
+  for (const revision of sorted) {
+    const key = `${revision.header.budgetId}|${revision.header.revision}`;
+    PREVIEW_BUDGET_INDEX.set(key, { ...revision, projectId });
+  }
+}
+
+export const getPreviewBudgetHeader = (projectId: string): PreviewBudgetHeader | null => {
+  const headers = PREVIEW_HEADERS_BY_PROJECT.get(projectId);
+  if (!headers || headers.length === 0) return null;
+  return clone(headers[0]);
+};
+
+export const getPreviewBudgetHeaders = (projectId: string): PreviewBudgetHeader[] => {
+  const headers = PREVIEW_HEADERS_BY_PROJECT.get(projectId);
+  if (!headers) return [];
+  return clone(headers);
+};
+
+export const getPreviewBudgetItems = (
+  budgetId: string,
+  revision?: number
+): PreviewBudgetLine[] => {
+  if (!budgetId) return [];
+  if (revision != null) {
+    const entry = PREVIEW_BUDGET_INDEX.get(`${budgetId}|${revision}`);
+    return entry ? clone(entry.items) : [];
+  }
+
+  let latest: BudgetRevisionIndexEntry | null = null;
+  for (const entry of PREVIEW_BUDGET_INDEX.values()) {
+    if (entry.header.budgetId !== budgetId) continue;
+    if (!latest || (entry.header.revision ?? 0) > (latest.header.revision ?? 0)) {
+      latest = entry;
+    }
+  }
+
+  return latest ? clone(latest.items) : [];
 };
 
 const noop = () => undefined;


### PR DESCRIPTION
## Summary
- add budget fixture data and helper accessors so preview mode can render budget headers and lines
- route budget fetch helpers through the preview fixtures when preview mode is enabled
- tweak the mobile budget header donut size and layout alignment for better centering

## Testing
- npm run typecheck *(fails: Task drawer related type errors present in main)*

------
https://chatgpt.com/codex/tasks/task_e_68df1e0a0ed483249f86018c26877d6b