### PR TITLE
Align budget popover on mobile

### DIFF
--- a/frontend/src/dashboard/project/features/budget/components/BudgetDonut.test.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetDonut.test.tsx
@@ -119,6 +119,38 @@ describe("BudgetDonut", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("aligns the center popover with the viewport edge on mobile widths", async () => {
+    const originalInnerWidth = window.innerWidth;
+
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: 480,
+      writable: true,
+    });
+
+    try {
+      render(
+        <div style={{ width: 320, height: 240 }}>
+          <BudgetDonut data={slices} total={1500} />
+        </div>
+      );
+
+      const centerButton = screen.getByRole("button", { name: /view budget allocation/i });
+      fireEvent.mouseEnter(centerButton);
+
+      const dialog = await screen.findByRole("dialog", { name: "Budget allocation breakdown" });
+
+      expect(dialog.style.transform).toBe("translate(-100%, -50%)");
+      expect(dialog.style.left).toBe("480px");
+    } finally {
+      Object.defineProperty(window, "innerWidth", {
+        configurable: true,
+        value: originalInnerWidth,
+        writable: true,
+      });
+    }
+  });
+
   it("refreshes the center popover when slice labels change", async () => {
     const { rerender } = render(
       <div style={{ width: 320, height: 240 }}>

--- a/frontend/src/dashboard/project/features/budget/components/BudgetDonut.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetDonut.tsx
@@ -204,6 +204,7 @@ const BudgetDonut: React.FC<BudgetDonutProps> = ({
     | {
         top: number;
         left: number;
+        transform: string;
       }
     | null
   >(null);
@@ -350,45 +351,73 @@ const BudgetDonut: React.FC<BudgetDonutProps> = ({
     if (!button || typeof window === "undefined") return;
 
     const rect = button.getBoundingClientRect();
-    const baseTop = rect.top + rect.height / 2;
-    const baseLeft = rect.left + rect.width / 2;
-    const viewportWidth = window.innerWidth;
-    const viewportHeight = window.innerHeight;
+    const visualViewport = typeof window.visualViewport !== "undefined" ? window.visualViewport : null;
+    const viewportOffsetLeft = visualViewport?.offsetLeft ?? 0;
+    const viewportOffsetTop = visualViewport?.offsetTop ?? 0;
+    const viewportWidth = visualViewport?.width ?? window.innerWidth;
+    const viewportHeight = visualViewport?.height ?? window.innerHeight;
     const isMobileViewport = viewportWidth <= 768;
     const margin = 16;
+    const mobileRightMargin = 0;
+
+    const baseTop = rect.top + rect.height / 2 + viewportOffsetTop;
+    const baseLeft = rect.left + rect.width / 2 + viewportOffsetLeft;
+
+    let top = baseTop;
+    let left = baseLeft;
+    let transform = "translate(-50%, -50%)";
+
+    if (isMobileViewport) {
+      transform = "translate(-100%, -50%)";
+      left = viewportOffsetLeft + viewportWidth - mobileRightMargin;
+    }
 
     const clampPosition = () => {
-      let top = baseTop;
-      let left = baseLeft;
-
       const popover = centerPopoverRef.current;
       if (popover) {
-        const halfWidth = popover.offsetWidth / 2;
-        const halfHeight = popover.offsetHeight / 2;
+        const popoverWidth = popover.offsetWidth;
+        const popoverHeight = popover.offsetHeight;
+        const halfWidth = popoverWidth / 2;
+        const halfHeight = popoverHeight / 2;
 
-        const leftMargin = margin;
-        const rightMargin = isMobileViewport ? 0 : margin;
-        const minLeft = leftMargin + halfWidth;
-        const maxLeft = viewportWidth - rightMargin - halfWidth;
-        const minTop = margin + halfHeight;
-        const maxTop = viewportHeight - margin - halfHeight;
+        const safeMinTop = viewportOffsetTop + margin + halfHeight;
+        const safeMaxTop = viewportOffsetTop + viewportHeight - margin - halfHeight;
 
         if (isMobileViewport) {
-          const desiredLeft = viewportWidth - rightMargin - halfWidth;
-          left = Math.min(Math.max(desiredLeft, minLeft), maxLeft);
+          const desiredRightEdge = viewportOffsetLeft + viewportWidth - mobileRightMargin;
+          const minRightEdge = viewportOffsetLeft + margin + popoverWidth;
+          const maxRightEdge = viewportOffsetLeft + viewportWidth - mobileRightMargin;
+          const clampedRightEdge = Math.min(
+            Math.max(desiredRightEdge, minRightEdge),
+            maxRightEdge
+          );
+          left = clampedRightEdge;
         } else {
-          left = Math.min(Math.max(left, minLeft), maxLeft);
+          const minLeft = viewportOffsetLeft + margin + halfWidth;
+          const maxLeft = viewportOffsetLeft + viewportWidth - margin - halfWidth;
+          left = Math.min(Math.max(left, minLeft), Math.max(minLeft, maxLeft));
         }
 
-        top = Math.min(Math.max(top, minTop), maxTop);
+        if (safeMinTop > safeMaxTop) {
+          top = viewportOffsetTop + viewportHeight / 2;
+        } else {
+          top = Math.min(Math.max(top, safeMinTop), safeMaxTop);
+        }
       } else {
-        left = Math.min(Math.max(left, margin), viewportWidth - margin);
-        top = Math.min(Math.max(top, margin), viewportHeight - margin);
+        const safeMinLeft = viewportOffsetLeft + margin;
+        const safeMaxLeft =
+          viewportOffsetLeft + viewportWidth - (isMobileViewport ? mobileRightMargin : margin);
+        const safeMinTop = viewportOffsetTop + margin;
+        const safeMaxTop = viewportOffsetTop + viewportHeight - margin;
+
+        left = Math.min(Math.max(left, safeMinLeft), safeMaxLeft);
+        top = Math.min(Math.max(top, safeMinTop), safeMaxTop);
       }
 
       setCenterPopoverPosition({
         top,
         left,
+        transform,
       });
     };
 
@@ -529,6 +558,7 @@ const BudgetDonut: React.FC<BudgetDonutProps> = ({
               ...centerPopoverStyles,
               top: centerPopoverPosition.top,
               left: centerPopoverPosition.left,
+              transform: centerPopoverPosition.transform,
             }}
             role="dialog"
             aria-label="Budget allocation breakdown"


### PR DESCRIPTION
## Summary
- adjust the budget donut popover positioning to use visual viewport metrics and clamp against the viewport on mobile widths
- store the desired transform for the popover position so mobile viewports can anchor to the right edge without overflow
- add a regression test that verifies the budget allocation popover aligns with the viewport edge on small screens

## Testing
- npm test -- BudgetDonut

------
https://chatgpt.com/codex/tasks/task_e_68e08b26026c83249074eca34e1c667a