### PR TITLE
Adjust budget chart quantity calculations

### DIFF
--- a/frontend/src/dashboard/project/features/budget/components/HeaderStats.test.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/HeaderStats.test.tsx
@@ -1,0 +1,140 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const budgetDonutCalls: Array<{
+  data: Array<{ id: string; label: string; value: number }>;
+  total: number;
+}> = [];
+
+vi.mock("./BudgetDonut", () => {
+  return {
+    __esModule: true,
+    default: (props: {
+      data: Array<{ id: string; label: string; value: number }>;
+      total: number;
+    }) => {
+      budgetDonutCalls.push({ data: props.data, total: props.total });
+      return (
+        <div data-testid="budget-donut-props">
+          {JSON.stringify({ data: props.data, total: props.total })}
+        </div>
+      );
+    },
+  };
+});
+
+vi.mock("@/dashboard/project/features/budget/components/EditBallparkModal", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+vi.mock("@/dashboard/project/features/budget/ClientInvoicePreviewModal", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+vi.mock("@/app/contexts/useSocket", () => ({
+  useSocket: () => ({ ws: null }),
+}));
+
+import BudgetHeader from "./HeaderStats";
+
+const createMatchMedia = (matches: boolean) => {
+  return () => ({
+    matches,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+    media: "",
+    onchange: null,
+  });
+};
+
+describe("BudgetHeader computeChartState", () => {
+  beforeEach(() => {
+    budgetDonutCalls.length = 0;
+    vi.stubGlobal("matchMedia", createMatchMedia(false));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const getLatestChart = () => {
+    const last = budgetDonutCalls[budgetDonutCalls.length - 1];
+    if (!last) {
+      throw new Error("No chart render captured");
+    }
+    return last;
+  };
+
+  it("multiplies grouped totals by quantity for budgeted and actual modes", async () => {
+    render(
+      <BudgetHeader
+        activeProject={{ projectId: "p1", color: "#123456" }}
+        budgetHeader={{
+          budgetItemId: "b1",
+          revision: 1,
+          headerBudgetedTotalCost: 450,
+          headerActualTotalCost: 425,
+          headerFinalTotalCost: 640,
+        }}
+        groupBy="category"
+        setGroupBy={() => {}}
+        budgetItems={[
+          {
+            category: "Design",
+            quantity: 2,
+            itemBudgetedCost: 150,
+            itemActualCost: 100,
+            itemFinalCost: 200,
+          },
+          {
+            category: "Labor",
+            quantity: 3,
+            itemBudgetedCost: 50,
+            itemActualCost: 75,
+            itemFinalCost: 80,
+          },
+        ]}
+        onOpenRevisionModal={() => {}}
+      />
+    );
+
+    await waitFor(() => expect(budgetDonutCalls.length).toBeGreaterThan(0));
+
+    const finalChart = getLatestChart();
+    expect(finalChart.data).toEqual([
+      { id: "category-Design", label: "Design", value: 400 },
+      { id: "category-Labor", label: "Labor", value: 240 },
+    ]);
+    expect(finalChart.total).toBe(640);
+
+    const budgetedButton = screen.getByRole("button", { name: /view budgeted totals/i });
+    fireEvent.click(budgetedButton);
+
+    await waitFor(() => {
+      const { data, total } = getLatestChart();
+      expect(data).toEqual([
+        { id: "category-Design", label: "Design", value: 300 },
+        { id: "category-Labor", label: "Labor", value: 150 },
+      ]);
+      expect(total).toBe(450);
+    });
+
+    const actualButton = screen.getByRole("button", { name: /view actual totals/i });
+    fireEvent.click(actualButton);
+
+    await waitFor(() => {
+      const { data, total } = getLatestChart();
+      expect(data).toEqual([
+        { id: "category-Labor", label: "Labor", value: 225 },
+        { id: "category-Design", label: "Design", value: 200 },
+      ]);
+      expect(total).toBe(425);
+    });
+  });
+});

--- a/frontend/src/dashboard/project/features/budget/components/HeaderStats.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/HeaderStats.tsx
@@ -685,9 +685,9 @@ const BudgetHeader: React.FC<BudgetHeaderProps> = ({
       const quantity = toQuantity(item.quantity);
 
       if (field === "markupAmount") {
-        const finalCost = toNumber(item.itemFinalCost);
-        const budgeted = toNumber(item.itemBudgetedCost);
-        const actual = toNumber(item.itemActualCost);
+        const finalCost = toNumber(item.itemFinalCost) * quantity;
+        const budgeted = toNumber(item.itemBudgetedCost) * quantity;
+        const actual = toNumber(item.itemActualCost) * quantity;
         const reconciled = toNumber(item.itemReconciledCost) * quantity;
         const resolvedMode: CostMode =
           activeMode === "Reconciled" && hasReconciled ? "Reconciled" : activeMode;
@@ -704,7 +704,12 @@ const BudgetHeader: React.FC<BudgetHeaderProps> = ({
       } else {
         const key = field as keyof BudgetItem;
         const numericValue = toNumber(item[key] as number | string | undefined | null);
-        val = key === "itemReconciledCost" ? numericValue * quantity : numericValue;
+        const shouldApplyQuantity =
+          key === "itemReconciledCost" ||
+          key === "itemBudgetedCost" ||
+          key === "itemActualCost" ||
+          key === "itemFinalCost";
+        val = shouldApplyQuantity ? numericValue * quantity : numericValue;
       }
 
       const safeValue = Number.isNaN(val) ? 0 : val;


### PR DESCRIPTION
## Summary
- apply quantity to budgeted, actual, final, and reconciled costs when computing grouped chart slices and markup bases
- add a HeaderStats test that exercises quantity-aware totals for budgeted and actual grouping modes

## Testing
- pnpm vitest run src/dashboard/project/features/budget/components/HeaderStats.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e0e4799ec48324b582e8b2c245f330