### PR TITLE
Adjust budget toolbar pills layout on mobile

### DIFF
--- a/frontend/src/dashboard/project/features/budget/components/BudgetToolbar.module.css
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetToolbar.module.css
@@ -128,3 +128,35 @@
     transform: none;
   }
 }
+
+@media (max-width: 768px) {
+  .toolbar {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.75rem;
+  }
+
+  .groupTabs {
+    width: 100%;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    overflow-y: hidden;
+    margin-right: 0;
+    padding-bottom: 4px;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+  }
+
+  .groupTabs::-webkit-scrollbar {
+    display: none;
+  }
+
+  .tabButton {
+    flex: 0 0 auto;
+  }
+
+  .actions {
+    width: 100%;
+    justify-content: flex-end;
+  }
+}


### PR DESCRIPTION
## Summary
- update the budget toolbar layout so grouping pills stay on a single scrollable row on small screens
- stack the toolbar controls vertically on mobile to keep the group pills directly under the header while keeping actions accessible

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df24be33b4832488a336554c967b17