### PR TITLE
Add skeleton shimmer loading for dashboard components

### DIFF
--- a/frontend/src/features/dashboard/components/ProjectsPanel.skeleton.tsx
+++ b/frontend/src/features/dashboard/components/ProjectsPanel.skeleton.tsx
@@ -1,0 +1,84 @@
+import React from "react";
+
+const avatarStyle: React.CSSProperties = {
+  width: 36,
+  height: 36,
+  borderRadius: 12,
+};
+
+const iconStyle: React.CSSProperties = {
+  width: 32,
+  height: 32,
+  borderRadius: 10,
+};
+
+const titleLine = (width: string) => (
+  <div className="skel rounded-md" style={{ height: 12, width }} />
+);
+
+const ProjectsPanelSkeleton = ({ className = "" }: { className?: string }) => {
+  const rootClass = ["skel", "rounded-3xl", className].filter(Boolean).join(" ");
+
+  return (
+    <div
+      className={rootClass}
+      style={{
+        border: "1px solid rgba(255, 255, 255, 0.08)",
+        padding: 16,
+        minHeight: 275,
+        display: "flex",
+        flexDirection: "column",
+        gap: 14,
+        pointerEvents: "none",
+        width: "100%",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          gap: 12,
+        }}
+      >
+        <div style={{ flex: 1, display: "grid", gap: 6 }}>
+          {titleLine("58%")}
+          <div className="skel rounded-md" style={{ height: 10, width: "36%" }} />
+        </div>
+        <div className="skel rounded-md" style={{ width: 68, height: 22 }} />
+      </div>
+
+      <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+        {Array.from({ length: 5 }).map((_, idx) => (
+          <div key={idx} className="skel rounded-xl" style={avatarStyle} />
+        ))}
+        <div className="skel rounded-md" style={{ width: 42, height: 18 }} />
+      </div>
+
+      <div style={{ display: "grid", gap: 12, flex: 1 }}>
+        {Array.from({ length: 5 }).map((_, idx) => (
+          <div
+            key={idx}
+            style={{
+              display: "grid",
+              gridTemplateColumns: "auto 1fr auto",
+              gap: 12,
+              alignItems: "center",
+            }}
+          >
+            <div className="skel rounded-xl" style={iconStyle} />
+            <div style={{ display: "grid", gap: 6 }}>
+              {titleLine("72%")}
+              <div className="skel rounded-md" style={{ height: 10, width: "48%" }} />
+            </div>
+            <div className="skel rounded-md" style={{ width: 54, height: 10 }} />
+          </div>
+        ))}
+      </div>
+
+      <div className="skel rounded-xl" style={{ height: 36 }} />
+    </div>
+  );
+};
+
+export default ProjectsPanelSkeleton;

--- a/frontend/src/features/dashboard/components/TasksRollup.skeleton.tsx
+++ b/frontend/src/features/dashboard/components/TasksRollup.skeleton.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+
+const TasksRollupSkeleton = ({ className = "" }: { className?: string }) => {
+  const rootClass = ["skel", "rounded-3xl", className, "tasks-rollup-skeleton"].filter(Boolean).join(" ");
+
+  return (
+    <div
+      className={rootClass}
+      style={{
+        border: "1px solid rgba(255, 255, 255, 0.08)",
+        padding: 16,
+        minHeight: 140,
+        pointerEvents: "none",
+        width: "100%",
+      }}
+    >
+      <div className="skel rounded-md" style={{ height: 12, width: "38%" }} />
+
+      <div className="tasks-rollup-skeleton-metrics">
+        {Array.from({ length: 4 }).map((_, idx) => (
+          <div key={idx} className="skel rounded-2xl tasks-rollup-skeleton-pill">
+            <div className="skel rounded-md" style={{ height: 12, width: "64%" }} />
+            <div className="skel rounded-md" style={{ height: 18, width: "48%" }} />
+          </div>
+        ))}
+      </div>
+
+      <div className="skel rounded-md" style={{ height: 10, width: "44%" }} />
+    </div>
+  );
+};
+
+export default TasksRollupSkeleton;

