### PR TITLE
Add mobile budget filter and query support

### DIFF
--- a/frontend/src/dashboard/project/features/budget/components/BudgetMobileFilter.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetMobileFilter.tsx
@@ -1,0 +1,160 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { ArrowUpDown, ChevronDown, Search } from "lucide-react";
+
+import mobileStyles from "@/dashboard/home/components/projects-panel.module.css";
+import desktopStyles from "@/dashboard/home/components/ProjectsPanelDesktop.module.css";
+import styles from "./BudgetToolbar.module.css";
+
+type SortOrder = "ascend" | "descend" | null;
+
+type SortOptionValue =
+  | "default"
+  | "elementKey-asc"
+  | "elementKey-desc"
+  | "description-asc"
+  | "description-desc"
+  | "budgeted-desc"
+  | "budgeted-asc"
+  | "final-desc"
+  | "final-asc";
+
+type SortOption = {
+  value: SortOptionValue;
+  label: string;
+  field: string | null;
+  order: SortOrder;
+};
+
+const SORT_OPTIONS: SortOption[] = [
+  { value: "default", label: "Default order", field: null, order: null },
+  { value: "elementKey-asc", label: "Element Key (A→Z)", field: "elementKey", order: "ascend" },
+  { value: "elementKey-desc", label: "Element Key (Z→A)", field: "elementKey", order: "descend" },
+  { value: "description-asc", label: "Description (A→Z)", field: "description", order: "ascend" },
+  { value: "description-desc", label: "Description (Z→A)", field: "description", order: "descend" },
+  { value: "budgeted-desc", label: "Budgeted Cost (High→Low)", field: "itemBudgetedCost", order: "descend" },
+  { value: "budgeted-asc", label: "Budgeted Cost (Low→High)", field: "itemBudgetedCost", order: "ascend" },
+  { value: "final-desc", label: "Final Cost (High→Low)", field: "itemFinalCost", order: "descend" },
+  { value: "final-asc", label: "Final Cost (Low→High)", field: "itemFinalCost", order: "ascend" },
+];
+
+interface BudgetMobileFilterProps {
+  filterQuery: string;
+  onFilterQueryChange: (query: string) => void;
+  sortField: string | null;
+  sortOrder: SortOrder;
+  onSortChange: (field: string | null, order: SortOrder) => void;
+}
+
+const BudgetMobileFilter: React.FC<BudgetMobileFilterProps> = ({
+  filterQuery,
+  onFilterQueryChange,
+  sortField,
+  sortOrder,
+  onSortChange,
+}) => {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const handlePointer = (event: MouseEvent | TouchEvent) => {
+      if (!containerRef.current) return;
+      if (event.target instanceof Node && containerRef.current.contains(event.target)) {
+        return;
+      }
+      setOpen(false);
+    };
+
+    document.addEventListener("mousedown", handlePointer);
+    document.addEventListener("touchstart", handlePointer);
+    return () => {
+      document.removeEventListener("mousedown", handlePointer);
+      document.removeEventListener("touchstart", handlePointer);
+    };
+  }, [open]);
+
+  const currentSortValue = useMemo<SortOptionValue>(() => {
+    if (!sortField || !sortOrder) {
+      return "default";
+    }
+
+    const match = SORT_OPTIONS.find(
+      (option) => option.field === sortField && option.order === sortOrder
+    );
+
+    return match ? match.value : "default";
+  }, [sortField, sortOrder]);
+
+  const isActive = filterQuery.trim().length > 0 || currentSortValue !== "default";
+
+  const handleSortChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const nextValue = event.target.value as SortOptionValue;
+    const option = SORT_OPTIONS.find((opt) => opt.value === nextValue) ?? SORT_OPTIONS[0];
+    onSortChange(option.field, option.order);
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      setOpen((prev) => !prev);
+    }
+    if (event.key === "Escape") {
+      setOpen(false);
+    }
+  };
+
+  return (
+    <div className={styles.mobileFilterRoot} ref={containerRef}>
+      <button
+        type="button"
+        className={`${mobileStyles.recents} ${styles.mobileFilterButton} ${
+          isActive ? styles.mobileFilterActive : ""
+        }`}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={() => setOpen((prev) => !prev)}
+        onKeyDown={handleKeyDown}
+      >
+        <span>Filter &amp; Sort</span>
+        <ChevronDown size={14} aria-hidden />
+      </button>
+      {open && (
+        <div className={`${mobileStyles.filterPop} ${styles.mobileFilterPopover}`} role="menu">
+          <div className={mobileStyles.filterSection}>
+            <div className={desktopStyles.filterField}>
+              <Search size={16} aria-hidden className={desktopStyles.filterFieldIcon} />
+              <input
+                type="search"
+                className={desktopStyles.filterInput}
+                placeholder="Search budget items..."
+                value={filterQuery}
+                onChange={(event) => onFilterQueryChange(event.target.value)}
+                aria-label="Filter budget items"
+                autoFocus
+              />
+            </div>
+            <div className={`${desktopStyles.filterField} ${desktopStyles.filterSelect}`}>
+              <ArrowUpDown size={16} aria-hidden className={desktopStyles.filterFieldIcon} />
+              <select
+                className={desktopStyles.filterSelectControl}
+                value={currentSortValue}
+                onChange={handleSortChange}
+                aria-label="Sort budget items"
+              >
+                {SORT_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+              <ChevronDown size={14} aria-hidden className={desktopStyles.filterSelectChevron} />
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default BudgetMobileFilter;

--- a/frontend/src/dashboard/project/features/budget/components/BudgetStateManager.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetStateManager.tsx
@@ -44,6 +44,8 @@ interface BudgetStateManagerState extends Record<string, unknown> {
   sortOrder: string | null;
   setSortField: (field: string | null) => void;
   setSortOrder: (order: string | null) => void;
+  filterQuery: string;
+  setFilterQuery: (query: string) => void;
   selectedRowKeys: string[];
   setSelectedRowKeys: React.Dispatch<React.SetStateAction<string[]>>;
   
@@ -104,6 +106,7 @@ const BudgetStateManager: React.FC<BudgetStateManagerProps> = ({
   const [groupBy, setGroupBy] = useState("none");
   const [sortField, setSortField] = useState<string | null>(null);
   const [sortOrder, setSortOrder] = useState<string | null>(null);
+  const [filterQuery, setFilterQuery] = useState("");
   const [selectedRowKeys, setSelectedRowKeys] = useState<string[]>([]);
   
   // Edit/Create state
@@ -121,7 +124,11 @@ const BudgetStateManager: React.FC<BudgetStateManagerProps> = ({
   // Pagination
   const [pageSize, setPageSize] = useState(10);
   const [currentPage, setCurrentPage] = useState(1);
-  
+
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [filterQuery]);
+
   // Line locking
   const [lockedLines, setLockedLines] = useState<string[]>([]);
   const [editingLineId, setEditingLineId] = useState<string | null>(null);
@@ -340,6 +347,8 @@ const BudgetStateManager: React.FC<BudgetStateManagerProps> = ({
     sortOrder,
     setSortField,
     setSortOrder,
+    filterQuery,
+    setFilterQuery,
     selectedRowKeys,
     setSelectedRowKeys,
     
@@ -380,7 +389,7 @@ const BudgetStateManager: React.FC<BudgetStateManagerProps> = ({
   }), [
     undoStack, redoStack, pushHistory, handleUndo, handleRedo,
     isBudgetModalOpen, isRevisionModalOpen, isCreateModalOpen, isEventModalOpen, isConfirmingDelete,
-    groupBy, sortField, sortOrder, selectedRowKeys,
+    groupBy, sortField, sortOrder, filterQuery, selectedRowKeys,
     editItem, prefillItem, nextElementKey,
     deleteTargets,
     eventItem, eventList,

--- a/frontend/src/dashboard/project/features/budget/components/BudgetTableLogic.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetTableLogic.tsx
@@ -13,6 +13,7 @@ interface BudgetTableLogicProps {
   groupBy: string;
   sortField: string | null;
   sortOrder: string | null;
+  filterQuery: string;
   selectedRowKeys: string[];
   eventsByLineItem: Record<string, Record<string, unknown>[]>;
   setSelectedRowKeys: (keys: string[] | ((prev: string[]) => string[])) => void;
@@ -34,6 +35,7 @@ const BudgetTableLogic: React.FC<BudgetTableLogicProps> = ({
   groupBy,
   sortField,
   sortOrder,
+  filterQuery,
   selectedRowKeys,
   eventsByLineItem,
   setSelectedRowKeys,
@@ -46,6 +48,32 @@ const BudgetTableLogic: React.FC<BudgetTableLogicProps> = ({
   
   // Use context selectors for data
   const budgetItems = getRows();
+
+  const normalizedQuery = filterQuery.trim().toLowerCase();
+
+  const filteredItems = useMemo(() => {
+    if (!normalizedQuery) {
+      return budgetItems;
+    }
+
+    const searchableKeys = [
+      "elementKey",
+      "elementId",
+      "description",
+      "category",
+      "areaGroup",
+      "invoiceGroup",
+      "paymentStatus",
+    ];
+
+    return budgetItems.filter((item) => {
+      return searchableKeys.some((key) => {
+        const value = item[key as keyof typeof item];
+        if (value === undefined || value === null) return false;
+        return String(value).toLowerCase().includes(normalizedQuery);
+      });
+    });
+  }, [budgetItems, normalizedQuery]);
 
   const isDefined = useCallback((val: unknown) => {
     if (val === undefined || val === null) return false;
@@ -138,7 +166,7 @@ const BudgetTableLogic: React.FC<BudgetTableLogicProps> = ({
       "endDate",
       "itemCost",
     ];
-    const safeBudgetItems = budgetItems.filter(Boolean);
+    const safeBudgetItems = filteredItems.filter(Boolean);
     const available = safeBudgetItems.length
       ? Array.from(
           new Set([
@@ -316,7 +344,7 @@ const BudgetTableLogic: React.FC<BudgetTableLogicProps> = ({
     });
     return cols;
   }, [
-    budgetItems,
+    filteredItems,
     groupBy,
     mainColumnsOrder,
     sortField,
@@ -335,11 +363,11 @@ const BudgetTableLogic: React.FC<BudgetTableLogicProps> = ({
 
   const tableData = useMemo(
     () =>
-      budgetItems.map((item) => ({
+      filteredItems.map((item) => ({
         ...item,
         key: item.budgetItemId,
       })),
-    [budgetItems]
+    [filteredItems]
   );
 
   const sortedTableData = useMemo(() => {

--- a/frontend/src/dashboard/project/features/budget/components/BudgetToolbar.module.css
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetToolbar.module.css
@@ -74,6 +74,53 @@
   gap: 0.5rem;
 }
 
+.selectionActions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  min-width: 80px;
+}
+
+.iconSlot {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+}
+
+.mobileRight {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-left: auto;
+}
+
+.mobileFilterWrap {
+  display: none;
+}
+
+.mobileFilterRoot {
+  position: relative;
+  width: 100%;
+}
+
+.mobileFilterButton {
+  width: 100%;
+  justify-content: space-between;
+  font-size: 0.82rem;
+}
+
+.mobileFilterActive {
+  border-color: rgba(255, 255, 255, 0.24);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.mobileFilterPopover {
+  margin-top: 4px;
+}
+
 .iconActionButton {
   display: inline-flex;
   align-items: center;
@@ -174,5 +221,32 @@
     width: 32px;
     height: 32px;
     font-size: 0.82rem;
+  }
+
+  .selectionActions {
+    min-width: 72px;
+  }
+
+  .iconSlot {
+    width: 32px;
+    height: 32px;
+  }
+
+  .actions {
+    width: 100%;
+    justify-content: flex-end;
+  }
+
+  .mobileRight {
+    flex: 1 1 auto;
+  }
+
+  .mobileFilterWrap {
+    display: flex;
+    flex: 1 1 auto;
+  }
+
+  .mobileFilterButton {
+    padding: 8px 12px;
   }
 }

--- a/frontend/src/dashboard/project/features/budget/components/BudgetToolbar.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetToolbar.tsx
@@ -2,7 +2,10 @@ import React from "react";
 import { Tooltip as AntTooltip } from "antd";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faClone, faTrash } from "@fortawesome/free-solid-svg-icons";
+import BudgetMobileFilter from "./BudgetMobileFilter";
 import styles from "./BudgetToolbar.module.css";
+
+type SortOrder = "ascend" | "descend" | null;
 
 interface BudgetToolbarProps {
   groupBy: string;
@@ -11,6 +14,11 @@ interface BudgetToolbarProps {
   handleDuplicateSelected: () => void;
   openDeleteModal: (ids: string[]) => void;
   openCreateModal: () => void;
+  filterQuery: string;
+  onFilterQueryChange: (query: string) => void;
+  sortField: string | null;
+  sortOrder: SortOrder;
+  onSortChange: (field: string | null, order: SortOrder) => void;
 }
 
 const GROUP_BY_OPTIONS = [
@@ -27,6 +35,11 @@ const BudgetToolbar: React.FC<BudgetToolbarProps> = ({
   handleDuplicateSelected,
   openDeleteModal,
   openCreateModal,
+  filterQuery,
+  onFilterQueryChange,
+  sortField,
+  sortOrder,
+  onSortChange,
 }) => (
   <div className={styles.toolbar}>
     <div className={styles.groupTabs} role="group" aria-label="Group budget items">
@@ -49,43 +62,63 @@ const BudgetToolbar: React.FC<BudgetToolbarProps> = ({
       })}
     </div>
     <div className={styles.actions}>
-      {selectedRowKeys.length > 0 && (
-        <>
-          <AntTooltip title="Duplicate Selected">
-            <button
-              type="button"
-              className={styles.iconActionButton}
-              onClick={handleDuplicateSelected}
-              aria-label="Duplicate selected"
-            >
-              <FontAwesomeIcon icon={faClone} />
-            </button>
-          </AntTooltip>
-          <AntTooltip title="Delete Selected">
-            <button
-              type="button"
-              className={styles.iconActionButton}
-              onClick={() => openDeleteModal(selectedRowKeys)}
-              aria-label="Delete selected"
-            >
-              <FontAwesomeIcon icon={faTrash} />
-            </button>
-          </AntTooltip>
-        </>
-      )}
-      <AntTooltip title="Create Line Item">
-        <button
-          type="button"
-          className={styles.addButton}
-          onClick={openCreateModal}
-          aria-label="Add item"
-        >
-          <span className={styles.addIcon} aria-hidden="true">
-            +
-          </span>
-          <span className={styles.addLabel}>Add Item</span>
-        </button>
-      </AntTooltip>
+      <div
+        className={styles.selectionActions}
+        aria-hidden={selectedRowKeys.length === 0 ? "true" : undefined}
+      >
+        <div className={styles.iconSlot}>
+          {selectedRowKeys.length > 0 && (
+            <AntTooltip title="Duplicate Selected">
+              <button
+                type="button"
+                className={styles.iconActionButton}
+                onClick={handleDuplicateSelected}
+                aria-label="Duplicate selected"
+              >
+                <FontAwesomeIcon icon={faClone} />
+              </button>
+            </AntTooltip>
+          )}
+        </div>
+        <div className={styles.iconSlot}>
+          {selectedRowKeys.length > 0 && (
+            <AntTooltip title="Delete Selected">
+              <button
+                type="button"
+                className={styles.iconActionButton}
+                onClick={() => openDeleteModal(selectedRowKeys)}
+                aria-label="Delete selected"
+              >
+                <FontAwesomeIcon icon={faTrash} />
+              </button>
+            </AntTooltip>
+          )}
+        </div>
+      </div>
+      <div className={styles.mobileRight}>
+        <div className={styles.mobileFilterWrap}>
+          <BudgetMobileFilter
+            filterQuery={filterQuery}
+            onFilterQueryChange={onFilterQueryChange}
+            sortField={sortField}
+            sortOrder={sortOrder}
+            onSortChange={onSortChange}
+          />
+        </div>
+        <AntTooltip title="Create Line Item">
+          <button
+            type="button"
+            className={styles.addButton}
+            onClick={openCreateModal}
+            aria-label="Add item"
+          >
+            <span className={styles.addIcon} aria-hidden="true">
+              +
+            </span>
+            <span className={styles.addLabel}>Add Item</span>
+          </button>
+        </AntTooltip>
+      </div>
     </div>
   </div>
 );

--- a/frontend/src/dashboard/project/features/budget/pages/BudgetPage.tsx
+++ b/frontend/src/dashboard/project/features/budget/pages/BudgetPage.tsx
@@ -531,15 +531,16 @@ const BudgetPageContent = () => {
                     stateManager={stateManager}
                   >
                     {(eventHandlers) => (
-                      <BudgetTableLogic
-                        groupBy={stateManager.groupBy}
-                        sortField={stateManager.sortField}
-                        sortOrder={stateManager.sortOrder}
-                        selectedRowKeys={stateManager.selectedRowKeys}
-                        eventsByLineItem={eventsByLineItem}
-                        setSelectedRowKeys={stateManager.setSelectedRowKeys}
-                        openEventModal={eventHandlers.openEventModal}
-                        openDeleteModal={eventHandlers.openDeleteModal}
+                        <BudgetTableLogic
+                          groupBy={stateManager.groupBy}
+                          sortField={stateManager.sortField}
+                          sortOrder={stateManager.sortOrder}
+                          filterQuery={stateManager.filterQuery as string}
+                          selectedRowKeys={stateManager.selectedRowKeys}
+                          eventsByLineItem={eventsByLineItem}
+                          setSelectedRowKeys={stateManager.setSelectedRowKeys}
+                          openEventModal={eventHandlers.openEventModal}
+                          openDeleteModal={eventHandlers.openDeleteModal}
                         openDuplicateModal={eventHandlers.openDuplicateModal}
                       >
                         {(tableConfig) => (
@@ -640,6 +641,14 @@ const BudgetPageContent = () => {
                                     handleDuplicateSelected={eventHandlers.handleDuplicateSelected}
                                     openDeleteModal={eventHandlers.openDeleteModal}
                                     openCreateModal={eventHandlers.openCreateModal}
+                                    filterQuery={stateManager.filterQuery as string}
+                                    onFilterQueryChange={stateManager.setFilterQuery as (query: string) => void}
+                                    sortField={stateManager.sortField as string | null}
+                                    sortOrder={stateManager.sortOrder as string | null}
+                                    onSortChange={(field, order) => {
+                                      stateManager.setSortField(field);
+                                      stateManager.setSortOrder(order);
+                                    }}
                                   />
                                   <BudgetItemsTable
                                     dataSource={


### PR DESCRIPTION
## Summary
- add a persisted filter query to the budget state manager so pagination resets when searching
- filter budget table rows by the query and reuse the projects panel mobile styles for a new BudgetMobileFilter component in the toolbar
- update the mobile toolbar layout to keep selection actions aligned and surface the filter alongside the Add Item button

## Testing
- npm run lint *(fails: existing lint errors in unrelated context files)*

------
https://chatgpt.com/codex/tasks/task_e_68df3cf040a88324ad64cb07884a71d1