### PR TITLE
Refactor budget table into responsive cards

### DIFF
--- a/frontend/src/dashboard/project/features/budget/components/BudgetTable.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetTable.tsx
@@ -1,13 +1,19 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
-import { Pagination, Table } from "antd";
-import type { ColumnsType, TableProps } from "antd/es/table";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { Pagination } from "antd";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faClone, faClock, faTrash } from "@fortawesome/free-solid-svg-icons";
 import styles from "@/dashboard/project/features/budget/pages/budget-page.module.css";
 import { formatUSD } from "@/shared/utils/budgetUtils";
 
-const TABLE_HEADER_FOOTER = 110;
 const MOBILE_BREAKPOINT = 768;
+
+const PAGINATION_ESTIMATE = 96;
 
 type BudgetItem = Record<string, unknown> & {
   budgetItemId: string;
@@ -16,11 +22,9 @@ type BudgetItem = Record<string, unknown> & {
 
 interface BudgetItemsTableProps {
   dataSource: BudgetItem[];
-  columns: ColumnsType<BudgetItem>;
   selectedRowKeys: string[];
   setSelectedRowKeys: (keys: string[] | ((prev: string[]) => string[])) => void;
   lockedLines: string[];
-  handleTableChange: TableProps<BudgetItem>['onChange'];
   openEditModal: (record: BudgetItem) => void;
   openDuplicateModal: (record: BudgetItem) => void;
   openDeleteModal: (ids: string[]) => void;
@@ -37,11 +41,9 @@ interface BudgetItemsTableProps {
 const BudgetItemsTable: React.FC<BudgetItemsTableProps> = React.memo(
   ({
     dataSource,
-    columns,
     selectedRowKeys,
     setSelectedRowKeys,
     lockedLines,
-    handleTableChange,
     openEditModal,
     openDuplicateModal,
     openDeleteModal,
@@ -55,6 +57,7 @@ const BudgetItemsTable: React.FC<BudgetItemsTableProps> = React.memo(
     setPageSize,
   }) => {
     const [isMobile, setIsMobile] = useState(false);
+    const selectAllRef = useRef<HTMLInputElement | null>(null);
 
     useEffect(() => {
       if (typeof window === "undefined") return;
@@ -119,6 +122,47 @@ const BudgetItemsTable: React.FC<BudgetItemsTableProps> = React.memo(
       []
     );
 
+    const availableIds = useMemo(
+      () => dataSource.map((item) => String(item.budgetItemId)),
+      [dataSource]
+    );
+
+    const availableIdSet = useMemo(() => new Set(availableIds), [availableIds]);
+
+    const selectedInScope = useMemo(
+      () => selectedRowKeys.filter((id) => availableIdSet.has(id)),
+      [selectedRowKeys, availableIdSet]
+    );
+
+    const isSelectAllChecked =
+      availableIds.length > 0 && selectedInScope.length === availableIds.length;
+
+    const isSelectAllIndeterminate =
+      selectedInScope.length > 0 && selectedInScope.length < availableIds.length;
+
+    useEffect(() => {
+      if (!selectAllRef.current) return;
+      selectAllRef.current.indeterminate = isSelectAllIndeterminate;
+    }, [isSelectAllIndeterminate]);
+
+    const handleSelectAllChange = useCallback(
+      (checked: boolean) => {
+        setSelectedRowKeys((prevKeys) => {
+          if (checked) {
+            const next = new Set(prevKeys);
+            availableIds.forEach((id) => next.add(id));
+            return Array.from(next);
+          }
+          return prevKeys.filter((id) => !availableIdSet.has(id));
+        });
+      },
+      [availableIds, availableIdSet, setSelectedRowKeys]
+    );
+
+    const handleClearSelection = useCallback(() => {
+      setSelectedRowKeys((prevKeys) => prevKeys.filter((id) => !availableIdSet.has(id)));
+    }, [availableIdSet, setSelectedRowKeys]);
+
     const handleCardKeyDown = useCallback(
       (event: React.KeyboardEvent<HTMLElement>, record: BudgetItem, isLocked: boolean) => {
         if (isLocked) return;
@@ -149,11 +193,18 @@ const BudgetItemsTable: React.FC<BudgetItemsTableProps> = React.memo(
       [setSelectedRowKeys]
     );
 
-    const paginatedMobileData = useMemo(() => {
-      if (!isMobile) return [];
+    useEffect(() => {
+      const totalItems = dataSource.length;
+      const totalPages = totalItems === 0 ? 1 : Math.ceil(totalItems / pageSize);
+      if (currentPage > totalPages) {
+        setCurrentPage(totalPages);
+      }
+    }, [currentPage, dataSource.length, pageSize, setCurrentPage]);
+
+    const paginatedData = useMemo(() => {
       const startIndex = Math.max(0, (currentPage - 1) * pageSize);
       return dataSource.slice(startIndex, startIndex + pageSize);
-    }, [isMobile, dataSource, currentPage, pageSize]);
+    }, [dataSource, currentPage, pageSize]);
 
     const formatMetricValue = useCallback(
       (record: BudgetItem, metricKey: string) => {
@@ -224,204 +275,181 @@ const BudgetItemsTable: React.FC<BudgetItemsTableProps> = React.memo(
       [pageSize, setCurrentPage, setPageSize]
     );
 
+    const listStyle = useMemo(() => {
+      if (!tableHeight) return undefined;
+      const minHeight = Math.max(0, tableHeight - PAGINATION_ESTIMATE);
+      return { minHeight };
+    }, [tableHeight]);
+
     return (
       <div ref={tableRef} className={styles.tableContainer}>
-        <div className={styles.desktopTable}>
-          <Table<BudgetItem>
-            dataSource={dataSource}
-            columns={columns.map((col) => ({
-              ...col,
-              ellipsis: col.key !== "actions" && col.key !== "events",
-            }))}
-            locale={{
-              emptyText: (
-                <div className={styles.emptyPlaceholder}>No budget items to display</div>
-              ),
-            }}
-            onChange={handleTableChange}
-            rowClassName={(record) =>
-              `${styles.clickableRow}${
-                selectedRowKeys.includes(record.budgetItemId)
-                  ? ` ${styles.selectedRow}`
-                  : ""
-              }${
-                lockedLines.includes(record.budgetItemId)
-                  ? ` ${styles.lockedRow}`
-                  : ""
-              }`
-            }
-            onRow={(record) => ({
-              onClick: () => openEditModal(record),
-              tabIndex: lockedLines.includes(record.budgetItemId) ? -1 : 0,
-              onKeyDown: (e) => {
-                if (e.key === "Enter") {
-                  e.preventDefault();
-                  openEditModal(record);
-                } else if (e.key === " ") {
-                  e.preventDefault();
-                  openDeleteModal([record.budgetItemId]);
-                }
-              },
-            })}
-            pagination={{
-              pageSize,
-              current: currentPage,
-              showSizeChanger: true,
-              pageSizeOptions: ["10", "20", "50", "100"],
-              position: ["bottomRight"],
-              showTotal: (total, range) => `Showing ${range[0]}–${range[1]} of ${total} items`,
-              size: "small",
-              onChange: (page, size) => {
-                setCurrentPage(page);
-                if (size !== pageSize) setPageSize(size);
-              },
-            }}
-            scroll={{ y: Math.max(0, tableHeight - TABLE_HEADER_FOOTER) }}
-            className={styles.tableMinHeight}
-            style={{ height: tableHeight }}
-          />
-        </div>
-
-        {isMobile && (
-          <div className={styles.mobileCardList}>
-            {paginatedMobileData.length === 0 ? (
-              <div className={styles.emptyPlaceholder}>No budget items to display</div>
-            ) : (
-              <>
-                {paginatedMobileData.map((record) => {
-                  const isSelected = selectedRowKeys.includes(record.budgetItemId);
-                  const isLocked = lockedLines.includes(record.budgetItemId);
-                  const events = eventsByLineItem[record.budgetItemId] || [];
-                  const eventCount = events.length;
-
-                  return (
-                    <article
-                      key={record.key}
-                      className={`${styles.mobileCard}${
-                        isSelected ? ` ${styles.mobileCardSelected}` : ""
-                      }${isLocked ? ` ${styles.mobileCardLocked}` : ""}`}
-                      role="button"
-                      tabIndex={isLocked ? -1 : 0}
-                      aria-pressed={isSelected}
-                      aria-disabled={isLocked}
-                      onClick={() => {
-                        if (!isLocked) {
-                          openEditModal(record);
-                        }
-                      }}
-                      onKeyDown={(event) => handleCardKeyDown(event, record, isLocked)}
-                    >
-                      <header className={styles.mobileCardHeader}>
-                        <div className={styles.mobileCardHeaderLeft}>
-                          <label className={styles.mobileCardCheckbox}>
-                            <input
-                              type="checkbox"
-                              checked={isSelected}
-                              disabled={isLocked}
-                              onChange={(event) => {
-                                event.stopPropagation();
-                                toggleSelection(record, event.target.checked);
-                              }}
-                              onClick={(event) => event.stopPropagation()}
-                              aria-label="Select budget line item"
-                            />
-                          </label>
-                          <div className={styles.mobileCardIdentifiers}>
-                            <span className={styles.mobileCardKey}>
-                              {String(record.elementKey ?? "—")}
-                            </span>
-                            {record.elementId && (
-                              <span className={styles.mobileCardId}>
-                                {String(record.elementId)}
-                              </span>
-                            )}
-                          </div>
-                        </div>
-                        <div className={styles.mobileCardControls}>
-                          <button
-                            className={styles.mobileIconButton}
-                            type="button"
-                            onClick={(event) => {
-                              event.stopPropagation();
-                              openEventModal(record);
-                            }}
-                            aria-label={
-                              eventCount > 0
-                                ? `Manage ${eventCount} scheduled events`
-                                : "Manage events"
-                            }
-                          >
-                            <FontAwesomeIcon icon={faClock} />
-                            {eventCount > 0 && (
-                              <span className={styles.mobileEventBadge}>{eventCount}</span>
-                            )}
-                          </button>
-                          <button
-                            className={styles.mobileIconButton}
-                            type="button"
-                            onClick={(event) => {
-                              event.stopPropagation();
-                              openDuplicateModal(record);
-                            }}
-                            aria-label="Duplicate line item"
-                          >
-                            <FontAwesomeIcon icon={faClone} />
-                          </button>
-                          <button
-                            className={styles.mobileIconButton}
-                            type="button"
-                            onClick={(event) => {
-                              event.stopPropagation();
-                              openDeleteModal([record.budgetItemId]);
-                            }}
-                            aria-label="Delete line item"
-                          >
-                            <FontAwesomeIcon icon={faTrash} />
-                          </button>
-                        </div>
-                      </header>
-
-                      <div className={styles.mobileCardDescription}>
-                        {record.description ? String(record.description) : "No description"}
-                      </div>
-
-                      <div className={styles.mobileCardMetrics}>
-                        {mobileMetrics.map((metric) => (
-                          <div key={metric.key} className={styles.mobileCardMetric}>
-                            <span className={styles.mobileCardMetricLabel}>{metric.label}</span>
-                            <span className={styles.mobileCardMetricValue}>
-                              {formatMetricValue(record, metric.key)}
-                            </span>
-                          </div>
-                        ))}
-                      </div>
-
-                      {record.paymentStatus && (
-                        <footer className={styles.mobileCardFooter}>
-                          <span className={styles.mobileCardFooterLabel}>Payment</span>
-                          <span className={styles.mobileCardFooterValue}>
-                            {renderPaymentStatus(String(record.paymentStatus))}
-                          </span>
-                        </footer>
-                      )}
-                    </article>
-                  );
-                })}
-
-                <Pagination
-                  className={styles.mobilePagination}
-                  current={currentPage}
-                  pageSize={pageSize}
-                  total={dataSource.length}
-                  showSizeChanger
-                  pageSizeOptions={["10", "20", "50", "100"]}
-                  size="small"
-                  onChange={handlePaginationChange}
-                  onShowSizeChange={handlePaginationChange}
-                />
-              </>
+        {dataSource.length > 0 && (
+          <div className={styles.cardListHeader}>
+            <label className={styles.selectAllControl}>
+              <input
+                ref={selectAllRef}
+                type="checkbox"
+                checked={isSelectAllChecked}
+                onChange={(event) => handleSelectAllChange(event.target.checked)}
+                aria-label="Select all budget items"
+              />
+              <span>Select all</span>
+              <span className={styles.selectionCount}>
+                {selectedInScope.length}/{availableIds.length}
+              </span>
+            </label>
+            {selectedInScope.length > 0 && (
+              <button
+                type="button"
+                className={styles.clearSelectionButton}
+                onClick={handleClearSelection}
+              >
+                Clear selection
+              </button>
             )}
           </div>
+        )}
+
+        <div className={styles.cardListWrapper} style={listStyle}>
+          {paginatedData.length === 0 ? (
+            <div className={styles.emptyPlaceholder}>No budget items to display</div>
+          ) : (
+            <div className={`${styles.cardList}${isMobile ? ` ${styles.cardListMobile}` : ""}`}>
+              {paginatedData.map((record) => {
+                const isSelected = selectedRowKeys.includes(record.budgetItemId);
+                const isLocked = lockedLines.includes(record.budgetItemId);
+                const events = eventsByLineItem[record.budgetItemId] || [];
+                const eventCount = events.length;
+
+                return (
+                  <article
+                    key={record.key}
+                    className={`${styles.card}${
+                      isSelected ? ` ${styles.cardSelected}` : ""
+                    }${isLocked ? ` ${styles.cardLocked}` : ""}`}
+                    role="button"
+                    tabIndex={isLocked ? -1 : 0}
+                    aria-pressed={isSelected}
+                    aria-disabled={isLocked}
+                    onClick={() => {
+                      if (!isLocked) {
+                        openEditModal(record);
+                      }
+                    }}
+                    onKeyDown={(event) => handleCardKeyDown(event, record, isLocked)}
+                  >
+                    <header className={styles.cardHeader}>
+                      <div className={styles.cardHeaderLeft}>
+                        <label className={styles.cardCheckbox}>
+                          <input
+                            type="checkbox"
+                            checked={isSelected}
+                            disabled={isLocked}
+                            onChange={(event) => {
+                              event.stopPropagation();
+                              toggleSelection(record, event.target.checked);
+                            }}
+                            onClick={(event) => event.stopPropagation()}
+                            aria-label="Select budget line item"
+                          />
+                        </label>
+                        <div className={styles.cardIdentifiers}>
+                          <span className={styles.cardKey}>
+                            {String(record.elementKey ?? "—")}
+                          </span>
+                          {record.elementId && (
+                            <span className={styles.cardId}>
+                              {String(record.elementId)}
+                            </span>
+                          )}
+                        </div>
+                      </div>
+                      <div className={styles.cardControls}>
+                        <button
+                          className={styles.cardIconButton}
+                          type="button"
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            openEventModal(record);
+                          }}
+                          aria-label={
+                            eventCount > 0
+                              ? `Manage ${eventCount} scheduled events`
+                              : "Manage events"
+                          }
+                        >
+                          <FontAwesomeIcon icon={faClock} />
+                          {eventCount > 0 && (
+                            <span className={styles.cardEventBadge}>{eventCount}</span>
+                          )}
+                        </button>
+                        <button
+                          className={styles.cardIconButton}
+                          type="button"
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            openDuplicateModal(record);
+                          }}
+                          aria-label="Duplicate line item"
+                        >
+                          <FontAwesomeIcon icon={faClone} />
+                        </button>
+                        <button
+                          className={styles.cardIconButton}
+                          type="button"
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            openDeleteModal([record.budgetItemId]);
+                          }}
+                          aria-label="Delete line item"
+                        >
+                          <FontAwesomeIcon icon={faTrash} />
+                        </button>
+                      </div>
+                    </header>
+
+                    <div className={styles.cardDescription}>
+                      {record.description ? String(record.description) : "No description"}
+                    </div>
+
+                    <div className={styles.cardMetrics}>
+                      {mobileMetrics.map((metric) => (
+                        <div key={metric.key} className={styles.cardMetric}>
+                          <span className={styles.cardMetricLabel}>{metric.label}</span>
+                          <span className={styles.cardMetricValue}>
+                            {formatMetricValue(record, metric.key)}
+                          </span>
+                        </div>
+                      ))}
+                    </div>
+
+                    {record.paymentStatus && (
+                      <footer className={styles.cardFooter}>
+                        <span className={styles.cardFooterLabel}>Payment</span>
+                        <span className={styles.cardFooterValue}>
+                          {renderPaymentStatus(String(record.paymentStatus))}
+                        </span>
+                      </footer>
+                    )}
+                  </article>
+                );
+              })}
+            </div>
+          )}
+        </div>
+
+        {dataSource.length > 0 && (
+          <Pagination
+            className={styles.cardPagination}
+            current={currentPage}
+            pageSize={pageSize}
+            total={dataSource.length}
+            showSizeChanger
+            pageSizeOptions={["10", "20", "50", "100"]}
+            size="small"
+            onChange={handlePaginationChange}
+            onShowSizeChange={handlePaginationChange}
+          />
         )}
       </div>
     );
@@ -429,15 +457,3 @@ const BudgetItemsTable: React.FC<BudgetItemsTableProps> = React.memo(
 );
 
 export default BudgetItemsTable;
-
-
-
-
-
-
-
-
-
-
-
-

--- a/frontend/src/dashboard/project/features/budget/components/BudgetTable.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetTable.tsx
@@ -338,8 +338,8 @@ const BudgetItemsTable: React.FC<BudgetItemsTableProps> = React.memo(
                     }}
                     onKeyDown={(event) => handleCardKeyDown(event, record, isLocked)}
                   >
-                    <header className={styles.cardHeader}>
-                      <div className={styles.cardHeaderLeft}>
+                    <div className={styles.cardRow}>
+                      <div className={styles.cardPrimary}>
                         <label className={styles.cardCheckbox}>
                           <input
                             type="checkbox"
@@ -353,17 +353,45 @@ const BudgetItemsTable: React.FC<BudgetItemsTableProps> = React.memo(
                             aria-label="Select budget line item"
                           />
                         </label>
-                        <div className={styles.cardIdentifiers}>
-                          <span className={styles.cardKey}>
-                            {String(record.elementKey ?? "—")}
-                          </span>
-                          {record.elementId && (
-                            <span className={styles.cardId}>
-                              {String(record.elementId)}
+                        <div className={styles.cardSummary}>
+                          <div className={styles.cardIdentifiers}>
+                            <span className={styles.cardKey}>
+                              {String(record.elementKey ?? "—")}
                             </span>
-                          )}
+                            {record.elementId && (
+                              <span className={styles.cardId}>
+                                {String(record.elementId)}
+                              </span>
+                            )}
+                          </div>
+                          <div className={styles.cardDescription}>
+                            {record.description
+                              ? String(record.description)
+                              : "No description"}
+                          </div>
                         </div>
                       </div>
+
+                      <div className={styles.cardMetrics}>
+                        {mobileMetrics.map((metric) => (
+                          <div key={metric.key} className={styles.cardMetric}>
+                            <span className={styles.cardMetricLabel}>{metric.label}</span>
+                            <span className={styles.cardMetricValue}>
+                              {formatMetricValue(record, metric.key)}
+                            </span>
+                          </div>
+                        ))}
+                      </div>
+
+                      {record.paymentStatus && (
+                        <div className={styles.cardPayment}>
+                          <span className={styles.cardFooterLabel}>Payment</span>
+                          <span className={styles.cardFooterValue}>
+                            {renderPaymentStatus(String(record.paymentStatus))}
+                          </span>
+                        </div>
+                      )}
+
                       <div className={styles.cardControls}>
                         <button
                           className={styles.cardIconButton}
@@ -406,31 +434,7 @@ const BudgetItemsTable: React.FC<BudgetItemsTableProps> = React.memo(
                           <FontAwesomeIcon icon={faTrash} />
                         </button>
                       </div>
-                    </header>
-
-                    <div className={styles.cardDescription}>
-                      {record.description ? String(record.description) : "No description"}
                     </div>
-
-                    <div className={styles.cardMetrics}>
-                      {mobileMetrics.map((metric) => (
-                        <div key={metric.key} className={styles.cardMetric}>
-                          <span className={styles.cardMetricLabel}>{metric.label}</span>
-                          <span className={styles.cardMetricValue}>
-                            {formatMetricValue(record, metric.key)}
-                          </span>
-                        </div>
-                      ))}
-                    </div>
-
-                    {record.paymentStatus && (
-                      <footer className={styles.cardFooter}>
-                        <span className={styles.cardFooterLabel}>Payment</span>
-                        <span className={styles.cardFooterValue}>
-                          {renderPaymentStatus(String(record.paymentStatus))}
-                        </span>
-                      </footer>
-                    )}
                   </article>
                 );
               })}

--- a/frontend/src/dashboard/project/features/budget/components/BudgetToolbar.module.css
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetToolbar.module.css
@@ -98,19 +98,21 @@
 }
 
 .mobileFilterWrap {
-  display: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  min-width: 220px;
 }
 
 .mobileFilterRoot {
   position: relative;
-  width: 100%;
+  width: auto;
 }
 
 .mobileFilterButton {
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
-  width: 100%;
   justify-content: space-between;
   padding: 8px 16px;
   border: 1px solid rgba(255, 255, 255, 0.15);

--- a/frontend/src/dashboard/project/features/budget/pages/BudgetPage.tsx
+++ b/frontend/src/dashboard/project/features/budget/pages/BudgetPage.tsx
@@ -658,29 +658,9 @@ const BudgetPageContent = () => {
                                           })[])
                                         : []
                                     }
-                                    columns={tableConfig.tableColumns}
                                     selectedRowKeys={stateManager.selectedRowKeys}
                                     setSelectedRowKeys={stateManager.setSelectedRowKeys}
                                     lockedLines={stateManager.lockedLines}
-                                    handleTableChange={(_pagination, _filters, sorter) => {
-                                      const sortConfig = Array.isArray(sorter) ? sorter[0] : sorter;
-
-                                      if (sortConfig && typeof sortConfig === "object") {
-                                        const columnKey = (sortConfig.columnKey ?? sortConfig.field) as
-                                          | string
-                                          | undefined;
-                                        const order = sortConfig.order ?? null;
-
-                                        if (columnKey && order) {
-                                          stateManager.setSortField(columnKey);
-                                          stateManager.setSortOrder(order);
-                                          return;
-                                        }
-                                      }
-
-                                      stateManager.setSortField(null);
-                                      stateManager.setSortOrder(null);
-                                    }}
                                     openEditModal={eventHandlers.openEditModal}
                                     openDuplicateModal={eventHandlers.openDuplicateModal}
                                     openDeleteModal={eventHandlers.openDeleteModal}

--- a/frontend/src/dashboard/project/features/budget/pages/budget-page.module.css
+++ b/frontend/src/dashboard/project/features/budget/pages/budget-page.module.css
@@ -736,15 +736,3 @@
 
 
 
-.cardList {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
-  gap: 12px;
-  align-content: flex-start;
-}
-
-.cardListMobile {
-  display: contents;
-}
-
-.card {

--- a/frontend/src/dashboard/project/features/budget/pages/budget-page.module.css
+++ b/frontend/src/dashboard/project/features/budget/pages/budget-page.module.css
@@ -237,6 +237,25 @@
   width: 100%;
 }
 
+.cardList {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(640px, 1fr));
+  gap: 12px;
+  width: 100%;
+}
+
+.cardListMobile {
+  display: flex !important;
+  flex-direction: column;
+  gap: 6px;
+}
+
+@media (max-width: 1400px) {
+  .cardList {
+    grid-template-columns: repeat(auto-fill, minmax(520px, 1fr));
+  }
+}
+
 .card {
   background: linear-gradient(160deg, rgba(24, 24, 24, 0.95), rgba(9, 9, 9, 0.95));
   border-radius: 20px;
@@ -244,7 +263,7 @@
   padding: 14px 16px;
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 12px;
   box-shadow: 0 12px 30px rgba(0, 0, 0, 0.45);
   transition: box-shadow 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
 }
@@ -263,23 +282,32 @@
   opacity: 0.6;
 }
 
-.cardHeader {
+.cardRow {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 6px;
+  flex-direction: column;
+  gap: 12px;
+  width: 100%;
 }
 
-.cardHeaderLeft {
+.cardPrimary {
   display: flex;
-  align-items: center;
-  gap: 8px;
+  align-items: flex-start;
+  gap: 12px;
+  min-width: 0;
+}
+
+.cardSummary {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
 }
 
 .cardCheckbox {
   display: flex;
   align-items: center;
   justify-content: center;
+  flex: 0 0 auto;
 }
 
 .cardCheckbox input {
@@ -314,6 +342,7 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
+  flex: 0 0 auto;
 }
 
 .cardIconButton {
@@ -358,22 +387,23 @@
   color: #e0e0e0;
   font-size: 0.88rem;
   line-height: 1.25;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
+  max-width: 100%;
 }
 
 .cardMetrics {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  display: flex;
+  flex-wrap: wrap;
   gap: 10px;
+  flex: 1 1 320px;
+  min-width: 220px;
 }
 
 .cardMetric {
   display: flex;
-  flex-direction: column;
-  gap: 2px;
+  align-items: baseline;
+  gap: 4px;
+  flex: 0 1 auto;
+  min-width: 56px;
 }
 
 .cardMetricLabel {
@@ -394,13 +424,12 @@
   color: inherit;
 }
 
-.cardFooter {
+.cardPayment {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  border-top: 1px solid #232323;
-  padding-top: 6px;
-  margin-top: 4px;
+  flex-direction: column;
+  gap: 4px;
+  flex: 0 0 auto;
+  min-width: 100px;
 }
 
 .cardFooterLabel {
@@ -444,17 +473,30 @@
 
 @media (max-width: 1200px) {
   .cardList {
-    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
   }
 }
 
 @media (max-width: 992px) {
   .cardList {
-    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  }
+
+  .cardRow {
+    gap: 16px;
   }
 
   .cardMetrics {
-    grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+    flex: 1 1 100%;
+    gap: 10px;
+  }
+
+  .cardMetric {
+    min-width: 88px;
+  }
+
+  .cardPayment {
+    min-width: 0;
   }
 }
 
@@ -463,20 +505,37 @@
     display: none;
   }
 
-  .cardList {
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-    width: 100%;
-  }
-
   .card {
     border-radius: 20px;
     padding: 13px 15px;
   }
 
+  .cardRow {
+    flex-direction: column;
+  }
+
+  .cardPrimary {
+    align-items: stretch;
+  }
+
   .cardMetrics {
+    display: grid;
     grid-template-columns: repeat(7, minmax(88px, 1fr));
+    gap: 8px;
+  }
+
+  .cardMetric {
+    flex: initial;
+    min-width: 0;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 2px;
+  }
+
+  .cardPayment {
+    flex-direction: row;
+    align-items: center;
+    gap: 8px;
   }
 }
 
@@ -500,6 +559,52 @@
 
   .cardMetricValue {
     font-size: 0.76rem;
+  }
+}
+
+@media (min-width: 768px) {
+  .cardRow {
+    flex-direction: row;
+    align-items: center;
+    flex-wrap: wrap;
+  }
+
+  .cardPrimary {
+    align-items: center;
+    flex: 1 1 260px;
+  }
+
+  .cardDescription {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .cardMetrics {
+    justify-content: flex-start;
+  }
+
+  .cardPayment {
+    align-items: flex-end;
+  }
+
+  .cardControls {
+    align-self: center;
+    margin-left: auto;
+  }
+}
+
+@media (max-width: 767px) {
+  .cardDescription {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  .cardControls {
+    align-self: flex-start;
+    margin-left: 0;
   }
 }
 

--- a/frontend/src/dashboard/project/features/budget/pages/budget-page.module.css
+++ b/frontend/src/dashboard/project/features/budget/pages/budget-page.module.css
@@ -137,18 +137,17 @@
 
 .tableContainer {
   width: 100%;
-  font-size: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
 }
 
 .desktopTable {
-  display: block;
+  display: none;
 }
 
 .tableMinHeight {
-  min-height: 100%;
-  height: 100%;
-  display: flex;
-  flex-direction: column;
+  display: none;
 }
 .clickableRow {
   transition: background-color 0.2s ease;
@@ -177,20 +176,68 @@
   justify-content: center;
 }
 
-.tableMinHeight .emptyPlaceholder {
-  flex: 1 1 auto;
+.cardListHeader {
   display: flex;
   align-items: center;
-  justify-content: center;
-  height: 750px;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
 }
 
-
-.mobileCardList {
-  display: none;
+.selectAllControl {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: rgba(255, 255, 255, 0.82);
+  font-size: 0.85rem;
+  font-weight: 500;
+  cursor: pointer;
+  user-select: none;
 }
 
-.mobileCard {
+.selectAllControl input {
+  width: 18px;
+  height: 18px;
+  margin: 0;
+  accent-color: #FA3356;
+}
+
+.selectionCount {
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.clearSelectionButton {
+  padding: 6px 14px;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: transparent;
+  color: rgba(255, 255, 255, 0.85);
+  font-size: 0.8rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.clearSelectionButton:hover,
+.clearSelectionButton:focus-visible {
+  outline: none;
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.28);
+  color: #ffffff;
+}
+
+.cardListWrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  width: 100%;
+}
+
+.card {
   background: linear-gradient(160deg, rgba(24, 24, 24, 0.95), rgba(9, 9, 9, 0.95));
   border-radius: 20px;
   border: 1px solid #2a2a2a;
@@ -202,53 +249,53 @@
   transition: box-shadow 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
 }
 
-.mobileCard:hover {
+.card:hover {
   transform: translateY(-2px);
   box-shadow: 0 18px 36px rgba(0, 0, 0, 0.5);
 }
 
-.mobileCardSelected {
+.cardSelected {
   border-color: #FA3356;
   box-shadow: 0 0 0 1px #FA3356, 0 20px 36px rgba(250, 51, 86, 0.25);
 }
 
-.mobileCardLocked {
+.cardLocked {
   opacity: 0.6;
 }
 
-.mobileCardHeader {
+.cardHeader {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 6px;
 }
 
-.mobileCardHeaderLeft {
+.cardHeaderLeft {
   display: flex;
   align-items: center;
   gap: 8px;
 }
 
-.mobileCardCheckbox {
+.cardCheckbox {
   display: flex;
   align-items: center;
   justify-content: center;
 }
 
-.mobileCardCheckbox input {
+.cardCheckbox input {
   width: 18px;
   height: 18px;
   margin: 0;
   accent-color: #FA3356;
 }
 
-.mobileCardIdentifiers {
+.cardIdentifiers {
   display: flex;
   flex-direction: row;
   gap: 8px;
 }
 
-.mobileCardKey {
+.cardKey {
   color: #ffffff;
   font-weight: 600;
   font-size: 0.8rem;
@@ -256,20 +303,20 @@
   text-transform: uppercase;
 }
 
-.mobileCardId {
+.cardId {
   color: #bbbbbb;
   font-size: 0.8rem;
   letter-spacing: 0.03em;
   text-transform: uppercase;
 }
 
-.mobileCardControls {
+.cardControls {
   display: inline-flex;
   align-items: center;
   gap: 6px;
 }
 
-.mobileIconButton {
+.cardIconButton {
   position: relative;
   width: 28px;
   height: 28px;
@@ -283,14 +330,14 @@
   transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
 }
 
-.mobileIconButton:hover,
-.mobileIconButton:focus-visible {
+.cardIconButton:hover,
+.cardIconButton:focus-visible {
   background: #FA3356;
   border-color: #FA3356;
   color: #ffffff;
 }
 
-.mobileEventBadge {
+.cardEventBadge {
   position: absolute;
   top: -4px;
   right: -4px;
@@ -307,7 +354,7 @@
   line-height: 1;
 }
 
-.mobileCardDescription {
+.cardDescription {
   color: #e0e0e0;
   font-size: 0.88rem;
   line-height: 1.25;
@@ -317,38 +364,37 @@
   overflow: hidden;
 }
 
-.mobileCardMetrics {
+.cardMetrics {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 8px;
-  row-gap: 6px;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 10px;
 }
 
-.mobileCardMetric {
+.cardMetric {
   display: flex;
   flex-direction: column;
   gap: 2px;
 }
 
-.mobileCardMetricLabel {
+.cardMetricLabel {
   font-size: 0.6rem;
   color: #8f8f8f;
   letter-spacing: 0.06em;
   text-transform: uppercase;
 }
 
-.mobileCardMetricValue {
+.cardMetricValue {
   font-size: 0.8rem;
   font-weight: 500;
   color: #f5f5f5;
   min-height: 1.1em;
 }
 
-.mobileCardMetricValue span {
+.cardMetricValue span {
   color: inherit;
 }
 
-.mobileCardFooter {
+.cardFooter {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -357,48 +403,58 @@
   margin-top: 4px;
 }
 
-.mobileCardFooterLabel {
+.cardFooterLabel {
   font-size: 0.75rem;
   color: #888888;
   text-transform: uppercase;
   letter-spacing: 0.08em;
 }
 
-.mobileCardFooterValue {
+.cardFooterValue {
   display: inline-flex;
   align-items: center;
 }
 
-.mobilePagination {
+.cardPagination {
   align-self: center;
   margin-top: 12px;
 }
 
-.mobilePagination :global(.ant-select-selector) {
+.cardPagination :global(.ant-select-selector) {
   background: transparent !important;
   border-color: #FA3356 !important;
   color: #ffffff !important;
 }
 
-.mobilePagination :global(.ant-select-arrow) {
+.cardPagination :global(.ant-select-arrow) {
   color: #ffffff !important;
 }
 
-.mobilePagination :global(.ant-pagination-item a) {
+.cardPagination :global(.ant-pagination-item a) {
   color: #ffffff !important;
 }
 
-.mobilePagination :global(.ant-pagination-item-active) {
+.cardPagination :global(.ant-pagination-item-active) {
   border-color: #FA3356 !important;
 }
 
-.mobilePagination :global(.ant-pagination-item-active a) {
+.cardPagination :global(.ant-pagination-item-active a) {
   color: #FA3356 !important;
 }
 
+@media (max-width: 1200px) {
+  .cardList {
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  }
+}
+
 @media (max-width: 992px) {
-  .mobileCardMetrics {
-    grid-template-columns: repeat(7, minmax(0, 1fr));
+  .cardList {
+    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  }
+
+  .cardMetrics {
+    grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
   }
 }
 
@@ -407,42 +463,42 @@
     display: none;
   }
 
-  .mobileCardList {
+  .cardList {
     display: flex;
     flex-direction: column;
     gap: 6px;
     width: 100%;
   }
 
-  .mobileCard {
+  .card {
     border-radius: 20px;
     padding: 13px 15px;
   }
 
-  .mobileCardMetrics {
+  .cardMetrics {
     grid-template-columns: repeat(7, minmax(88px, 1fr));
   }
 }
 
 @media (max-width: 480px) {
-  .mobileCardMetrics {
+  .cardMetrics {
     grid-template-columns: repeat(7, minmax(0, 1fr));
     gap: 8px;
   }
 
-  .mobileCard {
+  .card {
     padding: 12px 14px;
   }
 
-  .mobileCardControls {
+  .cardControls {
     gap: 4px;
   }
 
-  .mobileCardFooterLabel {
+  .cardFooterLabel {
     font-size: 0.7rem;
   }
 
-  .mobileCardMetricValue {
+  .cardMetricValue {
     font-size: 0.76rem;
   }
 }
@@ -680,3 +736,15 @@
 
 
 
+.cardList {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+  gap: 12px;
+  align-content: flex-start;
+}
+
+.cardListMobile {
+  display: contents;
+}
+
+.card {


### PR DESCRIPTION
## Summary
- replace the desktop budget table with the modern card layout used on mobile, including selection controls and row actions
- add responsive styling for the new card grid and expose the filter/sort pill on larger screens
- simplify the budget table props now that the Ant table is removed

## Testing
- `npm run lint` *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e57236d304832498b543301d805a1b