--- a/frontend/src/features/dashboard/components/WeekWidget.skeleton.tsx
+++ b/frontend/src/features/dashboard/components/WeekWidget.skeleton.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+
+const weekPillStyle: React.CSSProperties = {
+  height: 54,
+};
+
+const navButtonStyle: React.CSSProperties = {
+  width: 32,
+  height: 28,
+};
+
+const progressStyle: React.CSSProperties = {
+  height: 10,
+};
+
+const WeekWidgetSkeleton = ({ className = "" }: { className?: string }) => {
+  const rootClass = ["skel", "rounded-3xl", className].filter(Boolean).join(" ");
+
+  return (
+    <div
+      className={rootClass}
+      style={{
+        border: "1px solid rgba(255, 255, 255, 0.08)",
+        padding: 14,
+        minHeight: 168,
+        pointerEvents: "none",
+        width: "100%",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "flex-start",
+          gap: 12,
+          marginBottom: 12,
+        }}
+      >
+        <div style={{ flex: 1, display: "grid", gap: 6 }}>
+          <div className="skel rounded-md" style={{ height: 14, width: "48%" }} />
+          <div className="skel rounded-md" style={{ height: 12, width: "32%" }} />
+        </div>
+        <div style={{ display: "flex", gap: 8 }}>
+          <div className="skel rounded-md" style={navButtonStyle} />
+          <div className="skel rounded-md" style={navButtonStyle} />
+        </div>
+      </div>
+
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(7, minmax(0, 1fr))",
+          gap: 6,
+          marginBottom: 14,
+        }}
+      >
+        {Array.from({ length: 7 }).map((_, idx) => (
+          <div key={idx} className="skel rounded-2xl" style={weekPillStyle} />
+        ))}
+      </div>
+
+      <div style={{ display: "grid", gap: 8 }}>
+        <div className="skel rounded-md" style={progressStyle} />
+        <div className="skel rounded-md" style={progressStyle} />
+      </div>
+    </div>
+  );
+};
+
+export default WeekWidgetSkeleton;

--- a/frontend/src/features/dashboard/pages/DashboardHome.tsx
+++ b/frontend/src/features/dashboard/pages/DashboardHome.tsx
@@ -18,6 +18,9 @@ import SpinnerScreen from "@/shared/ui/SpinnerScreen";
 import PendingApprovalScreen from "@/shared/ui/PendingApprovalScreen";
 import AllProjectsCalendar from "@/features/dashboard/components/AllProjectsCalendar";
 import AllProjectsWeekWidget from "@/features/dashboard/components/AllProjectsWeekWidget";
+import SkeletonSwap from "@/shared/ui/SkeletonSwap";
+import ProjectsPanelSkeleton from "@/features/dashboard/components/ProjectsPanel.skeleton";
+import WeekWidgetSkeleton from "@/features/dashboard/components/WeekWidget.skeleton";
 
 import "./dashboard-styles.css";
 
@@ -39,6 +42,7 @@ const WelcomeScreen: React.FC = () => {
     allUsers,
     projects,
     fetchProjectDetails,
+    isLoading,
   } = useData();
 
   const location = useLocation();
