### PR TITLE
Update budget toolbar selection button styling

### DIFF
--- a/frontend/src/dashboard/project/features/budget/components/BudgetToolbar.module.css
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetToolbar.module.css
@@ -74,6 +74,54 @@
   gap: 0.5rem;
 }
 
+.selectionActionButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  padding: 0;
+  border: none;
+  border-radius: 10px;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.82);
+  cursor: pointer;
+  transition: color 0.2s ease, transform 0.2s ease;
+}
+
+.selectionActionButton svg {
+  width: 16px;
+  height: 16px;
+}
+
+.selectionActionButton:hover,
+.selectionActionButton:focus-visible {
+  color: #ffffff;
+  transform: translateY(-1px);
+}
+
+.selectionActionButton:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.35);
+}
+
+.selectionActionButton:active {
+  transform: scale(0.96);
+}
+
+.duplicateSelectedButton {
+  color: rgba(255, 255, 255, 0.82);
+}
+
+.deleteSelectedButton {
+  color: #ff8080;
+}
+
+.deleteSelectedButton:hover,
+.deleteSelectedButton:focus-visible {
+  color: #ffb3b3;
+}
+
 .addButton {
   display: inline-flex;
   align-items: center;
@@ -158,5 +206,14 @@
   .actions {
     width: 100%;
     justify-content: flex-end;
+  }
+
+  .selectionActionButton {
+    width: 30px;
+    height: 30px;
+  }
+
+  .actions {
+    gap: 0.35rem;
   }
 }

--- a/frontend/src/dashboard/project/features/budget/components/BudgetToolbar.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetToolbar.tsx
@@ -54,8 +54,7 @@ const BudgetToolbar: React.FC<BudgetToolbarProps> = ({
           <AntTooltip title="Duplicate Selected">
             <button
               type="button"
-              className="modal-button secondary"
-              style={{ borderRadius: "10px" }}
+              className={`${styles.selectionActionButton} ${styles.duplicateSelectedButton}`}
               onClick={handleDuplicateSelected}
               aria-label="Duplicate selected"
             >
@@ -65,8 +64,7 @@ const BudgetToolbar: React.FC<BudgetToolbarProps> = ({
           <AntTooltip title="Delete Selected">
             <button
               type="button"
-              className="modal-button secondary"
-              style={{ borderRadius: "10px" }}
+              className={`${styles.selectionActionButton} ${styles.deleteSelectedButton}`}
               onClick={() => openDeleteModal(selectedRowKeys)}
               aria-label="Delete selected"
             >


### PR DESCRIPTION
## Summary
- replace the budget toolbar selection actions to use scoped styles instead of the shared modal-button class
- add compact, borderless styling for the duplicate and delete selection buttons with mobile adjustments

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df39c7cb588324acbe31943de21bec