### PR TITLE
Fix final cost metric presentation in budget header

### DIFF
--- a/frontend/src/dashboard/project/features/budget/components/HeaderStats.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/HeaderStats.tsx
@@ -90,6 +90,8 @@ interface SummaryCardProps {
   children?: React.ReactNode;
   ariaLabel?: string;
   ariaPressed?: boolean;
+  disableHover?: boolean;
+  disablePointer?: boolean;
 }
 
 type MetricField = keyof BudgetItem | "markupAmount" | null;
@@ -109,6 +111,8 @@ interface MetricConfig {
   onSelect?: () => void;
   ariaLabel?: string;
   isSelectable?: boolean;
+  disableHover?: boolean;
+  disablePointer?: boolean;
 }
 
 interface BudgetHeaderProps {
@@ -201,9 +205,15 @@ const SummaryCard: React.FC<SummaryCardProps> = ({
   children,
   ariaLabel,
   ariaPressed,
+  disableHover,
+  disablePointer,
 }) => (
   <div
-    className={`${summaryStyles.card} ${active ? summaryStyles.active : ""} ${className}`}
+    className={`${summaryStyles.card} ${
+      active ? summaryStyles.active : ""
+    } ${disableHover ? summaryStyles.noHover : ""} ${
+      disablePointer ? summaryStyles.noPointer : ""
+    } ${className}`}
     onClick={onClick}
     role={onClick ? "button" : undefined}
     tabIndex={onClick ? 0 : undefined}
@@ -429,7 +439,7 @@ const BudgetHeader: React.FC<BudgetHeaderProps> = ({
     const modeLabel =
       resolvedMode === "Reconciled" && !hasReconciled ? "Actual" : resolvedMode;
 
-    const finalDescription = `All-in ${modeLabel.toLowerCase()} cost`;
+    const finalDescription = "All-in cost";
 
     return [
       {
@@ -492,7 +502,7 @@ const BudgetHeader: React.FC<BudgetHeaderProps> = ({
       },
       {
         title: "Final Cost" as MetricTitle,
-        tag: modeLabel,
+        tag: "Final",
         icon: faFileInvoiceDollar,
         color: CHART_COLORS[3],
         value: formatUSD(finalTotal),
@@ -503,6 +513,8 @@ const BudgetHeader: React.FC<BudgetHeaderProps> = ({
         onSelect: handleSelectFinal,
         ariaLabel: "View final totals",
         isSelectable: true,
+        disableHover: true,
+        disablePointer: true,
         extra: (
           <div className={summaryStyles.invoicePreviewContainer}>
             <FontAwesomeIcon
@@ -840,6 +852,8 @@ const BudgetHeader: React.FC<BudgetHeaderProps> = ({
               active={Boolean(m.isSelectable && selectedMetric === m.title)}
               ariaLabel={m.ariaLabel}
               ariaPressed={m.isSelectable ? selectedMetric === m.title : undefined}
+              disableHover={m.disableHover}
+              disablePointer={m.disablePointer}
             >
               {m.extra}
             </SummaryCard>
@@ -861,6 +875,8 @@ const BudgetHeader: React.FC<BudgetHeaderProps> = ({
               active={Boolean(m.isSelectable && selectedMetric === m.title)}
               ariaLabel={m.ariaLabel}
               ariaPressed={m.isSelectable ? selectedMetric === m.title : undefined}
+              disableHover={m.disableHover}
+              disablePointer={m.disablePointer}
             >
               {m.extra}
             </SummaryCard>

--- a/frontend/src/dashboard/project/features/budget/components/budget-header-summary.module.css
+++ b/frontend/src/dashboard/project/features/budget/components/budget-header-summary.module.css
@@ -32,6 +32,13 @@
 .card:hover {
   transform: translateY(-4px);
 }
+.noHover:hover {
+  transform: none;
+}
+.noPointer,
+.noPointer:hover {
+  cursor: default;
+}
 .active {
   box-shadow: 0 0 0 2px #fff inset;
 }


### PR DESCRIPTION
## Summary
- keep the Final Cost metric card title and description static so it always reads "Final Cost" with an "All-in cost" description
- add component flags and CSS hooks to suppress hover and pointer cues on the Final Cost card while preserving its layout

## Testing
- `npm run test -- --run "BudgetProvider"`


------
https://chatgpt.com/codex/tasks/task_e_68e0dbcb4d248324a84dfab7bbf4b177