@@ -61,6 +65,8 @@ const WelcomeScreen: React.FC = () => {
   const [activeView, setActiveView] = useState<string>(initialView);
   const [dmUserSlug, setDmUserSlug] = useState<string | null>(initialDMUserSlug);
   const [isMobile, setIsMobile] = useState(false);
+  const isProjectsLoading = Boolean(isLoading);
+  const isWeekLoading = Boolean(isLoading);
 
   useEffect(() => {
     const handleResize = () => setIsMobile(window.innerWidth < 768);
@@ -170,10 +176,26 @@ const WelcomeScreen: React.FC = () => {
                     {/* DashboardHome.tsx (mobile welcome layout) */}
                     <div className="mobile-welcome-layout">
                       <div className="mobile-projects-section">
-                        <ProjectsPanel onOpenProject={(projectId) => handleNavigateToProject({ projectId })} />
+                        <SkeletonSwap
+                          ready={!isProjectsLoading}
+                          skeleton={<ProjectsPanelSkeleton />}
+                          className="projects-panel-shell"
+                        >
+                          <ProjectsPanel
+                            onOpenProject={(projectId) =>
+                              handleNavigateToProject({ projectId })
+                            }
+                          />
+                        </SkeletonSwap>
                       </div>
                       <div className="mobile-calendar-section">
-                        <AllProjectsWeekWidget />
+                        <SkeletonSwap
+                          ready={!isWeekLoading}
+                          skeleton={<WeekWidgetSkeleton />}
+                          className="week-widget-shell"
+                        >
+                          <AllProjectsWeekWidget />
+                        </SkeletonSwap>
                       </div>
                     </div>
                   </>

--- a/frontend/src/features/dashboard/pages/overrides.css
+++ b/frontend/src/features/dashboard/pages/overrides.css
@@ -20,3 +20,22 @@
 
 /* Leave empty unless temporarily staging a small set of page-specific rules. */
 
+.projects-panel-shell,
+.week-widget-shell,
+.tasks-rollup-shell {
+  position: relative;
+  width: 100%;
+}
+
+.projects-panel-shell {
+  min-height: 275px;
+}
+
+.week-widget-shell {
+  min-height: 180px;
+}
+
+.tasks-rollup-shell {
+  min-height: 140px;
+}
+

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,4 +1,5 @@
 import './shared/styles/index.css';
+import './styles/skeleton.css';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { Amplify } from 'aws-amplify';

--- a/frontend/src/shared/ui/SkeletonSwap.tsx
+++ b/frontend/src/shared/ui/SkeletonSwap.tsx
@@ -1,0 +1,116 @@
+import React, { ReactNode, useEffect, useRef, useState } from "react";
+
+type SkeletonSwapProps = {
+  ready: boolean;
+  skeleton: ReactNode;
+  children: ReactNode;
+  className?: string;
+  minShowMs?: number;
+};
+
+const now = () => {
+  if (typeof performance !== "undefined" && typeof performance.now === "function") {
+    return performance.now();
+  }
+  return Date.now();
+};
+
+const SkeletonSwap: React.FC<SkeletonSwapProps> = ({
+  ready,
+  skeleton,
+  children,
+  className = "",
+  minShowMs = 300,
+}) => {
+  const [resolvedReady, setResolvedReady] = useState<boolean>(ready);
+  const [showSkeleton, setShowSkeleton] = useState<boolean>(!ready);
+  const [showContent, setShowContent] = useState<boolean>(ready);
+  const showSinceRef = useRef<number | null>(ready ? null : now());
+  const timeoutRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!ready) {
+      if (timeoutRef.current != null) {
+        window.clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
+      }
+      setResolvedReady(false);
+      setShowContent(false);
+      setShowSkeleton(true);
+      showSinceRef.current = now();
+      return () => {};
+    }
+
+    const since = showSinceRef.current;
+    if (since == null) {
+      setResolvedReady(true);
+      setShowSkeleton(false);
+      setShowContent(true);
+      return () => {};
+    }
+
+    const elapsed = now() - since;
+    if (elapsed >= minShowMs) {
+      setResolvedReady(true);
+      setShowSkeleton(false);
+      setShowContent(true);
+      showSinceRef.current = null;
+      return () => {};
+    }
+
+    timeoutRef.current = window.setTimeout(() => {
+      setResolvedReady(true);
+      setShowSkeleton(false);
+      setShowContent(true);
+      showSinceRef.current = null;
+      timeoutRef.current = null;
+    }, minShowMs - elapsed);
+
+    return () => {
+      if (timeoutRef.current != null) {
+        window.clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
+      }
+    };
+  }, [ready, minShowMs]);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current != null) {
+        window.clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  const containerClass = ["skeleton-swap", className].filter(Boolean).join(" ");
+
+  return (
+    <div className={containerClass} role="status" aria-busy={!resolvedReady}>
+      <div
+        className={[
+          "skeleton-swap-layer",
+          showSkeleton ? "skeleton-visible" : "skeleton-hidden",
+        ].join(" ")}
+        data-layer="skeleton"
+        aria-hidden={!showSkeleton}
+      >
+        <div style={{ pointerEvents: "none" }}>{skeleton}</div>
+      </div>
+      <div
+        className={[
+          "skeleton-swap-layer",
+          showContent ? "skeleton-visible" : "skeleton-hidden",
+          showContent && resolvedReady ? "" : "disable-interactions",
+        ]
+          .filter(Boolean)
+          .join(" ")}
+        data-layer="content"
+        aria-hidden={!showContent}
+      >
+        <div style={{ pointerEvents: resolvedReady ? "auto" : "none" }}>{children}</div>
+      </div>
+    </div>
+  );
+};
+
+export default SkeletonSwap;

--- a/frontend/src/styles/skeleton.css
+++ b/frontend/src/styles/skeleton.css
@@ -1,0 +1,128 @@
+:root {
+  --skel-base: #0c0c0c;
+  --skel-highlight: #1a1a1a;
+}
+
+.skel {
+  position: relative;
+  display: block;
+  overflow: hidden;
+  background-color: var(--skel-base);
+  background-image: linear-gradient(135deg, rgba(26, 26, 26, 0.9), rgba(12, 12, 12, 0.95));
+  background-size: 200% 200%;
+  color: transparent;
+}
+
+.skel::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    120deg,
+    rgba(12, 12, 12, 0) 0%,
+    rgba(48, 48, 48, 0.35) 45%,
+    rgba(90, 90, 90, 0.45) 50%,
+    rgba(12, 12, 12, 0) 70%
+  );
+  transform: translateX(-100%);
+  animation: skel-shimmer 1.35s ease-in-out infinite;
+  will-change: transform;
+}
+
+@keyframes skel-shimmer {
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skel::after {
+    animation: none;
+    transform: translateX(0);
+    background: linear-gradient(
+      120deg,
+      rgba(40, 40, 40, 0.6),
+      rgba(12, 12, 12, 0.2)
+    );
+    opacity: 0.6;
+  }
+}
+
+.skel.rounded-3xl {
+  border-radius: 24px;
+}
+
+.skel.rounded-2xl {
+  border-radius: 18px;
+}
+
+.skel.rounded-xl {
+  border-radius: 14px;
+}
+
+.skel.rounded-lg {
+  border-radius: 10px;
+}
+
+.skel.rounded-md {
+  border-radius: 8px;
+}
+
+.skeleton-swap {
+  position: relative;
+  display: grid;
+}
+
+.skeleton-swap-layer {
+  grid-area: 1 / 1;
+  transition: opacity 200ms ease-in-out;
+}
+
+.skeleton-swap-layer.skeleton-hidden {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.skeleton-swap-layer.skeleton-visible {
+  opacity: 1;
+}
+
+.skeleton-swap-layer[data-layer="skeleton"] {
+  pointer-events: none;
+}
+
+.skeleton-swap-layer[data-layer="content"].disable-interactions {
+  pointer-events: none;
+}
+
+.tasks-rollup-skeleton {
+  display: grid;
+  gap: 12px;
+}
+
+.tasks-rollup-skeleton-metrics {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.tasks-rollup-skeleton-pill {
+  min-height: 68px;
+  padding: 16px;
+  display: grid;
+  align-content: space-between;
+  gap: 10px;
+}
+
+@media (max-width: 768px) {
+  .tasks-rollup-skeleton-metrics {
+    display: flex;
+    gap: 10px;
+    overflow-x: auto;
+    padding-bottom: 2px;
+  }
+
+  .tasks-rollup-skeleton-pill {
+    min-width: 160px;
+  }
+}


### PR DESCRIPTION
## Summary
- add a shared `SkeletonSwap` wrapper and shimmer styling to support zero-layout-shift skeleton states
- create geometry-matched skeleton components for the week widget, projects panel, and tasks rollup cards
- wrap the dashboard home mobile widgets with `SkeletonSwap` and reserve layout space while data loads

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e07e7ad6488324be68e6092460b27f