### PR TITLE
Refactor dashboard routing to nest HQ under dashboard

### DIFF
--- a/frontend/src/app/routes.tsx
+++ b/frontend/src/app/routes.tsx
@@ -83,6 +83,26 @@ const pageTransition = {
   duration: 1,
 };
 
+const mapHqPathToDashboard = (pathname: string) => {
+  const suffix = pathname.replace(/^\/hq/, "");
+  if (!suffix || suffix === "/") {
+    return "/dashboard";
+  }
+
+  const normalizedSuffix = suffix.startsWith("/") ? suffix : `/${suffix}`;
+  return `/dashboard/hq${normalizedSuffix}`;
+};
+
+const HQRedirect: React.FC = () => {
+  const location = useLocation();
+  const target = React.useMemo(
+    () => `${mapHqPathToDashboard(location.pathname)}${location.search}${location.hash}`,
+    [location.hash, location.pathname, location.search]
+  );
+
+  return <Navigate to={target} replace />;
+};
+
 function AppRoutes(): React.ReactElement {
   const location = useLocation();
   
@@ -152,10 +172,6 @@ const ActualRoutes: React.FC<ActualRoutesProps> = ({ location }) => {
           }
         />
 
-        {hqRoutes.map((route) => (
-          <Route key={route.path} path={route.path} element={route.element} />
-        ))}
-        
         <Route
           path="/gallery/:projectId/:gallerySlug"
           element={
@@ -179,6 +195,13 @@ const ActualRoutes: React.FC<ActualRoutesProps> = ({ location }) => {
             </ProtectedRoute>
           }
         >
+          {hqRoutes.map((route) => {
+            const key = route.index ? "dashboard-hq-index" : `dashboard-${route.path}`;
+            if ("index" in route && route.index) {
+              return <Route key={key} index element={route.element} />;
+            }
+            return <Route key={key} path={route.path} element={route.element} />;
+          })}
           <Route
             path="projects/:projectId/:projectName?"
             element={<DashboardSingleProject key={location.key} />}
@@ -295,8 +318,8 @@ const ActualRoutes: React.FC<ActualRoutesProps> = ({ location }) => {
           } 
         />
         
-        <Route 
-          path="*" 
+        <Route
+          path="*"
           element={
             <motion.div
               initial="initial"
@@ -307,8 +330,9 @@ const ActualRoutes: React.FC<ActualRoutesProps> = ({ location }) => {
             >
               <NotFound />
             </motion.div>
-          } 
+          }
         />
+        <Route path="/hq/*" element={<HQRedirect />} />
       </Routes>
     </AnimatePresence>
   );

--- a/frontend/src/dashboard/NewProject/NewProject.tsx
+++ b/frontend/src/dashboard/NewProject/NewProject.tsx
@@ -304,7 +304,7 @@ const NewProject: React.FC = () => {
           <header className={styles.newProjectHeader}>
             <button
               className={styles.backButton}
-              onClick={() => navigate("/dashboard")}
+              onClick={() => navigate("/dashboard/projects")}
               aria-label="Back to dashboard"
             >
               <FaArrowLeft />

--- a/frontend/src/dashboard/home/components/ProjectsPanelDesktop.tsx
+++ b/frontend/src/dashboard/home/components/ProjectsPanelDesktop.tsx
@@ -71,7 +71,7 @@ const ProjectsPanelDesktop: React.FC<ProjectsPanelDesktopProps> = ({ onOpenProje
         return;
       }
 
-      navigate("/dashboard/projects");
+      navigate("/dashboard/projects/allprojects");
     },
     [onOpenProject, navigate, projects]
   );
@@ -129,7 +129,7 @@ const ProjectsPanelDesktop: React.FC<ProjectsPanelDesktopProps> = ({ onOpenProje
     setScope("all");
     setQuery("");
     setStatusFilter("");
-    navigate("/dashboard/projects");
+    navigate("/dashboard/projects/allprojects");
   }, [navigate, setQuery, setScope, setStatusFilter]);
 
   const handleTogglePendingFilter = useCallback(() => {

--- a/frontend/src/dashboard/home/components/ProjectsPanelMobile.tsx
+++ b/frontend/src/dashboard/home/components/ProjectsPanelMobile.tsx
@@ -519,7 +519,7 @@ const ProjectsPanelMobile: React.FC<Props> = ({ onOpenProject }) => {
         <button
           type="button"
           className={styles.cta}
-          onClick={() => navigate("/dashboard/projects")}
+          onClick={() => navigate("/dashboard/projects/allprojects")}
         >
           See all projects
         </button>

--- a/frontend/src/dashboard/home/components/ProjectsRecentsCard.tsx
+++ b/frontend/src/dashboard/home/components/ProjectsRecentsCard.tsx
@@ -94,7 +94,7 @@ const ProjectsRecentsCard: React.FC<Props> = ({ onOpenProject }) => {
   const handleOpen = (id: string) => {
     if (onOpenProject) return onOpenProject(id);
     // Fallback: route to projects list, then rely on default flow
-    navigate("/dashboard/projects");
+    navigate("/dashboard/projects/allprojects");
   };
 
   const handleKeyRow = (e: React.KeyboardEvent, id: string) => {
@@ -231,7 +231,7 @@ const ProjectsRecentsCard: React.FC<Props> = ({ onOpenProject }) => {
       <button
         type="button"
         className="prc-cta"
-        onClick={() => navigate("/dashboard/projects")}
+        onClick={() => navigate("/dashboard/projects/allprojects")}
       >
         See all projects
       </button>

--- a/frontend/src/dashboard/home/hooks/useTasksOverview.ts
+++ b/frontend/src/dashboard/home/hooks/useTasksOverview.ts
@@ -518,7 +518,7 @@ export function useTasksOverview() {
   const navigateToProject = useCallback(
     (projectId?: string | null) => {
       if (!projectId) {
-        navigate("/dashboard/projects");
+        navigate("/dashboard/projects/allprojects");
         return;
       }
 

--- a/frontend/src/dashboard/home/pages/DashboardHome.tsx
+++ b/frontend/src/dashboard/home/pages/DashboardHome.tsx
@@ -71,6 +71,41 @@ export const parseDashboardPath = (
   let view = segments[idx + 1] || PROJECTS_OVERVIEW_VIEW;
   let userSlug = segments[idx + 2] || null;
 
+  if (view === "projects") {
+    const subSegment = segments[idx + 2];
+    if (!subSegment) {
+      return { view: PROJECTS_OVERVIEW_VIEW, userSlug: null };
+    }
+
+    if (subSegment === "allprojects") {
+      return { view: PROJECTS_LIST_VIEW, userSlug: null };
+    }
+
+    if (subSegment === "features") {
+      return {
+        view: segments[idx + 3] || PROJECTS_OVERVIEW_VIEW,
+        userSlug: segments[idx + 4] || null,
+      };
+    }
+
+    if (subSegment === "welcome") {
+      const nestedView = segments[idx + 3];
+      if (nestedView) {
+        return {
+          view: nestedView,
+          userSlug: segments[idx + 4] || null,
+        };
+      }
+
+      return { view: PROJECTS_OVERVIEW_VIEW, userSlug: null };
+    }
+
+    return {
+      view: subSegment,
+      userSlug: segments[idx + 3] || null,
+    };
+  }
+
   if (view === "features") {
     view = segments[idx + 2] || PROJECTS_OVERVIEW_VIEW;
     userSlug = segments[idx + 3] || null;
@@ -84,13 +119,6 @@ export const parseDashboardPath = (
     } else {
       view = PROJECTS_OVERVIEW_VIEW;
       userSlug = null;
-    }
-  }
-
-  if (view === "projects") {
-    const hasAdditionalSegment = segments.length > idx + 2;
-    if (!hasAdditionalSegment) {
-      view = PROJECTS_LIST_VIEW;
     }
   }
 
@@ -190,7 +218,8 @@ const WelcomeScreen: React.FC = () => {
   const { view: initialView, userSlug: initialDMUserSlug } = parsePath();
   const normalizeView = useCallback((view: string) => {
     if (view === "welcome") return PROJECTS_OVERVIEW_VIEW;
-    if (view === "projects") return PROJECTS_LIST_VIEW;
+    if (view === "projects") return PROJECTS_OVERVIEW_VIEW;
+    if (view === "allprojects") return PROJECTS_LIST_VIEW;
     return view;
   }, []);
   const [activeView, setActiveView] = useState<string>(() =>

--- a/frontend/src/dashboard/home/pages/DashboardLayout.tsx
+++ b/frontend/src/dashboard/home/pages/DashboardLayout.tsx
@@ -5,6 +5,43 @@ import { useData } from "@/app/contexts/useData";
 import "./dashboard-styles.css";
 
 
+const DASHBOARD_LAST_PATH_KEY = "dashboardLastPath";
+const DASHBOARD_LAST_PATH_VERSION_KEY = "dashboardLastPathVersion";
+const DASHBOARD_LAST_PATH_VERSION = "2";
+
+const buildDashboardHQPath = (suffix: string): string => {
+  if (!suffix || suffix === "/") {
+    return "/dashboard";
+  }
+
+  const normalizedSuffix = suffix.startsWith("/") ? suffix : `/${suffix}`;
+  return `/dashboard/hq${normalizedSuffix}`;
+};
+
+const mapLegacyDashboardPath = (fullPath: string): string => {
+  if (!fullPath) {
+    return "/dashboard";
+  }
+
+  const [pathOnly, rest = ""] = fullPath.split(/(?=[?#])/);
+  let nextPath = pathOnly;
+
+  if (
+    pathOnly === "/dashboard" ||
+    pathOnly === "/dashboard/welcome" ||
+    pathOnly === "/dashboard/projects-overview"
+  ) {
+    nextPath = "/dashboard/projects";
+  } else if (pathOnly === "/dashboard/projects") {
+    nextPath = "/dashboard/projects/allprojects";
+  } else if (pathOnly.startsWith("/hq")) {
+    const suffix = pathOnly.replace(/^\/hq/, "");
+    nextPath = buildDashboardHQPath(suffix);
+  }
+
+  return `${nextPath}${rest}`;
+};
+
 const Dashboard: React.FC = () => {
   // If your DataProvider has types, replace `any` below with the real shape.
   const { userName, opacity } = useData() as { userName?: string; opacity?: number };
@@ -15,13 +52,20 @@ const Dashboard: React.FC = () => {
 
   const getPageTitle = (): string => {
     const path = location.pathname;
-    if (path.startsWith("/dashboard/projects/")) return "Dashboard - Project Details";
+    if (
+      path.startsWith("/dashboard/projects/") &&
+      !path.startsWith("/dashboard/projects/allprojects")
+    ) {
+      return "Dashboard - Project Details";
+    }
     switch (path) {
       case "/dashboard":
-        return "Dashboard - Projects";
+        return "Dashboard - HQ";
       case "/dashboard/new":
         return "Dashboard - Start something";
       case "/dashboard/projects":
+        return "Dashboard - Project List";
+      case "/dashboard/projects/allprojects":
         return "Dashboard - Project List";
       case "/dashboard/tasks":
         return "Dashboard - Tasks";
@@ -29,6 +73,20 @@ const Dashboard: React.FC = () => {
         return "Dashboard - Settings";
       case "/dashboard/collaborators":
         return "Dashboard - Collaborators";
+      case "/dashboard/hq/accounts":
+        return "Dashboard - Accounts";
+      case "/dashboard/hq/transactions":
+        return "Dashboard - Transactions";
+      case "/dashboard/hq/reports":
+        return "Dashboard - Reports";
+      case "/dashboard/hq/invoices":
+        return "Dashboard - Invoices";
+      case "/dashboard/hq/tasks":
+        return "Dashboard - Tasks";
+      case "/dashboard/hq/events":
+        return "Dashboard - Events";
+      case "/dashboard/hq/messages":
+        return "Dashboard - Messages";
       default:
         return "Dashboard";
     }
@@ -38,7 +96,11 @@ const Dashboard: React.FC = () => {
   useEffect(() => {
     if (location.pathname.startsWith("/dashboard")) {
       try {
-        localStorage.setItem("dashboardLastPath", location.pathname + location.search);
+        localStorage.setItem(
+          DASHBOARD_LAST_PATH_KEY,
+          location.pathname + location.search
+        );
+        localStorage.setItem(DASHBOARD_LAST_PATH_VERSION_KEY, DASHBOARD_LAST_PATH_VERSION);
       } catch {
         // ignore storage errors
       }
@@ -52,20 +114,27 @@ const Dashboard: React.FC = () => {
 
     if (location.pathname === "/dashboard") {
       let saved: string | null = null;
+      let savedVersion: string | null = null;
       try {
-        saved = localStorage.getItem("dashboardLastPath");
+        saved = localStorage.getItem(DASHBOARD_LAST_PATH_KEY);
+        savedVersion = localStorage.getItem(DASHBOARD_LAST_PATH_VERSION_KEY);
       } catch {
         // ignore storage errors
       }
 
-      if (saved && saved !== "/dashboard") {
-        const normalized = saved
-          .replace("/dashboard/welcome", "/dashboard")
-          .replace("/dashboard/projects-overview", "/dashboard");
-        navigate(normalized, { replace: true });
-      } else {
-        navigate("/dashboard", { replace: true });
+      if (saved) {
+        const normalized =
+          savedVersion === DASHBOARD_LAST_PATH_VERSION
+            ? saved
+            : mapLegacyDashboardPath(saved);
+
+        if (normalized !== "/dashboard") {
+          navigate(normalized, { replace: true });
+          return;
+        }
       }
+
+      navigate("/dashboard", { replace: true });
     }
   }, [location, navigate]);
 

--- a/frontend/src/dashboard/home/pages/TasksListPage.tsx
+++ b/frontend/src/dashboard/home/pages/TasksListPage.tsx
@@ -123,7 +123,7 @@ const TasksListPage: React.FC = () => {
     if (typeof window !== "undefined" && window.history.length > 1) {
       navigate(-1);
     } else {
-      navigate("/dashboard");
+      navigate("/dashboard/projects");
     }
   }, [navigate, returnTo]);
 

--- a/frontend/src/dashboard/project/components/Shared/MobileProjectHeader.tsx
+++ b/frontend/src/dashboard/project/components/Shared/MobileProjectHeader.tsx
@@ -80,7 +80,7 @@ const MobileProjectHeader: React.FC<MobileProjectHeaderProps> = ({
   };
 
   const handleBackToDashboard = React.useCallback(() => {
-    navigate("/dashboard");
+    navigate("/dashboard/projects");
   }, [navigate]);
 
   const handleOpenChat = React.useCallback(() => {

--- a/frontend/src/dashboard/project/components/Shared/useProjectTabs.tsx
+++ b/frontend/src/dashboard/project/components/Shared/useProjectTabs.tsx
@@ -39,7 +39,7 @@ export const useProjectTabs = (
     () =>
       hasProject
         ? getProjectDashboardPath(projectId, projectTitle ?? undefined)
-        : "/dashboard/projects",
+        : "/dashboard/projects/allprojects",
     [hasProject, projectId, projectTitle]
   );
 
@@ -51,7 +51,7 @@ export const useProjectTabs = (
             projectTitle ?? undefined,
             "/budget"
           )
-        : "/dashboard/projects",
+        : "/dashboard/projects/allprojects",
     [hasProject, projectId, projectTitle]
   );
 
@@ -63,7 +63,7 @@ export const useProjectTabs = (
             projectTitle ?? undefined,
             "/calendar"
           )
-        : "/dashboard/projects",
+        : "/dashboard/projects/allprojects",
     [hasProject, projectId, projectTitle]
   );
 
@@ -75,7 +75,7 @@ export const useProjectTabs = (
             projectTitle ?? undefined,
             "/editor"
           )
-        : "/dashboard/projects",
+        : "/dashboard/projects/allprojects",
     [hasProject, projectId, projectTitle]
   );
 

--- a/frontend/src/dashboard/project/features/budget/pages/BudgetPage.tsx
+++ b/frontend/src/dashboard/project/features/budget/pages/BudgetPage.tsx
@@ -149,7 +149,7 @@ const BudgetPageContent = () => {
 
   const handleBack = () => {
     if (!projectId) {
-      navigate("/dashboard/projects");
+      navigate("/dashboard/projects/allprojects");
       return;
     }
 
@@ -174,7 +174,7 @@ const BudgetPageContent = () => {
   const handleProjectDeleted = (deletedProjectId) => {
     setProjects((prev) => prev.filter((p) => p.projectId !== deletedProjectId));
     setSelectedProjects((prev) => prev.filter((id) => id !== deletedProjectId));
-    navigate("/dashboard/projects");
+    navigate("/dashboard/projects/allprojects");
   };
 
   const handleBallparkChange = async (val) => {

--- a/frontend/src/dashboard/project/features/calendar/calendar.tsx
+++ b/frontend/src/dashboard/project/features/calendar/calendar.tsx
@@ -133,12 +133,12 @@ const CalendarPage: React.FC = () => {
   const handleProjectDeleted = (deletedProjectId: string) => {
     setProjects((prev: Project[]) => prev.filter((p) => p.projectId !== deletedProjectId));
     setSelectedProjects((prev: string[]) => prev.filter((id) => id !== deletedProjectId));
-    navigate('/dashboard/projects');
+    navigate('/dashboard/projects/allprojects');
   };
 
   const handleBack = () => {
     if (!projectId) {
-      navigate('/dashboard/projects');
+      navigate('/dashboard/projects/allprojects');
       return;
     }
 

--- a/frontend/src/dashboard/project/features/editor/pages/editorpage.tsx
+++ b/frontend/src/dashboard/project/features/editor/pages/editorpage.tsx
@@ -156,12 +156,12 @@ const EditorPage: React.FC = () => {
   const handleProjectDeleted = (deletedProjectId: string) => {
     setProjects((prev: Project[]) => prev.filter((p) => p.projectId !== deletedProjectId));
     setSelectedProjects((prev: string[]) => prev.filter((id) => id !== deletedProjectId));
-    navigate("/dashboard/projects");
+    navigate("/dashboard/projects/allprojects");
   };
 
   const handleBack = () => {
     if (!projectId) {
-      navigate('/dashboard/projects');
+      navigate('/dashboard/projects/allprojects');
       return;
     }
 

--- a/frontend/src/dashboard/project/features/gallery/GalleryPage.tsx
+++ b/frontend/src/dashboard/project/features/gallery/GalleryPage.tsx
@@ -151,7 +151,7 @@ const GalleryPage: FC<GalleryPageProps> = ({ projectId: propProjectId }) => {
     if (projectId) {
       navigate(`/dashboard/projects/${encodeURIComponent(projectId)}`);
     } else {
-      navigate("/dashboard");
+      navigate("/dashboard/projects");
     }
   }, [navigate, projectId]);
 

--- a/frontend/src/dashboard/project/features/moodboard/pages/MoodboardPage.tsx
+++ b/frontend/src/dashboard/project/features/moodboard/pages/MoodboardPage.tsx
@@ -155,7 +155,7 @@ const MoodboardPage: React.FC = () => {
     (projectId: string) => {
       setProjects((prev) => prev.filter((item) => item.projectId !== projectId));
       setSelectedProjects((prev) => prev.filter((id) => id !== projectId));
-      navigate("/dashboard/projects");
+      navigate("/dashboard/projects/allprojects");
     },
     [navigate, setProjects, setSelectedProjects]
   );
@@ -165,7 +165,7 @@ const MoodboardPage: React.FC = () => {
   }, []);
 
   const showWelcomeScreen = useCallback(() => {
-    navigate("/dashboard");
+    navigate("/dashboard/projects");
   }, [navigate]);
 
   const resolvedProjectId = activeProject?.projectId ?? "";

--- a/frontend/src/dashboard/project/pages/NewProject.tsx
+++ b/frontend/src/dashboard/project/pages/NewProject.tsx
@@ -304,7 +304,7 @@ const NewProject: React.FC = () => {
           <header className={styles.newProjectHeader}>
             <button
               className={styles.backButton}
-              onClick={() => navigate("/dashboard")}
+              onClick={() => navigate("/dashboard/projects")}
               aria-label="Back to dashboard"
             >
               <FaArrowLeft />

--- a/frontend/src/dashboard/project/project.tsx
+++ b/frontend/src/dashboard/project/project.tsx
@@ -104,7 +104,7 @@ const SingleProject: React.FC = () => {
 
 
   const showWelcome = useCallback(() => {
-    navigate("/dashboard");
+    navigate("/dashboard/projects");
   }, [navigate]);
 
   const openCalendarPage = useCallback(() => {
@@ -122,7 +122,7 @@ const SingleProject: React.FC = () => {
     (deletedProjectId: string) => {
       setProjects((prev) => prev.filter((p) => p.projectId !== deletedProjectId));
       setSelectedProjects((prev) => prev.filter((id: string) => id !== deletedProjectId));
-      navigate("/dashboard/projects");
+      navigate("/dashboard/projects/allprojects");
     },
     [navigate, setProjects, setSelectedProjects]
   );

--- a/frontend/src/hq/components/HQLayout.tsx
+++ b/frontend/src/hq/components/HQLayout.tsx
@@ -74,7 +74,7 @@ const HQLayout: React.FC<HQLayoutProps> = ({
 }) => {
   const { isAdmin, userName } = useUser();
   const [flags, setFlags] = useState<ViewportFlags>(() => getViewportFlags());
-  const [isNavCollapsed, setIsNavCollapsed] = useNavCollapsed("hq");
+  const [isNavCollapsed, setIsNavCollapsed] = useNavCollapsed("dashboard");
   const [isNavigationOpen, setIsNavigationOpen] = useState(false);
   const rawDrawerId = useId();
   const drawerId = useMemo(

--- a/frontend/src/hq/routes.tsx
+++ b/frontend/src/hq/routes.tsx
@@ -9,15 +9,30 @@ const HQTasksPage = React.lazy(() => import("./pages/HQTasksPage"));
 const HQEventsPage = React.lazy(() => import("./pages/HQEventsPage"));
 const HQMessagesPage = React.lazy(() => import("./pages/HQMessagesPage"));
 
-export const hqRoutes = [
-  { path: "/hq", element: <HQOverview /> },
-  { path: "/hq/accounts", element: <AccountsPage /> },
-  { path: "/hq/transactions", element: <TransactionsPage /> },
-  { path: "/hq/reports", element: <ReportsPage /> },
-  { path: "/hq/invoices", element: <InvoicesPage /> },
-  { path: "/hq/tasks", element: <HQTasksPage /> },
-  { path: "/hq/events", element: <HQEventsPage /> },
-  { path: "/hq/messages", element: <HQMessagesPage /> },
+export type HQRouteConfig =
+  | { index: true; element: React.ReactElement }
+  | { index?: false; path: string; element: React.ReactElement };
+
+export const HQ_ROUTE_SEGMENTS = [
+  "",
+  "hq/accounts",
+  "hq/transactions",
+  "hq/reports",
+  "hq/invoices",
+  "hq/tasks",
+  "hq/events",
+  "hq/messages",
+] as const;
+
+export const hqRoutes: HQRouteConfig[] = [
+  { index: true, element: <HQOverview /> },
+  { path: "hq/accounts", element: <AccountsPage /> },
+  { path: "hq/transactions", element: <TransactionsPage /> },
+  { path: "hq/reports", element: <ReportsPage /> },
+  { path: "hq/invoices", element: <InvoicesPage /> },
+  { path: "hq/tasks", element: <HQTasksPage /> },
+  { path: "hq/events", element: <HQEventsPage /> },
+  { path: "hq/messages", element: <HQMessagesPage /> },
 ];
 
 export default hqRoutes;

--- a/frontend/src/shared/ui/useDashboardNavigation.tsx
+++ b/frontend/src/shared/ui/useDashboardNavigation.tsx
@@ -20,6 +20,7 @@ import {
   PROJECTS_OVERVIEW_VIEW,
   parseDashboardPath,
 } from "@/dashboard/home/pages/DashboardHome";
+import { HQ_ROUTE_SEGMENTS } from "@/hq/routes";
 
 export type DashboardNavItem = {
   key: string;
@@ -40,6 +41,10 @@ export type UseDashboardNavigationArgs = {
   onClose?: () => void;
 };
 
+const HQ_DASHBOARD_PATHS = HQ_ROUTE_SEGMENTS.map((segment) =>
+  segment ? `/dashboard/${segment}` : "/dashboard"
+);
+
 export function useDashboardNavigation({ setActiveView, onClose }: UseDashboardNavigationArgs) {
   const { setIsAuthenticated, setCognitoUser } = useAuth();
   const { inbox } = useData();
@@ -52,7 +57,17 @@ export function useDashboardNavigation({ setActiveView, onClose }: UseDashboardN
     if (!isDashboardPath) return null;
     return parseDashboardPath(location.pathname).view;
   }, [isDashboardPath, location.pathname]);
-  const isHQActive = location.pathname.startsWith("/hq");
+  const isHQActive = useMemo(() => {
+    return HQ_DASHBOARD_PATHS.some((path) => {
+      if (path === "/dashboard") {
+        return location.pathname === path;
+      }
+
+      return (
+        location.pathname === path || location.pathname.startsWith(`${path}/`)
+      );
+    });
+  }, [location.pathname]);
 
   const unreadNotifications = useMemo(
     () => notifications.filter((n) => !n.read).length,
@@ -75,11 +90,11 @@ export function useDashboardNavigation({ setActiveView, onClose }: UseDashboardN
       switch (view) {
         case PROJECTS_OVERVIEW_VIEW:
         case "welcome":
-          path = base;
+          path = `${base}/projects`;
           break;
         case PROJECTS_LIST_VIEW:
         case "projects":
-          path = `${base}/projects`;
+          path = `${base}/projects/allprojects`;
           break;
         default:
           path = `${base}/${view}`;
@@ -96,7 +111,7 @@ export function useDashboardNavigation({ setActiveView, onClose }: UseDashboardN
   }, [navigate, close]);
 
   const handleHQNavigation = useCallback(() => {
-    navigate("/hq");
+    navigate("/dashboard");
     close();
   }, [navigate, close]);
 
@@ -136,12 +151,12 @@ export function useDashboardNavigation({ setActiveView, onClose }: UseDashboardN
         label: "Projects",
         onClick: () => handleNavigation(PROJECTS_OVERVIEW_VIEW),
         isActive:
-          (isDashboardPath &&
-            (!activeDashboardView ||
-              activeDashboardView === PROJECTS_OVERVIEW_VIEW ||
-              activeDashboardView === PROJECTS_LIST_VIEW ||
-              activeDashboardView === "projects")) ||
-          location.pathname === "/dashboard",
+          isDashboardPath &&
+          location.pathname.startsWith("/dashboard/projects") &&
+          (!activeDashboardView ||
+            activeDashboardView === PROJECTS_OVERVIEW_VIEW ||
+            activeDashboardView === PROJECTS_LIST_VIEW ||
+            activeDashboardView === "projects"),
       },
       {
         key: "notifications",


### PR DESCRIPTION
## Summary
- redirect legacy /hq URLs into the dashboard and mount HQ screens as nested routes under /dashboard
- update dashboard navigation logic and path parsing for the new /dashboard/projects and /dashboard/projects/allprojects structure
- adjust layout persistence and project navigation entry points to use the new dashboard routes while sharing the nav collapse state

## Testing
- `npm run build` *(fails: rollup could not resolve optional dependency "recharts" from BudgetDonut)*

------
https://chatgpt.com/codex/tasks/task_e_68e4d900f5cc83248eb25da65966e3af