### PR TITLE
Improve mobile budget filter alignment and styling

### DIFF
--- a/frontend/src/dashboard/project/features/budget/components/BudgetMobileFilter.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetMobileFilter.tsx
@@ -131,7 +131,6 @@ const BudgetMobileFilter: React.FC<BudgetMobileFilterProps> = ({
                 value={filterQuery}
                 onChange={(event) => onFilterQueryChange(event.target.value)}
                 aria-label="Filter budget items"
-                autoFocus
               />
             </div>
             <div className={`${desktopStyles.filterField} ${desktopStyles.filterSelect}`}>

--- a/frontend/src/dashboard/project/features/budget/components/BudgetToolbar.module.css
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetToolbar.module.css
@@ -107,9 +107,21 @@
 }
 
 .mobileFilterButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
   width: 100%;
   justify-content: space-between;
-  font-size: 0.82rem;
+  padding: 8px 16px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 16px;
+  background-color: transparent;
+  color: #ffffff;
+  font-size: 0.875rem;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  transition: transform 0.15s ease, background-color 0.2s ease, border-color 0.2s ease,
+    box-shadow 0.2s ease;
 }
 
 .mobileFilterActive {
@@ -119,6 +131,24 @@
 
 .mobileFilterPopover {
   margin-top: 4px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 16px;
+  background: rgba(10, 13, 30, 0.92);
+  backdrop-filter: blur(8px);
+}
+
+.mobileFilterButton:hover {
+  background-color: rgba(255, 255, 255, 0.04);
+  border-color: rgba(255, 255, 255, 0.25);
+}
+
+.mobileFilterButton:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.7), 0 0 0 4px rgba(0, 0, 0, 0.45);
+}
+
+.mobileFilterButton:active {
+  transform: scale(0.98);
 }
 
 .iconActionButton {
@@ -234,19 +264,19 @@
 
   .actions {
     width: 100%;
-    justify-content: flex-end;
+    justify-content: space-between;
   }
 
   .mobileRight {
     flex: 1 1 auto;
+    width: 100%;
+    margin-left: 0;
+    justify-content: space-between;
   }
 
   .mobileFilterWrap {
     display: flex;
     flex: 1 1 auto;
-  }
-
-  .mobileFilterButton {
-    padding: 8px 12px;
+    justify-content: flex-start;
   }
 }


### PR DESCRIPTION
## Summary
- restyle the mobile budget filter trigger to mirror the add-item button treatment and keep it aligned to the left on small screens
- update the mobile popover to inherit the bordered theme and avoid auto-focusing the search field when opened

## Testing
- npm run lint *(fails: existing lint issues in MessagesProvider.tsx and other files)*

------
https://chatgpt.com/codex/tasks/task_e_68df42952c7c83249ba94acba6a10836