### PR TITLE
Fix budget toolbar selection action button styling

### DIFF
--- a/frontend/src/dashboard/project/features/budget/components/BudgetToolbar.module.css
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetToolbar.module.css
@@ -74,6 +74,37 @@
   gap: 0.5rem;
 }
 
+.iconActionButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  border: none;
+  border-radius: 10px;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.85);
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: color 0.2s ease, transform 0.2s ease;
+}
+
+.iconActionButton:hover,
+.iconActionButton:focus-visible {
+  color: #ffffff;
+  transform: translateY(-1px);
+}
+
+.iconActionButton:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.55);
+  outline-offset: 2px;
+}
+
+.iconActionButton:active {
+  transform: translateY(0);
+}
+
 .addButton {
   display: inline-flex;
   align-items: center;
@@ -137,5 +168,11 @@
 
   .groupTabs {
     display: none;
+  }
+
+  .iconActionButton {
+    width: 32px;
+    height: 32px;
+    font-size: 0.82rem;
   }
 }

--- a/frontend/src/dashboard/project/features/budget/components/BudgetToolbar.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetToolbar.tsx
@@ -54,8 +54,7 @@ const BudgetToolbar: React.FC<BudgetToolbarProps> = ({
           <AntTooltip title="Duplicate Selected">
             <button
               type="button"
-              className="modal-button secondary"
-              style={{ borderRadius: "10px" }}
+              className={styles.iconActionButton}
               onClick={handleDuplicateSelected}
               aria-label="Duplicate selected"
             >
@@ -65,8 +64,7 @@ const BudgetToolbar: React.FC<BudgetToolbarProps> = ({
           <AntTooltip title="Delete Selected">
             <button
               type="button"
-              className="modal-button secondary"
-              style={{ borderRadius: "10px" }}
+              className={styles.iconActionButton}
               onClick={() => openDeleteModal(selectedRowKeys)}
               aria-label="Delete selected"
             >


### PR DESCRIPTION
## Summary
- create a dedicated `iconActionButton` style for the budget toolbar's duplicate and delete controls
- apply the new styles so the buttons no longer inherit modal styles, remain borderless/background-free, and shrink on mobile

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df3a45e5448324a9bf4a3934e9f4d4