### PR TITLE
Restyle mobile budget header final summary card

### DIFF
--- a/frontend/src/dashboard/project/features/budget/components/HeaderStats.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/HeaderStats.tsx
@@ -506,6 +506,15 @@ const BudgetHeader: React.FC<BudgetHeaderProps> = ({
     [budgetHeader]
   );
 
+  const finalMetric = useMemo(
+    () => metrics.find((metric) => metric.title === "Final Cost"),
+    [metrics]
+  );
+
+  const finalMetricTag = finalMetric?.tag ?? "Final";
+  const finalMetricDescription = finalMetric?.description ?? "All-in total";
+  const finalMetricIcon = finalMetric?.icon ?? faFileInvoiceDollar;
+
   const handleBallparkSave = async (val: number) => {
     if (!activeProject?.projectId || !budgetHeader) {
       setBallparkModalOpen(false);
@@ -946,10 +955,22 @@ const BudgetHeader: React.FC<BudgetHeaderProps> = ({
 
       <div className={mobileStyles.summaryLayout}>
         <div className={mobileStyles.summaryColumn}>
-          <div className={mobileStyles.amountRow}>
-            <span className={mobileStyles.amountValue}>{finalDisplay}</span>
+          <div className={mobileStyles.summaryCard}>
+            <div className={mobileStyles.summaryCardHeader}>
+              <span className={mobileStyles.summaryCardTitle}>
+                <FontAwesomeIcon
+                  icon={finalMetricIcon}
+                  className={mobileStyles.summaryCardTitleIcon}
+                />
+                {finalMetricTag}
+              </span>
+            </div>
+            <span className={mobileStyles.summaryCardValue}>{finalDisplay}</span>
+            <span className={mobileStyles.summaryCardDescription}>
+              {finalMetricDescription}
+            </span>
+            <span className={mobileStyles.summaryCardDate}>{createdDateLabel}</span>
           </div>
-          <div className={mobileStyles.dateRow}>{createdDateLabel}</div>
         </div>
         <div className={mobileStyles.chartContainer}>
           <BudgetDonut

--- a/frontend/src/dashboard/project/features/budget/components/budget-header-mobile.module.css
+++ b/frontend/src/dashboard/project/features/budget/components/budget-header-mobile.module.css
@@ -76,24 +76,66 @@
 .summaryColumn {
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  flex: 1 1 220px;
+  gap: 12px;
+  flex: 1 1 240px;
   min-width: 0;
-  padding: 0px 16px;
-  align-items: flex-start;
+  padding: 0 16px;
+  align-items: stretch;
 }
 
-.amountRow {
+.summaryCard {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  width: 100%;
+  box-sizing: border-box;
+  background: linear-gradient(155deg, rgba(17, 24, 39, 0.94), var(--budget-accent-chip));
+  border-radius: 14px;
+  padding: 12px 14px;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  color: var(--budget-accent-text);
+  box-shadow: 0 10px 22px rgba(8, 13, 32, 0.42), 0 0 0 1px var(--budget-accent-soft);
+}
+
+.summaryCardHeader {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
+  gap: 8px;
 }
 
-.amountValue {
-  font-size: 1.6rem;
+.summaryCardTitle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(249, 250, 251, 0.72);
+}
+
+.summaryCardTitleIcon {
+  font-size: 0.75rem;
+  color: var(--budget-accent-text);
+}
+
+.summaryCardValue {
+  font-size: 1.55rem;
   font-weight: 700;
   letter-spacing: 0.01em;
+  color: var(--budget-accent-text);
+}
+
+.summaryCardDescription {
+  font-size: 0.75rem;
+  color: rgba(241, 245, 249, 0.74);
+}
+
+.summaryCardDate {
+  font-size: 0.68rem;
+  color: rgba(226, 232, 240, 0.64);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
 }
 
 .amountActions {
@@ -133,11 +175,6 @@
   background: var(--budget-accent-softer);
   color: var(--budget-accent-text);
   box-shadow: 0 0 0 1px var(--budget-accent-border), 0 0 0 4px var(--budget-accent-soft);
-}
-
-.dateRow {
-  font-size: 0.75rem;
-  color: rgba(249, 250, 251, 0.7);
 }
 
 .controls {


### PR DESCRIPTION
## Summary
- wrap the mobile final total and created date inside a dedicated summary card that matches the styling of other budget metric chips
- surface the final metric label, description, and icon when rendering the highlighted summary card
- extend the mobile budget header styles with gradient card, typography, and spacing adjustments for the summary section

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68e0452874008324942b57e399ed3015