### PR TITLE
Refactor dashboard routes to integrate HQ area

### DIFF
--- a/frontend/src/app/routes.tsx
+++ b/frontend/src/app/routes.tsx
@@ -83,9 +83,11 @@ const pageTransition = {
   duration: 1,
 };
 
+const hqRootRoute = hqRoutes.find((route) => route.path === "hq");
+
 function AppRoutes(): React.ReactElement {
   const location = useLocation();
-  
+
   return (
     <ErrorBoundary>
       <Suspense fallback={<Spinner />}>
@@ -152,10 +154,36 @@ const ActualRoutes: React.FC<ActualRoutesProps> = ({ location }) => {
           }
         />
 
-        {hqRoutes.map((route) => (
-          <Route key={route.path} path={route.path} element={route.element} />
-        ))}
-        
+        <Route path="/hq" element={<Navigate to="/dashboard" replace />} />
+        <Route
+          path="/hq/accounts"
+          element={<Navigate to="/dashboard/hq/accounts" replace />}
+        />
+        <Route
+          path="/hq/transactions"
+          element={<Navigate to="/dashboard/hq/transactions" replace />}
+        />
+        <Route
+          path="/hq/reports"
+          element={<Navigate to="/dashboard/hq/reports" replace />}
+        />
+        <Route
+          path="/hq/invoices"
+          element={<Navigate to="/dashboard/hq/invoices" replace />}
+        />
+        <Route
+          path="/hq/tasks"
+          element={<Navigate to="/dashboard/hq/tasks" replace />}
+        />
+        <Route
+          path="/hq/events"
+          element={<Navigate to="/dashboard/hq/events" replace />}
+        />
+        <Route
+          path="/hq/messages"
+          element={<Navigate to="/dashboard/hq/messages" replace />}
+        />
+
         <Route
           path="/gallery/:projectId/:gallerySlug"
           element={
@@ -179,6 +207,16 @@ const ActualRoutes: React.FC<ActualRoutesProps> = ({ location }) => {
             </ProtectedRoute>
           }
         >
+          {hqRootRoute ? (
+            <Route index element={hqRootRoute.element} />
+          ) : null}
+          {hqRoutes.map((route) => (
+            <Route
+              key={`dashboard-${route.path}`}
+              path={route.path}
+              element={route.element}
+            />
+          ))}
           <Route
             path="projects/:projectId/:projectName?"
             element={<DashboardSingleProject key={location.key} />}

--- a/frontend/src/dashboard/home/pages/DashboardLayout.tsx
+++ b/frontend/src/dashboard/home/pages/DashboardLayout.tsx
@@ -7,7 +7,7 @@ import "./dashboard-styles.css";
 
 const Dashboard: React.FC = () => {
   // If your DataProvider has types, replace `any` below with the real shape.
-  const { userName, opacity } = useData() as { userName?: string; opacity?: number };
+  const { opacity } = useData() as { opacity?: number };
 
   const location = useLocation();
   const navigate = useNavigate();
@@ -16,9 +16,13 @@ const Dashboard: React.FC = () => {
   const getPageTitle = (): string => {
     const path = location.pathname;
     if (path.startsWith("/dashboard/projects/")) return "Dashboard - Project Details";
+    if (path === "/dashboard" || path === "/dashboard/hq") {
+      return "Dashboard - HQ";
+    }
+    if (path.startsWith("/dashboard/hq/")) {
+      return "Dashboard - HQ";
+    }
     switch (path) {
-      case "/dashboard":
-        return "Dashboard - Projects";
       case "/dashboard/new":
         return "Dashboard - Start something";
       case "/dashboard/projects":
@@ -58,13 +62,26 @@ const Dashboard: React.FC = () => {
         // ignore storage errors
       }
 
-      if (saved && saved !== "/dashboard") {
-        const normalized = saved
-          .replace("/dashboard/welcome", "/dashboard")
-          .replace("/dashboard/projects-overview", "/dashboard");
+      if (!saved) return;
+
+      let normalized = saved;
+      if (normalized === "/hq") {
+        normalized = "/dashboard";
+      } else if (normalized.startsWith("/hq/")) {
+        normalized = normalized.replace("/hq/", "/dashboard/hq/");
+      }
+
+      normalized = normalized
+        .replace("/dashboard/welcome", "/dashboard/projects")
+        .replace("/dashboard/projects-overview", "/dashboard/projects");
+
+      const shouldRedirect =
+        normalized !== "/dashboard" &&
+        normalized !== "/dashboard/projects" &&
+        !normalized.startsWith("/dashboard/hq");
+
+      if (shouldRedirect) {
         navigate(normalized, { replace: true });
-      } else {
-        navigate("/dashboard", { replace: true });
       }
     }
   }, [location, navigate]);

--- a/frontend/src/hq/components/HQLayout.tsx
+++ b/frontend/src/hq/components/HQLayout.tsx
@@ -74,7 +74,7 @@ const HQLayout: React.FC<HQLayoutProps> = ({
 }) => {
   const { isAdmin, userName } = useUser();
   const [flags, setFlags] = useState<ViewportFlags>(() => getViewportFlags());
-  const [isNavCollapsed, setIsNavCollapsed] = useNavCollapsed("hq");
+  const [isNavCollapsed, setIsNavCollapsed] = useNavCollapsed("dashboard");
   const [isNavigationOpen, setIsNavigationOpen] = useState(false);
   const rawDrawerId = useId();
   const drawerId = useMemo(

--- a/frontend/src/hq/routes.tsx
+++ b/frontend/src/hq/routes.tsx
@@ -10,14 +10,14 @@ const HQEventsPage = React.lazy(() => import("./pages/HQEventsPage"));
 const HQMessagesPage = React.lazy(() => import("./pages/HQMessagesPage"));
 
 export const hqRoutes = [
-  { path: "/hq", element: <HQOverview /> },
-  { path: "/hq/accounts", element: <AccountsPage /> },
-  { path: "/hq/transactions", element: <TransactionsPage /> },
-  { path: "/hq/reports", element: <ReportsPage /> },
-  { path: "/hq/invoices", element: <InvoicesPage /> },
-  { path: "/hq/tasks", element: <HQTasksPage /> },
-  { path: "/hq/events", element: <HQEventsPage /> },
-  { path: "/hq/messages", element: <HQMessagesPage /> },
+  { path: "hq", element: <HQOverview /> },
+  { path: "hq/accounts", element: <AccountsPage /> },
+  { path: "hq/transactions", element: <TransactionsPage /> },
+  { path: "hq/reports", element: <ReportsPage /> },
+  { path: "hq/invoices", element: <InvoicesPage /> },
+  { path: "hq/tasks", element: <HQTasksPage /> },
+  { path: "hq/events", element: <HQEventsPage /> },
+  { path: "hq/messages", element: <HQMessagesPage /> },
 ];
 
 export default hqRoutes;

--- a/frontend/src/shared/ui/useDashboardNavigation.tsx
+++ b/frontend/src/shared/ui/useDashboardNavigation.tsx
@@ -48,11 +48,15 @@ export function useDashboardNavigation({ setActiveView, onClose }: UseDashboardN
   const location = useLocation();
 
   const isDashboardPath = location.pathname.startsWith("/dashboard");
+  const isHQSection =
+    location.pathname === "/dashboard" ||
+    location.pathname.startsWith("/dashboard/hq");
   const activeDashboardView = useMemo(() => {
     if (!isDashboardPath) return null;
+    if (isHQSection) return "hq";
     return parseDashboardPath(location.pathname).view;
-  }, [isDashboardPath, location.pathname]);
-  const isHQActive = location.pathname.startsWith("/hq");
+  }, [isDashboardPath, isHQSection, location.pathname]);
+  const isHQActive = isHQSection;
 
   const unreadNotifications = useMemo(
     () => notifications.filter((n) => !n.read).length,
@@ -96,7 +100,7 @@ export function useDashboardNavigation({ setActiveView, onClose }: UseDashboardN
   }, [navigate, close]);
 
   const handleHQNavigation = useCallback(() => {
-    navigate("/hq");
+    navigate("/dashboard");
     close();
   }, [navigate, close]);
 
@@ -136,12 +140,12 @@ export function useDashboardNavigation({ setActiveView, onClose }: UseDashboardN
         label: "Projects",
         onClick: () => handleNavigation(PROJECTS_OVERVIEW_VIEW),
         isActive:
-          (isDashboardPath &&
-            (!activeDashboardView ||
-              activeDashboardView === PROJECTS_OVERVIEW_VIEW ||
-              activeDashboardView === PROJECTS_LIST_VIEW ||
-              activeDashboardView === "projects")) ||
-          location.pathname === "/dashboard",
+          isDashboardPath &&
+          !isHQSection &&
+          (!activeDashboardView ||
+            activeDashboardView === PROJECTS_OVERVIEW_VIEW ||
+            activeDashboardView === PROJECTS_LIST_VIEW ||
+            activeDashboardView === "projects"),
       },
       {
         key: "notifications",
@@ -175,8 +179,8 @@ export function useDashboardNavigation({ setActiveView, onClose }: UseDashboardN
       unreadNotifications,
       unreadMessages,
       isDashboardPath,
+      isHQSection,
       activeDashboardView,
-      location.pathname,
       handleHQNavigation,
       isHQActive,
     ]


### PR DESCRIPTION
## Summary
- redirect legacy `/hq` paths into the `/dashboard/hq` route tree and expose the HQ overview at the `/dashboard` index
- adjust the dashboard layout title and restore logic for the new HQ default while sharing the nav collapse preference with the HQ layout
- update the dashboard navigation hook so the HQ item targets `/dashboard` and project highlighting ignores HQ pages

## Testing
- npm run lint *(fails: existing lint violations in contexts, tasks components, and budget tests)*

------
https://chatgpt.com/codex/tasks/task_e_68e4a93a6de08324ad7dde08ce070b3e