### PR TITLE
feat: add dashboard skeleton loaders

### DIFF
--- a/frontend/src/dashboard/home/components/MobileTasksOverviewCard.tsx
+++ b/frontend/src/dashboard/home/components/MobileTasksOverviewCard.tsx
@@ -6,11 +6,16 @@ import styles from "./MobileTasksOverviewCard.module.css";
 
 type MobileTasksOverviewCardProps = {
   className?: string;
+  onLoadingChange?: (loading: boolean) => void;
 };
 
-const MobileTasksOverviewCard: React.FC<MobileTasksOverviewCardProps> = ({ className }) => {
+const MobileTasksOverviewCard: React.FC<MobileTasksOverviewCardProps> = ({ className, onLoadingChange }) => {
   const { loading, error, stats, groups } = useTasksOverview();
   const location = useLocation();
+
+  React.useEffect(() => {
+    onLoadingChange?.(loading);
+  }, [loading, onLoadingChange]);
 
   const formatStatValue = (value: number): string | number => {
     if (error) return "—";

--- a/frontend/src/dashboard/home/components/ProjectsPanel.skeleton.tsx
+++ b/frontend/src/dashboard/home/components/ProjectsPanel.skeleton.tsx
@@ -1,0 +1,110 @@
+import React from "react";
+
+import desktopStyles from "./ProjectsPanelDesktop.module.css";
+import mobileStyles from "./projects-panel.module.css";
+
+type ProjectsPanelSkeletonProps = {
+  variant?: "desktop" | "mobile";
+  className?: string;
+};
+
+const AVATAR_COUNT = 6;
+const ROW_COUNT = 5;
+const KPI_COUNT = 3;
+
+const ProjectsPanelSkeleton: React.FC<ProjectsPanelSkeletonProps> = ({ variant = "desktop", className = "" }) => {
+  if (variant === "mobile") {
+    const classes = [
+      mobileStyles.panel,
+      mobileStyles.panelFullBleed,
+      "skeleton-projects-panel",
+      "skeleton-projects-panel--mobile",
+      className,
+    ]
+      .filter(Boolean)
+      .join(" ");
+
+    return (
+      <section className={classes} aria-hidden="true">
+        <header className={mobileStyles.header}>
+          <div className={mobileStyles.titleWrap}>
+            <span className="skel skel-rounded-md skeleton-projects-panel__title" />
+            <div className="skeleton-projects-panel__avatars">
+              {Array.from({ length: AVATAR_COUNT }).map((_, index) => (
+                <span key={index} className="skel skel-rounded-lg skeleton-projects-panel__avatar" />
+              ))}
+            </div>
+          </div>
+          <span className="skel skel-rounded-full skeleton-projects-panel__tag" />
+        </header>
+        <div className={mobileStyles.kpis}>
+          {Array.from({ length: KPI_COUNT }).map((_, index) => (
+            <span key={index} className="skel skel-rounded-full skeleton-projects-panel__tag" style={{ width: "96px", height: "18px" }} />
+          ))}
+        </div>
+        <div className="skeleton-projects-panel__list">
+          {Array.from({ length: ROW_COUNT }).map((_, index) => (
+            <div key={index} className="skeleton-projects-panel__row">
+              <span className="skel skel-rounded-lg skeleton-projects-panel__icon" />
+              <div className="skeleton-projects-panel__text">
+                <span className="skel skel-rounded-md skeleton-projects-panel__line" />
+                <span className="skel skel-rounded-md skeleton-projects-panel__line skeleton-projects-panel__line--sm" />
+              </div>
+            </div>
+          ))}
+        </div>
+        <span className="skel skel-rounded-xl skeleton-projects-panel__footer" />
+      </section>
+    );
+  }
+
+  const classes = [
+    desktopStyles.card,
+    "week-widget",
+    "week-widget--desktop",
+    "skeleton-projects-panel",
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <section className={classes} aria-hidden="true">
+      <header className={desktopStyles.header}>
+        <div className={desktopStyles.headerTop}>
+          <div className={mobileStyles.titleWrap}>
+            <span className="skel skel-rounded-md skeleton-projects-panel__title" />
+            <div className="skeleton-projects-panel__avatars">
+              {Array.from({ length: AVATAR_COUNT }).map((_, index) => (
+                <span key={index} className="skel skel-rounded-lg skeleton-projects-panel__avatar" />
+              ))}
+            </div>
+          </div>
+          <span className="skel skel-rounded-full skeleton-projects-panel__tag" />
+        </div>
+        <div className={mobileStyles.kpis}>
+          {Array.from({ length: KPI_COUNT }).map((_, index) => (
+            <span key={index} className="skel skel-rounded-full skeleton-projects-panel__tag" style={{ width: "110px", height: "20px" }} />
+          ))}
+        </div>
+      </header>
+      <div className={desktopStyles.content}>
+        <div className="skeleton-projects-panel__list">
+          {Array.from({ length: ROW_COUNT }).map((_, index) => (
+            <div key={index} className="skeleton-projects-panel__row">
+              <span className="skel skel-rounded-lg skeleton-projects-panel__icon" />
+              <div className="skeleton-projects-panel__text">
+                <span className="skel skel-rounded-md skeleton-projects-panel__line" />
+                <span className="skel skel-rounded-md skeleton-projects-panel__line skeleton-projects-panel__line--sm" />
+              </div>
+              <span className="skel skel-rounded-md skeleton-projects-panel__date" />
+            </div>
+          ))}
+        </div>
+      </div>
+      <span className="skel skel-rounded-xl skeleton-projects-panel__footer" />
+    </section>
+  );
+};
+
+export default ProjectsPanelSkeleton;

--- a/frontend/src/dashboard/home/components/TasksOverviewCard.tsx
+++ b/frontend/src/dashboard/home/components/TasksOverviewCard.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { Plus, MoreHorizontal } from "lucide-react";
 
@@ -10,13 +10,18 @@ import styles from "./TasksOverviewCard.module.css";
 
 type TasksOverviewCardProps = {
   className?: string;
+  onLoadingChange?: (loading: boolean) => void;
 };
-const TasksOverviewCard: React.FC<TasksOverviewCardProps> = ({ className }) => {
+const TasksOverviewCard: React.FC<TasksOverviewCardProps> = ({ className, onLoadingChange }) => {
   const { loading, error, stats, groups, refreshTasks, projectOptions, getTaskById } =
     useTasksOverview();
   const location = useLocation();
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
   const [taskToEdit, setTaskToEdit] = useState<QuickCreateTaskModalTask | null>(null);
+
+  useEffect(() => {
+    onLoadingChange?.(loading);
+  }, [loading, onLoadingChange]);
 
   const openCreateModal = useCallback(() => {
     setTaskToEdit(null);

--- a/frontend/src/dashboard/home/components/TasksRollup.skeleton.tsx
+++ b/frontend/src/dashboard/home/components/TasksRollup.skeleton.tsx
@@ -1,0 +1,73 @@
+import React from "react";
+
+import desktopStyles from "./TasksOverviewCard.module.css";
+import mobileStyles from "./MobileTasksOverviewCard.module.css";
+
+type TasksRollupSkeletonProps = {
+  variant?: "desktop" | "mobile";
+  className?: string;
+};
+
+const METRIC_COUNT = 3;
+const GROUP_COUNT = 2;
+const CHIPS_PER_GROUP = 3;
+
+const TasksRollupSkeleton: React.FC<TasksRollupSkeletonProps> = ({ variant = "desktop", className = "" }) => {
+  if (variant === "mobile") {
+    const classes = [mobileStyles.card, "skeleton-tasks", "skeleton-tasks--mobile", className]
+      .filter(Boolean)
+      .join(" ");
+
+    return (
+      <section className={classes} aria-hidden="true">
+        <header className={mobileStyles.header}>
+          <span className="skel skel-rounded-md skeleton-tasks__title" />
+          <span className="skel skel-rounded-full" style={{ width: "64px", height: "16px" }} />
+        </header>
+        <div className={`${mobileStyles.statRow} skeleton-tasks__metrics`}>
+          {Array.from({ length: METRIC_COUNT }).map((_, index) => (
+            <span key={index} className="skel skel-rounded-xl skeleton-tasks__metric" />
+          ))}
+        </div>
+        <span className="skel skel-rounded-md skeleton-tasks__caption" />
+      </section>
+    );
+  }
+
+  const classes = [desktopStyles.card, "skeleton-tasks", className].filter(Boolean).join(" ");
+
+  return (
+    <section className={classes} aria-hidden="true">
+      <header className={desktopStyles.header}>
+        <div className={desktopStyles.titleWrap}>
+          <span className="skel skel-rounded-md skeleton-tasks__title" />
+          <span className="skel skel-rounded-md skeleton-tasks__subtitle" />
+        </div>
+        <div className="skeleton-tasks__actions">
+          <span className="skel skel-rounded-lg skeleton-tasks__action" />
+          <span className="skel skel-rounded-lg skeleton-tasks__action" />
+        </div>
+      </header>
+      <div className={`${desktopStyles.statGrid} skeleton-tasks__metrics`}>
+        {Array.from({ length: METRIC_COUNT }).map((_, index) => (
+          <span key={index} className="skel skel-rounded-xl skeleton-tasks__metric" />
+        ))}
+      </div>
+      <div style={{ display: "flex", flexDirection: "column", gap: "14px" }}>
+        {Array.from({ length: GROUP_COUNT }).map((_, index) => (
+          <div key={index} className="skeleton-tasks__group">
+            <span className="skel skel-rounded-md skeleton-tasks__group-label" />
+            <div className="skeleton-tasks__group-chips">
+              {Array.from({ length: CHIPS_PER_GROUP }).map((__, chipIndex) => (
+                <span key={chipIndex} className="skel skel-rounded-full skeleton-tasks__group-chip" />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+      <span className="skel skel-rounded-md skeleton-tasks__caption" />
+    </section>
+  );
+};
+
+export default TasksRollupSkeleton;

--- a/frontend/src/dashboard/home/components/WeekWidget.skeleton.tsx
+++ b/frontend/src/dashboard/home/components/WeekWidget.skeleton.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+
+import "./week-widget.css";
+
+type WeekWidgetSkeletonProps = {
+  variant?: "desktop" | "mobile";
+  className?: string;
+};
+
+const DAY_COUNT = 7;
+
+const WeekWidgetSkeleton: React.FC<WeekWidgetSkeletonProps> = ({ variant = "desktop", className = "" }) => {
+  const classes = [
+    "week-widget",
+    variant === "desktop" ? "week-widget--desktop" : "week-widget--mobile",
+    "skeleton-week-widget",
+    className,
+    variant === "mobile" ? "skeleton-week-widget--mobile" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <div className={classes} aria-hidden="true">
+      <div className="skeleton-week-widget__header">
+        <div style={{ display: "flex", flexDirection: "column", gap: "6px", flex: "1 1 auto" }}>
+          <span className="skel skel-rounded-md skeleton-week-widget__title" />
+          <span className="skel skel-rounded-md skeleton-week-widget__subtitle" />
+        </div>
+        <div className="skeleton-week-widget__actions">
+          <span className="skel skel-rounded-lg skeleton-week-widget__button" />
+          <span className="skel skel-rounded-lg skeleton-week-widget__button" />
+        </div>
+      </div>
+      <div className="skeleton-week-widget__days">
+        {Array.from({ length: DAY_COUNT }).map((_, index) => (
+          <span key={index} className="skel skel-rounded-2xl skeleton-week-widget__day" />
+        ))}
+      </div>
+      <div className="skeleton-week-widget__bars">
+        <span className="skel skel-rounded-full skeleton-week-widget__bar" />
+        <span className="skel skel-rounded-full skeleton-week-widget__bar skeleton-week-widget__bar--short" />
+      </div>
+    </div>
+  );
+};
+
+export default WeekWidgetSkeleton;

--- a/frontend/src/dashboard/home/pages/DashboardHome.tsx
+++ b/frontend/src/dashboard/home/pages/DashboardHome.tsx
@@ -23,6 +23,10 @@ import DashboardNavPanel from "@/shared/ui/DashboardNavPanel";
 import ProjectsPanelDesktop from "@/dashboard/home/components/ProjectsPanelDesktop";
 import { getColor } from "@/shared/utils/colorUtils";
 import { useNavCollapsed } from "@/shared/hooks/useNavCollapsed";
+import SkeletonSwap from "@/shared/ui/SkeletonSwap";
+import WeekWidgetSkeleton from "@/dashboard/home/components/WeekWidget.skeleton";
+import ProjectsPanelSkeleton from "@/dashboard/home/components/ProjectsPanel.skeleton";
+import TasksRollupSkeleton from "@/dashboard/home/components/TasksRollup.skeleton";
 
 import "./dashboard-styles.css";
 
@@ -90,6 +94,7 @@ const WelcomeScreen: React.FC = () => {
     allUsers,
     projects,
     fetchProjectDetails,
+    isLoading: projectsLoading,
   } = useData();
 
   const location = useLocation();
@@ -193,11 +198,16 @@ const WelcomeScreen: React.FC = () => {
   );
   const [isNavigationOpen, setIsNavigationOpen] = useState(false);
   const [isNavCollapsed, setIsNavCollapsed] = useNavCollapsed("dashboard");
+  const [isTasksLoading, setIsTasksLoading] = useState(true);
   const rawDrawerId = useId();
   const drawerId = React.useMemo(
     () => `dashboard-nav-${rawDrawerId.replace(/[^a-zA-Z0-9_-]/g, "")}`,
     [rawDrawerId]
   );
+
+  useEffect(() => {
+    setIsTasksLoading(true);
+  }, [isDesktop]);
 
   useEffect(() => {
     if (typeof window === "undefined") {
@@ -313,26 +323,48 @@ const WelcomeScreen: React.FC = () => {
             id="calendar"
             className="welcome-section-anchor welcome-desktop-header"
           >
-            <WeekWidgetDesktop
-              weekOf={weekOf}
-              tracks={tracks}
-              dots={dots}
-              onPrevWeek={(d) => setWeekOf(d)}
-              onNextWeek={(d) => setWeekOf(d)}
-              onSelectDate={(d) => setWeekOf(d)}
-              getTooltipItems={getTooltipItems}
-            />
+            <SkeletonSwap
+              ready={!projectsLoading}
+              skeleton={
+                <WeekWidgetSkeleton
+                  variant="desktop"
+                  className="skeleton-reserve-week-widget"
+                />
+              }
+              className="skeleton-reserve-week-widget"
+            >
+              <WeekWidgetDesktop
+                weekOf={weekOf}
+                tracks={tracks}
+                dots={dots}
+                onPrevWeek={(d) => setWeekOf(d)}
+                onNextWeek={(d) => setWeekOf(d)}
+                onSelectDate={(d) => setWeekOf(d)}
+                getTooltipItems={getTooltipItems}
+              />
+            </SkeletonSwap>
           </section>
           <section
             id="projects"
             className="welcome-section-anchor welcome-desktop-projects"
           >
             <div className="welcome-desktop-projects-scroll">
-              <ProjectsPanelDesktop
-                onOpenProject={(projectId) =>
-                  handleNavigateToProject({ projectId })
+              <SkeletonSwap
+                ready={!projectsLoading}
+                skeleton={
+                  <ProjectsPanelSkeleton
+                    variant="desktop"
+                    className="skeleton-reserve-projects"
+                  />
                 }
-              />
+                className="skeleton-reserve-projects"
+              >
+                <ProjectsPanelDesktop
+                  onOpenProject={(projectId) =>
+                    handleNavigateToProject({ projectId })
+                  }
+                />
+              </SkeletonSwap>
             </div>
           </section>
 
@@ -340,7 +372,21 @@ const WelcomeScreen: React.FC = () => {
             id="tasks"
             className="welcome-section-anchor welcome-desktop-footer"
           >
-            <TasksOverviewCard className="welcome-header-tasks-card" />
+            <SkeletonSwap
+              ready={!isTasksLoading}
+              skeleton={
+                <TasksRollupSkeleton
+                  variant="desktop"
+                  className="welcome-header-tasks-card skeleton-reserve-tasks"
+                />
+              }
+              className="welcome-header-tasks-card skeleton-reserve-tasks"
+            >
+              <TasksOverviewCard
+                className="welcome-header-tasks-card"
+                onLoadingChange={setIsTasksLoading}
+              />
+            </SkeletonSwap>
           </section>
         </div>
       );
@@ -349,20 +395,53 @@ const WelcomeScreen: React.FC = () => {
     return (
       <div className="mobile-welcome-layout">
         <div className="mobile-calendar-section">
-          <AllProjectsWeekWidget />
+          <SkeletonSwap
+            ready={!projectsLoading}
+            skeleton={
+              <WeekWidgetSkeleton
+                variant="mobile"
+                className="skeleton-reserve-week-widget"
+              />
+            }
+            className="skeleton-reserve-week-widget"
+          >
+            <AllProjectsWeekWidget />
+          </SkeletonSwap>
         </div>
         <div className="mobile-projects-tasks">
           <div className="mobile-projects-section">
             <div className="mobile-projects-panel">
-              <ProjectsPanelMobile
-                onOpenProject={(projectId) =>
-                  handleNavigateToProject({ projectId })
+              <SkeletonSwap
+                ready={!projectsLoading}
+                skeleton={
+                  <ProjectsPanelSkeleton
+                    variant="mobile"
+                    className="skeleton-reserve-projects"
+                  />
                 }
-              />
+                className="skeleton-reserve-projects"
+              >
+                <ProjectsPanelMobile
+                  onOpenProject={(projectId) =>
+                    handleNavigateToProject({ projectId })
+                  }
+                />
+              </SkeletonSwap>
             </div>
           </div>
           <div className="mobile-tasks-section dashboard-footer">
-            <MobileTasksOverviewCard />
+            <SkeletonSwap
+              ready={!isTasksLoading}
+              skeleton={
+                <TasksRollupSkeleton
+                  variant="mobile"
+                  className="skeleton-reserve-tasks"
+                />
+              }
+              className="skeleton-reserve-tasks"
+            >
+              <MobileTasksOverviewCard onLoadingChange={setIsTasksLoading} />
+            </SkeletonSwap>
           </div>
         </div>
       </div>

--- a/frontend/src/dashboard/project/project.tsx
+++ b/frontend/src/dashboard/project/project.tsx
@@ -24,6 +24,8 @@ import { useProjectPalette } from "@/dashboard/project/hooks/useProjectPalette";
 import { resolveProjectCoverUrl } from "@/dashboard/project/utils/theme";
 import { getProjectDashboardPath } from "@/shared/utils/projectUrl";
 import Spinner from "@/shared/ui/Spinner";
+import SkeletonSwap from "@/shared/ui/SkeletonSwap";
+import WeekWidgetSkeleton from "@/dashboard/home/components/WeekWidget.skeleton";
 
 const MOBILE_LAYOUT_WIDTH = 640;
 const TASKS_MOBILE_WIDTH = 768;
@@ -310,15 +312,28 @@ const SingleProject: React.FC = () => {
     />
   ) : null;
 
-  const calendarWeekWidget = calendarProject ? (
-    <ProjectWeekWidget
-      project={calendarProject}
-      initialFlashDate={flashDate}
-      showEventList={false}
-      onWrapperClick={openCalendarPage}
-      onDateSelect={noop}
-    />
-  ) : null;
+  const calendarWeekWidget = (
+    <SkeletonSwap
+      ready={Boolean(calendarProject)}
+      skeleton={
+        <WeekWidgetSkeleton
+          variant={isMobileBudgetLayout ? "mobile" : "desktop"}
+          className="skeleton-reserve-week-widget"
+        />
+      }
+      className="skeleton-reserve-week-widget"
+    >
+      {calendarProject ? (
+        <ProjectWeekWidget
+          project={calendarProject}
+          initialFlashDate={flashDate}
+          showEventList={false}
+          onWrapperClick={openCalendarPage}
+          onDateSelect={noop}
+        />
+      ) : null}
+    </SkeletonSwap>
+  );
 
   const shouldShowLoader = Boolean(
     projectId &&

--- a/frontend/src/shared/styles/index.css
+++ b/frontend/src/shared/styles/index.css
@@ -32,6 +32,9 @@
 
 @import './components/blog-row-layouts.css';
 
+/* Loading states */
+@import '../../styles/skeleton.css';
+
 /* Marketing Page Styles */
 @import './marketing/index.css';
 

--- a/frontend/src/shared/ui/SkeletonSwap.tsx
+++ b/frontend/src/shared/ui/SkeletonSwap.tsx
@@ -1,0 +1,81 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
+
+type SkeletonSwapProps = {
+  ready: boolean;
+  skeleton: React.ReactNode;
+  children: React.ReactNode;
+  className?: string;
+  minShowMs?: number;
+};
+
+const DEFAULT_MIN_SHOW = 300;
+
+export default function SkeletonSwap({
+  ready,
+  skeleton,
+  children,
+  className = "",
+  minShowMs = DEFAULT_MIN_SHOW,
+}: SkeletonSwapProps) {
+  const [showSkeleton, setShowSkeleton] = useState(!ready);
+  const visibleSinceRef = useRef<number | null>(!ready ? Date.now() : null);
+
+  useEffect(() => {
+    let timeout: number | undefined;
+
+    if (!ready) {
+      visibleSinceRef.current = Date.now();
+      setShowSkeleton(true);
+      return () => {
+        if (timeout) window.clearTimeout(timeout);
+      };
+    }
+
+    const since = visibleSinceRef.current;
+    const elapsed = since ? Date.now() - since : minShowMs;
+    const remaining = Math.max(0, minShowMs - elapsed);
+
+    timeout = window.setTimeout(() => {
+      setShowSkeleton(false);
+      visibleSinceRef.current = null;
+    }, remaining);
+
+    return () => {
+      if (timeout) window.clearTimeout(timeout);
+    };
+  }, [ready, minShowMs]);
+
+  const containerClassName = useMemo(() => {
+    return ["skeleton-swap", className].filter(Boolean).join(" ");
+  }, [className]);
+
+  const contentReady = ready && !showSkeleton;
+
+  return (
+    <div
+      className={containerClassName}
+      aria-busy={!contentReady}
+      role="status"
+    >
+      <div
+        className="skeleton-layer"
+        style={{
+          opacity: showSkeleton ? 1 : 0,
+          pointerEvents: "none",
+        }}
+        aria-hidden={contentReady}
+      >
+        {skeleton}
+      </div>
+      <div
+        className="skeleton-content"
+        style={{
+          opacity: contentReady ? 1 : 0,
+          pointerEvents: contentReady ? undefined : "none",
+        }}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/styles/skeleton.css
+++ b/frontend/src/styles/skeleton.css
@@ -1,0 +1,414 @@
+/* Neutral shimmer skeleton styles */
+.skel {
+  position: relative;
+  display: block;
+  background: linear-gradient(120deg, #0c0c0c 25%, #161616 37%, #0c0c0c 63%);
+  background-size: 200% 100%;
+  animation: skel-shimmer 1.4s ease-in-out infinite;
+  color: transparent;
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+@keyframes skel-shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skel {
+    animation: none;
+    background: #141414;
+  }
+}
+
+.skel-rounded-3xl {
+  border-radius: 28px;
+}
+
+.skel-rounded-2xl {
+  border-radius: 20px;
+}
+
+.skel-rounded-xl {
+  border-radius: 16px;
+}
+
+.skel-rounded-lg {
+  border-radius: 14px;
+}
+
+.skel-rounded-md {
+  border-radius: 10px;
+}
+
+.skel-rounded-full {
+  border-radius: 999px;
+}
+
+.skeleton-swap {
+  position: relative;
+  display: grid;
+  width: 100%;
+}
+
+.skeleton-swap > .skeleton-layer,
+.skeleton-swap > .skeleton-content {
+  grid-area: 1 / 1;
+  transition: opacity 200ms ease;
+}
+
+.skeleton-layer {
+  pointer-events: none;
+}
+
+.skeleton-content {
+  position: relative;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skeleton-swap > .skeleton-layer,
+  .skeleton-swap > .skeleton-content {
+    transition: none;
+  }
+}
+
+/* Week widget skeleton */
+.skeleton-week-widget {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  width: 100%;
+  height: 100%;
+}
+
+.skeleton-week-widget__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.skeleton-week-widget__title {
+  width: min(200px, 60%);
+  height: 18px;
+}
+
+.skeleton-week-widget__subtitle {
+  width: min(160px, 50%);
+  height: 12px;
+  border-radius: 8px;
+}
+
+.skeleton-week-widget__actions {
+  display: inline-flex;
+  gap: 8px;
+}
+
+.skeleton-week-widget__button {
+  width: 36px;
+  height: 36px;
+  border-radius: 12px;
+}
+
+.skeleton-week-widget__days {
+  display: flex;
+  gap: 8px;
+}
+
+.skeleton-week-widget__day {
+  flex: 1 1 0;
+  height: 72px;
+  border-radius: 18px;
+}
+
+.skeleton-week-widget__bars {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: auto;
+}
+
+.skeleton-week-widget__bar {
+  height: 8px;
+  border-radius: 999px;
+}
+
+.skeleton-week-widget__bar--short {
+  width: 72%;
+}
+
+.skeleton-week-widget--mobile .skeleton-week-widget__header {
+  align-items: flex-start;
+}
+
+.skeleton-week-widget--mobile .skeleton-week-widget__button {
+  width: 32px;
+  height: 32px;
+}
+
+.skeleton-week-widget--mobile .skeleton-week-widget__day {
+  height: 64px;
+}
+
+.skeleton-week-widget--mobile .skeleton-week-widget__bars {
+  gap: 6px;
+}
+
+/* Projects panel skeleton */
+.skeleton-projects-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  width: 100%;
+  height: 100%;
+}
+
+.skeleton-projects-panel__header {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.skeleton-projects-panel__title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.skeleton-projects-panel__title {
+  width: 150px;
+  height: 18px;
+}
+
+.skeleton-projects-panel__tag {
+  width: 90px;
+  height: 14px;
+  border-radius: 12px;
+}
+
+.skeleton-projects-panel__avatars {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  overflow: hidden;
+}
+
+.skeleton-projects-panel__avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 12px;
+  flex: 0 0 auto;
+}
+
+.skeleton-projects-panel__list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.skeleton-projects-panel__row {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 12px;
+  align-items: center;
+  padding: 6px 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.skeleton-projects-panel__row:last-child {
+  border-bottom: none;
+}
+
+.skeleton-projects-panel__icon {
+  width: 38px;
+  height: 38px;
+  border-radius: 12px;
+}
+
+.skeleton-projects-panel__text {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.skeleton-projects-panel__line {
+  height: 12px;
+  border-radius: 8px;
+}
+
+.skeleton-projects-panel__line--sm {
+  width: 50%;
+}
+
+.skeleton-projects-panel__date {
+  width: 72px;
+  height: 12px;
+  border-radius: 8px;
+  justify-self: end;
+}
+
+.skeleton-projects-panel__footer {
+  margin-top: auto;
+  height: 44px;
+  border-radius: 16px;
+}
+
+.skeleton-projects-panel--mobile .skeleton-projects-panel__row {
+  grid-template-columns: auto 1fr;
+  gap: 10px;
+}
+
+.skeleton-projects-panel--mobile .skeleton-projects-panel__date {
+  justify-self: start;
+  width: 58px;
+  height: 11px;
+}
+
+.skeleton-projects-panel--mobile .skeleton-projects-panel__footer {
+  height: 38px;
+}
+
+/* Tasks rollup skeleton */
+.skeleton-tasks {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  width: 100%;
+  height: 100%;
+}
+
+.skeleton-tasks__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.skeleton-tasks__title {
+  width: 140px;
+  height: 18px;
+}
+
+.skeleton-tasks__subtitle {
+  width: 220px;
+  height: 12px;
+  border-radius: 8px;
+}
+
+.skeleton-tasks__actions {
+  display: inline-flex;
+  gap: 8px;
+}
+
+.skeleton-tasks__action {
+  width: 36px;
+  height: 36px;
+  border-radius: 12px;
+}
+
+.skeleton-tasks__metrics {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}
+
+.skeleton-tasks__metric {
+  height: 78px;
+  border-radius: 18px;
+}
+
+.skeleton-tasks__group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.skeleton-tasks__group-label {
+  width: 110px;
+  height: 11px;
+  border-radius: 8px;
+}
+
+.skeleton-tasks__group-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.skeleton-tasks__group-chip {
+  flex: 0 0 140px;
+  height: 34px;
+  border-radius: 16px;
+}
+
+.skeleton-tasks__caption {
+  width: 60%;
+  height: 12px;
+  border-radius: 8px;
+}
+
+.skeleton-tasks--mobile {
+  gap: 12px;
+}
+
+.skeleton-tasks--mobile .skeleton-tasks__header {
+  align-items: center;
+}
+
+.skeleton-tasks--mobile .skeleton-tasks__actions {
+  display: none;
+}
+
+.skeleton-tasks--mobile .skeleton-tasks__metrics {
+  display: flex;
+  gap: 8px;
+  overflow-x: auto;
+  padding-bottom: 4px;
+}
+
+.skeleton-tasks--mobile .skeleton-tasks__metric {
+  flex: 0 0 120px;
+  height: 64px;
+}
+
+.skeleton-tasks--mobile .skeleton-tasks__group,
+.skeleton-tasks--mobile .skeleton-tasks__group-chips {
+  display: none;
+}
+
+.skeleton-tasks--mobile .skeleton-tasks__caption {
+  width: 80%;
+}
+
+/* Reserved height helpers */
+.skeleton-reserve-week-widget {
+  min-height: 220px;
+}
+
+.skeleton-reserve-projects {
+  min-height: 340px;
+}
+
+.skeleton-reserve-tasks {
+  min-height: 220px;
+}
+
+@media (max-width: 767px) {
+  .skeleton-reserve-week-widget {
+    min-height: 190px;
+  }
+
+  .skeleton-reserve-projects {
+    min-height: 300px;
+  }
+
+  .skeleton-reserve-tasks {
+    min-height: 180px;
+  }
+}


### PR DESCRIPTION
## Summary
- add reusable shimmer styles and a `SkeletonSwap` wrapper for zero-shift loading states
- create week widget, projects panel, and tasks rollup skeleton components and wire them into the dashboard
- surface loading state from task overview cards and reuse the week skeleton in the project view

## Testing
- `npm run typecheck` *(fails: existing type errors in tasks and budget modules)*

------
https://chatgpt.com/codex/tasks/task_e_68e0847977148324896d1c5a9a2caf4a