### PR TITLE
Add mobile skeleton for Projects overview card

### DIFF
--- a/frontend/src/dashboard/home/components/ProjectsPanelMobile.tsx
+++ b/frontend/src/dashboard/home/components/ProjectsPanelMobile.tsx
@@ -69,6 +69,11 @@ const ProjectsPanelMobile: React.FC<Props> = ({ onOpenProject }) => {
       typeof window === "undefined" ? undefined : window.innerWidth
     )
   );
+  const skeletonRows = useMemo(() => Array.from({ length: 4 }), []);
+  const skeletonQuickIcons = useMemo(
+    () => Array.from({ length: Math.min(Math.max(maxQuickIcons, 3), 6) }),
+    [maxQuickIcons]
+  );
 
   // Compact filter/sort options (mirrors AllProjects)
   type SortOption = "titleAsc" | "titleDesc" | "dateNewest" | "dateOldest";
@@ -397,11 +402,30 @@ const ProjectsPanelMobile: React.FC<Props> = ({ onOpenProject }) => {
 
       <div className={styles.list} role="list">
         {isLoading ? (
-          <div className={`${styles.row} ${styles.skeleton}`} aria-hidden>
-            <div className={`${styles.icon} ${styles.skel}`} />
-            <div className={styles.meta}>
-              <div className={styles.skelBar} />
+          <div className={styles.skeletonList} aria-hidden>
+            <div className={styles.skeletonIconsStrip}>
+              {skeletonQuickIcons.map((_, index) => (
+                <div
+                  key={`skeleton-icon-${index}`}
+                  className={styles.skeletonIconBtn}
+                />
+              ))}
             </div>
+            {skeletonRows.map((_, index) => (
+              <div
+                key={`skeleton-row-${index}`}
+                className={`${styles.row} ${styles.skeletonRow}`}
+              >
+                <div className={`${styles.rowMain} ${styles.skeletonRowMain}`}>
+                  <div className={styles.skeletonThumb} />
+                  <div className={styles.skeletonMeta}>
+                    <div className={styles.skeletonLine} />
+                    <div className={styles.skeletonLineShort} />
+                  </div>
+                </div>
+                <div className={styles.skeletonMenu} />
+              </div>
+            ))}
           </div>
         ) : items.length === 0 ? (
           <div className={styles.empty} role="note">

--- a/frontend/src/dashboard/home/components/projects-panel.module.css
+++ b/frontend/src/dashboard/home/components/projects-panel.module.css
@@ -679,6 +679,71 @@
   background: rgba(255, 255, 255, .08);
 }
 
+.skeletonList {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 2px 0 6px;
+}
+
+.skeletonIconsStrip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 4px;
+}
+
+.skeletonIconBtn {
+  width: 24px;
+  height: 24px;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, .08);
+}
+
+.skeletonRow {
+  pointer-events: none;
+}
+
+.skeletonRowMain {
+  padding: 4px 6px;
+  gap: 10px;
+}
+
+.skeletonThumb {
+  width: 32px;
+  height: 32px;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, .08);
+}
+
+.skeletonMeta {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.skeletonLine,
+.skeletonLineShort,
+.skeletonMenu {
+  background: rgba(255, 255, 255, .08);
+  border-radius: 999px;
+  height: 10px;
+}
+
+.skeletonLine {
+  width: 160px;
+}
+
+.skeletonLineShort {
+  width: 96px;
+}
+
+.skeletonMenu {
+  width: 18px;
+  height: 18px;
+  justify-self: center;
+}
+
 /* iPhone compact widths */
 @media (max-width: 390px) {
   .panel {
@@ -692,6 +757,14 @@
 
   .cta {
     padding: 10px;
+  }
+
+  .skeletonLine {
+    width: 120px;
+  }
+
+  .skeletonLineShort {
+    width: 72px;
   }
 
   .grid {


### PR DESCRIPTION
## Summary
- add structured skeleton markup for the Projects overview card on mobile while data loads
- style the mobile skeleton placeholders to mirror the desktop table layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e572b977bc832499002a888d093b8d