### PR TITLE
Align budget ballpark modal with project accent color

### DIFF
--- a/frontend/src/dashboard/project/features/budget/components/EditBallparkModal.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/EditBallparkModal.tsx
@@ -1,8 +1,33 @@
-import React, { useEffect, useId, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import Modal from "@/shared/ui/ModalWithStack";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faXmark } from "@fortawesome/free-solid-svg-icons";
 import styles from "./edit-ball-park-modal.module.css";
+
+type AccentOverrides = {
+  accent?: string;
+  accentSoft?: string;
+  accentStrong?: string;
+  accentBorder?: string;
+  accentGlow?: string;
+  accentText?: string;
+};
+
+const ACCENT_VARIABLE_KEYS = [
+  "--edit-ballpark-accent",
+  "--edit-ballpark-accent-soft",
+  "--edit-ballpark-accent-strong",
+  "--edit-ballpark-accent-border",
+  "--edit-ballpark-accent-glow",
+  "--edit-ballpark-button-text",
+] as const;
 
 if (typeof document !== "undefined") {
   Modal.setAppElement("#root");
@@ -13,6 +38,7 @@ type EditBallparkModalProps = {
   onRequestClose: () => void;
   onSubmit: (value: number) => void;
   initialValue?: number | string;
+  accentColors?: AccentOverrides;
 };
 
 const EditBallparkModal: React.FC<EditBallparkModalProps> = ({
@@ -20,17 +46,82 @@ const EditBallparkModal: React.FC<EditBallparkModalProps> = ({
   onRequestClose,
   onSubmit,
   initialValue,
+  accentColors,
 }) => {
   const [value, setValue] = useState<string>(
     initialValue !== undefined && initialValue !== null ? String(initialValue) : ""
   );
   const inputId = useId();
+  const contentNodeRef = useRef<HTMLDivElement | null>(null);
+
+  const accentVariableEntries = useMemo(() => {
+    if (!accentColors) {
+      return null;
+    }
+
+    const entries: Array<[typeof ACCENT_VARIABLE_KEYS[number], string]> = [];
+
+    if (typeof accentColors.accent === "string" && accentColors.accent.trim() !== "") {
+      entries.push(["--edit-ballpark-accent", accentColors.accent]);
+    }
+    if (typeof accentColors.accentSoft === "string" && accentColors.accentSoft.trim() !== "") {
+      entries.push(["--edit-ballpark-accent-soft", accentColors.accentSoft]);
+    }
+    if (typeof accentColors.accentStrong === "string" && accentColors.accentStrong.trim() !== "") {
+      entries.push(["--edit-ballpark-accent-strong", accentColors.accentStrong]);
+    }
+    if (typeof accentColors.accentBorder === "string" && accentColors.accentBorder.trim() !== "") {
+      entries.push(["--edit-ballpark-accent-border", accentColors.accentBorder]);
+    }
+    if (typeof accentColors.accentGlow === "string" && accentColors.accentGlow.trim() !== "") {
+      entries.push(["--edit-ballpark-accent-glow", accentColors.accentGlow]);
+    }
+    if (typeof accentColors.accentText === "string" && accentColors.accentText.trim() !== "") {
+      entries.push(["--edit-ballpark-button-text", accentColors.accentText]);
+    }
+
+    return entries.length > 0 ? entries : null;
+  }, [accentColors]);
+
+  const applyAccentVariables = useCallback(
+    (node: HTMLDivElement | null) => {
+      if (!node) {
+        return;
+      }
+
+      ACCENT_VARIABLE_KEYS.forEach((key) => {
+        node.style.removeProperty(key);
+      });
+
+      accentVariableEntries?.forEach(([key, value]) => {
+        node.style.setProperty(key, value);
+      });
+    },
+    [accentVariableEntries]
+  );
+
+  const handleContentRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      contentNodeRef.current = node;
+      if (node) {
+        applyAccentVariables(node);
+      }
+    },
+    [applyAccentVariables]
+  );
 
   useEffect(() => {
     setValue(
       initialValue !== undefined && initialValue !== null ? String(initialValue) : ""
     );
   }, [initialValue]);
+
+  useEffect(() => {
+    if (!contentNodeRef.current) {
+      return;
+    }
+    applyAccentVariables(contentNodeRef.current);
+  }, [applyAccentVariables]);
 
   const handleSubmit: React.FormEventHandler<HTMLFormElement> = (e) => {
     e.preventDefault();
@@ -54,6 +145,7 @@ const EditBallparkModal: React.FC<EditBallparkModalProps> = ({
         afterOpen: styles.modalOverlayAfterOpen,
         beforeClose: styles.modalOverlayBeforeClose,
       }}
+      contentRef={handleContentRef}
     >
       <div className={styles.modalHeader}>
         <div className={styles.modalTitle}>Edit Ballpark</div>

--- a/frontend/src/dashboard/project/features/budget/components/HeaderStats.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/HeaderStats.tsx
@@ -154,6 +154,49 @@ const rgbaFromHex = (hex: string, alpha: number): string => {
   return `rgba(${r}, ${g}, ${b}, ${alpha})`;
 };
 
+const clamp = (value: number, min: number, max: number): number =>
+  Math.min(Math.max(value, min), max);
+
+const hexToRgb = (hex: string): [number, number, number] | null => {
+  const normalized = hex.startsWith("#") ? hex.slice(1) : hex;
+  if (normalized.length !== 6) {
+    return null;
+  }
+  const r = Number.parseInt(normalized.slice(0, 2), 16);
+  const g = Number.parseInt(normalized.slice(2, 4), 16);
+  const b = Number.parseInt(normalized.slice(4, 6), 16);
+  if ([r, g, b].some((channel) => Number.isNaN(channel))) {
+    return null;
+  }
+  return [r, g, b];
+};
+
+const rgbChannelToHex = (value: number): string =>
+  clamp(Math.round(value), 0, 255)
+    .toString(16)
+    .padStart(2, "0")
+    .toUpperCase();
+
+const mixHexColors = (base: string, other: string, weight: number): string | null => {
+  const baseRgb = hexToRgb(base);
+  const otherRgb = hexToRgb(other);
+  if (!baseRgb || !otherRgb) {
+    return null;
+  }
+  const ratio = clamp(weight, 0, 1);
+  const [r1, g1, b1] = baseRgb;
+  const [r2, g2, b2] = otherRgb;
+
+  const r = r1 * (1 - ratio) + r2 * ratio;
+  const g = g1 * (1 - ratio) + g2 * ratio;
+  const b = b1 * (1 - ratio) + b2 * ratio;
+
+  return `#${rgbChannelToHex(r)}${rgbChannelToHex(g)}${rgbChannelToHex(b)}`;
+};
+
+const lightenHexColor = (hex: string, intensity: number): string =>
+  mixHexColors(hex, "#FFFFFF", intensity) ?? hex;
+
 /* =========================
    Helpers
    ========================= */
@@ -823,6 +866,18 @@ const BudgetHeader: React.FC<BudgetHeaderProps> = ({
     [accentAlpha, accentHex]
   );
 
+  const modalAccentColors = useMemo(
+    () => ({
+      accent: accentHex,
+      accentSoft: accentAlpha(0.2),
+      accentStrong: lightenHexColor(accentHex, 0.32),
+      accentBorder: accentAlpha(0.4),
+      accentGlow: accentAlpha(0.28),
+      accentText: "rgba(8, 11, 18, 0.92)",
+    }),
+    [accentAlpha, accentHex]
+  );
+
   const renderMetricChip = (metric: (typeof metrics)[number]) => {
     const isReconciledToggleMetric =
       hasReconciled &&
@@ -1011,6 +1066,7 @@ const BudgetHeader: React.FC<BudgetHeaderProps> = ({
         onRequestClose={() => setBallparkModalOpen(false)}
         onSubmit={handleBallparkSave}
         initialValue={toNumber(budgetHeader?.headerBallPark)}
+        accentColors={modalAccentColors}
       />
 
       <ClientInvoicePreviewModal

--- a/frontend/src/dashboard/project/features/budget/components/edit-ball-park-modal.module.css
+++ b/frontend/src/dashboard/project/features/budget/components/edit-ball-park-modal.module.css
@@ -36,6 +36,12 @@
     inset 0 0 0 1px rgba(255, 255, 255, 0.05),
     0 28px 56px rgba(8, 15, 35, 0.55);
   font-family: "Helvetica Neue", "Helvetica Display", sans-serif;
+  --edit-ballpark-accent: #f43f5e;
+  --edit-ballpark-accent-soft: rgba(244, 63, 94, 0.18);
+  --edit-ballpark-accent-strong: #fb7185;
+  --edit-ballpark-accent-border: rgba(244, 63, 94, 0.45);
+  --edit-ballpark-accent-glow: rgba(244, 63, 94, 0.28);
+  --edit-ballpark-button-text: #0b0f1a;
 }
 
 .modalContentAfterOpen {
@@ -139,8 +145,8 @@
 .input:focus,
 .input:focus-visible {
   outline: none;
-  border-color: rgba(250, 51, 86, 0.7);
-  box-shadow: 0 0 0 3px rgba(250, 51, 86, 0.25);
+  border-color: var(--edit-ballpark-accent-border, rgba(244, 63, 94, 0.45));
+  box-shadow: 0 0 0 3px var(--edit-ballpark-accent-glow, rgba(244, 63, 94, 0.28));
   background: rgba(15, 23, 42, 0.95);
 }
 
@@ -184,16 +190,24 @@
 }
 
 .primaryButton {
-  background: linear-gradient(135deg, #fa3356, #f43f5e);
+  background: linear-gradient(
+    135deg,
+    var(--edit-ballpark-accent-soft, rgba(244, 63, 94, 0.18)),
+    var(--edit-ballpark-accent, #f43f5e)
+  );
   border-color: transparent;
-  color: #0b0f1a;
-  box-shadow: 0 12px 24px rgba(244, 63, 94, 0.35);
+  color: var(--edit-ballpark-button-text, #0b0f1a);
+  box-shadow: 0 12px 24px var(--edit-ballpark-accent-glow, rgba(244, 63, 94, 0.28));
 }
 
 .primaryButton:hover,
 .primaryButton:focus-visible {
-  background: linear-gradient(135deg, #ff4d6b, #fb7185);
-  box-shadow: 0 16px 28px rgba(244, 63, 94, 0.45);
+  background: linear-gradient(
+    135deg,
+    var(--edit-ballpark-accent-soft, rgba(244, 63, 94, 0.18)),
+    var(--edit-ballpark-accent-strong, #fb7185)
+  );
+  box-shadow: 0 16px 28px var(--edit-ballpark-accent-glow, rgba(244, 63, 94, 0.28));
   transform: translateY(-1px);
   outline: none;
 }


### PR DESCRIPTION
## Summary
- add accent color overrides to the ballpark estimate modal so it can adapt to the active project's palette
- expose computed accent tones from the budget header to feed the modal
- update modal styles to consume CSS custom properties with sensible fallbacks

## Testing
- npm run lint -- --max-warnings=0 *(fails: pre-existing lint errors in contexts and tasks components)*

------
https://chatgpt.com/codex/tasks/task_e_68e03c8ae2bc8324ace49de276c41b2c