### PR TITLE
Adjust budget card metrics layout

### DIFF
--- a/frontend/src/dashboard/project/features/budget/components/BudgetTable.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetTable.tsx
@@ -109,13 +109,19 @@ const BudgetItemsTable: React.FC<BudgetItemsTableProps> = React.memo(
       [isDefined]
     );
 
-    const mobileMetrics = useMemo(
+    const primaryMetrics = useMemo(
       () => [
         { key: "quantity", label: "Qty" },
         { key: "unit", label: "U" },
         { key: "itemBudgetedCost", label: "BC" },
         { key: "itemActualCost", label: "AC" },
         { key: "itemReconciledCost", label: "RC" },
+      ],
+      []
+    );
+
+    const summaryMetrics = useMemo(
+      () => [
         { key: "itemMarkUp", label: "MK" },
         { key: "itemFinalCost", label: "FC" },
       ],
@@ -373,14 +379,31 @@ const BudgetItemsTable: React.FC<BudgetItemsTableProps> = React.memo(
                       </div>
 
                       <div className={styles.cardMetrics}>
-                        {mobileMetrics.map((metric) => (
-                          <div key={metric.key} className={styles.cardMetric}>
-                            <span className={styles.cardMetricLabel}>{metric.label}</span>
-                            <span className={styles.cardMetricValue}>
-                              {formatMetricValue(record, metric.key)}
-                            </span>
-                          </div>
-                        ))}
+                        <div className={styles.cardMetricRow}>
+                          {primaryMetrics.map((metric) => (
+                            <div key={metric.key} className={styles.cardMetric}>
+                              <span className={styles.cardMetricLabel}>{metric.label}</span>
+                              <span className={styles.cardMetricValue}>
+                                {formatMetricValue(record, metric.key)}
+                              </span>
+                            </div>
+                          ))}
+                        </div>
+                        <div
+                          className={`${styles.cardMetricRow} ${styles.cardMetricRowSummary}`}
+                        >
+                          {summaryMetrics.map((metric) => (
+                            <div
+                              key={metric.key}
+                              className={`${styles.cardMetric} ${styles.cardMetricSummary}`}
+                            >
+                              <span className={styles.cardMetricLabel}>{metric.label}</span>
+                              <span className={styles.cardMetricValue}>
+                                {formatMetricValue(record, metric.key)}
+                              </span>
+                            </div>
+                          ))}
+                        </div>
                       </div>
 
                       {record.paymentStatus && (

--- a/frontend/src/dashboard/project/features/budget/pages/budget-page.module.css
+++ b/frontend/src/dashboard/project/features/budget/pages/budget-page.module.css
@@ -566,24 +566,44 @@
   }
 
   .cardMetricRow {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(60px, 1fr));
     gap: 8px;
-    justify-content: flex-end;
+    justify-content: flex-start;
+    justify-items: start;
   }
 
   .cardMetric {
     flex: initial;
     min-width: 0;
     flex-direction: column;
-    align-items: flex-end;
+    align-items: flex-start;
     gap: 2px;
+    text-align: left;
   }
 
   .cardMetricRowSummary {
+    display: flex;
     justify-content: flex-end;
+    gap: 8px;
   }
 
   .cardMetricRowSummary .cardMetric {
     align-items: flex-end;
+    text-align: right;
+  }
+
+  .cardMetricLabel {
+    text-align: left;
+  }
+
+  .cardMetricValue {
+    text-align: left;
+  }
+
+  .cardMetricRowSummary .cardMetricLabel,
+  .cardMetricRowSummary .cardMetricValue {
+    text-align: right;
   }
 
   .cardPayment {
@@ -599,6 +619,11 @@
   }
 
   .cardMetricRow {
+    grid-template-columns: repeat(auto-fit, minmax(56px, 1fr));
+    gap: 6px;
+  }
+
+  .cardMetricRowSummary {
     gap: 6px;
   }
 

--- a/frontend/src/dashboard/project/features/budget/pages/budget-page.module.css
+++ b/frontend/src/dashboard/project/features/budget/pages/budget-page.module.css
@@ -311,8 +311,8 @@
 }
 
 .cardCheckbox input {
-  width: 18px;
-  height: 18px;
+  width: 16px;
+  height: 16px;
   margin: 0;
   accent-color: #FA3356;
 }
@@ -341,14 +341,14 @@
 .cardControls {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  gap: 4px;
   flex: 0 0 auto;
 }
 
 .cardIconButton {
   position: relative;
-  width: 28px;
-  height: 28px;
+  width: 24px;
+  height: 24px;
   border-radius: 50%;
   border: 1px solid #2a2a2a;
   background: #131313;
@@ -357,6 +357,10 @@
   align-items: center;
   justify-content: center;
   transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.cardIconButton :global(svg) {
+  font-size: 12px;
 }
 
 .cardIconButton:hover,
@@ -391,6 +395,7 @@
 }
 
 
+
 .cardMetrics {
   display: flex;
   flex-direction: column;
@@ -404,6 +409,8 @@
   flex-wrap: wrap;
   gap: 10px;
   align-items: baseline;
+  justify-content: flex-end;
+  width: 100%;
 }
 
 .cardMetricRowSummary {
@@ -416,6 +423,8 @@
   gap: 4px;
   flex: 0 1 auto;
   min-width: 56px;
+  justify-content: flex-end;
+  text-align: right;
 }
 
 .cardMetricSummary {
@@ -427,11 +436,13 @@
   text-align: right;
 }
 
+
 .cardMetricLabel {
   font-size: 0.6rem;
   color: #8f8f8f;
   letter-spacing: 0.06em;
   text-transform: uppercase;
+  text-align: right;
 }
 
 .cardMetricValue {
@@ -556,13 +567,14 @@
 
   .cardMetricRow {
     gap: 8px;
+    justify-content: flex-end;
   }
 
   .cardMetric {
     flex: initial;
     min-width: 0;
     flex-direction: column;
-    align-items: flex-start;
+    align-items: flex-end;
     gap: 2px;
   }
 

--- a/frontend/src/dashboard/project/features/budget/pages/budget-page.module.css
+++ b/frontend/src/dashboard/project/features/budget/pages/budget-page.module.css
@@ -390,12 +390,24 @@
   max-width: 100%;
 }
 
+
 .cardMetrics {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  flex: 1 1 320px;
+  min-width: 220px;
+}
+
+.cardMetricRow {
   display: flex;
   flex-wrap: wrap;
   gap: 10px;
-  flex: 1 1 320px;
-  min-width: 220px;
+  align-items: baseline;
+}
+
+.cardMetricRowSummary {
+  justify-content: flex-end;
 }
 
 .cardMetric {
@@ -404,6 +416,15 @@
   gap: 4px;
   flex: 0 1 auto;
   min-width: 56px;
+}
+
+.cardMetricSummary {
+  text-align: right;
+}
+
+.cardMetricRowSummary .cardMetric {
+  justify-content: flex-end;
+  text-align: right;
 }
 
 .cardMetricLabel {
@@ -418,6 +439,14 @@
   font-weight: 500;
   color: #f5f5f5;
   min-height: 1.1em;
+}
+
+.cardMetricRowSummary .cardMetricLabel {
+  color: rgba(250, 51, 86, 0.72);
+}
+
+.cardMetricRowSummary .cardMetricValue {
+  color: rgba(250, 51, 86, 0.88);
 }
 
 .cardMetricValue span {
@@ -488,7 +517,10 @@
 
   .cardMetrics {
     flex: 1 1 100%;
-    gap: 10px;
+  }
+
+  .cardMetricRow {
+    gap: 8px;
   }
 
   .cardMetric {
@@ -519,8 +551,10 @@
   }
 
   .cardMetrics {
-    display: grid;
-    grid-template-columns: repeat(7, minmax(88px, 1fr));
+    gap: 10px;
+  }
+
+  .cardMetricRow {
     gap: 8px;
   }
 
@@ -532,6 +566,14 @@
     gap: 2px;
   }
 
+  .cardMetricRowSummary {
+    justify-content: flex-end;
+  }
+
+  .cardMetricRowSummary .cardMetric {
+    align-items: flex-end;
+  }
+
   .cardPayment {
     flex-direction: row;
     align-items: center;
@@ -541,8 +583,11 @@
 
 @media (max-width: 480px) {
   .cardMetrics {
-    grid-template-columns: repeat(7, minmax(0, 1fr));
     gap: 8px;
+  }
+
+  .cardMetricRow {
+    gap: 6px;
   }
 
   .card {


### PR DESCRIPTION
## Summary
- separate budget card metrics into primary and summary rows so markup and final cost always render together
- update metric styling to right-align summary values with subtle accent coloring across breakpoints

## Testing
- `npm run lint` *(fails: existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e5824cb26483249a0bcd3db62c73f9