### PR TITLE
Adjust budget header mobile group controls layout

### DIFF
--- a/frontend/src/dashboard/project/features/budget/components/HeaderStats.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/HeaderStats.tsx
@@ -47,6 +47,13 @@ type GroupBy = "none" | "areaGroup" | "invoiceGroup" | "category";
 
 type MarkupBasis = "Budgeted" | "Actual" | "Reconciled";
 
+const GROUP_BY_OPTIONS: { label: string; value: GroupBy }[] = [
+  { label: "None", value: "none" },
+  { label: "Area Group", value: "areaGroup" },
+  { label: "Invoice Group", value: "invoiceGroup" },
+  { label: "Category", value: "category" },
+];
+
 export interface BudgetItem {
   [key: string]: unknown;
   areaGroup?: string;
@@ -855,6 +862,17 @@ const BudgetHeader: React.FC<BudgetHeaderProps> = ({
         >
           {`Rev.${budgetHeader?.revision ?? 1}`}
         </button>
+      </div>
+
+      <div className={mobileStyles.groupByRow}>
+        <Segmented
+          size="small"
+          options={GROUP_BY_OPTIONS}
+          value={groupBy}
+          onChange={(val: SegmentedValue) => setGroupBy(val as GroupBy)}
+          className={mobileStyles.groupBySegmented}
+          aria-label="Group budget items"
+        />
       </div>
 
       <div className={mobileStyles.summaryLayout}>

--- a/frontend/src/dashboard/project/features/budget/components/budget-header-mobile.module.css
+++ b/frontend/src/dashboard/project/features/budget/components/budget-header-mobile.module.css
@@ -119,6 +119,31 @@
   gap: 8px;
 }
 
+.groupByRow {
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  margin: 4px 0 0;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.groupByRow::-webkit-scrollbar {
+  display: none;
+}
+
+.groupBySegmented {
+  display: inline-flex;
+  padding: 2px;
+  background: rgba(30, 41, 59, 0.9) !important;
+  border-radius: 9999px !important;
+  border: 1px solid rgba(255, 255, 255, 0.08) !important;
+}
+
+.groupBySegmented :global(.ant-segmented-item-label) {
+  white-space: nowrap;
+}
+
 .controlRow {
   display: flex;
   gap: 8px;


### PR DESCRIPTION
## Summary
- add the group-by segmented control to the mobile budget header just beneath the title
- style the segmented control so the grouping pill stays on a single row while allowing horizontal scrolling when needed

## Testing
- npm run build *(fails: [vite]: Rollup failed to resolve import "recharts" from BudgetDonut.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68df1ccf49548324a4063fb29256fd71