### PR TITLE
Add skeleton loaders for dashboard surfaces

### DIFF
--- a/frontend/src/dashboard/home/components/ProjectsPanel.skeleton.tsx
+++ b/frontend/src/dashboard/home/components/ProjectsPanel.skeleton.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+
+import { cn } from "@/components/ui/utils";
+
+type ProjectsPanelSkeletonProps = {
+  variant?: "desktop" | "mobile";
+  className?: string;
+};
+
+const ProjectsPanelSkeleton: React.FC<ProjectsPanelSkeletonProps> = ({
+  variant = "desktop",
+  className,
+}) => {
+  const avatarCount = variant === "desktop" ? 7 : 5;
+  const rowCount = variant === "desktop" ? 5 : 4;
+
+  return (
+    <div
+      className={cn(
+        "relative flex w-full flex-col gap-6 rounded-[24px] border border-white/10 p-5 shadow-[0_16px_48px_rgba(0,0,0,0.35)] backdrop-blur-sm",
+        variant === "mobile" ? "p-4" : "p-6",
+        className
+      )}
+      style={{ background: "var(--bg2, #111111)" }}
+    >
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div className="space-y-2">
+          <div className="skel h-5 w-32 rounded-md" />
+          <div className="skel h-3 w-24 rounded-md" />
+        </div>
+        <div className="skel h-6 w-20 rounded-full" />
+      </div>
+
+      <div className="flex items-center gap-3">
+        {Array.from({ length: avatarCount }).map((_, index) => (
+          <div key={index} className="skel h-10 w-10 rounded-full" />
+        ))}
+      </div>
+
+      <div className="flex flex-col gap-4">
+        {Array.from({ length: rowCount }).map((_, index) => (
+          <div key={index} className="flex items-center gap-4">
+            <div className="skel h-10 w-10 rounded-2xl" />
+            <div className="flex flex-1 items-center justify-between gap-4">
+              <div className="flex flex-1 flex-col gap-2">
+                <div className="skel h-3 w-40 max-w-[16rem] rounded-md" />
+                <div className="skel h-3 w-28 max-w-[10rem] rounded-md" />
+              </div>
+              <div className="skel h-3 w-20 rounded-md" />
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="skel h-11 w-full rounded-2xl" />
+    </div>
+  );
+};
+
+export default ProjectsPanelSkeleton;

--- a/frontend/src/dashboard/home/components/TasksRollup.skeleton.tsx
+++ b/frontend/src/dashboard/home/components/TasksRollup.skeleton.tsx
@@ -1,0 +1,88 @@
+import React from "react";
+
+import { cn } from "@/components/ui/utils";
+
+type TasksRollupSkeletonProps = {
+  variant?: "desktop" | "mobile";
+  className?: string;
+};
+
+const TasksRollupSkeleton: React.FC<TasksRollupSkeletonProps> = ({
+  variant = "desktop",
+  className,
+}) => {
+  if (variant === "mobile") {
+    return (
+      <div
+        className={cn(
+          "flex w-full flex-col gap-4 rounded-[24px] border border-white/10 p-4 shadow-[0_16px_40px_rgba(0,0,0,0.35)] backdrop-blur-sm",
+          className
+        )}
+        style={{ background: "var(--bg2, #111111)" }}
+      >
+        <div className="flex items-center justify-between gap-3">
+          <div className="skel h-5 w-24 rounded-md" />
+          <div className="skel h-6 w-16 rounded-md" />
+        </div>
+        <div className="flex gap-3 overflow-hidden">
+          {Array.from({ length: 4 }).map((_, index) => (
+            <div
+              key={index}
+              className="skel h-16 min-w-[120px] flex-1 rounded-2xl"
+            />
+          ))}
+        </div>
+        <div className="skel h-4 w-3/4 rounded-md" />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={cn(
+        "flex w-full flex-col gap-5 rounded-[24px] border border-white/10 p-6 shadow-[0_18px_48px_rgba(0,0,0,0.4)] backdrop-blur-sm",
+        className
+      )}
+      style={{ background: "var(--bg2, #111111)" }}
+    >
+      <div className="flex items-center justify-between gap-4">
+        <div className="space-y-2">
+          <div className="skel h-5 w-28 rounded-md" />
+          <div className="skel h-3 w-20 rounded-md" />
+        </div>
+        <div className="flex items-center gap-2">
+          <div className="skel h-9 w-9 rounded-xl" />
+          <div className="skel h-9 w-9 rounded-xl" />
+        </div>
+      </div>
+
+      <div className="hidden gap-3 md:grid md:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, index) => (
+          <div key={index} className="skel h-20 rounded-2xl" />
+        ))}
+      </div>
+      <div className="flex gap-3 overflow-hidden md:hidden">
+        {Array.from({ length: 4 }).map((_, index) => (
+          <div
+            key={index}
+            className="skel h-16 min-w-[130px] flex-1 rounded-2xl"
+          />
+        ))}
+      </div>
+
+      <div className="space-y-3">
+        {Array.from({ length: 3 }).map((_, index) => (
+          <div key={index} className="flex flex-wrap items-center gap-2">
+            <div className="skel h-3 w-16 rounded-md" />
+            <div className="skel h-7 w-24 rounded-full" />
+            <div className="skel h-7 w-32 rounded-full" />
+          </div>
+        ))}
+      </div>
+
+      <div className="skel h-3 w-36 rounded-md" />
+    </div>
+  );
+};
+
+export default TasksRollupSkeleton;

--- a/frontend/src/dashboard/home/components/WeekWidget.skeleton.tsx
+++ b/frontend/src/dashboard/home/components/WeekWidget.skeleton.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+
+import { cn } from "@/components/ui/utils";
+
+type WeekWidgetSkeletonProps = {
+  variant?: "desktop" | "mobile";
+  className?: string;
+};
+
+const days = Array.from({ length: 7 });
+
+const WeekWidgetSkeleton: React.FC<WeekWidgetSkeletonProps> = ({
+  variant = "desktop",
+  className,
+}) => {
+  const navSize = variant === "desktop" ? "h-10 w-10" : "h-9 w-9";
+  const dayHeight = variant === "desktop" ? "h-20" : "h-16";
+
+  return (
+    <div
+      className={cn(
+        "week-widget",
+        variant === "desktop" ? "week-widget--desktop" : "week-widget--mobile",
+        "relative isolate flex w-full flex-col gap-4 rounded-[24px]",
+        className
+      )}
+    >
+      <div className="flex flex-col gap-3">
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex items-center gap-3">
+            <div className={cn("skel rounded-2xl", navSize)} />
+            <div className="skel h-5 w-40 rounded-md" />
+          </div>
+          <div className={cn("skel rounded-2xl", navSize)} />
+        </div>
+        <div className="skel h-3 w-24 rounded-md" />
+      </div>
+
+      <div
+        className={cn(
+          "grid gap-2",
+          variant === "desktop"
+            ? "grid-cols-7"
+            : "grid-cols-7 sm:grid-cols-7"
+        )}
+      >
+        {days.map((_, index) => (
+          <div
+            key={index}
+            className={cn("skel rounded-2xl", dayHeight)}
+          />
+        ))}
+      </div>
+
+      <div className="mt-2 space-y-2">
+        <div className="skel h-2 w-full rounded-full" />
+        <div className="skel h-2 w-3/4 rounded-full" />
+      </div>
+    </div>
+  );
+};
+
+export default WeekWidgetSkeleton;

--- a/frontend/src/dashboard/home/pages/DashboardHome.tsx
+++ b/frontend/src/dashboard/home/pages/DashboardHome.tsx
@@ -23,6 +23,10 @@ import DashboardNavPanel from "@/shared/ui/DashboardNavPanel";
 import ProjectsPanelDesktop from "@/dashboard/home/components/ProjectsPanelDesktop";
 import { getColor } from "@/shared/utils/colorUtils";
 import { useNavCollapsed } from "@/shared/hooks/useNavCollapsed";
+import SkeletonSwap from "@/shared/ui/SkeletonSwap";
+import WeekWidgetSkeleton from "@/dashboard/home/components/WeekWidget.skeleton";
+import ProjectsPanelSkeleton from "@/dashboard/home/components/ProjectsPanel.skeleton";
+import TasksRollupSkeleton from "@/dashboard/home/components/TasksRollup.skeleton";
 
 import "./dashboard-styles.css";
 
@@ -82,6 +86,7 @@ export const parseDashboardPath = (
 };
 
 const WelcomeScreen: React.FC = () => {
+  const data = useData() as ReturnType<typeof useData> & { isLoading: boolean };
   const {
     userData,
     userName,
@@ -90,12 +95,18 @@ const WelcomeScreen: React.FC = () => {
     allUsers,
     projects,
     fetchProjectDetails,
-  } = useData();
+    isLoading: projectsLoading,
+  } = data;
 
   const location = useLocation();
   const navigate = useNavigate();
 
   const [weekOf, setWeekOf] = useState<Date>(new Date());
+  const [hasMounted, setHasMounted] = useState(false);
+
+  useEffect(() => {
+    setHasMounted(true);
+  }, []);
 
   // Map for consistent colors
   const colorMap = useMemo(() => {
@@ -301,6 +312,11 @@ const WelcomeScreen: React.FC = () => {
     }
   }, [activeView, dmUserSlug, inbox, userData, allUsers, navigate, isMobile]);
 
+  const isHydratingProjects = !hasMounted || projectsLoading;
+  const isWeekLoading = isHydratingProjects;
+  const isProjectsPanelLoading = isHydratingProjects;
+  const isTasksLoading = isHydratingProjects;
+
   if (loadingProfile) return <SpinnerScreen />;
   if (userData?.pending) return <PendingApprovalScreen />;
 
@@ -313,26 +329,38 @@ const WelcomeScreen: React.FC = () => {
             id="calendar"
             className="welcome-section-anchor welcome-desktop-header"
           >
-            <WeekWidgetDesktop
-              weekOf={weekOf}
-              tracks={tracks}
-              dots={dots}
-              onPrevWeek={(d) => setWeekOf(d)}
-              onNextWeek={(d) => setWeekOf(d)}
-              onSelectDate={(d) => setWeekOf(d)}
-              getTooltipItems={getTooltipItems}
-            />
+            <SkeletonSwap
+              ready={!isWeekLoading}
+              skeleton={<WeekWidgetSkeleton variant="desktop" className="h-full" />}
+              className="min-h-[220px]"
+            >
+              <WeekWidgetDesktop
+                weekOf={weekOf}
+                tracks={tracks}
+                dots={dots}
+                onPrevWeek={(d) => setWeekOf(d)}
+                onNextWeek={(d) => setWeekOf(d)}
+                onSelectDate={(d) => setWeekOf(d)}
+                getTooltipItems={getTooltipItems}
+              />
+            </SkeletonSwap>
           </section>
           <section
             id="projects"
             className="welcome-section-anchor welcome-desktop-projects"
           >
             <div className="welcome-desktop-projects-scroll">
-              <ProjectsPanelDesktop
-                onOpenProject={(projectId) =>
-                  handleNavigateToProject({ projectId })
-                }
-              />
+              <SkeletonSwap
+                ready={!isProjectsPanelLoading}
+                skeleton={<ProjectsPanelSkeleton variant="desktop" className="h-full" />}
+                className="min-h-[360px]"
+              >
+                <ProjectsPanelDesktop
+                  onOpenProject={(projectId) =>
+                    handleNavigateToProject({ projectId })
+                  }
+                />
+              </SkeletonSwap>
             </div>
           </section>
 
@@ -340,7 +368,13 @@ const WelcomeScreen: React.FC = () => {
             id="tasks"
             className="welcome-section-anchor welcome-desktop-footer"
           >
-            <TasksOverviewCard className="welcome-header-tasks-card" />
+            <SkeletonSwap
+              ready={!isTasksLoading}
+              skeleton={<TasksRollupSkeleton className="h-full" />}
+              className="min-h-[320px]"
+            >
+              <TasksOverviewCard className="welcome-header-tasks-card" />
+            </SkeletonSwap>
           </section>
         </div>
       );
@@ -349,20 +383,38 @@ const WelcomeScreen: React.FC = () => {
     return (
       <div className="mobile-welcome-layout">
         <div className="mobile-calendar-section">
-          <AllProjectsWeekWidget />
+          <SkeletonSwap
+            ready={!isWeekLoading}
+            skeleton={<WeekWidgetSkeleton variant="mobile" className="h-full" />}
+            className="min-h-[200px]"
+          >
+            <AllProjectsWeekWidget />
+          </SkeletonSwap>
         </div>
         <div className="mobile-projects-tasks">
           <div className="mobile-projects-section">
             <div className="mobile-projects-panel">
-              <ProjectsPanelMobile
-                onOpenProject={(projectId) =>
-                  handleNavigateToProject({ projectId })
-                }
-              />
+              <SkeletonSwap
+                ready={!isProjectsPanelLoading}
+                skeleton={<ProjectsPanelSkeleton variant="mobile" className="h-full" />}
+                className="min-h-[320px]"
+              >
+                <ProjectsPanelMobile
+                  onOpenProject={(projectId) =>
+                    handleNavigateToProject({ projectId })
+                  }
+                />
+              </SkeletonSwap>
             </div>
           </div>
           <div className="mobile-tasks-section dashboard-footer">
-            <MobileTasksOverviewCard />
+            <SkeletonSwap
+              ready={!isTasksLoading}
+              skeleton={<TasksRollupSkeleton variant="mobile" className="h-full" />}
+              className="min-h-[220px]"
+            >
+              <MobileTasksOverviewCard />
+            </SkeletonSwap>
           </div>
         </div>
       </div>

--- a/frontend/src/dashboard/project/project.tsx
+++ b/frontend/src/dashboard/project/project.tsx
@@ -24,6 +24,8 @@ import { useProjectPalette } from "@/dashboard/project/hooks/useProjectPalette";
 import { resolveProjectCoverUrl } from "@/dashboard/project/utils/theme";
 import { getProjectDashboardPath } from "@/shared/utils/projectUrl";
 import Spinner from "@/shared/ui/Spinner";
+import SkeletonSwap from "@/shared/ui/SkeletonSwap";
+import WeekWidgetSkeleton from "@/dashboard/home/components/WeekWidget.skeleton";
 
 const MOBILE_LAYOUT_WIDTH = 640;
 const TASKS_MOBILE_WIDTH = 768;
@@ -310,15 +312,28 @@ const SingleProject: React.FC = () => {
     />
   ) : null;
 
-  const calendarWeekWidget = calendarProject ? (
-    <ProjectWeekWidget
-      project={calendarProject}
-      initialFlashDate={flashDate}
-      showEventList={false}
-      onWrapperClick={openCalendarPage}
-      onDateSelect={noop}
-    />
-  ) : null;
+  const calendarWeekWidget = (
+    <SkeletonSwap
+      ready={Boolean(calendarProject) && !isProjectLoading}
+      skeleton={
+        <WeekWidgetSkeleton
+          variant={isMobileBudgetLayout ? "mobile" : "desktop"}
+          className="h-full"
+        />
+      }
+      className="min-h-[200px]"
+    >
+      {calendarProject ? (
+        <ProjectWeekWidget
+          project={calendarProject}
+          initialFlashDate={flashDate}
+          showEventList={false}
+          onWrapperClick={openCalendarPage}
+          onDateSelect={noop}
+        />
+      ) : null}
+    </SkeletonSwap>
+  );
 
   const shouldShowLoader = Boolean(
     projectId &&

--- a/frontend/src/shared/styles/index.css
+++ b/frontend/src/shared/styles/index.css
@@ -29,6 +29,7 @@
 @import './components/grid-layouts.css';
 @import './components/work-layouts.css';
 @import '../ui/squircle/squircle.css';
+@import '../styles/skeleton.css';
 
 @import './components/blog-row-layouts.css';
 

--- a/frontend/src/shared/ui/SkeletonSwap.tsx
+++ b/frontend/src/shared/ui/SkeletonSwap.tsx
@@ -1,0 +1,99 @@
+import React, { useEffect, useRef, useState } from "react";
+
+import { cn } from "@/components/ui/utils";
+
+type SkeletonSwapProps = {
+  ready: boolean;
+  skeleton: React.ReactNode;
+  children: React.ReactNode;
+  className?: string;
+  minShowMs?: number;
+};
+
+const DEFAULT_MIN_SHOW = 300;
+
+const SkeletonSwap: React.FC<SkeletonSwapProps> = ({
+  ready,
+  skeleton,
+  children,
+  className,
+  minShowMs = DEFAULT_MIN_SHOW,
+}) => {
+  const [isReady, setIsReady] = useState<boolean>(() => ready);
+  const skeletonShownAtRef = useRef<number>(ready ? 0 : Date.now());
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+
+    if (!ready) {
+      skeletonShownAtRef.current = Date.now();
+      setIsReady(false);
+      return undefined;
+    }
+
+    const elapsed = Date.now() - skeletonShownAtRef.current;
+    if (elapsed >= minShowMs) {
+      setIsReady(true);
+      return undefined;
+    }
+
+    timeoutRef.current = setTimeout(() => {
+      setIsReady(true);
+      timeoutRef.current = null;
+    }, Math.max(0, minShowMs - elapsed));
+
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
+      }
+    };
+  }, [ready, minShowMs]);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  const isLoading = !isReady;
+
+  return (
+    <div
+      className={cn(
+        "relative grid w-full",
+        className,
+        isLoading ? "pointer-events-none" : undefined
+      )}
+      aria-busy={isLoading}
+      role="status"
+    >
+      <div
+        className={cn(
+          "col-start-1 row-start-1 transition-opacity duration-200 ease-in-out",
+          isReady ? "opacity-0" : "opacity-100"
+        )}
+        aria-hidden={isReady || undefined}
+      >
+        {skeleton}
+      </div>
+      <div
+        className={cn(
+          "col-start-1 row-start-1 transition-opacity duration-200 ease-in-out",
+          isReady ? "opacity-100" : "opacity-0",
+          isReady ? undefined : "pointer-events-none"
+        )}
+      >
+        {children}
+      </div>
+    </div>
+  );
+};
+
+export default SkeletonSwap;

--- a/frontend/src/styles/skeleton.css
+++ b/frontend/src/styles/skeleton.css
@@ -1,0 +1,43 @@
+/* Instagram-style skeleton shimmer */
+:root {
+  --skeleton-base: color-mix(in srgb, #0c0c0c 92%, #1f1f1f 8%);
+  --skeleton-highlight: color-mix(in srgb, #0c0c0c 76%, #383838 24%);
+}
+
+.skel {
+  position: relative;
+  display: block;
+  background: linear-gradient(
+    120deg,
+    var(--skeleton-base) 20%,
+    var(--skeleton-highlight) 35%,
+    var(--skeleton-base) 60%
+  );
+  background-size: 200% 100%;
+  animation: skel-shimmer 1.4s ease-in-out infinite;
+  color: transparent;
+}
+
+.skel::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: transparent;
+}
+
+@keyframes skel-shimmer {
+  0% {
+    background-position: 200% 50%;
+  }
+  100% {
+    background-position: -200% 50%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skel {
+    animation: none;
+    background: var(--skeleton-base);
+  }
+}


### PR DESCRIPTION
## Summary
- add shimmer skeleton styles and a shared SkeletonSwap wrapper for cross-fading content
- implement week, projects panel, and tasks rollup skeleton components for desktop and mobile layouts
- apply SkeletonSwap on dashboard and project pages to prevent layout shift while loading

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e08935cb688324974b0e88dd22d9c6