### PR TITLE
feat: tint mobile budget header with project accent color

### DIFF
--- a/frontend/src/dashboard/project/features/budget/components/HeaderStats.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/HeaderStats.tsx
@@ -129,6 +129,30 @@ type ChartState = {
 };
 
 const MOBILE_BREAKPOINT = 768;
+const FALLBACK_ACCENT_COLOR = "#38BDF8";
+
+const normalizeHexColor = (value: string): string | null => {
+  const trimmed = value.trim();
+  if (!/^#([0-9a-f]{3}|[0-9a-f]{6})$/i.test(trimmed)) {
+    return null;
+  }
+  if (trimmed.length === 4) {
+    const [, r, g, b] = trimmed;
+    return `#${r}${r}${g}${g}${b}${b}`.toUpperCase();
+  }
+  return trimmed.toUpperCase();
+};
+
+const rgbaFromHex = (hex: string, alpha: number): string => {
+  const value = hex.startsWith("#") ? hex.slice(1) : hex;
+  if (value.length !== 6) {
+    return rgbaFromHex(FALLBACK_ACCENT_COLOR, alpha);
+  }
+  const r = Number.parseInt(value.slice(0, 2), 16);
+  const g = Number.parseInt(value.slice(2, 4), 16);
+  const b = Number.parseInt(value.slice(4, 6), 16);
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+};
 
 /* =========================
    Helpers
@@ -508,11 +532,27 @@ const BudgetHeader: React.FC<BudgetHeaderProps> = ({
     [activeProject?.projectId]
   );
 
-  const computeChartState = useCallback((): ChartState => {
-    const baseColorSource =
+  const accentHex = useMemo(() => {
+    const providedColor =
       typeof activeProject?.color === "string" && activeProject.color.trim() !== ""
-        ? activeProject.color
-        : getColor(resolvedProjectKey ?? "budget");
+        ? normalizeHexColor(activeProject.color)
+        : null;
+
+    if (providedColor) {
+      return providedColor;
+    }
+
+    const generated = normalizeHexColor(getColor(resolvedProjectKey ?? "budget"));
+    return generated ?? FALLBACK_ACCENT_COLOR;
+  }, [activeProject?.color, resolvedProjectKey]);
+
+  const accentAlpha = useCallback(
+    (alpha: number) => rgbaFromHex(accentHex, alpha),
+    [accentHex]
+  );
+
+  const computeChartState = useCallback((): ChartState => {
+    const baseColorSource = accentHex;
 
     if (groupBy === "none") {
       const slices = metrics.map((metric) => ({
@@ -584,13 +624,12 @@ const BudgetHeader: React.FC<BudgetHeaderProps> = ({
       signature: computeSignature(sortedSlices),
     };
   }, [
-    activeProject?.color,
+    accentHex,
     budgetHeader?.headerFinalTotalCost,
     budgetItems,
     groupBy,
     markupBasis,
     metrics,
-    resolvedProjectKey,
     selectedMetric,
   ]);
 
@@ -769,6 +808,21 @@ const BudgetHeader: React.FC<BudgetHeaderProps> = ({
   const topMetrics = metrics.slice(0, 3);
   const bottomMetrics = metrics.slice(3);
 
+  const mobileAccentStyle = useMemo(
+    () =>
+      ({
+        "--budget-accent": accentHex,
+        "--budget-accent-soft": accentAlpha(0.16),
+        "--budget-accent-softer": accentAlpha(0.24),
+        "--budget-accent-border": accentAlpha(0.32),
+        "--budget-accent-glow": accentAlpha(0.22),
+        "--budget-accent-chip": accentAlpha(0.18),
+        "--budget-accent-chip-active": accentAlpha(0.3),
+        "--budget-accent-text": "rgba(255, 255, 255, 0.92)",
+      }) as React.CSSProperties,
+    [accentAlpha, accentHex]
+  );
+
   const renderMetricChip = (metric: (typeof metrics)[number]) => {
     const isReconciledToggleMetric =
       hasReconciled &&
@@ -866,7 +920,7 @@ const BudgetHeader: React.FC<BudgetHeaderProps> = ({
   };
 
   const mobileContent = (
-    <div className={mobileStyles.card}>
+    <div className={mobileStyles.card} style={mobileAccentStyle}>
       <div className={mobileStyles.headerRow}>
         <div className={mobileStyles.titleGroup}>
           <span>Budget</span>

--- a/frontend/src/dashboard/project/features/budget/components/budget-header-mobile.module.css
+++ b/frontend/src/dashboard/project/features/budget/components/budget-header-mobile.module.css
@@ -1,5 +1,13 @@
 .card {
-  background: #111;
+  --budget-accent: #38bdf8;
+  --budget-accent-soft: rgba(56, 189, 248, 0.16);
+  --budget-accent-softer: rgba(56, 189, 248, 0.24);
+  --budget-accent-border: rgba(56, 189, 248, 0.32);
+  --budget-accent-glow: rgba(56, 189, 248, 0.18);
+  --budget-accent-chip: rgba(56, 189, 248, 0.18);
+  --budget-accent-chip-active: rgba(56, 189, 248, 0.28);
+  --budget-accent-text: rgba(255, 255, 255, 0.92);
+  background: linear-gradient(160deg, rgba(17, 24, 39, 0.96), rgba(15, 23, 42, 0.88));
   width: 100%;
   max-width: 100%;
   box-sizing: border-box;
@@ -10,8 +18,10 @@
   flex-direction: column;
   gap: 12px;
   color: #f9fafb;
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.06), 0 12px 28px rgba(15, 23, 42, 0.4);
-  border: 1px solid rgba(255, 255, 255, 0.08) !important;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04), 0 12px 28px rgba(15, 23, 42, 0.45),
+    0 0 32px var(--budget-accent-glow);
+  border: 1px solid var(--budget-accent-border) !important;
+  transition: border-color 0.3s ease, box-shadow 0.3s ease;
 }
 
 .headerRow {
@@ -30,19 +40,23 @@
 }
 
 .revisionButton {
-  background: rgba(255, 255, 255, 0.08);
-  border: none;
+  background: var(--budget-accent-soft);
+  border: 1px solid transparent;
   border-radius: 9999px;
   padding: 4px 10px;
   font-size: 0.75rem;
-  color: inherit;
+  color: var(--budget-accent-text);
   cursor: pointer;
-  transition: background-color 0.2s ease, transform 0.2s ease;
+  transition: background-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.05);
 }
 
-.revisionButton:hover:not(:disabled) {
-  background: rgba(255, 255, 255, 0.16);
+.revisionButton:hover:not(:disabled),
+.revisionButton:focus-visible {
+  background: var(--budget-accent-softer);
   transform: translateY(-1px);
+  box-shadow: 0 0 0 1px var(--budget-accent-border), 0 0 0 4px var(--budget-accent-soft);
+  outline: none;
 }
 
 .revisionButton:disabled {
@@ -89,7 +103,7 @@
 
 .iconButton {
   background: transparent;
-  border: none;
+  border: 1px solid transparent;
   color: inherit;
   display: inline-flex;
   align-items: center;
@@ -97,17 +111,27 @@
   border-radius: 9999px;
   padding: 6px;
   cursor: pointer;
-  transition: background-color 0.2s ease, transform 0.2s ease;
+  transition: background-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease,
+    color 0.2s ease;
 }
 
 .iconButton:hover:not(:disabled) {
-  background: rgba(255, 255, 255, 0.12);
+  background: var(--budget-accent-soft);
   transform: scale(1.05);
+  color: var(--budget-accent-text);
+  box-shadow: 0 0 0 1px var(--budget-accent-border);
 }
 
 .iconButton:disabled {
   opacity: 0.4;
   cursor: not-allowed;
+}
+
+.iconButton:focus-visible {
+  outline: none;
+  background: var(--budget-accent-softer);
+  color: var(--budget-accent-text);
+  box-shadow: 0 0 0 1px var(--budget-accent-border), 0 0 0 4px var(--budget-accent-soft);
 }
 
 .dateRow {
@@ -136,18 +160,35 @@
 }
 
 .controlSelect :global(.ant-select-selector) {
-  background: rgba(30, 41, 59, 0.9) !important;
+  background: linear-gradient(135deg, rgba(30, 41, 59, 0.92), var(--budget-accent-soft)) !important;
   border-radius: 12px !important;
-  border: 1px solid rgba(255, 255, 255, 0.08) !important;
-  color: #f9fafb !important;
+  border: 1px solid var(--budget-accent-border) !important;
+  color: var(--budget-accent-text) !important;
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.12), 0 0 0 1px var(--budget-accent-soft);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.3s ease;
 }
 
 .controlSelect :global(.ant-select-selection-item) {
-  color: inherit !important;
+  color: var(--budget-accent-text) !important;
 }
 
 .controlSelect :global(.ant-select-arrow) {
-  color: rgba(249, 250, 251, 0.8);
+  color: var(--budget-accent) !important;
+}
+
+.controlSelect :global(.ant-select-selection-placeholder) {
+  color: rgba(248, 250, 252, 0.75) !important;
+}
+
+.controlSelect :global(.ant-select-selector:hover) {
+  border-color: var(--budget-accent) !important;
+  box-shadow: 0 0 0 1px var(--budget-accent), 0 0 0 4px var(--budget-accent-soft) !important;
+}
+
+.controlSelect :global(.ant-select-focused .ant-select-selector),
+.controlSelect :global(.ant-select-open .ant-select-selector) {
+  border-color: var(--budget-accent) !important;
+  box-shadow: 0 0 0 1px var(--budget-accent), 0 0 0 4px var(--budget-accent-soft) !important;
 }
 
 .chartRow {
@@ -164,6 +205,11 @@
   position: relative;
   margin: 0;
   box-sizing: border-box;
+  border-radius: 18px;
+  overflow: hidden;
+  background: radial-gradient(circle at top right, var(--budget-accent-soft), rgba(15, 23, 42, 0.4));
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.4), 0 10px 28px rgba(8, 13, 32, 0.45);
 }
 
 .legend {
@@ -228,6 +274,20 @@
   z-index: 1;
 }
 
+.metricChipSwitch :global(.ant-switch) {
+  background: rgba(148, 163, 184, 0.32);
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.45);
+}
+
+.metricChipSwitch :global(.ant-switch-checked) {
+  background: var(--budget-accent);
+  box-shadow: 0 0 0 1px var(--budget-accent-border);
+}
+
+.metricChipSwitch :global(.ant-switch-checked .ant-switch-handle::before) {
+  background: #0f172a;
+}
+
 .metricRowTop {
   grid-template-columns: repeat(3, minmax(0, 1fr));
 }
@@ -240,16 +300,18 @@
   width: 100%;
   min-width: 0;
   box-sizing: border-box;
-  background: rgba(30, 41, 59, 0.85);
+  background: linear-gradient(155deg, rgba(17, 24, 39, 0.94), var(--budget-accent-chip));
   border-radius: 12px;
   padding: 8px 10px;
   display: flex;
   flex-direction: column;
   gap: 4px;
-  border: 1px solid transparent;
-  color: inherit;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  color: var(--budget-accent-text);
   text-align: left;
-  transition: border-color 0.2s ease, transform 0.2s ease;
+  transition: border-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease,
+    background 0.3s ease;
+  box-shadow: 0 10px 22px rgba(8, 13, 32, 0.4), 0 0 0 1px var(--budget-accent-soft);
 }
 
 .metricChip:active:not(.metricChipActive) {
@@ -262,8 +324,9 @@
 }
 
 .metricChipActive {
-  border-color: rgba(255, 255, 255, 0.8);
-  background: rgba(17, 24, 39, 0.9);
+  border-color: var(--budget-accent);
+  background: linear-gradient(155deg, rgba(17, 24, 39, 0.95), var(--budget-accent-chip-active));
+  box-shadow: 0 0 0 1px var(--budget-accent), 0 0 28px var(--budget-accent-soft);
 }
 
 .metricTag {
@@ -274,7 +337,7 @@
 }
 
 .metricTagBallpark {
-  color: rgba(249, 250, 251, 0.85);
+  color: var(--budget-accent-text);
   text-transform: none;
   letter-spacing: 0.02em;
   font-weight: 600;
@@ -283,11 +346,18 @@
 .metricValue {
   font-size: 1rem;
   font-weight: 600;
+  color: var(--budget-accent-text);
 }
 
 .metricDescription {
   font-size: 0.65rem;
-  color: rgba(249, 250, 251, 0.55);
+  color: rgba(241, 245, 249, 0.66);
+}
+
+.metricChip:focus-visible {
+  outline: none;
+  border-color: var(--budget-accent);
+  box-shadow: 0 0 0 1px var(--budget-accent), 0 0 0 4px var(--budget-accent-soft);
 }
 
 .groupControls {


### PR DESCRIPTION
## Summary
- derive the mobile budget header accent color from the active project in `HeaderStats`
- update the mobile budget header styles to reuse the accent color across controls, dropdowns, and metric chips

## Testing
- no automated tests (not run)

------
https://chatgpt.com/codex/tasks/task_e_68df3c6cc0f08324b1c17e073aabc51d