### PR TITLE
Add skeleton loading experience to dashboard home

### DIFF
--- a/frontend/src/dashboard/home/pages/DashboardHome.tsx
+++ b/frontend/src/dashboard/home/pages/DashboardHome.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useId, useState, useMemo } from "react";
+import React, { useEffect, useId, useState, useMemo, useRef } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useData } from "@/app/contexts/useData";
 import { UserLite } from "@/app/contexts/DataProvider";
@@ -12,7 +12,6 @@ import NotificationsPage from "@/dashboard/home/components/NotificationsPage";
 import Messages from "@/dashboard/features/messages";
 import Settings from "@/dashboard/home/components/Settings";
 import Collaborators from "@/dashboard/home/components/Collaborators";
-import SpinnerScreen from "@/shared/ui/SpinnerScreen";
 import PendingApprovalScreen from "@/shared/ui/PendingApprovalScreen";
 import AllProjectsWeekWidget from "@/dashboard/home/components/AllProjectsWeekWidget";
 import WeekWidgetDesktop, { type Track, type Dot } from "@/dashboard/home/components/WeekWidgetDesktop";
@@ -25,6 +24,7 @@ import { getColor } from "@/shared/utils/colorUtils";
 import { useNavCollapsed } from "@/shared/hooks/useNavCollapsed";
 
 import "./dashboard-styles.css";
+import DashboardHomeSkeleton from "./DashboardHomeSkeleton";
 
 type Project = { projectId: string; title: string };
 
@@ -81,7 +81,10 @@ export const parseDashboardPath = (
   return { view, userSlug };
 };
 
