### PR TITLE
Fix budget mobile donut alignment and tooltip behavior

### DIFF
--- a/frontend/src/dashboard/project/features/budget/components/BudgetDonut.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetDonut.tsx
@@ -99,6 +99,8 @@ const centerValueStyles: React.CSSProperties = {
   fontWeight: 700,
 };
 
+const CENTER_POPOVER_MARGIN = 16;
+
 const centerPopoverStyles: React.CSSProperties = {
   position: "fixed",
   transform: "translate(-50%, -50%)",
@@ -108,7 +110,7 @@ const centerPopoverStyles: React.CSSProperties = {
   padding: "16px 18px",
   boxShadow: "0 20px 45px rgba(15, 23, 42, 0.45)",
   minWidth: "220px",
-  maxWidth: "260px",
+  maxWidth: `min(260px, calc(100vw - ${CENTER_POPOVER_MARGIN * 2}px))`,
   zIndex: 20,
   pointerEvents: "auto",
   backdropFilter: "blur(18px)",
@@ -329,7 +331,7 @@ const BudgetDonut: React.FC<BudgetDonutProps> = ({
     const baseLeft = rect.left + rect.width / 2;
     const viewportWidth = window.innerWidth;
     const viewportHeight = window.innerHeight;
-    const margin = 16;
+    const margin = CENTER_POPOVER_MARGIN;
 
     const clampPosition = () => {
       let top = baseTop;
@@ -345,7 +347,12 @@ const BudgetDonut: React.FC<BudgetDonutProps> = ({
         const minTop = margin + halfHeight;
         const maxTop = viewportHeight - margin - halfHeight;
 
-        left = Math.min(Math.max(left, minLeft), maxLeft);
+        if (isMobile) {
+          const desiredLeft = margin + halfWidth;
+          left = Math.min(Math.max(desiredLeft, minLeft), maxLeft);
+        } else {
+          left = Math.min(Math.max(left, minLeft), maxLeft);
+        }
         top = Math.min(Math.max(top, minTop), maxTop);
       } else {
         left = Math.min(Math.max(left, margin), viewportWidth - margin);
@@ -365,7 +372,7 @@ const BudgetDonut: React.FC<BudgetDonutProps> = ({
     } else {
       clampPosition();
     }
-  }, []);
+  }, [isMobile]);
 
   const updateTooltipPosition = useCallback(() => {
     if (!isMobile) {

--- a/frontend/src/dashboard/project/features/budget/components/BudgetDonut.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetDonut.tsx
@@ -170,6 +170,9 @@ const tooltipStyles: React.CSSProperties = {
   backdropFilter: "blur(10px)", // Add blur for frosted effect
   WebkitBackdropFilter: "blur(10px)", // Safari support
 };
+const MOBILE_BREAKPOINT = 768;
+const TOOLTIP_MARGIN = 12;
+const TOOLTIP_HEIGHT_ESTIMATE = 48;
 const renderActiveShape = (props: SectorProps) => {
   const outerRadius = typeof props.outerRadius === "number" ? props.outerRadius : 0;
   return <Sector {...props} outerRadius={outerRadius + 8} />;
@@ -207,6 +210,17 @@ const BudgetDonut: React.FC<BudgetDonutProps> = ({
       }
     | null
   >(null);
+  const [isMobile, setIsMobile] = useState<boolean>(() => {
+    if (typeof window === "undefined") return false;
+    return window.innerWidth <= MOBILE_BREAKPOINT;
+  });
+  const [tooltipPosition, setTooltipPosition] = useState<
+    | {
+        x: number;
+        y: number;
+      }
+    | undefined
+  >(undefined);
 
   const centerButtonRef = useRef<HTMLButtonElement | null>(null);
   const centerPopoverRef = useRef<HTMLDivElement | null>(null);
@@ -353,6 +367,29 @@ const BudgetDonut: React.FC<BudgetDonutProps> = ({
     }
   }, []);
 
+  const updateTooltipPosition = useCallback(() => {
+    if (!isMobile) {
+      setTooltipPosition(undefined);
+      return;
+    }
+
+    const container = containerRef.current;
+    if (!container) return;
+
+    const height = container.clientHeight || container.getBoundingClientRect().height;
+    if (!height) return;
+
+    const minY = TOOLTIP_MARGIN;
+    const maxY = Math.max(minY, height - TOOLTIP_HEIGHT_ESTIMATE - TOOLTIP_MARGIN);
+    const centeredY = height / 2 - TOOLTIP_HEIGHT_ESTIMATE / 2;
+    const clampedY = Math.min(Math.max(centeredY, minY), maxY);
+
+    setTooltipPosition({
+      x: TOOLTIP_MARGIN,
+      y: clampedY,
+    });
+  }, [isMobile]);
+
   const openCenterPopover = useCallback(() => {
     setIsCenterOpen(true);
     updateCenterPopoverPosition();
@@ -455,6 +492,41 @@ const BudgetDonut: React.FC<BudgetDonutProps> = ({
       window.removeEventListener("scroll", handleReposition, true);
     };
   }, [isCenterOpen, updateCenterPopoverPosition]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const handleResize = () => {
+      setIsMobile(window.innerWidth <= MOBILE_BREAKPOINT);
+    };
+
+    handleResize();
+
+    window.addEventListener("resize", handleResize);
+    return () => {
+      window.removeEventListener("resize", handleResize);
+    };
+  }, []);
+
+  useEffect(() => {
+    updateTooltipPosition();
+    if (!isMobile) return;
+
+    if (typeof ResizeObserver === "undefined") return;
+    const container = containerRef.current;
+    if (!container) return;
+
+    const observer = new ResizeObserver(() => {
+      updateTooltipPosition();
+    });
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, [isMobile, updateTooltipPosition]);
+
+  useEffect(() => {
+    if (!isMobile) return;
+    updateTooltipPosition();
+  }, [isMobile, total, stableData, updateTooltipPosition]);
 
   useEffect(() => {
     closeCenterPopover();
@@ -570,7 +642,13 @@ const BudgetDonut: React.FC<BudgetDonutProps> = ({
           <Tooltip
             content={tooltipRenderer}
             cursor={{ fill: "rgba(255,255,255,0.08)" }}
-            wrapperStyle={{ zIndex: 10 }}
+            wrapperStyle={{
+              zIndex: 10,
+              pointerEvents: "none",
+              maxWidth: "min(220px, calc(100vw - 24px))",
+            }}
+            position={isMobile && tooltipPosition ? tooltipPosition : undefined}
+            allowEscapeViewBox={{ x: false, y: false }}
           />
         </PieChart>
       </ResponsiveContainer>

--- a/frontend/src/dashboard/project/features/budget/components/budget-header-mobile.module.css
+++ b/frontend/src/dashboard/project/features/budget/components/budget-header-mobile.module.css
@@ -386,6 +386,23 @@
   border: 0;
 }
 
+@media (max-width: 768px) {
+  .summaryLayout {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .chartContainer {
+    margin: 0 auto;
+  }
+
+  .summaryColumn {
+    align-items: center;
+    text-align: center;
+    padding: 0;
+  }
+}
+
 @media (max-width: 480px) {
   .summaryLayout {
     gap: 12px;


### PR DESCRIPTION
## Summary
- center the mobile budget header donut layout on small screens for improved readability
- adjust the budget donut tooltip positioning logic to pin it to the left on mobile without overflowing the viewport

## Testing
- npm run test -- BudgetDonut

------
https://chatgpt.com/codex/tasks/task_e_68e03874f2788324afdafc2bee0ff432