### PR TITLE
Fix budget donut popover on mobile viewports

### DIFF
--- a/frontend/src/dashboard/project/features/budget/components/BudgetDonut.test.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetDonut.test.tsx
@@ -183,4 +183,105 @@ describe("BudgetDonut", () => {
       expect(slice).toHaveAttribute("data-active", "false");
     });
   });
+
+  it("anchors the center popover to the viewport edge on mobile", async () => {
+    const originalInnerWidthDescriptor = Object.getOwnPropertyDescriptor(window, "innerWidth");
+    const originalInnerHeightDescriptor = Object.getOwnPropertyDescriptor(window, "innerHeight");
+    const originalOffsetWidthDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, "offsetWidth");
+    const originalOffsetHeightDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, "offsetHeight");
+
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      get() {
+        return 360;
+      },
+    });
+    Object.defineProperty(window, "innerHeight", {
+      configurable: true,
+      get() {
+        return 640;
+      },
+    });
+
+    Object.defineProperty(HTMLElement.prototype, "offsetWidth", {
+      configurable: true,
+      get() {
+        return 220;
+      },
+    });
+    Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
+      configurable: true,
+      get() {
+        return 160;
+      },
+    });
+
+    const raf = vi.spyOn(window, "requestAnimationFrame").mockImplementation((cb: FrameRequestCallback) => {
+      cb(0);
+      return 1;
+    });
+
+    const restoreGlobals = () => {
+      raf.mockRestore();
+      if (originalOffsetWidthDescriptor) {
+        Object.defineProperty(HTMLElement.prototype, "offsetWidth", originalOffsetWidthDescriptor);
+      } else {
+        delete (HTMLElement.prototype as { offsetWidth?: number }).offsetWidth;
+      }
+      if (originalOffsetHeightDescriptor) {
+        Object.defineProperty(HTMLElement.prototype, "offsetHeight", originalOffsetHeightDescriptor);
+      } else {
+        delete (HTMLElement.prototype as { offsetHeight?: number }).offsetHeight;
+      }
+      if (originalInnerWidthDescriptor) {
+        Object.defineProperty(window, "innerWidth", originalInnerWidthDescriptor);
+      }
+      if (originalInnerHeightDescriptor) {
+        Object.defineProperty(window, "innerHeight", originalInnerHeightDescriptor);
+      }
+    };
+
+    try {
+      render(
+        <div style={{ width: 320, height: 240 }}>
+          <BudgetDonut
+            data={slices}
+            total={1500}
+            totalFormatter={(value) => `$${value.toFixed(0)}`}
+          />
+        </div>
+      );
+
+      const centerButton = screen.getByRole("button", { name: /view budget allocation/i });
+      Object.defineProperty(centerButton, "getBoundingClientRect", {
+        configurable: true,
+        value: () => ({
+          width: 64,
+          height: 64,
+          top: 150,
+          left: 180,
+          right: 244,
+          bottom: 214,
+          x: 180,
+          y: 150,
+          toJSON: () => ({}),
+        }),
+      });
+
+      fireEvent.mouseEnter(centerButton);
+
+      const dialog = await screen.findByRole("dialog", { name: "Budget allocation breakdown" });
+      const left = Number.parseFloat(dialog.style.left || "0");
+      const top = Number.parseFloat(dialog.style.top || "0");
+      const halfWidth = dialog.offsetWidth / 2;
+      const halfHeight = dialog.offsetHeight / 2;
+
+      expect(left - halfWidth).toBeCloseTo(16, 1);
+      expect(left + halfWidth).toBeLessThanOrEqual(window.innerWidth - 16 + 0.0001);
+      expect(top - halfHeight).toBeGreaterThanOrEqual(0);
+      expect(top + halfHeight).toBeLessThanOrEqual(window.innerHeight);
+    } finally {
+      restoreGlobals();
+    }
+  });
 });

--- a/frontend/src/dashboard/project/features/budget/components/BudgetDonut.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetDonut.tsx
@@ -67,6 +67,7 @@ const srOnlyStyles: React.CSSProperties = {
 
 const centerButtonBaseBackground = "rgba(17, 17, 17, 0.6)";
 const centerButtonBaseShadow = "0 8px 20px rgba(17, 17, 17, 0.45)";
+const MOBILE_BREAKPOINT = 768;
 
 const centerButtonStyles: React.CSSProperties = {
   position: "absolute",
@@ -108,7 +109,7 @@ const centerPopoverStyles: React.CSSProperties = {
   padding: "16px 18px",
   boxShadow: "0 20px 45px rgba(15, 23, 42, 0.45)",
   minWidth: "220px",
-  maxWidth: "260px",
+  maxWidth: "min(260px, calc(100vw - 32px))",
   zIndex: 20,
   pointerEvents: "auto",
   backdropFilter: "blur(18px)",
@@ -355,6 +356,7 @@ const BudgetDonut: React.FC<BudgetDonutProps> = ({
     const viewportWidth = window.innerWidth;
     const viewportHeight = window.innerHeight;
     const margin = 16;
+    const isMobileViewport = viewportWidth <= MOBILE_BREAKPOINT;
 
     const clampPosition = () => {
       let top = baseTop;
@@ -370,10 +372,19 @@ const BudgetDonut: React.FC<BudgetDonutProps> = ({
         const minTop = margin + halfHeight;
         const maxTop = viewportHeight - margin - halfHeight;
 
-        left = Math.min(Math.max(left, minLeft), maxLeft);
+        if (isMobileViewport) {
+          left = Math.min(margin + halfWidth, maxLeft);
+        } else {
+          left = Math.min(Math.max(left, minLeft), maxLeft);
+        }
+
         top = Math.min(Math.max(top, minTop), maxTop);
       } else {
-        left = Math.min(Math.max(left, margin), viewportWidth - margin);
+        if (isMobileViewport) {
+          left = margin;
+        } else {
+          left = Math.min(Math.max(left, margin), viewportWidth - margin);
+        }
         top = Math.min(Math.max(top, margin), viewportHeight - margin);
       }
 


### PR DESCRIPTION
## Summary
- adjust the budget donut center popover to anchor to the left edge on small screens and clamp within the viewport
- tighten popover styling to respect viewport width limits
- add a regression test covering the mobile popover positioning logic

## Testing
- npm run test -- BudgetDonut

------
https://chatgpt.com/codex/tasks/task_e_68e0421da9388324b09ae0ee7bd7620d