### PR TITLE
feat: tint mobile estimate modal with project accent

### DIFF
--- a/frontend/src/dashboard/project/features/budget/components/EditBallparkModal.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/EditBallparkModal.tsx
@@ -1,8 +1,38 @@
-import React, { useEffect, useId, useState } from "react";
+import React, { useEffect, useId, useMemo, useState } from "react";
+import type { Styles as ReactModalStyles } from "react-modal";
 import Modal from "@/shared/ui/ModalWithStack";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faXmark } from "@fortawesome/free-solid-svg-icons";
 import styles from "./edit-ball-park-modal.module.css";
+
+const normalizeHexColor = (value: string): string | null => {
+  const trimmed = value.trim();
+  if (!/^#([0-9a-f]{3}|[0-9a-f]{6})$/i.test(trimmed)) {
+    return null;
+  }
+
+  if (trimmed.length === 4) {
+    const [, r, g, b] = trimmed;
+    return `#${r}${r}${g}${g}${b}${b}`.toUpperCase();
+  }
+
+  return trimmed.toUpperCase();
+};
+
+const hexToRgb = (value: string): [number, number, number] | null => {
+  const normalized = value.startsWith("#") ? value.slice(1) : value;
+  if (normalized.length !== 6) return null;
+
+  const r = Number.parseInt(normalized.slice(0, 2), 16);
+  const g = Number.parseInt(normalized.slice(2, 4), 16);
+  const b = Number.parseInt(normalized.slice(4, 6), 16);
+
+  if ([r, g, b].some((component) => Number.isNaN(component))) {
+    return null;
+  }
+
+  return [r, g, b];
+};
 
 if (typeof document !== "undefined") {
   Modal.setAppElement("#root");
@@ -13,6 +43,7 @@ type EditBallparkModalProps = {
   onRequestClose: () => void;
   onSubmit: (value: number) => void;
   initialValue?: number | string;
+  accentColor?: string;
 };
 
 const EditBallparkModal: React.FC<EditBallparkModalProps> = ({
@@ -20,11 +51,35 @@ const EditBallparkModal: React.FC<EditBallparkModalProps> = ({
   onRequestClose,
   onSubmit,
   initialValue,
+  accentColor,
 }) => {
   const [value, setValue] = useState<string>(
     initialValue !== undefined && initialValue !== null ? String(initialValue) : ""
   );
   const inputId = useId();
+
+  const accentStyles = useMemo<ReactModalStyles | undefined>(() => {
+    if (typeof accentColor !== "string" || accentColor.trim() === "") {
+      return undefined;
+    }
+
+    const normalized = normalizeHexColor(accentColor);
+    if (!normalized) {
+      return undefined;
+    }
+
+    const rgb = hexToRgb(normalized);
+    if (!rgb) {
+      return undefined;
+    }
+
+    return {
+      content: {
+        "--edit-ballpark-accent": normalized,
+        "--edit-ballpark-accent-rgb": `${rgb[0]}, ${rgb[1]}, ${rgb[2]}`,
+      } as React.CSSProperties,
+    };
+  }, [accentColor]);
 
   useEffect(() => {
     setValue(
@@ -49,6 +104,7 @@ const EditBallparkModal: React.FC<EditBallparkModalProps> = ({
         afterOpen: styles.modalContentAfterOpen,
         beforeClose: styles.modalContentBeforeClose,
       }}
+      style={accentStyles}
       overlayClassName={{
         base: styles.modalOverlay,
         afterOpen: styles.modalOverlayAfterOpen,

--- a/frontend/src/dashboard/project/features/budget/components/HeaderStats.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/HeaderStats.tsx
@@ -1011,6 +1011,7 @@ const BudgetHeader: React.FC<BudgetHeaderProps> = ({
         onRequestClose={() => setBallparkModalOpen(false)}
         onSubmit={handleBallparkSave}
         initialValue={toNumber(budgetHeader?.headerBallPark)}
+        accentColor={accentHex}
       />
 
       <ClientInvoicePreviewModal

--- a/frontend/src/dashboard/project/features/budget/components/edit-ball-park-modal.module.css
+++ b/frontend/src/dashboard/project/features/budget/components/edit-ball-park-modal.module.css
@@ -20,6 +20,8 @@
 }
 
 .modalContent {
+  --edit-ballpark-accent: #fa3356;
+  --edit-ballpark-accent-rgb: 250, 51, 86;
   background: linear-gradient(160deg, rgba(16, 16, 16, .96), rgba(12, 12, 12, .88));
   color: #f9fafb;
   border: none;
@@ -77,7 +79,8 @@
 .iconButton:hover,
 .iconButton:focus-visible {
   background: rgba(15, 23, 42, 0.85);
-  border-color: rgba(255, 255, 255, 0.2);
+  border-color: rgba(var(--edit-ballpark-accent-rgb), 0.3);
+  box-shadow: 0 0 0 2px rgba(var(--edit-ballpark-accent-rgb), 0.18);
   transform: translateY(-1px);
   outline: none;
 }
@@ -122,7 +125,7 @@
   padding: 16px 18px 16px 52px;
   border-radius: 18px;
   border: 1px solid rgba(255, 255, 255, 0.1);
- background: rgba(255, 255, 255, 0.05);
+  background: rgba(255, 255, 255, 0.05);
   color: inherit;
   font-size: 1.3rem;
   font-weight: 600;
@@ -139,9 +142,9 @@
 .input:focus,
 .input:focus-visible {
   outline: none;
-  border-color: rgba(250, 51, 86, 0.7);
-  box-shadow: 0 0 0 3px rgba(250, 51, 86, 0.25);
-   background: rgba(255, 255, 255, 0.05);
+  border-color: rgba(var(--edit-ballpark-accent-rgb), 0.65);
+  box-shadow: 0 0 0 3px rgba(var(--edit-ballpark-accent-rgb), 0.25);
+  background: rgba(255, 255, 255, 0.06);
 }
 
 .input::-webkit-outer-spin-button,
@@ -172,28 +175,37 @@
 
 .secondaryButton {
   border-color: rgba(255, 255, 255, 0.14);
-   background: rgba(255, 255, 255, 0.05);
+  background: rgba(255, 255, 255, 0.05);
 }
 
 .secondaryButton:hover,
 .secondaryButton:focus-visible {
   background: rgba(15, 23, 42, 0.85);
-  border-color: rgba(255, 255, 255, 0.24);
+  border-color: rgba(var(--edit-ballpark-accent-rgb), 0.32);
+  box-shadow: 0 0 0 2px rgba(var(--edit-ballpark-accent-rgb), 0.18);
   outline: none;
   transform: translateY(-1px);
 }
 
 .primaryButton {
-  background: linear-gradient(135deg, #fa3356, #f43f5e);
+  background: linear-gradient(
+    135deg,
+    rgba(var(--edit-ballpark-accent-rgb), 0.92),
+    rgba(var(--edit-ballpark-accent-rgb), 0.78)
+  );
   border-color: transparent;
   color: #0b0f1a;
-  box-shadow: 0 12px 24px rgba(244, 63, 94, 0.35);
+  box-shadow: 0 12px 24px rgba(var(--edit-ballpark-accent-rgb), 0.28);
 }
 
 .primaryButton:hover,
 .primaryButton:focus-visible {
-  background: linear-gradient(135deg, #ff4d6b, #fb7185);
-  box-shadow: 0 16px 28px rgba(244, 63, 94, 0.45);
+  background: linear-gradient(
+    135deg,
+    rgba(var(--edit-ballpark-accent-rgb), 0.98),
+    rgba(var(--edit-ballpark-accent-rgb), 0.86)
+  );
+  box-shadow: 0 16px 28px rgba(var(--edit-ballpark-accent-rgb), 0.36);
   transform: translateY(-1px);
   outline: none;
 }


### PR DESCRIPTION
## Summary
- allow the budget mobile estimate modal to receive the active project accent color
- restyle the modal controls to derive gradients, focus rings, and hover states from the accent color while keeping a subtle look

## Testing
- npm run lint *(fails: pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e041b812d48324ac2cbe3851829df5