### PR TITLE
Refactor dashboard routing to integrate HQ into /dashboard

### DIFF
--- a/frontend/src/app/routes.tsx
+++ b/frontend/src/app/routes.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useLayoutEffect, Suspense } from "react";
-import { Routes, Route, Navigate, useLocation, Location } from "react-router-dom";
+import { Routes, Route, Navigate, useLocation, Location, useParams } from "react-router-dom";
 import Login from "../dashboard/features/auth/Login/Login";
 import Register from "../dashboard/features/auth/Register/Register";
 import EmailVerification from "@/dashboard/features/auth/email-verification/EmailVerification";
@@ -116,6 +116,15 @@ const LegacyDashboardProjectsRedirect: React.FC<{ to: string }> = ({ to }) => {
   return <Navigate to={`${to}${location.search}${location.hash}`} replace />;
 };
 
+const LegacyDashboardMessagesRedirect: React.FC = () => {
+  const location = useLocation();
+  const { userSlug } = useParams<{ userSlug?: string }>();
+  const basePath = "/dashboard/projects/messages";
+  const target = userSlug ? `${basePath}/${userSlug}` : basePath;
+
+  return <Navigate to={`${target}${location.search}${location.hash}`} replace />;
+};
+
 const ActualRoutes: React.FC<ActualRoutesProps> = ({ location }) => {
   return (
     <AnimatePresence mode="wait">
@@ -187,6 +196,27 @@ const ActualRoutes: React.FC<ActualRoutesProps> = ({ location }) => {
         <Route
           path="/dashboard/tasks"
           element={<LegacyDashboardProjectsRedirect to="/dashboard/projects/tasks" />}
+        />
+        <Route
+          path="/dashboard/notifications"
+          element={
+            <LegacyDashboardProjectsRedirect to="/dashboard/projects/notifications" />
+          }
+        />
+        <Route
+          path="/dashboard/messages"
+          element={<LegacyDashboardProjectsRedirect to="/dashboard/projects/messages" />}
+        />
+        <Route path="/dashboard/messages/:userSlug" element={<LegacyDashboardMessagesRedirect />} />
+        <Route
+          path="/dashboard/collaborators"
+          element={
+            <LegacyDashboardProjectsRedirect to="/dashboard/projects/collaborators" />
+          }
+        />
+        <Route
+          path="/dashboard/settings"
+          element={<LegacyDashboardProjectsRedirect to="/dashboard/projects/settings" />}
         />
         <Route
           path="/dashboard/new"

--- a/frontend/src/app/routes.tsx
+++ b/frontend/src/app/routes.tsx
@@ -100,8 +100,23 @@ interface ActualRoutesProps {
   location: Location;
 }
 
+const LegacyHQRedirect: React.FC = () => {
+  const location = useLocation();
+  const remainder = location.pathname.slice(3); // remove "/hq"
+  const normalizedRemainder = remainder.startsWith("/") || remainder.length === 0
+    ? remainder
+    : `/${remainder}`;
+  const targetPath = `/dashboard${normalizedRemainder}`;
+
+  return <Navigate to={`${targetPath}${location.search}${location.hash}`} replace />;
+};
+
+const LegacyDashboardProjectsRedirect: React.FC<{ to: string }> = ({ to }) => {
+  const location = useLocation();
+  return <Navigate to={`${to}${location.search}${location.hash}`} replace />;
+};
+
 const ActualRoutes: React.FC<ActualRoutesProps> = ({ location }) => {
-  
   return (
     <AnimatePresence mode="wait">
       <Routes key={location.pathname} location={location}>
@@ -152,9 +167,7 @@ const ActualRoutes: React.FC<ActualRoutesProps> = ({ location }) => {
           }
         />
 
-        {hqRoutes.map((route) => (
-          <Route key={route.path} path={route.path} element={route.element} />
-        ))}
+        <Route path="/hq/*" element={<LegacyHQRedirect />} />
         
         <Route
           path="/gallery/:projectId/:gallerySlug"
@@ -172,6 +185,26 @@ const ActualRoutes: React.FC<ActualRoutesProps> = ({ location }) => {
         />
         
         <Route
+          path="/dashboard/tasks"
+          element={<LegacyDashboardProjectsRedirect to="/dashboard/projects/tasks" />}
+        />
+        <Route
+          path="/dashboard/new"
+          element={<LegacyDashboardProjectsRedirect to="/dashboard/projects/new" />}
+        />
+        <Route
+          path="/dashboard/welcome/*"
+          element={<LegacyDashboardProjectsRedirect to="/dashboard/projects" />}
+        />
+        <Route
+          path="/dashboard/projects-overview"
+          element={<LegacyDashboardProjectsRedirect to="/dashboard/projects" />}
+        />
+        <Route
+          path="/dashboard/allprojects/*"
+          element={<LegacyDashboardProjectsRedirect to="/dashboard/projects/allprojects" />}
+        />
+        <Route
           path="/dashboard/*"
           element={
             <ProtectedRoute>
@@ -179,6 +212,13 @@ const ActualRoutes: React.FC<ActualRoutesProps> = ({ location }) => {
             </ProtectedRoute>
           }
         >
+          {hqRoutes.map((route) =>
+            route.path === "" ? (
+              <Route key="hq-index" index element={route.element} />
+            ) : (
+              <Route key={`hq-${route.path}`} path={route.path} element={route.element} />
+            )
+          )}
           <Route
             path="projects/:projectId/:projectName?"
             element={<DashboardSingleProject key={location.key} />}
@@ -199,10 +239,11 @@ const ActualRoutes: React.FC<ActualRoutesProps> = ({ location }) => {
             path="projects/:projectId/:projectName?/editor"
             element={<DashboardEditorPage />}
           />
-          <Route path="tasks" element={<DashboardTasksPage />} />
-          <Route path="new" element={<DashboardNewProject />} />
-          <Route path="welcome/*" element={<Navigate to=".." replace />} />
-          <Route path="*" element={<DashboardWelcome />} />
+          <Route path="projects/tasks" element={<DashboardTasksPage />} />
+          <Route path="projects/new" element={<DashboardNewProject />} />
+          <Route path="projects" element={<DashboardWelcome />} />
+          <Route path="projects/allprojects" element={<DashboardWelcome />} />
+          <Route path="projects/*" element={<DashboardWelcome />} />
         </Route>
         
         <Route 

--- a/frontend/src/dashboard/features/messages/Messages.tsx
+++ b/frontend/src/dashboard/features/messages/Messages.tsx
@@ -840,7 +840,7 @@ const fetchMessages = async () => {
     const otherId = a === userData.userId ? b : a;
     const otherUser = allUsers.find((u) => u.userId === otherId);
     const slug = otherUser ? slugify(`${otherUser.firstName}-${otherUser.lastName}`) : otherId;
-    navigate(`/dashboard/features/messages/${slug}`);
+    navigate(`/dashboard/projects/messages/${slug}`);
 
     setSelectedConversation(normalizedConversationId);
     if (isMobile) setShowConversation(true);

--- a/frontend/src/dashboard/home/components/CollaboratorList.tsx
+++ b/frontend/src/dashboard/home/components/CollaboratorList.tsx
@@ -121,7 +121,7 @@ const CollaboratorList: React.FC<CollaboratorListProps> = ({
                 aria-label="Message"
                 onClick={(e) => {
                   e.stopPropagation();
-                  navigate(`/dashboard/features/messages/${slug}`);
+                  navigate(`/dashboard/projects/messages/${slug}`);
                 }}
               >
                 <MessageCircle size={18} />

--- a/frontend/src/dashboard/home/components/GlobalSearch.test.tsx
+++ b/frontend/src/dashboard/home/components/GlobalSearch.test.tsx
@@ -248,7 +248,7 @@ describe('GlobalSearch', () => {
     fireEvent.click(collaboratorButton!);
 
     await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith('/dashboard/features/messages/jane-collaborator');
+      expect(mockNavigate).toHaveBeenCalledWith('/dashboard/projects/messages/jane-collaborator');
     });
   });
 

--- a/frontend/src/dashboard/home/components/GlobalSearch.tsx
+++ b/frontend/src/dashboard/home/components/GlobalSearch.tsx
@@ -559,7 +559,7 @@ const GlobalSearch: React.FC<GlobalSearchProps> = ({ className = '', onNavigate 
           : '';
         const fallback = collaborator?.userId || result.userId || 'conversation';
         const slug = slugify(slugSource || fallback);
-        navigate(`/dashboard/features/messages/${slug}`);
+        navigate(`/dashboard/projects/messages/${slug}`);
       } catch (error) {
         console.error('Error navigating to collaborator conversation:', error);
       }

--- a/frontend/src/dashboard/home/components/MobileTasksOverviewCard.tsx
+++ b/frontend/src/dashboard/home/components/MobileTasksOverviewCard.tsx
@@ -39,7 +39,7 @@ const MobileTasksOverviewCard: React.FC<MobileTasksOverviewCardProps> = ({ class
       <header className={styles.header}>
         <h3 className={styles.title}>Tasks</h3>
         <Link
-          to="/dashboard/tasks"
+          to="/dashboard/projects/tasks"
           className={styles.viewAllButton}
           aria-label="View all tasks"
           state={{ from: `${location.pathname}${location.search}` }}

--- a/frontend/src/dashboard/home/components/TasksOverviewCard.tsx
+++ b/frontend/src/dashboard/home/components/TasksOverviewCard.tsx
@@ -388,7 +388,7 @@ const TasksOverviewCard: React.FC<TasksOverviewCardProps> = ({ className }) => {
               New task
             </Button>
             <Link
-              to="/dashboard/tasks"
+              to="/dashboard/projects/tasks"
               className={cn(styles.secondaryAction, styles.actionButton)}
               state={{ from: `${location.pathname}${location.search}` }}
             >

--- a/frontend/src/dashboard/home/components/WelcomeHeader.tsx
+++ b/frontend/src/dashboard/home/components/WelcomeHeader.tsx
@@ -180,7 +180,7 @@ const WelcomeHeader: React.FC<WelcomeHeaderProps> = ({
           <div className="welcome-header-actions">
             <div
               className="nav-item-style"
-              onClick={() => navigate("/dashboard/new")}
+              onClick={() => navigate("/dashboard/projects/new")}
               title="Start something"
             >
               <Plus size={isMobile ? 20 : 26} color="white" />

--- a/frontend/src/dashboard/home/hooks/useTasksOverview.ts
+++ b/frontend/src/dashboard/home/hooks/useTasksOverview.ts
@@ -533,7 +533,7 @@ export function useTasksOverview() {
   }, [navigateToProject, primaryProjectId]);
 
   const handleViewAll = useCallback(() => {
-    navigate("/dashboard/tasks");
+    navigate("/dashboard/projects/tasks");
   }, [navigate]);
 
   const tasksById = useMemo(() => {

--- a/frontend/src/dashboard/home/pages/DashboardHome.tsx
+++ b/frontend/src/dashboard/home/pages/DashboardHome.tsx
@@ -68,30 +68,37 @@ export const parseDashboardPath = (
     return { view: PROJECTS_OVERVIEW_VIEW, userSlug: null };
   }
 
-  let view = segments[idx + 1] || PROJECTS_OVERVIEW_VIEW;
-  let userSlug = segments[idx + 2] || null;
+  const afterDashboard = segments.slice(idx + 1);
+  if (afterDashboard[0] !== "projects") {
+    return { view: PROJECTS_OVERVIEW_VIEW, userSlug: null };
+  }
+
+  let view = afterDashboard[1] || PROJECTS_OVERVIEW_VIEW;
+  let userSlug = afterDashboard[2] || null;
 
   if (view === "features") {
-    view = segments[idx + 2] || PROJECTS_OVERVIEW_VIEW;
-    userSlug = segments[idx + 3] || null;
+    view = afterDashboard[2] || PROJECTS_OVERVIEW_VIEW;
+    userSlug = afterDashboard[3] || null;
   }
 
   if (view === "welcome") {
-    const nestedView = segments[idx + 2];
+    const nestedView = afterDashboard[2];
     if (nestedView) {
       view = nestedView;
-      userSlug = segments[idx + 3] || null;
+      userSlug = afterDashboard[3] || null;
     } else {
       view = PROJECTS_OVERVIEW_VIEW;
       userSlug = null;
     }
   }
 
-  if (view === "projects") {
-    const hasAdditionalSegment = segments.length > idx + 2;
-    if (!hasAdditionalSegment) {
-      view = PROJECTS_LIST_VIEW;
-    }
+  if (view === "projects" || view === "allprojects") {
+    view = PROJECTS_LIST_VIEW;
+    userSlug = null;
+  }
+
+  if (view === "messages") {
+    userSlug = afterDashboard[2] || null;
   }
 
   return { view, userSlug };
@@ -190,7 +197,7 @@ const WelcomeScreen: React.FC = () => {
   const { view: initialView, userSlug: initialDMUserSlug } = parsePath();
   const normalizeView = useCallback((view: string) => {
     if (view === "welcome") return PROJECTS_OVERVIEW_VIEW;
-    if (view === "projects") return PROJECTS_LIST_VIEW;
+    if (view === "projects" || view === "allprojects") return PROJECTS_LIST_VIEW;
     return view;
   }, []);
   const [activeView, setActiveView] = useState<string>(() =>
@@ -319,7 +326,7 @@ const WelcomeScreen: React.FC = () => {
             ? slugify(`${user.firstName}-${user.lastName}`)
             : otherId;
           setDmUserSlug(slug);
-          navigate(`/dashboard/features/messages/${slug}`, { replace: true });
+          navigate(`/dashboard/projects/messages/${slug}`, { replace: true });
         }
       }
     }
@@ -400,6 +407,7 @@ const WelcomeScreen: React.FC = () => {
         return renderWelcomeView();
       case PROJECTS_LIST_VIEW:
       case "projects":
+      case "allprojects":
         return <AllProjects />;
       case "notifications":
         return (

--- a/frontend/src/dashboard/home/pages/DashboardLayout.tsx
+++ b/frontend/src/dashboard/home/pages/DashboardLayout.tsx
@@ -14,23 +14,60 @@ const Dashboard: React.FC = () => {
   const hasRestored = useRef<boolean>(false);
 
   const getPageTitle = (): string => {
-    const path = location.pathname;
-    if (path.startsWith("/dashboard/projects/")) return "Dashboard - Project Details";
-    switch (path) {
-      case "/dashboard":
+    const segments = location.pathname.split("/").filter(Boolean);
+    if (segments[0] !== "dashboard") {
+      return "Dashboard";
+    }
+
+    const section = segments[1];
+
+    if (!section) {
+      return "Dashboard - Home";
+    }
+
+    if (section !== "projects") {
+      switch (section) {
+        case "accounts":
+          return "Dashboard - Accounts";
+        case "transactions":
+          return "Dashboard - Transactions";
+        case "reports":
+          return "Dashboard - Reports";
+        case "invoices":
+          return "Dashboard - Invoices";
+        case "tasks":
+          return "Dashboard - Tasks";
+        case "events":
+          return "Dashboard - Events";
+        case "messages":
+          return "Dashboard - Messages";
+        default:
+          return "Dashboard";
+      }
+    }
+
+    const projectView = segments[2];
+
+    switch (projectView) {
+      case undefined:
         return "Dashboard - Projects";
-      case "/dashboard/new":
-        return "Dashboard - Start something";
-      case "/dashboard/projects":
+      case "allprojects":
+      case "projects":
         return "Dashboard - Project List";
-      case "/dashboard/tasks":
+      case "new":
+        return "Dashboard - Start something";
+      case "tasks":
         return "Dashboard - Tasks";
-      case "/dashboard/settings":
-        return "Dashboard - Settings";
-      case "/dashboard/collaborators":
+      case "notifications":
+        return "Dashboard - Notifications";
+      case "messages":
+        return "Dashboard - Messages";
+      case "collaborators":
         return "Dashboard - Collaborators";
+      case "settings":
+        return "Dashboard - Settings";
       default:
-        return "Dashboard";
+        return "Dashboard - Project Details";
     }
   };
 
@@ -59,12 +96,18 @@ const Dashboard: React.FC = () => {
       }
 
       if (saved && saved !== "/dashboard") {
-        const normalized = saved
-          .replace("/dashboard/welcome", "/dashboard")
-          .replace("/dashboard/projects-overview", "/dashboard");
+        const normalized = (saved === "/dashboard/projects"
+          ? "/dashboard/projects/allprojects"
+          : saved)
+          .replace("/dashboard/welcome", "/dashboard/projects")
+          .replace("/dashboard/projects-overview", "/dashboard/projects")
+          .replace("/dashboard/tasks", "/dashboard/projects/tasks")
+          .replace("/dashboard/new", "/dashboard/projects/new")
+          .replace(
+            "/dashboard/projects/projects",
+            "/dashboard/projects/allprojects"
+          );
         navigate(normalized, { replace: true });
-      } else {
-        navigate("/dashboard", { replace: true });
       }
     }
   }, [location, navigate]);

--- a/frontend/src/hq/routes.tsx
+++ b/frontend/src/hq/routes.tsx
@@ -1,23 +1,23 @@
 import React from "react";
 
-const HQOverview = React.lazy(() => import("./pages/HQOverview"));
-const AccountsPage = React.lazy(() => import("./pages/AccountsPage"));
-const TransactionsPage = React.lazy(() => import("./pages/TransactionsPage"));
-const ReportsPage = React.lazy(() => import("./pages/ReportsPage"));
-const InvoicesPage = React.lazy(() => import("./pages/InvoicesPage"));
-const HQTasksPage = React.lazy(() => import("./pages/HQTasksPage"));
-const HQEventsPage = React.lazy(() => import("./pages/HQEventsPage"));
-const HQMessagesPage = React.lazy(() => import("./pages/HQMessagesPage"));
+export const HQOverview = React.lazy(() => import("./pages/HQOverview"));
+export const AccountsPage = React.lazy(() => import("./pages/AccountsPage"));
+export const TransactionsPage = React.lazy(() => import("./pages/TransactionsPage"));
+export const ReportsPage = React.lazy(() => import("./pages/ReportsPage"));
+export const InvoicesPage = React.lazy(() => import("./pages/InvoicesPage"));
+export const HQTasksPage = React.lazy(() => import("./pages/HQTasksPage"));
+export const HQEventsPage = React.lazy(() => import("./pages/HQEventsPage"));
+export const HQMessagesPage = React.lazy(() => import("./pages/HQMessagesPage"));
 
 export const hqRoutes = [
-  { path: "/hq", element: <HQOverview /> },
-  { path: "/hq/accounts", element: <AccountsPage /> },
-  { path: "/hq/transactions", element: <TransactionsPage /> },
-  { path: "/hq/reports", element: <ReportsPage /> },
-  { path: "/hq/invoices", element: <InvoicesPage /> },
-  { path: "/hq/tasks", element: <HQTasksPage /> },
-  { path: "/hq/events", element: <HQEventsPage /> },
-  { path: "/hq/messages", element: <HQMessagesPage /> },
+  { path: "", element: <HQOverview /> },
+  { path: "accounts", element: <AccountsPage /> },
+  { path: "transactions", element: <TransactionsPage /> },
+  { path: "reports", element: <ReportsPage /> },
+  { path: "invoices", element: <InvoicesPage /> },
+  { path: "tasks", element: <HQTasksPage /> },
+  { path: "events", element: <HQEventsPage /> },
+  { path: "messages", element: <HQMessagesPage /> },
 ];
 
 export default hqRoutes;

--- a/frontend/src/pages/home/DashboardHome.test.ts
+++ b/frontend/src/pages/home/DashboardHome.test.ts
@@ -13,26 +13,22 @@ describe("parseDashboardPath", () => {
     });
   });
 
-  it("returns nested welcome view and slug", () => {
-    expect(parseDashboardPath("/dashboard/welcome/messages/my-user")).toEqual({
-      view: "messages",
-      userSlug: "my-user",
+  it("interprets project routes", () => {
+    expect(parseDashboardPath("/dashboard/projects")).toEqual({
+      view: PROJECTS_OVERVIEW_VIEW,
+      userSlug: null,
+    });
+
+    expect(parseDashboardPath("/dashboard/projects/allprojects")).toEqual({
+      view: "projects-list",
+      userSlug: null,
     });
   });
 
-  it("returns direct feature view and slug", () => {
-    expect(parseDashboardPath("/dashboard/messages/teammate")).toEqual({
+  it("returns the direct messages view and slug", () => {
+    expect(parseDashboardPath("/dashboard/projects/messages/teammate")).toEqual({
       view: "messages",
       userSlug: "teammate",
-    });
-  });
-
-  it("handles feature routes under the features prefix", () => {
-    expect(
-      parseDashboardPath("/dashboard/features/messages/another-user")
-    ).toEqual({
-      view: "messages",
-      userSlug: "another-user",
     });
   });
 

--- a/frontend/src/shared/ui/NotificationsDrawer.tsx
+++ b/frontend/src/shared/ui/NotificationsDrawer.tsx
@@ -202,7 +202,7 @@ const NotificationsDrawer: React.FC<NotificationsDrawerProps> = ({
         : user.username || thread.otherUserId
       : thread.otherUserId;
 
-    navigate(`/dashboard/features/messages/${slug}`);
+    navigate(`/dashboard/projects/messages/${slug}`);
     handleItemClick();
   };
 

--- a/frontend/src/shared/ui/useDashboardNavigation.tsx
+++ b/frontend/src/shared/ui/useDashboardNavigation.tsx
@@ -47,12 +47,13 @@ export function useDashboardNavigation({ setActiveView, onClose }: UseDashboardN
   const navigate = useNavigate();
   const location = useLocation();
 
-  const isDashboardPath = location.pathname.startsWith("/dashboard");
+  const isProjectsPath = location.pathname.startsWith("/dashboard/projects");
   const activeDashboardView = useMemo(() => {
-    if (!isDashboardPath) return null;
+    if (!isProjectsPath) return null;
     return parseDashboardPath(location.pathname).view;
-  }, [isDashboardPath, location.pathname]);
-  const isHQActive = location.pathname.startsWith("/hq");
+  }, [isProjectsPath, location.pathname]);
+  const isHQActive =
+    location.pathname.startsWith("/dashboard") && !isProjectsPath;
 
   const unreadNotifications = useMemo(
     () => notifications.filter((n) => !n.read).length,
@@ -70,7 +71,7 @@ export function useDashboardNavigation({ setActiveView, onClose }: UseDashboardN
   const handleNavigation = useCallback(
     (view: string) => {
       setActiveView(view);
-      const base = "/dashboard";
+      const base = "/dashboard/projects";
       let path: string;
       switch (view) {
         case PROJECTS_OVERVIEW_VIEW:
@@ -79,7 +80,8 @@ export function useDashboardNavigation({ setActiveView, onClose }: UseDashboardN
           break;
         case PROJECTS_LIST_VIEW:
         case "projects":
-          path = `${base}/projects`;
+        case "allprojects":
+          path = `${base}/allprojects`;
           break;
         default:
           path = `${base}/${view}`;
@@ -91,12 +93,12 @@ export function useDashboardNavigation({ setActiveView, onClose }: UseDashboardN
   );
 
   const handleCreateProject = useCallback(() => {
-    navigate("/dashboard/new");
+    navigate("/dashboard/projects/new");
     close();
   }, [navigate, close]);
 
   const handleHQNavigation = useCallback(() => {
-    navigate("/hq");
+    navigate("/dashboard");
     close();
   }, [navigate, close]);
 
@@ -136,12 +138,12 @@ export function useDashboardNavigation({ setActiveView, onClose }: UseDashboardN
         label: "Projects",
         onClick: () => handleNavigation(PROJECTS_OVERVIEW_VIEW),
         isActive:
-          (isDashboardPath &&
-            (!activeDashboardView ||
-              activeDashboardView === PROJECTS_OVERVIEW_VIEW ||
-              activeDashboardView === PROJECTS_LIST_VIEW ||
-              activeDashboardView === "projects")) ||
-          location.pathname === "/dashboard",
+          isProjectsPath &&
+          (!activeDashboardView ||
+            activeDashboardView === PROJECTS_OVERVIEW_VIEW ||
+            activeDashboardView === PROJECTS_LIST_VIEW ||
+            activeDashboardView === "projects" ||
+            activeDashboardView === "allprojects"),
       },
       {
         key: "notifications",
@@ -150,7 +152,7 @@ export function useDashboardNavigation({ setActiveView, onClose }: UseDashboardN
         onClick: () => handleNavigation("notifications"),
         badgeCount: unreadNotifications,
         badgeLabel: "notification",
-        isActive: isDashboardPath && activeDashboardView === "notifications",
+        isActive: isProjectsPath && activeDashboardView === "notifications",
       },
       {
         key: "messages",
@@ -159,14 +161,14 @@ export function useDashboardNavigation({ setActiveView, onClose }: UseDashboardN
         onClick: () => handleNavigation("messages"),
         badgeCount: unreadMessages,
         badgeLabel: "message",
-        isActive: isDashboardPath && activeDashboardView === "messages",
+        isActive: isProjectsPath && activeDashboardView === "messages",
       },
       {
         key: "collaborators",
         icon: <Users size={24} color="white" />,
         label: "Collaborators",
         onClick: () => handleNavigation("collaborators"),
-        isActive: isDashboardPath && activeDashboardView === "collaborators",
+        isActive: isProjectsPath && activeDashboardView === "collaborators",
       },
     ],
     [
@@ -174,7 +176,7 @@ export function useDashboardNavigation({ setActiveView, onClose }: UseDashboardN
       handleNavigation,
       unreadNotifications,
       unreadMessages,
-      isDashboardPath,
+      isProjectsPath,
       activeDashboardView,
       location.pathname,
       handleHQNavigation,
@@ -197,7 +199,7 @@ export function useDashboardNavigation({ setActiveView, onClose }: UseDashboardN
         icon: <Settings size={24} color="white" />,
         label: "Settings",
         onClick: () => handleNavigation("settings"),
-        isActive: isDashboardPath && activeDashboardView === "settings",
+        isActive: isProjectsPath && activeDashboardView === "settings",
       },
       {
         key: "sign-out",
@@ -206,7 +208,7 @@ export function useDashboardNavigation({ setActiveView, onClose }: UseDashboardN
         onClick: handleSignOut,
       },
     ],
-    [close, handleNavigation, handleSignOut, isDashboardPath, activeDashboardView]
+    [close, handleNavigation, handleSignOut, isProjectsPath, activeDashboardView]
   );
 
   return {


### PR DESCRIPTION
## Summary
- nest HQ screens under the protected `/dashboard` layout and add redirects for legacy `/hq` and dashboard URLs
- move project-area routes beneath `/dashboard/projects` while updating navigation and layout logic to match the new hierarchy
- refresh supporting links, navigation helpers, and tests so tasks/messages routes and expectations follow the updated structure

## Testing
- `npm run test -- DashboardHome.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68e4ac7f15788324a0322bbb21ee89b7