### PR TITLE
Fix tasks panel overflow with scrollable list

### DIFF
--- a/frontend/src/dashboard/project/components/Tasks/TasksComponent.module.css
+++ b/frontend/src/dashboard/project/components/Tasks/TasksComponent.module.css
@@ -10,12 +10,17 @@
   flex-direction: column;
   gap: 18px;
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.03), 0 22px 48px rgba(0, 0, 0, 0.35);
+  flex: 1 1 auto;
+  min-height: 0;
 }
 
 .inner {
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: hidden;
 }
 
 .header {
@@ -141,6 +146,9 @@
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: hidden;
 }
 
 .listHeader {
@@ -167,6 +175,9 @@
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
 }
 
 .taskItem {

--- a/frontend/src/dashboard/project/components/Tasks/TasksComponent.tsx
+++ b/frontend/src/dashboard/project/components/Tasks/TasksComponent.tsx
@@ -590,7 +590,7 @@ const TasksComponent: React.FC<TasksComponentProps> = ({
   }, [error, loading, tasks.length]);
 
   return (
-    <section className={styles.panel} aria-label="Project tasks overview">
+    <section className={`${styles.panel} tasks-component`} aria-label="Project tasks overview">
       <div className={styles.inner}>
         <header className={styles.header}>
           <div className={styles.titleGroup}>


### PR DESCRIPTION
## Summary
- align the desktop tasks panel with the shared layout class and flex behavior
- allow the task list section to grow and scroll within the panel to prevent overflow

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4a99cc20c8324b0c2753edb728b35