### PR TITLE
Improve budget header chip interactions

### DIFF
--- a/frontend/src/dashboard/project/features/budget/components/HeaderStats.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/HeaderStats.tsx
@@ -92,6 +92,29 @@ interface SummaryCardProps {
   active?: boolean;
   className?: string;
   children?: React.ReactNode;
+  ariaLabel?: string;
+  isToggle?: boolean;
+  ariaHasPopup?: React.AriaAttributes["aria-haspopup"];
+}
+
+type MetricField = keyof BudgetItem | "markupAmount" | null;
+
+interface MetricDefinition {
+  title: MetricTitle;
+  tag: string;
+  icon: IconDefinition;
+  color: string;
+  value: string;
+  chartValue: number;
+  description: string;
+  field: MetricField;
+  sticky?: boolean;
+  extra?: React.ReactNode;
+  isPercentage?: boolean;
+  isSelectable?: boolean;
+  onCardClick?: () => void;
+  ariaLabel?: string;
+  ariaHasPopup?: React.AriaAttributes["aria-haspopup"];
 }
 
 interface BudgetHeaderProps {
@@ -182,13 +205,19 @@ const SummaryCard: React.FC<SummaryCardProps> = ({
   active,
   className = "",
   children,
+  ariaLabel,
+  isToggle,
+  ariaHasPopup,
 }) => (
   <div
     className={`${summaryStyles.card} ${active ? summaryStyles.active : ""} ${className}`}
     onClick={onClick}
     role={onClick ? "button" : undefined}
     tabIndex={onClick ? 0 : undefined}
-    aria-label={onClick ? title : undefined}
+    aria-label={onClick ? ariaLabel ?? title : undefined}
+    aria-pressed={onClick && isToggle ? active : undefined}
+    aria-haspopup={onClick ? ariaHasPopup : undefined}
+    data-clickable={onClick ? "true" : "false"}
     onKeyDown={
       onClick
         ? (e) => {
@@ -306,13 +335,41 @@ const BudgetHeader: React.FC<BudgetHeaderProps> = ({
     [budgetItems]
   );
 
+  const openBallparkEditor = useCallback(() => {
+    setBallparkModalOpen(true);
+  }, []);
+
+  const activateBudgetedMetric = useCallback(() => {
+    setMarkupBasis("Budgeted");
+    setSelectedMetric("Budgeted Cost");
+  }, []);
+
+  const activateActualMetric = useCallback(() => {
+    const nextTitle = (showReconciled ? "Reconciled Cost" : "Actual Cost") as MetricTitle;
+    const nextBasis = showReconciled ? "Reconciled" : "Actual";
+    setSelectedMetric(nextTitle);
+    setMarkupBasis(nextBasis);
+  }, [showReconciled]);
+
+  const toggleActualBasis = useCallback(() => {
+    if (!hasReconciled) return;
+    const nextShowReconciled = !showReconciled;
+    setShowReconciled(nextShowReconciled);
+    const nextTitle = nextShowReconciled
+      ? ("Reconciled Cost" as MetricTitle)
+      : ("Actual Cost" as MetricTitle);
+    const nextBasis = nextShowReconciled ? "Reconciled" : "Actual";
+    setSelectedMetric(nextTitle);
+    setMarkupBasis(nextBasis);
+  }, [hasReconciled, showReconciled]);
+
   useEffect(() => {
     if (selectedMetric === "Actual Cost" || selectedMetric === "Reconciled Cost") {
       setSelectedMetric(showReconciled ? "Reconciled Cost" : "Actual Cost");
     }
   }, [showReconciled, selectedMetric]);
 
-  const metrics = useMemo(
+  const metrics = useMemo<MetricDefinition[]>(
     () => [
       {
         title: "Ballpark" as MetricTitle,
@@ -323,11 +380,15 @@ const BudgetHeader: React.FC<BudgetHeaderProps> = ({
         chartValue: toNumber(budgetHeader?.headerBallPark),
         description: "Estimated total",
         field: null,
+        isSelectable: false,
+        onCardClick: openBallparkEditor,
+        ariaLabel: "Open estimate editor",
+        ariaHasPopup: "dialog",
         extra: (
           <button
             className={headerStyles.editButton}
-            onClick={() => setBallparkModalOpen(true)}
-            aria-label="Edit Ballpark"
+            onClick={openBallparkEditor}
+            aria-label="Edit estimate"
             type="button"
           >
             <FontAwesomeIcon icon={faPen} />
@@ -344,6 +405,8 @@ const BudgetHeader: React.FC<BudgetHeaderProps> = ({
         description: "Planned expenses",
         field: "itemBudgetedCost",
         sticky: true,
+        onCardClick: activateBudgetedMetric,
+        ariaLabel: "View budgeted totals",
       },
       {
         title: (showReconciled ? "Reconciled Cost" : "Actual Cost") as MetricTitle,
@@ -359,11 +422,24 @@ const BudgetHeader: React.FC<BudgetHeaderProps> = ({
         description: showReconciled ? "Reconciled spending" : "Recorded spending",
         field: showReconciled ? "itemReconciledCost" : "itemActualCost",
         sticky: true,
+        onCardClick: activateActualMetric,
+        ariaLabel: hasReconciled
+          ? "View actual totals or toggle reconciled totals"
+          : "View actual totals",
         extra: hasReconciled ? (
           <Switch
             size="small"
             checked={showReconciled}
-            onChange={(val) => setShowReconciled(val)}
+            onChange={(val) => {
+              setShowReconciled(val);
+              if (val) {
+                setSelectedMetric("Reconciled Cost");
+                setMarkupBasis("Reconciled");
+              } else {
+                setSelectedMetric("Actual Cost");
+                setMarkupBasis("Actual");
+              }
+            }}
             className={summaryStyles.toggleSwitch}
           />
         ) : null,
@@ -403,6 +479,8 @@ const BudgetHeader: React.FC<BudgetHeaderProps> = ({
         description: "Markup amount",
         field: "markupAmount",
         isPercentage: true,
+        isSelectable: false,
+        ariaLabel: "Effective markup amount",
         extra: (
           <Segmented
             size="small"
@@ -427,6 +505,8 @@ const BudgetHeader: React.FC<BudgetHeaderProps> = ({
         description: "All-in total",
         field: "itemFinalCost",
         sticky: true,
+        ariaLabel: "View final totals",
+        onCardClick: () => setSelectedMetric("Final Cost"),
         extra: (
           <div className={summaryStyles.invoicePreviewContainer}>
             <FontAwesomeIcon
@@ -471,13 +551,16 @@ const BudgetHeader: React.FC<BudgetHeaderProps> = ({
       },
     ],
     [
+      activateActualMetric,
+      activateBudgetedMetric,
       budgetHeader,
-      showReconciled,
-      reconciledTotal,
-      hasReconciled,
       markupBasis,
-      openInvoicePreview,
       onOpenRevisionModal,
+      openBallparkEditor,
+      openInvoicePreview,
+      reconciledTotal,
+      showReconciled,
+      hasReconciled,
     ]
   );
 
@@ -741,41 +824,11 @@ const BudgetHeader: React.FC<BudgetHeaderProps> = ({
     <div className={summaryStyles.container}>
       <div className={summaryStyles.cardsColumn}>
         <div className={summaryStyles.cardsRow}>
-          {metrics.slice(0, 3).map((m) => (
-            <SummaryCard
-              key={m.title}
-              icon={m.icon}
-              color={m.color}
-              title={m.title}
-              tag={m.tag}
-              value={m.value}
-              description={m.description}
-              className={m.sticky ? summaryStyles.stickyCard : ""}
-              onClick={m.field ? () => setSelectedMetric(m.title) : undefined}
-              active={selectedMetric === m.title}
-            >
-              {m.extra}
-            </SummaryCard>
-          ))}
+          {metrics.slice(0, 3).map((m) => renderSummaryCard(m))}
         </div>
 
         <div className={summaryStyles.cardsRow}>
-          {metrics.slice(3).map((m) => (
-            <SummaryCard
-              key={m.title}
-              icon={m.icon}
-              color={m.color}
-              title={m.title}
-              tag={m.tag}
-              value={m.value}
-              description={m.description}
-              className={m.sticky ? summaryStyles.stickyCard : ""}
-              onClick={m.field ? () => setSelectedMetric(m.title) : undefined}
-              active={selectedMetric === m.title}
-            >
-              {m.extra}
-            </SummaryCard>
-          ))}
+          {metrics.slice(3).map((m) => renderSummaryCard(m))}
         </div>
       </div>
 
@@ -832,28 +885,27 @@ const BudgetHeader: React.FC<BudgetHeaderProps> = ({
     [accentAlpha, accentHex]
   );
 
-  const renderMetricChip = (metric: (typeof metrics)[number]) => {
-    const isReconciledToggleMetric =
-      hasReconciled &&
-      metric.field === (showReconciled ? "itemReconciledCost" : "itemActualCost");
-    const isBudgetedMetric = metric.title === "Budgeted Cost";
+  const renderMetricChip = (metric: MetricDefinition) => {
     const isBallparkMetric = metric.title === "Ballpark";
+    const isBudgetedMetric = metric.title === "Budgeted Cost";
+    const isActualMetric =
+      metric.title === "Actual Cost" || metric.title === "Reconciled Cost";
+    const isMarkupMetric = metric.title === "Effective Markup";
 
-    const activateBudgetedMetric = () => {
-      setMarkupBasis("Budgeted");
-      setSelectedMetric("Budgeted Cost");
-    };
-
-    const activateActualMetric = () => {
-      const nextTitle = (showReconciled ? "Reconciled Cost" : "Actual Cost") as MetricTitle;
-      const nextBasis = showReconciled ? "Reconciled" : "Actual";
-      setSelectedMetric(nextTitle);
-      setMarkupBasis(nextBasis);
-    };
+    const isActualSelected =
+      selectedMetric === "Actual Cost" || selectedMetric === "Reconciled Cost";
+    const isBudgetedSelected = selectedMetric === "Budgeted Cost";
+    const isMetricSelected = isBallparkMetric
+      ? false
+      : isBudgetedMetric
+      ? isBudgetedSelected
+      : isActualMetric
+      ? isActualSelected
+      : selectedMetric === metric.title;
 
     const chipClassName = [
       mobileStyles.metricChip,
-      selectedMetric === metric.title ? mobileStyles.metricChipActive : "",
+      isMetricSelected ? mobileStyles.metricChipActive : "",
     ]
       .filter(Boolean)
       .join(" ");
@@ -865,58 +917,63 @@ const BudgetHeader: React.FC<BudgetHeaderProps> = ({
       .filter(Boolean)
       .join(" ");
 
+    let ariaLabel: string | undefined;
+    if (isBallparkMetric) {
+      ariaLabel = "Edit estimate";
+    } else if (isBudgetedMetric) {
+      ariaLabel = "View budgeted totals";
+    } else if (isActualMetric) {
+      ariaLabel = hasReconciled
+        ? `Toggle between actual and reconciled totals (currently ${
+            showReconciled ? "reconciled" : "actual"
+          })`
+        : "View actual totals";
+    } else if (isMarkupMetric) {
+      ariaLabel = "Effective markup amount";
+    } else if (metric.field) {
+      ariaLabel = `View ${metric.title}`;
+    }
+
+    const supportsToggle =
+      isBudgetedMetric || isActualMetric || (!!metric.field && metric.isSelectable !== false);
+
+    const handleClick = () => {
+      if (isBallparkMetric) {
+        openBallparkEditor();
+        return;
+      }
+
+      if (isBudgetedMetric) {
+        activateBudgetedMetric();
+        return;
+      }
+
+      if (isActualMetric) {
+        if (!isMetricSelected) {
+          activateActualMetric();
+          return;
+        }
+        toggleActualBasis();
+        return;
+      }
+
+      if (metric.field && metric.isSelectable !== false) {
+        setSelectedMetric(metric.title);
+      }
+    };
+
+    const isDisabled = !isBallparkMetric && metric.isSelectable === false;
+
     return (
       <div key={metric.title} className={mobileStyles.metricChipWrapper}>
         <button
           type="button"
           className={chipClassName}
-          onClick={() => {
-            if (isBallparkMetric) {
-              setBallparkModalOpen(true);
-              return;
-            }
-            if (isBudgetedMetric) {
-              activateBudgetedMetric();
-              return;
-            }
-            if (isReconciledToggleMetric) {
-              const isSelected =
-                selectedMetric === metric.title ||
-                selectedMetric === (showReconciled ? "Reconciled Cost" : "Actual Cost");
-
-              if (!isSelected) {
-                activateActualMetric();
-                return;
-              }
-
-              const nextShowReconciled = !showReconciled;
-              setShowReconciled(nextShowReconciled);
-              const nextTitle = nextShowReconciled
-                ? ("Reconciled Cost" as MetricTitle)
-                : ("Actual Cost" as MetricTitle);
-              const nextBasis = nextShowReconciled ? "Reconciled" : "Actual";
-              setSelectedMetric(nextTitle);
-              setMarkupBasis(nextBasis);
-              return;
-            }
-            if (metric.field) {
-              setSelectedMetric(metric.title);
-              if (
-                metric.title === "Actual Cost" ||
-                metric.title === "Reconciled Cost"
-              ) {
-                setMarkupBasis(metric.title === "Reconciled Cost" ? "Reconciled" : "Actual");
-              }
-            }
-          }}
-          disabled={!metric.field && !isBallparkMetric}
-          aria-label={
-            isBallparkMetric
-              ? "Edit estimate"
-              : metric.field
-              ? undefined
-              : metric.title
-          }
+          onClick={handleClick}
+          disabled={isDisabled}
+          aria-label={ariaLabel}
+          aria-haspopup={isBallparkMetric ? "dialog" : undefined}
+          aria-pressed={supportsToggle && !isBallparkMetric ? isMetricSelected : undefined}
         >
           <div className={mobileStyles.metricChipHeader}>
             <span className={tagClassName}>{metric.tag}</span>
@@ -925,6 +982,76 @@ const BudgetHeader: React.FC<BudgetHeaderProps> = ({
           <span className={mobileStyles.metricDescription}>{metric.description}</span>
         </button>
       </div>
+    );
+  };
+
+  const renderSummaryCard = (metric: MetricDefinition) => {
+    const isBallparkMetric = metric.title === "Ballpark";
+    const isBudgetedMetric = metric.title === "Budgeted Cost";
+    const isActualMetric =
+      metric.title === "Actual Cost" || metric.title === "Reconciled Cost";
+    const isMarkupMetric = metric.title === "Effective Markup";
+    const isSelectableCard = metric.isSelectable !== false && metric.field !== null;
+
+    const onClick = metric.onCardClick
+      ? metric.onCardClick
+      : isSelectableCard
+      ? () => setSelectedMetric(metric.title)
+      : undefined;
+
+    const isActualSelected =
+      selectedMetric === "Actual Cost" || selectedMetric === "Reconciled Cost";
+    const isBudgetedSelected = selectedMetric === "Budgeted Cost";
+
+    const active = metric.isSelectable === false && !isBudgetedMetric && !isActualMetric
+      ? false
+      : isBudgetedMetric
+      ? isBudgetedSelected
+      : isActualMetric
+      ? isActualSelected
+      : selectedMetric === metric.title;
+
+    let ariaLabel = metric.ariaLabel;
+    if (!ariaLabel) {
+      if (isBallparkMetric) {
+        ariaLabel = "Open estimate editor";
+      } else if (isBudgetedMetric) {
+        ariaLabel = "View budgeted totals";
+      } else if (isActualMetric) {
+        ariaLabel = hasReconciled
+          ? `Toggle between actual and reconciled totals (currently ${
+              showReconciled ? "reconciled" : "actual"
+            })`
+          : "View actual totals";
+      } else if (isMarkupMetric) {
+        ariaLabel = "Effective markup amount";
+      } else if (metric.field) {
+        ariaLabel = `View ${metric.title}`;
+      }
+    }
+
+    const isToggle =
+      !isBallparkMetric &&
+      (isBudgetedMetric || isActualMetric || (isSelectableCard && metric.isSelectable !== false));
+
+    return (
+      <SummaryCard
+        key={metric.title}
+        icon={metric.icon}
+        color={metric.color}
+        title={metric.title}
+        tag={metric.tag}
+        value={metric.value}
+        description={metric.description}
+        className={metric.sticky ? summaryStyles.stickyCard : ""}
+        onClick={onClick}
+        active={active}
+        ariaLabel={ariaLabel}
+        isToggle={isToggle}
+        ariaHasPopup={metric.ariaHasPopup}
+      >
+        {metric.extra}
+      </SummaryCard>
     );
   };
 

--- a/frontend/src/dashboard/project/features/budget/components/budget-header-mobile.module.css
+++ b/frontend/src/dashboard/project/features/budget/components/budget-header-mobile.module.css
@@ -344,13 +344,14 @@
   padding: 8px 10px;
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 6px;
   border: 1px solid rgba(148, 163, 184, 0.16);
   color: var(--budget-accent-text);
   text-align: left;
   transition: border-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease,
     background 0.3s ease;
   box-shadow: 0 10px 22px rgba(8, 13, 32, 0.4), 0 0 0 1px var(--budget-accent-soft);
+  cursor: pointer;
 }
 
 .metricChip:active:not(.metricChipActive) {
@@ -358,8 +359,10 @@
 }
 
 .metricChip:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
+  opacity: 1;
+  cursor: default;
+  transform: none;
+  box-shadow: 0 10px 22px rgba(8, 13, 32, 0.32), 0 0 0 1px var(--budget-accent-soft);
 }
 
 .metricChipActive {
@@ -369,10 +372,21 @@
 }
 
 .metricTag {
-  font-size: 0.65rem;
-  color: rgba(249, 250, 251, 0.65);
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-start;
+  width: fit-content;
+  padding: 2px 8px;
+  border-radius: 9999px;
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
+  color: rgba(248, 250, 252, 0.85);
+  background: rgba(15, 23, 42, 0.58);
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  box-shadow: 0 2px 6px rgba(15, 23, 42, 0.4);
+  text-shadow: 0 1px 1px rgba(15, 23, 42, 0.8);
 }
 
 .metricTagBallpark {
@@ -380,6 +394,8 @@
   text-transform: none;
   letter-spacing: 0.02em;
   font-weight: 600;
+  background: rgba(59, 130, 246, 0.32);
+  border-color: rgba(125, 211, 252, 0.42);
 }
 
 .metricValue {

--- a/frontend/src/dashboard/project/features/budget/components/budget-header-summary.module.css
+++ b/frontend/src/dashboard/project/features/budget/components/budget-header-summary.module.css
@@ -27,9 +27,11 @@
   display: flex;
   flex-direction: column;
   min-height: 100px;
+}
+.card[data-clickable="true"] {
   cursor: pointer;
 }
-.card:hover {
+.card[data-clickable="true"]:hover {
   transform: translateY(-4px);
 }
 .active {


### PR DESCRIPTION
## Summary
- update the budget header logic to open the estimate editor from the chip, simplify budgeted/actual toggling, and add explicit accessibility labelling
- refresh the mobile budget chips so markup is view-only and the tag styling is easier to read
- only show desktop summary cards as interactive when they can be clicked

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e0aea59d808324a7bccbcd23971b94