### PR TITLE
Add skeleton loading state to desktop projects overview

### DIFF
--- a/frontend/src/dashboard/home/components/ProjectsPanelDesktop.module.css
+++ b/frontend/src/dashboard/home/components/ProjectsPanelDesktop.module.css
@@ -160,6 +160,83 @@
   overflow: auto;
 }
 
+.tableSkeleton {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  min-width: 640px;
+  padding: 12px 16px 16px;
+}
+
+.skeletonHead,
+.skeletonRow {
+  display: grid;
+  grid-template-columns: minmax(0, 2.5fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1.5fr) minmax(0, 0.8fr);
+  gap: 16px;
+}
+
+.skeletonHead {
+  padding-bottom: 8px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.skeletonHeadCol {
+  height: 10px;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.skeletonRow {
+  align-items: center;
+  padding: 12px 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.skeletonRow:last-of-type {
+  border-bottom: none;
+}
+
+.skeletonProject {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.skeletonThumb {
+  width: 36px;
+  height: 36px;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.skeletonLine,
+.skeletonLineShort,
+.skeletonBadge,
+.skeletonPill {
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.skeletonLine {
+  height: 12px;
+  width: 160px;
+}
+
+.skeletonLineShort {
+  height: 12px;
+  width: 110px;
+}
+
+.skeletonBadge {
+  height: 18px;
+  width: 80px;
+}
+
+.skeletonPill {
+  height: 22px;
+  width: 48px;
+}
+
 .table {
   width: 100%;
   border-collapse: collapse;

--- a/frontend/src/dashboard/home/components/ProjectsTable.tsx
+++ b/frontend/src/dashboard/home/components/ProjectsTable.tsx
@@ -56,10 +56,32 @@ const ProjectsTable: FC<ProjectsTableProps> = ({
     return <div className={desktopStyles.errorState}>{errorText}</div>;
   }
 
+  const skeletonRows = Array.from({ length: 5 });
+
   return (
     <div className={desktopStyles.tableWrap}>
       {isLoading ? (
-        <div className={desktopStyles.emptyState}>Loading projects…</div>
+        <div className={desktopStyles.tableSkeleton} aria-hidden>
+          <div className={desktopStyles.skeletonHead}>
+            <div className={desktopStyles.skeletonHeadCol} />
+            <div className={desktopStyles.skeletonHeadCol} />
+            <div className={desktopStyles.skeletonHeadCol} />
+            <div className={desktopStyles.skeletonHeadCol} />
+            <div className={desktopStyles.skeletonHeadCol} />
+          </div>
+          {skeletonRows.map((_, index) => (
+            <div className={desktopStyles.skeletonRow} key={index}>
+              <div className={desktopStyles.skeletonProject}>
+                <div className={desktopStyles.skeletonThumb} />
+                <div className={desktopStyles.skeletonLine} />
+              </div>
+              <div className={desktopStyles.skeletonBadge} />
+              <div className={desktopStyles.skeletonLineShort} />
+              <div className={desktopStyles.skeletonLine} />
+              <div className={desktopStyles.skeletonPill} />
+            </div>
+          ))}
+        </div>
       ) : projects.length === 0 ? (
         <div className={desktopStyles.emptyState}>No projects match filters.</div>
       ) : (


### PR DESCRIPTION
## Summary
- replace the desktop Projects overview loading message with a table skeleton placeholder
- add skeleton-specific styling so the placeholder mirrors the table layout

## Testing
- `npm run lint` *(fails: existing lint errors in unrelated providers and dashboard components)*

------
https://chatgpt.com/codex/tasks/task_e_68e570a0cde08324a5540d85d94421d3