### PR TITLE
Fix budget toolbar mobile layout

### DIFF
--- a/frontend/src/dashboard/project/features/budget/components/BudgetToolbar.module.css
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetToolbar.module.css
@@ -234,19 +234,35 @@
 
   .actions {
     width: 100%;
-    justify-content: flex-end;
+    justify-content: flex-start;
   }
 
   .mobileRight {
-    flex: 1 1 auto;
+    flex: 1 1 100%;
+    width: 100%;
+    margin-left: 0;
+    justify-content: flex-start;
   }
 
   .mobileFilterWrap {
     display: flex;
-    flex: 1 1 auto;
+    flex: 0 0 auto;
   }
 
   .mobileFilterButton {
     padding: 8px 12px;
+    width: auto;
+  }
+
+  .mobileFilterRoot {
+    width: auto;
+  }
+
+  .selectionActions {
+    min-width: auto;
+  }
+
+  .addButton {
+    margin-left: auto;
   }
 }

--- a/frontend/src/dashboard/project/features/budget/components/BudgetToolbar.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetToolbar.tsx
@@ -62,39 +62,6 @@ const BudgetToolbar: React.FC<BudgetToolbarProps> = ({
       })}
     </div>
     <div className={styles.actions}>
-      <div
-        className={styles.selectionActions}
-        aria-hidden={selectedRowKeys.length === 0 ? "true" : undefined}
-      >
-        <div className={styles.iconSlot}>
-          {selectedRowKeys.length > 0 && (
-            <AntTooltip title="Duplicate Selected">
-              <button
-                type="button"
-                className={styles.iconActionButton}
-                onClick={handleDuplicateSelected}
-                aria-label="Duplicate selected"
-              >
-                <FontAwesomeIcon icon={faClone} />
-              </button>
-            </AntTooltip>
-          )}
-        </div>
-        <div className={styles.iconSlot}>
-          {selectedRowKeys.length > 0 && (
-            <AntTooltip title="Delete Selected">
-              <button
-                type="button"
-                className={styles.iconActionButton}
-                onClick={() => openDeleteModal(selectedRowKeys)}
-                aria-label="Delete selected"
-              >
-                <FontAwesomeIcon icon={faTrash} />
-              </button>
-            </AntTooltip>
-          )}
-        </div>
-      </div>
       <div className={styles.mobileRight}>
         <div className={styles.mobileFilterWrap}>
           <BudgetMobileFilter
@@ -105,6 +72,34 @@ const BudgetToolbar: React.FC<BudgetToolbarProps> = ({
             onSortChange={onSortChange}
           />
         </div>
+        {selectedRowKeys.length > 0 && (
+          <div className={styles.selectionActions}>
+            <div className={styles.iconSlot}>
+              <AntTooltip title="Duplicate Selected">
+                <button
+                  type="button"
+                  className={styles.iconActionButton}
+                  onClick={handleDuplicateSelected}
+                  aria-label="Duplicate selected"
+                >
+                  <FontAwesomeIcon icon={faClone} />
+                </button>
+              </AntTooltip>
+            </div>
+            <div className={styles.iconSlot}>
+              <AntTooltip title="Delete Selected">
+                <button
+                  type="button"
+                  className={styles.iconActionButton}
+                  onClick={() => openDeleteModal(selectedRowKeys)}
+                  aria-label="Delete selected"
+                >
+                  <FontAwesomeIcon icon={faTrash} />
+                </button>
+              </AntTooltip>
+            </div>
+          </div>
+        )}
         <AntTooltip title="Create Line Item">
           <button
             type="button"


### PR DESCRIPTION
## Summary
- move the selection action buttons inside the right-side toolbar group so they sit next to the add action
- tweak the budget toolbar mobile styles so the filter button is left aligned and the add action remains on the edge

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e03b24b5a48324bf042d4e641cfb1a