### PR TITLE
Align budget header chart math with stored totals

### DIFF
--- a/frontend/src/dashboard/project/features/budget/components/HeaderStats.test.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/HeaderStats.test.tsx
@@ -90,14 +90,14 @@ describe("BudgetHeader computeChartState", () => {
             quantity: 2,
             itemBudgetedCost: 150,
             itemActualCost: 100,
-            itemFinalCost: 200,
+            itemFinalCost: 400,
           },
           {
             category: "Labor",
             quantity: 3,
             itemBudgetedCost: 50,
             itemActualCost: 75,
-            itemFinalCost: 80,
+            itemFinalCost: 240,
           },
         ]}
         onOpenRevisionModal={() => {}}
@@ -136,5 +136,49 @@ describe("BudgetHeader computeChartState", () => {
       ]);
       expect(total).toBe(425);
     });
+  });
+
+  it("computes grouped markup totals without reapplying quantity to final cost", async () => {
+    render(
+      <BudgetHeader
+        activeProject={{ projectId: "p1", color: "#123456" }}
+        budgetHeader={{
+          budgetItemId: "b1",
+          revision: 1,
+          headerBudgetedTotalCost: 450,
+          headerActualTotalCost: 425,
+          headerFinalTotalCost: 640,
+        }}
+        groupBy="category"
+        setGroupBy={() => {}}
+        budgetItems={[
+          {
+            category: "Design",
+            quantity: 2,
+            itemBudgetedCost: 150,
+            itemActualCost: 100,
+            itemFinalCost: 400,
+          },
+          {
+            category: "Labor",
+            quantity: 3,
+            itemBudgetedCost: 50,
+            itemActualCost: 75,
+            itemFinalCost: 240,
+          },
+        ]}
+        onOpenRevisionModal={() => {}}
+        initialMetric="Effective Markup"
+      />
+    );
+
+    await waitFor(() => expect(budgetDonutCalls.length).toBeGreaterThan(0));
+
+    const { data, total } = getLatestChart();
+    expect(data).toEqual([
+      { id: "category-Design", label: "Design", value: 100 },
+      { id: "category-Labor", label: "Labor", value: 90 },
+    ]);
+    expect(total).toBe(190);
   });
 });

--- a/frontend/src/dashboard/project/features/budget/components/HeaderStats.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/HeaderStats.tsx
@@ -123,6 +123,7 @@ interface BudgetHeaderProps {
   budgetItems?: BudgetItem[];
   onBallparkChange?: (val: number) => void;
   onOpenRevisionModal: () => void;
+  initialMetric?: MetricTitle;
 }
 
 const RELEVANT_WS_ACTIONS = new Set<unknown>([
@@ -253,8 +254,11 @@ const BudgetHeader: React.FC<BudgetHeaderProps> = ({
   budgetItems = [],
   onBallparkChange,
   onOpenRevisionModal,
+  initialMetric,
 }) => {
-  const [selectedMetric, setSelectedMetric] = useState<MetricTitle>("Final Cost");
+  const [selectedMetric, setSelectedMetric] = useState<MetricTitle>(
+    initialMetric ?? "Final Cost"
+  );
   const [isMobile, setIsMobile] = useState(false);
 
   const hasReconciled = useMemo(
@@ -683,12 +687,34 @@ const BudgetHeader: React.FC<BudgetHeaderProps> = ({
       const key = rawKey && rawKey.trim() !== "" ? rawKey : "Unspecified";
       let val: number;
       const quantity = toQuantity(item.quantity);
+      const applyQuantityIfNeeded = (
+        fieldName: keyof BudgetItem | null,
+        value: number
+      ): number => {
+        if (
+          fieldName === "itemBudgetedCost" ||
+          fieldName === "itemActualCost" ||
+          fieldName === "itemReconciledCost"
+        ) {
+          return value * quantity;
+        }
+        return value;
+      };
 
       if (field === "markupAmount") {
-        const finalCost = toNumber(item.itemFinalCost) * quantity;
-        const budgeted = toNumber(item.itemBudgetedCost) * quantity;
-        const actual = toNumber(item.itemActualCost) * quantity;
-        const reconciled = toNumber(item.itemReconciledCost) * quantity;
+        const finalCost = toNumber(item.itemFinalCost);
+        const budgeted = applyQuantityIfNeeded(
+          "itemBudgetedCost",
+          toNumber(item.itemBudgetedCost)
+        );
+        const actual = applyQuantityIfNeeded(
+          "itemActualCost",
+          toNumber(item.itemActualCost)
+        );
+        const reconciled = applyQuantityIfNeeded(
+          "itemReconciledCost",
+          toNumber(item.itemReconciledCost)
+        );
         const resolvedMode: CostMode =
           activeMode === "Reconciled" && hasReconciled ? "Reconciled" : activeMode;
         const base =
@@ -704,12 +730,7 @@ const BudgetHeader: React.FC<BudgetHeaderProps> = ({
       } else {
         const key = field as keyof BudgetItem;
         const numericValue = toNumber(item[key] as number | string | undefined | null);
-        const shouldApplyQuantity =
-          key === "itemReconciledCost" ||
-          key === "itemBudgetedCost" ||
-          key === "itemActualCost" ||
-          key === "itemFinalCost";
-        val = shouldApplyQuantity ? numericValue * quantity : numericValue;
+        val = applyQuantityIfNeeded(key, numericValue);
       }
 
       const safeValue = Number.isNaN(val) ? 0 : val;


### PR DESCRIPTION
## Summary
- stop multiplying final cost totals by quantity when shaping grouped chart data and reuse quantity logic for markup bases
- allow tests to load the markup metric via an optional initialMetric prop and validate grouped markup differences
- update sample data so grouped final totals use already-extended costs and add regression coverage for the markup chart

## Testing
- npm test -- HeaderStats

------
https://chatgpt.com/codex/tasks/task_e_68e0e8f9996c8324afa00d1541f1874d