### PR TITLE
Update dashboard routes for projects overview

### DIFF
--- a/frontend/src/app/contexts/ProjectsProvider.tsx
+++ b/frontend/src/app/contexts/ProjectsProvider.tsx
@@ -163,9 +163,13 @@ const RegularProjectsProvider: React.FC<PropsWithChildren> = ({ children }) => {
   const [selectedProjects, setSelectedProjects] = useState<string[]>([]);
   const [projectsViewState] = useState<string>(() => {
     try {
-      return localStorage.getItem("dashboardViewState") || "welcome";
+      const stored = localStorage.getItem("dashboardViewState");
+      if (!stored) return "projects-overview";
+      if (stored === "welcome") return "projects-overview";
+      if (stored === "projects") return "projects-list";
+      return stored;
     } catch {
-      return "welcome";
+      return "projects-overview";
     }
   });
 

--- a/frontend/src/dashboard/home/pages/DashboardHome.tsx
+++ b/frontend/src/dashboard/home/pages/DashboardHome.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useId, useState, useMemo } from "react";
+import React, { useCallback, useEffect, useId, useState, useMemo } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useData } from "@/app/contexts/useData";
 import { UserLite } from "@/app/contexts/DataProvider";
@@ -54,6 +54,9 @@ function sameDay(a: Date | null, b: Date | null) {
   return !!(a && b) && a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth() && a.getDate() === b.getDate();
 }
 