+const MIN_SKELETON_DURATION = 400;
+
 const WelcomeScreen: React.FC = () => {
+  const data = useData();
   const {
     userData,
     userName,
@@ -90,7 +93,8 @@ const WelcomeScreen: React.FC = () => {
     allUsers,
     projects,
     fetchProjectDetails,
-  } = useData();
+  } = data;
+  const projectsLoading = (data as { isLoading?: boolean }).isLoading ?? false;
 
   const location = useLocation();
   const navigate = useNavigate();
@@ -193,10 +197,49 @@ const WelcomeScreen: React.FC = () => {
   );
   const [isNavigationOpen, setIsNavigationOpen] = useState(false);
   const [isNavCollapsed, setIsNavCollapsed] = useNavCollapsed("dashboard");
+  const skeletonStartRef = useRef<number>(Date.now());
+  const [showSkeleton, setShowSkeleton] = useState(true);
+  const [contentVisible, setContentVisible] = useState(false);
+  const isDataResolved = !loadingProfile && !projectsLoading;
   const rawDrawerId = useId();
   const drawerId = React.useMemo(
     () => `dashboard-nav-${rawDrawerId.replace(/[^a-zA-Z0-9_-]/g, "")}`,
     [rawDrawerId]
+  );
+
+  useEffect(() => {
+    if (!isDataResolved) {
+      skeletonStartRef.current = Date.now();
+      setShowSkeleton(true);
+      setContentVisible(false);
+      return;
+    }
+
+    const elapsed = Date.now() - skeletonStartRef.current;
+    const delay = Math.max(MIN_SKELETON_DURATION - elapsed, 0);
+    const timer = window.setTimeout(() => {
+      setShowSkeleton(false);
+      setContentVisible(true);
+    }, delay);
+
+    return () => window.clearTimeout(timer);
+  }, [isDataResolved]);
+
+  const skeletonOverlayStyle = React.useMemo<React.CSSProperties>(
+    () => ({
+      opacity: showSkeleton ? 1 : 0,
+      transition: "opacity 200ms ease",
+      pointerEvents: showSkeleton ? "auto" : "none",
+    }),
+    [showSkeleton]
+  );
+
+  const contentLayerStyle = React.useMemo<React.CSSProperties>(
+    () => ({
+      opacity: contentVisible ? 1 : 0,
+      transition: "opacity 200ms ease",
+    }),
+    [contentVisible]
   );
 
   useEffect(() => {
@@ -301,7 +344,6 @@ const WelcomeScreen: React.FC = () => {
     }
   }, [activeView, dmUserSlug, inbox, userData, allUsers, navigate, isMobile]);
 
-  if (loadingProfile) return <SpinnerScreen />;
   if (userData?.pending) return <PendingApprovalScreen />;
 
 
@@ -400,28 +442,52 @@ const WelcomeScreen: React.FC = () => {
     setIsNavCollapsed((previous) => !previous);
 
   const mainContent = (
-    <main className="dashboard-main">
-      <div className="dashboard-wrapper welcome-screen no-vertical-center">
-        <WelcomeHeader
-          userName={userName}
-          setActiveView={setActiveView}
-          onToggleNavigation={!isDesktop ? handleOpenNavigation : undefined}
-          isNavigationOpen={!isDesktop ? isNavigationOpen : undefined}
-          navigationDrawerId={!isDesktop ? drawerId : undefined}
-          isDesktopLayout={isDesktop}
+    <main
+      className="dashboard-main"
+      style={{ position: "relative", pointerEvents: contentVisible ? undefined : "none" }}
+    >
+      <div
+        style={{
+          position: "absolute",
+          top: 0,
+          right: 0,
+          bottom: 0,
+          left: 0,
+          overflowY: "auto",
+          ...skeletonOverlayStyle,
+        }}
+      >
+        <DashboardHomeSkeleton
+          isDesktop={isDesktop}
+          isMobile={isMobile}
+          busy={showSkeleton}
+          hidden={!showSkeleton}
         />
+      </div>
 
-        <div className="row-layout">
-          <div className="welcome-screen-details">
-            <div className="dashboard-content">
-              <div
-                className={`main-content${
-                  activeView === "welcome" && isDesktop
-                    ? " main-content--welcome"
-                    : ""
-                }`}
-              >
-                {renderActiveView()}
+      <div style={{ ...contentLayerStyle, height: "100%" }} aria-hidden={!contentVisible}>
+        <div className="dashboard-wrapper welcome-screen no-vertical-center">
+          <WelcomeHeader
+            userName={userName}
+            setActiveView={setActiveView}
+            onToggleNavigation={!isDesktop ? handleOpenNavigation : undefined}
+            isNavigationOpen={!isDesktop ? isNavigationOpen : undefined}
+            navigationDrawerId={!isDesktop ? drawerId : undefined}
+            isDesktopLayout={isDesktop}
+          />
+
+          <div className="row-layout">
+            <div className="welcome-screen-details">
+              <div className="dashboard-content">
+                <div
+                  className={`main-content${
+                    activeView === "welcome" && isDesktop
+                      ? " main-content--welcome"
+                      : ""
+                  }`}
+                >
+                  {renderActiveView()}
+                </div>
               </div>
             </div>
           </div>
@@ -437,7 +503,7 @@ const WelcomeScreen: React.FC = () => {
           isNavCollapsed ? " dashboard-root--nav-collapsed" : ""
         }`}
       >
-        <aside>
+        <aside style={{ pointerEvents: contentVisible ? undefined : "none" }}>
           <DashboardNavPanel
             variant="persistent"
             setActiveView={setActiveView}
@@ -452,12 +518,14 @@ const WelcomeScreen: React.FC = () => {
 
   return (
     <>
-      <NavigationDrawer
-        open={isNavigationOpen}
-        onClose={handleCloseNavigation}
-        setActiveView={setActiveView}
-        drawerId={drawerId}
-      />
+      <div style={{ pointerEvents: contentVisible ? undefined : "none" }}>
+        <NavigationDrawer
+          open={isNavigationOpen}
+          onClose={handleCloseNavigation}
+          setActiveView={setActiveView}
+          drawerId={drawerId}
+        />
+      </div>
       {mainContent}
     </>
   );

--- a/frontend/src/dashboard/home/pages/DashboardHomeSkeleton.tsx
+++ b/frontend/src/dashboard/home/pages/DashboardHomeSkeleton.tsx
@@ -1,0 +1,340 @@
+import React from "react";
+
+import {
+  SkeletonAvatar,
+  SkeletonBox,
+  SkeletonText,
+  SkeletonThumbnail,
+} from "@/shared/ui/Skeleton";
+import desktopPanelStyles from "../components/ProjectsPanelDesktop.module.css";
+import projectsPanelStyles from "../components/projects-panel.module.css";
+import tasksCardStyles from "../components/TasksOverviewCard.module.css";
+import mobileTasksStyles from "../components/MobileTasksOverviewCard.module.css";
+
+type DashboardHomeSkeletonProps = {
+  isDesktop: boolean;
+  isMobile: boolean;
+  busy: boolean;
+  hidden?: boolean;
+};
+
+const HeaderSkeleton: React.FC<{ isDesktop: boolean; isMobile: boolean }> = ({
+  isDesktop,
+  isMobile,
+}) => {
+  const chips = Array.from({ length: isDesktop ? 4 : 3 });
+
+  return (
+    <div className="welcome-header">
+      <div className="welcome-header-desktop">
+        <div className="welcome-header-left flex items-center gap-2">
+          <SkeletonBox radius="card" style={{ width: isMobile ? 34 : 40, height: isMobile ? 34 : 40 }} />
+          {!isDesktop ? (
+            <SkeletonBox radius="card" style={{ width: 36, height: 36 }} />
+          ) : null}
+        </div>
+
+        {isDesktop ? (
+          <div className="welcome-header-greeting">
+            <SkeletonText width="240px" className="h-6" />
+          </div>
+        ) : null}
+
+        <div className="welcome-header-right flex items-center gap-3">
+          {isDesktop ? (
+            <div className="welcome-header-search">
+              <SkeletonBox radius="card" style={{ width: "100%", height: 44 }} />
+            </div>
+          ) : (
+            <SkeletonText width="45%" className="h-5" />
+          )}
+
+          <div className="welcome-header-actions flex items-center gap-2">
+            <SkeletonBox radius="full" style={{ width: 36, height: 36 }} />
+            <SkeletonBox radius="full" style={{ width: 36, height: 36 }} />
+            <SkeletonAvatar size={isMobile ? 34 : 40} />
+          </div>
+        </div>
+      </div>
+
+      <div className="welcome-header-extras">
+        <div className="welcome-header-toc flex flex-wrap gap-2">
+          {chips.map((_, index) => (
+            <SkeletonBox
+              key={index}
+              radius="line"
+              style={{ width: isDesktop ? 120 : 94, height: 30 }}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const WeekWidgetSkeleton: React.FC<{ variant: "desktop" | "mobile" }> = ({ variant }) => {
+  const isDesktop = variant === "desktop";
+  const dayCount = isDesktop ? 7 : 7;
+
+  return (
+    <div
+      className={`week-widget ${isDesktop ? "week-widget--desktop" : "week-widget--mobile"}`}
+      aria-hidden="true"
+    >
+      <div className="flex items-center justify-between gap-3 week-widget-header">
+        <SkeletonText width={isDesktop ? "200px" : "160px"} className="h-6" />
+        <div className="flex items-center gap-2">
+          <SkeletonBox radius="line" style={{ width: 34, height: 34 }} />
+          <SkeletonBox radius="line" style={{ width: 34, height: 34 }} />
+        </div>
+      </div>
+
+      <div className="flex gap-2 week-days" style={{ marginBottom: 12 }}>
+        {Array.from({ length: dayCount }).map((_, index) => (
+          <SkeletonBox key={index} radius="inherit" className="week-day" />
+        ))}
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <SkeletonBox radius="line" style={{ width: "100%", height: 12 }} />
+        <SkeletonBox radius="line" style={{ width: "75%", height: 12 }} />
+      </div>
+    </div>
+  );
+};
+
+const ProjectsDesktopSkeleton: React.FC = () => (
+  <section
+    aria-hidden="true"
+    className={`${desktopPanelStyles.card} flex flex-col gap-5`}
+    style={{ minHeight: 420 }}
+  >
+    <header className={desktopPanelStyles.header}>
+      <div className={desktopPanelStyles.headerTop}>
+        <div className={projectsPanelStyles.titleWrap}>
+          <SkeletonText width="120px" className={`${projectsPanelStyles.title} h-6`} radius="inherit" />
+          <div className="flex items-center gap-2">
+            {Array.from({ length: 5 }).map((_, index) => (
+              <SkeletonAvatar key={index} size={32} />
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className={`${projectsPanelStyles.kpis} flex gap-2`}>
+        {Array.from({ length: 4 }).map((_, index) => (
+          <SkeletonBox
+            key={index}
+            radius="inherit"
+            className={projectsPanelStyles.chip}
+            style={{ height: 32, minWidth: 96 }}
+          />
+        ))}
+      </div>
+    </header>
+
+    <div className={`${desktopPanelStyles.content} flex flex-col gap-3`} style={{ minHeight: 300 }}>
+      {Array.from({ length: 6 }).map((_, index) => (
+        <SkeletonBox key={index} radius="line" style={{ height: 56 }} />
+      ))}
+    </div>
+  </section>
+);
+
+const ProjectsMobileSkeleton: React.FC = () => (
+  <div className={`${projectsPanelStyles.panel} flex flex-col gap-4`} style={{ minHeight: 320 }} aria-hidden="true">
+    <div className={projectsPanelStyles.header}>
+      <div className={projectsPanelStyles.titleWrap}>
+        <SkeletonText width="110px" className={`${projectsPanelStyles.title} h-5`} radius="inherit" />
+      </div>
+      <SkeletonBox radius="full" style={{ width: 28, height: 28 }} />
+    </div>
+
+    <div className={`${projectsPanelStyles.kpis} flex gap-2`}>
+      {Array.from({ length: 3 }).map((_, index) => (
+        <SkeletonBox
+          key={index}
+          radius="inherit"
+          className={projectsPanelStyles.chip}
+          style={{ height: 28, minWidth: 88 }}
+        />
+      ))}
+    </div>
+
+    <div className="flex flex-col gap-3" style={{ minHeight: 220 }}>
+      {Array.from({ length: 5 }).map((_, index) => (
+        <SkeletonBox key={index} radius="line" style={{ height: 52 }} />
+      ))}
+    </div>
+  </div>
+);
+
+const TasksDesktopSkeleton: React.FC = () => (
+  <section
+    aria-hidden="true"
+    className={`${tasksCardStyles.card} flex flex-col gap-4`}
+    style={{ minHeight: 360 }}
+  >
+    <div className={`${tasksCardStyles.header} flex flex-wrap gap-4`}>
+      <div className={`${tasksCardStyles.titleWrap} flex flex-col gap-2`}>
+        <SkeletonText width="120px" className="h-5" />
+        <SkeletonText width="200px" className="h-4" />
+      </div>
+      <div className={`${tasksCardStyles.actions} flex items-center gap-2`}>
+        <SkeletonBox radius="full" style={{ width: 36, height: 36 }} />
+        <SkeletonBox radius="full" style={{ width: 36, height: 36 }} />
+      </div>
+    </div>
+
+    <div className={tasksCardStyles.statGrid}>
+      {Array.from({ length: 3 }).map((_, index) => (
+        <SkeletonBox
+          key={index}
+          radius="inherit"
+          className={`${tasksCardStyles.stat} flex flex-col gap-2`}
+        >
+          <SkeletonText width="40%" className="h-3" />
+          <SkeletonText width="35%" className="h-5" />
+        </SkeletonBox>
+      ))}
+    </div>
+
+    <div className={`${tasksCardStyles.groups} flex flex-col gap-3`}>
+      {Array.from({ length: 3 }).map((_, index) => (
+        <div key={index} className={`${tasksCardStyles.group} flex flex-col gap-2`}>
+          <SkeletonText width="120px" className="h-3" />
+          <div className={`${tasksCardStyles.chips} flex flex-wrap gap-2`}>
+            {Array.from({ length: 2 }).map((_, chipIndex) => (
+              <SkeletonBox
+                key={chipIndex}
+                radius="inherit"
+                className={tasksCardStyles.chip}
+                style={{ height: 32, minWidth: 120 }}
+              >
+                <div className="flex items-center gap-2">
+                  <SkeletonAvatar size={10} />
+                  <SkeletonText width="70%" className="h-3" />
+                </div>
+              </SkeletonBox>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  </section>
+);
+
+const TasksMobileSkeleton: React.FC = () => (
+  <section
+    aria-hidden="true"
+    className={`${mobileTasksStyles.card} flex flex-col gap-3`}
+    style={{ minHeight: 240 }}
+  >
+    <div className={`${mobileTasksStyles.header} flex items-center justify-between gap-3`}>
+      <SkeletonText width="110px" className="h-5" />
+      <SkeletonText width="60px" className="h-4" />
+    </div>
+
+    <div className={`${mobileTasksStyles.statRow} flex gap-2`}>
+      {Array.from({ length: 3 }).map((_, index) => (
+        <SkeletonBox
+          key={index}
+          radius="inherit"
+          className={`${mobileTasksStyles.stat} flex flex-col gap-2`}
+        >
+          <SkeletonText width="35%" className="h-5" />
+          <SkeletonText width="50%" className="h-3" />
+        </SkeletonBox>
+      ))}
+    </div>
+
+    <SkeletonText width="80%" className={`${mobileTasksStyles.status} h-4`} />
+  </section>
+);
+
+const GalleriesSkeleton: React.FC<{ isDesktop: boolean }> = ({ isDesktop }) => (
+  <div className="flex w-full gap-3" aria-hidden="true" style={{ minHeight: isDesktop ? 140 : 120 }}>
+    {Array.from({ length: isDesktop ? 4 : 2 }).map((_, index) => (
+      <SkeletonThumbnail
+        key={index}
+        radius="card"
+        aspect="16 / 9"
+        style={{ flex: 1, minWidth: 0 }}
+      />
+    ))}
+  </div>
+);
+
+const DesktopLayoutSkeleton: React.FC = () => (
+  <div className="welcome-desktop-layout" aria-hidden="true">
+    <section className="welcome-section-anchor welcome-desktop-header">
+      <WeekWidgetSkeleton variant="desktop" />
+    </section>
+
+    <section className="welcome-section-anchor welcome-desktop-projects flex flex-col gap-5">
+      <ProjectsDesktopSkeleton />
+      <GalleriesSkeleton isDesktop />
+    </section>
+
+    <section className="welcome-section-anchor welcome-desktop-footer flex flex-col gap-5">
+      <TasksDesktopSkeleton />
+    </section>
+  </div>
+);
+
+const MobileLayoutSkeleton: React.FC = () => (
+  <div className="mobile-welcome-layout" aria-hidden="true">
+    <div className="mobile-calendar-section">
+      <WeekWidgetSkeleton variant="mobile" />
+    </div>
+
+    <div className="mobile-projects-tasks flex flex-col gap-4">
+      <div className="mobile-projects-section">
+        <div className="mobile-projects-panel">
+          <ProjectsMobileSkeleton />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-4">
+        <GalleriesSkeleton isDesktop={false} />
+        <div className="mobile-tasks-section dashboard-footer">
+          <TasksMobileSkeleton />
+        </div>
+      </div>
+    </div>
+  </div>
+);
+
+const DashboardHomeSkeleton: React.FC<DashboardHomeSkeletonProps> = ({
+  isDesktop,
+  isMobile,
+  busy,
+  hidden = false,
+}) => {
+  const layout = isDesktop ? <DesktopLayoutSkeleton /> : <MobileLayoutSkeleton />;
+
+  return (
+    <div
+      role="status"
+      aria-busy={busy}
+      aria-hidden={hidden}
+      aria-live="polite"
+      style={{ width: "100%", height: "100%", overflow: "hidden" }}
+    >
+      <div className="dashboard-wrapper welcome-screen no-vertical-center">
+        <HeaderSkeleton isDesktop={isDesktop} isMobile={isMobile} />
+        <div className="row-layout">
+          <div className="welcome-screen-details">
+            <div className="dashboard-content">
+              <div className={`main-content${isDesktop ? " main-content--welcome" : ""}`}>
+                {layout}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default React.memo(DashboardHomeSkeleton);

--- a/frontend/src/shared/ui/Skeleton.tsx
+++ b/frontend/src/shared/ui/Skeleton.tsx
@@ -1,0 +1,176 @@
+import React from "react";
+
+type RadiusToken = "card" | "line" | "full" | "none" | "inherit";
+
+type SkeletonBaseProps = React.PropsWithChildren<
+  React.HTMLAttributes<HTMLDivElement> & {
+    radius?: RadiusToken;
+  }
+>;
+
+const radiusClassMap: Record<Exclude<RadiusToken, "inherit">, string> = {
+  card: "rounded-2xl",
+  line: "rounded-lg",
+  full: "rounded-full",
+  none: "rounded-none",
+};
+
+const joinClasses = (...classes: Array<string | undefined | false>): string =>
+  classes.filter(Boolean).join(" ");
+
+const styleElementId = "skeleton-primitives-styles";
+
+const ensureSkeletonStyles = () => {
+  if (typeof document === "undefined") return;
+  if (document.getElementById(styleElementId)) return;
+
+  const style = document.createElement("style");
+  style.id = styleElementId;
+  style.textContent = `
+:root,
+[data-theme='dark'],
+body.dark {
+  --skeleton-surface: rgba(255, 255, 255, 0.08);
+  --skeleton-highlight: rgba(255, 255, 255, 0.16);
+}
+
+[data-theme='light'],
+body.light {
+  --skeleton-surface: rgba(12, 12, 12, 0.08);
+  --skeleton-highlight: rgba(12, 12, 12, 0.14);
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    --skeleton-surface: rgba(12, 12, 12, 0.08);
+    --skeleton-highlight: rgba(12, 12, 12, 0.14);
+  }
+}
+
+@keyframes skeleton-shimmer {
+  0% {
+    background-position: -200% 0;
+  }
+  100% {
+    background-position: 200% 0;
+  }
+}
+`;
+  document.head.appendChild(style);
+};
+
+const useSkeletonTokens = () => {
+  React.useEffect(() => {
+    ensureSkeletonStyles();
+  }, []);
+};
+
+const usePrefersReducedMotion = () => {
+  const [reduced, setReduced] = React.useState(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      return false;
+    }
+    return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  });
+
+  React.useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      return undefined;
+    }
+
+    const query = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const update = (event: MediaQueryList | MediaQueryListEvent) => {
+      setReduced(event.matches);
+    };
+
+    update(query);
+
+    if (typeof query.addEventListener === "function") {
+      query.addEventListener("change", update);
+      return () => query.removeEventListener("change", update);
+    }
+
+    query.addListener(update);
+    return () => query.removeListener(update);
+  }, []);
+
+  return reduced;
+};
+
+const SkeletonBoxInner = React.forwardRef<HTMLDivElement, SkeletonBaseProps>(
+  ({ className, style, radius = "card", children, ...rest }, ref) => {
+    useSkeletonTokens();
+    const prefersReducedMotion = usePrefersReducedMotion();
+
+    const radiusClass = radius === "inherit" ? undefined : radiusClassMap[radius] ?? radiusClassMap.card;
+    const composedClassName = joinClasses(
+      "relative overflow-hidden",
+      radiusClass,
+      className
+    );
+
+    const animatedStyle = React.useMemo<React.CSSProperties>(() => {
+      const base: React.CSSProperties = {
+        backgroundColor: "var(--skeleton-surface, rgba(255, 255, 255, 0.08))",
+      };
+
+      if (!prefersReducedMotion) {
+        base.backgroundImage =
+          "linear-gradient(110deg, var(--skeleton-surface, rgba(255, 255, 255, 0.08)) 20%, var(--skeleton-highlight, rgba(255, 255, 255, 0.16)) 40%, var(--skeleton-surface, rgba(255, 255, 255, 0.08)) 60%)";
+        base.backgroundSize = "200% 100%";
+        base.animation = "skeleton-shimmer 1.6s ease-in-out infinite";
+      }
+
+      return base;
+    }, [prefersReducedMotion]);
+
+    return (
+      <div
+        ref={ref}
+        aria-hidden="true"
+        className={composedClassName}
+        style={{ ...animatedStyle, ...style }}
+        {...rest}
+      >
+        {children}
+      </div>
+    );
+  }
+);
+SkeletonBoxInner.displayName = "SkeletonBox";
+
+export const SkeletonBox = React.memo(SkeletonBoxInner);
+
+export const SkeletonText = React.memo<
+  React.ComponentProps<typeof SkeletonBox> & { width?: string | number }
+>(({ width = "60%", style, className, radius = "line", ...rest }) => (
+  <SkeletonBox
+    radius={radius}
+    className={joinClasses("h-3", className)}
+    style={{ width, ...style }}
+    {...rest}
+  />
+));
+
+export const SkeletonAvatar = React.memo<
+  React.ComponentProps<typeof SkeletonBox> & { size?: number }
+>(({ size = 40, style, radius = "full", ...rest }) => (
+  <SkeletonBox
+    radius={radius}
+    style={{ width: size, height: size, ...style }}
+    {...rest}
+  />
+));
+
+export const SkeletonThumbnail = React.memo<
+  React.ComponentProps<typeof SkeletonBox> & { aspect?: string }
+>(({ aspect = "16 / 9", style, className, radius = "card", ...rest }) => (
+  <SkeletonBox
+    radius={radius}
+    className={className}
+    style={{ width: "100%", aspectRatio: aspect, ...style }}
+    {...rest}
+  />
+));
+
+export default SkeletonBox;


### PR DESCRIPTION
## Summary
- add reusable skeleton UI primitives with configurable variants and reduced-motion aware shimmer
- build a DashboardHomeSkeleton that mirrors desktop and mobile layouts with stable placeholder sizing
- integrate the skeleton cross-fade into DashboardHome with a minimum display window and disabled interactions while loading

## Testing
- npm run lint *(fails: pre-existing lint violations in MessagesProvider, ProjectsProvider, UserProvider, QuickCreateTaskModal, TasksComponentMobile, BudgetStateManager.test)*

------
https://chatgpt.com/codex/tasks/task_e_68e06b6c2f108324a4e1f005877a3c6a