### PR TITLE
Adjust mobile budget header grouping controls

### DIFF
--- a/frontend/src/dashboard/project/features/budget/components/BudgetToolbar.module.css
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetToolbar.module.css
@@ -128,3 +128,14 @@
     transform: none;
   }
 }
+
+@media (max-width: 768px) {
+  .toolbar {
+    justify-content: flex-end;
+    flex-wrap: wrap;
+  }
+
+  .groupTabs {
+    display: none;
+  }
+}

--- a/frontend/src/dashboard/project/features/budget/components/HeaderStats.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/HeaderStats.tsx
@@ -30,6 +30,7 @@ import {
 import summaryStyles from "./budget-header-summary.module.css";
 import headerStyles from "./header-stats.module.css";
 import mobileStyles from "./budget-header-mobile.module.css";
+import toolbarStyles from "./BudgetToolbar.module.css";
 
 /* =========================
    Types
@@ -913,16 +914,33 @@ const BudgetHeader: React.FC<BudgetHeaderProps> = ({
         </div>
       </div>
 
-      <div className={mobileStyles.groupControls} role="group" aria-label="Group budget items">
-        <span className={mobileStyles.groupControlsLabel}>Group</span>
-        <Segmented
-          size="middle"
-          options={groupOptions}
-          value={groupBy}
-          onChange={(value: SegmentedValue) => setGroupBy(value as GroupBy)}
-          block
-          className={mobileStyles.groupSegmented}
-        />
+      <div className={mobileStyles.groupControls}>
+        <span id="budget-mobile-group-label" className={mobileStyles.srOnly}>
+          Group budget items
+        </span>
+        <div
+          className={mobileStyles.groupTabs}
+          role="group"
+          aria-labelledby="budget-mobile-group-label"
+        >
+          {groupOptions.map((option) => {
+            const isActive = option.value === groupBy;
+            const className = isActive
+              ? `${toolbarStyles.tabButton} ${toolbarStyles.activeTab}`
+              : toolbarStyles.tabButton;
+            return (
+              <button
+                key={option.value}
+                type="button"
+                aria-pressed={isActive}
+                className={className}
+                onClick={() => setGroupBy(option.value)}
+              >
+                <span>{option.label}</span>
+              </button>
+            );
+          })}
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/dashboard/project/features/budget/components/HeaderStats.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/HeaderStats.tsx
@@ -194,6 +194,7 @@ const BudgetHeader: React.FC<BudgetHeaderProps> = ({
   activeProject,
   budgetHeader,
   groupBy,
+  setGroupBy,
   budgetItems = [],
   onBallparkChange,
   onOpenRevisionModal,
@@ -465,6 +466,16 @@ const BudgetHeader: React.FC<BudgetHeaderProps> = ({
         value,
       })),
     [showReconciled]
+  );
+
+  const groupOptions = useMemo(
+    () => [
+      { label: "None", value: "none" as GroupBy },
+      { label: "Area Group", value: "areaGroup" as GroupBy },
+      { label: "Invoice Group", value: "invoiceGroup" as GroupBy },
+      { label: "Category", value: "category" as GroupBy },
+    ],
+    []
   );
 
   const createdDateLabel = useMemo(() => {
@@ -900,6 +911,18 @@ const BudgetHeader: React.FC<BudgetHeaderProps> = ({
         <div className={`${mobileStyles.metricRow} ${mobileStyles.metricRowBottom}`}>
           {bottomMetrics.map((metric) => renderMetricChip(metric))}
         </div>
+      </div>
+
+      <div className={mobileStyles.groupControls} role="group" aria-label="Group budget items">
+        <span className={mobileStyles.groupControlsLabel}>Group</span>
+        <Segmented
+          size="middle"
+          options={groupOptions}
+          value={groupBy}
+          onChange={(value: SegmentedValue) => setGroupBy(value as GroupBy)}
+          block
+          className={mobileStyles.groupSegmented}
+        />
       </div>
     </div>
   );

--- a/frontend/src/dashboard/project/features/budget/components/budget-header-mobile.module.css
+++ b/frontend/src/dashboard/project/features/budget/components/budget-header-mobile.module.css
@@ -290,6 +290,42 @@
   color: rgba(249, 250, 251, 0.55);
 }
 
+.groupControls {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.groupControlsLabel {
+  font-size: 0.65rem;
+  color: rgba(249, 250, 251, 0.6);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.groupSegmented :global(.ant-segmented) {
+  width: 100%;
+  background: rgba(30, 41, 59, 0.85);
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 4px;
+}
+
+.groupSegmented :global(.ant-segmented-item) {
+  color: rgba(249, 250, 251, 0.75);
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.groupSegmented :global(.ant-segmented-item-selected) {
+  color: #0f172a;
+}
+
+.groupSegmented :global(.ant-segmented-thumb) {
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: 999px;
+}
+
 .srOnly {
   position: absolute;
   width: 1px;

--- a/frontend/src/dashboard/project/features/budget/components/budget-header-mobile.module.css
+++ b/frontend/src/dashboard/project/features/budget/components/budget-header-mobile.module.css
@@ -292,38 +292,15 @@
 
 .groupControls {
   display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.groupControlsLabel {
-  font-size: 0.65rem;
-  color: rgba(249, 250, 251, 0.6);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-}
-
-.groupSegmented :global(.ant-segmented) {
+  justify-content: center;
   width: 100%;
-  background: rgba(30, 41, 59, 0.85);
-  border-radius: 999px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  padding: 4px;
 }
 
-.groupSegmented :global(.ant-segmented-item) {
-  color: rgba(249, 250, 251, 0.75);
-  font-size: 0.75rem;
-  font-weight: 600;
-}
-
-.groupSegmented :global(.ant-segmented-item-selected) {
-  color: #0f172a;
-}
-
-.groupSegmented :global(.ant-segmented-thumb) {
-  background: rgba(255, 255, 255, 0.9);
-  border-radius: 999px;
+.groupTabs {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 6px;
 }
 
 .srOnly {


### PR DESCRIPTION
## Summary
- embed the group-by pills within the mobile budget header beneath the metric chips
- style the new segmented control and hide the external toolbar pills on small screens so the controls only appear inside the header

## Testing
- npm run lint *(fails: existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68df31b69564832496c5d4fdd8779a5c