+export const PROJECTS_OVERVIEW_VIEW = "projects-overview" as const;
+export const PROJECTS_LIST_VIEW = "projects-list" as const;
+
 // eslint-disable-next-line react-refresh/only-export-components
 export const parseDashboardPath = (
   pathname: string
@@ -62,20 +65,33 @@ export const parseDashboardPath = (
   const idx = segments.indexOf("dashboard");
 
   if (idx === -1) {
-    return { view: "welcome", userSlug: null };
+    return { view: PROJECTS_OVERVIEW_VIEW, userSlug: null };
   }
 
-  let view = segments[idx + 1] || "welcome";
+  let view = segments[idx + 1] || PROJECTS_OVERVIEW_VIEW;
   let userSlug = segments[idx + 2] || null;
 
   if (view === "features") {
-    view = segments[idx + 2] || "welcome";
+    view = segments[idx + 2] || PROJECTS_OVERVIEW_VIEW;
     userSlug = segments[idx + 3] || null;
   }
 
   if (view === "welcome") {
-    view = segments[idx + 2] || "welcome";
-    userSlug = segments[idx + 3] || null;
+    const nestedView = segments[idx + 2];
+    if (nestedView) {
+      view = nestedView;
+      userSlug = segments[idx + 3] || null;
+    } else {
+      view = PROJECTS_OVERVIEW_VIEW;
+      userSlug = null;
+    }
+  }
+
+  if (view === "projects") {
+    const hasAdditionalSegment = segments.length > idx + 2;
+    if (!hasAdditionalSegment) {
+      view = PROJECTS_LIST_VIEW;
+    }
   }
 
   return { view, userSlug };
@@ -172,7 +188,14 @@ const WelcomeScreen: React.FC = () => {
   const parsePath = () => parseDashboardPath(location.pathname);
 
   const { view: initialView, userSlug: initialDMUserSlug } = parsePath();
-  const [activeView, setActiveView] = useState<string>(initialView);
+  const normalizeView = useCallback((view: string) => {
+    if (view === "welcome") return PROJECTS_OVERVIEW_VIEW;
+    if (view === "projects") return PROJECTS_LIST_VIEW;
+    return view;
+  }, []);
+  const [activeView, setActiveView] = useState<string>(() =>
+    normalizeView(initialView)
+  );
   const [dmUserSlug, setDmUserSlug] = useState<string | null>(
     initialDMUserSlug
   );
@@ -261,10 +284,11 @@ const WelcomeScreen: React.FC = () => {
 
   useEffect(() => {
     const { view, userSlug } = parsePath();
-    if (view !== activeView) setActiveView(view);
+    const normalizedView = normalizeView(view);
+    if (normalizedView !== activeView) setActiveView(normalizedView);
     if (userSlug !== dmUserSlug) setDmUserSlug(userSlug);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [location.pathname]);
+  }, [location.pathname, normalizeView]);
 
   useEffect(() => {
     if (
@@ -371,8 +395,10 @@ const WelcomeScreen: React.FC = () => {
 
   const renderActiveView = () => {
     switch (activeView) {
+      case PROJECTS_OVERVIEW_VIEW:
       case "welcome":
         return renderWelcomeView();
+      case PROJECTS_LIST_VIEW:
       case "projects":
         return <AllProjects />;
       case "notifications":
@@ -416,7 +442,8 @@ const WelcomeScreen: React.FC = () => {
             <div className="dashboard-content">
               <div
                 className={`main-content${
-                  activeView === "welcome" && isDesktop
+                  (activeView === PROJECTS_OVERVIEW_VIEW || activeView === "welcome") &&
+                  isDesktop
                     ? " main-content--welcome"
                     : ""
                 }`}

--- a/frontend/src/dashboard/home/pages/DashboardLayout.tsx
+++ b/frontend/src/dashboard/home/pages/DashboardLayout.tsx
@@ -18,11 +18,11 @@ const Dashboard: React.FC = () => {
     if (path.startsWith("/dashboard/projects/")) return "Dashboard - Project Details";
     switch (path) {
       case "/dashboard":
-        return `Dashboard - Welcome, ${userName ?? "Guest"}`;
+        return "Dashboard - Projects";
       case "/dashboard/new":
         return "Dashboard - Start something";
       case "/dashboard/projects":
-        return "Dashboard - All Projects";
+        return "Dashboard - Project List";
       case "/dashboard/tasks":
         return "Dashboard - Tasks";
       case "/dashboard/settings":
@@ -59,7 +59,9 @@ const Dashboard: React.FC = () => {
       }
 
       if (saved && saved !== "/dashboard") {
-        const normalized = saved.replace("/dashboard/welcome", "/dashboard");
+        const normalized = saved
+          .replace("/dashboard/welcome", "/dashboard")
+          .replace("/dashboard/projects-overview", "/dashboard");
         navigate(normalized, { replace: true });
       } else {
         navigate("/dashboard", { replace: true });

--- a/frontend/src/pages/home/DashboardHome.test.ts
+++ b/frontend/src/pages/home/DashboardHome.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, it } from "vitest";
 
-import { parseDashboardPath } from "../../dashboard/home/pages/DashboardHome";
+import {
+  PROJECTS_OVERVIEW_VIEW,
+  parseDashboardPath,
+} from "../../dashboard/home/pages/DashboardHome";
 
 describe("parseDashboardPath", () => {
-  it("returns the welcome view by default", () => {
+  it("returns the projects overview view by default", () => {
     expect(parseDashboardPath("/dashboard")).toEqual({
-      view: "welcome",
+      view: PROJECTS_OVERVIEW_VIEW,
       userSlug: null,
     });
   });
@@ -35,7 +38,7 @@ describe("parseDashboardPath", () => {
 
   it("tolerates missing dashboard segment", () => {
     expect(parseDashboardPath("/other/path")).toEqual({
-      view: "welcome",
+      view: PROJECTS_OVERVIEW_VIEW,
       userSlug: null,
     });
   });

--- a/frontend/src/shared/ui/useDashboardNavigation.tsx
+++ b/frontend/src/shared/ui/useDashboardNavigation.tsx
@@ -15,7 +15,11 @@ import Cookies from "js-cookie";
 import { useAuth } from "@/app/contexts/useAuth";
 import { useData } from "@/app/contexts/useData";
 import { useNotifications } from "@/app/contexts/useNotifications";
-import { parseDashboardPath } from "@/dashboard/home/pages/DashboardHome";
+import {
+  PROJECTS_LIST_VIEW,
+  PROJECTS_OVERVIEW_VIEW,
+  parseDashboardPath,
+} from "@/dashboard/home/pages/DashboardHome";
 
 export type DashboardNavItem = {
   key: string;
@@ -67,7 +71,19 @@ export function useDashboardNavigation({ setActiveView, onClose }: UseDashboardN
     (view: string) => {
       setActiveView(view);
       const base = "/dashboard";
-      const path = view === "welcome" ? base : `${base}/${view}`;
+      let path: string;
+      switch (view) {
+        case PROJECTS_OVERVIEW_VIEW:
+        case "welcome":
+          path = base;
+          break;
+        case PROJECTS_LIST_VIEW:
+        case "projects":
+          path = `${base}/projects`;
+          break;
+        default:
+          path = `${base}/${view}`;
+      }
       navigate(path);
       close();
     },
@@ -118,9 +134,13 @@ export function useDashboardNavigation({ setActiveView, onClose }: UseDashboardN
         key: "home",
         icon: <Folder size={24} color="white" />,
         label: "Projects",
-        onClick: () => handleNavigation("welcome"),
+        onClick: () => handleNavigation(PROJECTS_OVERVIEW_VIEW),
         isActive:
-          (isDashboardPath && (!activeDashboardView || activeDashboardView === "welcome")) ||
+          (isDashboardPath &&
+            (!activeDashboardView ||
+              activeDashboardView === PROJECTS_OVERVIEW_VIEW ||
+              activeDashboardView === PROJECTS_LIST_VIEW ||
+              activeDashboardView === "projects")) ||
           location.pathname === "/dashboard",
       },
       {


### PR DESCRIPTION
## Summary
- map the dashboard root to the projects overview view and expose constants for downstream use
- migrate stored dashboard view state and navigation/page-title logic to the new projects overview naming
- refresh the dashboard route parsing test to reflect the updated default view

## Testing
- npm run test -- pages/home/DashboardHome.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e4a3e7efc48324a461a543696cd8a1