### PR TITLE
Refactor budget card controls into dropdown menu

### DIFF
--- a/frontend/src/dashboard/project/features/budget/components/BudgetTable.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetTable.tsx
@@ -7,7 +7,12 @@ import React, {
 } from "react";
 import { Pagination } from "antd";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faClone, faClock, faTrash } from "@fortawesome/free-solid-svg-icons";
+import {
+  faChevronDown,
+  faClone,
+  faClock,
+  faTrash,
+} from "@fortawesome/free-solid-svg-icons";
 import styles from "@/dashboard/project/features/budget/pages/budget-page.module.css";
 import { formatUSD } from "@/shared/utils/budgetUtils";
 
@@ -57,7 +62,9 @@ const BudgetItemsTable: React.FC<BudgetItemsTableProps> = React.memo(
     setPageSize,
   }) => {
     const [isMobile, setIsMobile] = useState(false);
+    const [openMenuId, setOpenMenuId] = useState<string | null>(null);
     const selectAllRef = useRef<HTMLInputElement | null>(null);
+    const menuContainersRef = useRef<Map<string, HTMLDivElement>>(new Map());
 
     useEffect(() => {
       if (typeof window === "undefined") return;
@@ -174,13 +181,15 @@ const BudgetItemsTable: React.FC<BudgetItemsTableProps> = React.memo(
         if (isLocked) return;
         if (event.key === "Enter") {
           event.preventDefault();
+          setOpenMenuId(null);
           openEditModal(record);
         } else if (event.key === " ") {
           event.preventDefault();
+          setOpenMenuId(null);
           openDeleteModal([record.budgetItemId]);
         }
       },
-      [openDeleteModal, openEditModal]
+      [openDeleteModal, openEditModal, setOpenMenuId]
     );
 
     const toggleSelection = useCallback(
@@ -287,6 +296,50 @@ const BudgetItemsTable: React.FC<BudgetItemsTableProps> = React.memo(
       return { minHeight };
     }, [tableHeight]);
 
+    const registerMenuContainer = useCallback(
+      (id: string, node: HTMLDivElement | null) => {
+        if (node) {
+          menuContainersRef.current.set(id, node);
+        } else {
+          menuContainersRef.current.delete(id);
+        }
+      },
+      []
+    );
+
+    useEffect(() => {
+      if (typeof document === "undefined") return undefined;
+
+      const handleDocumentClick = (event: MouseEvent) => {
+        const target = event.target;
+        if (!(target instanceof Node)) return;
+
+        for (const container of menuContainersRef.current.values()) {
+          if (container.contains(target)) {
+            return;
+          }
+        }
+
+        setOpenMenuId(null);
+      };
+
+      document.addEventListener("click", handleDocumentClick);
+      return () => document.removeEventListener("click", handleDocumentClick);
+    }, [setOpenMenuId]);
+
+    useEffect(() => {
+      if (typeof document === "undefined") return undefined;
+
+      const handleEscape = (event: KeyboardEvent) => {
+        if (event.key === "Escape") {
+          setOpenMenuId(null);
+        }
+      };
+
+      document.addEventListener("keydown", handleEscape);
+      return () => document.removeEventListener("keydown", handleEscape);
+    }, [setOpenMenuId]);
+
     return (
       <div ref={tableRef} className={styles.tableContainer}>
         {dataSource.length > 0 && (
@@ -339,6 +392,7 @@ const BudgetItemsTable: React.FC<BudgetItemsTableProps> = React.memo(
                     aria-disabled={isLocked}
                     onClick={() => {
                       if (!isLocked) {
+                        setOpenMenuId(null);
                         openEditModal(record);
                       }
                     }}
@@ -414,48 +468,95 @@ const BudgetItemsTable: React.FC<BudgetItemsTableProps> = React.memo(
                           </span>
                         </div>
                       )}
-
-                      <div className={styles.cardControls}>
+                      <div
+                        className={styles.cardControls}
+                        ref={(node) => registerMenuContainer(record.budgetItemId, node)}
+                      >
                         <button
-                          className={styles.cardIconButton}
+                          className={`${styles.cardMenuTrigger}${
+                            openMenuId === record.budgetItemId
+                              ? ` ${styles.cardMenuTriggerActive}`
+                              : ""
+                          }`}
                           type="button"
                           onClick={(event) => {
                             event.stopPropagation();
-                            openEventModal(record);
+                            setOpenMenuId((prev) =>
+                              prev === record.budgetItemId ? null : record.budgetItemId
+                            );
                           }}
                           aria-label={
                             eventCount > 0
-                              ? `Manage ${eventCount} scheduled events`
-                              : "Manage events"
+                              ? `View options for ${eventCount} scheduled events`
+                              : "View budget line item options"
+                          }
+                          aria-haspopup="menu"
+                          aria-expanded={openMenuId === record.budgetItemId}
+                          aria-controls={
+                            openMenuId === record.budgetItemId
+                              ? `budget-card-menu-${record.key}`
+                              : undefined
                           }
                         >
-                          <FontAwesomeIcon icon={faClock} />
+                          <FontAwesomeIcon icon={faChevronDown} />
                           {eventCount > 0 && (
                             <span className={styles.cardEventBadge}>{eventCount}</span>
                           )}
                         </button>
-                        <button
-                          className={styles.cardIconButton}
-                          type="button"
-                          onClick={(event) => {
-                            event.stopPropagation();
-                            openDuplicateModal(record);
-                          }}
-                          aria-label="Duplicate line item"
-                        >
-                          <FontAwesomeIcon icon={faClone} />
-                        </button>
-                        <button
-                          className={styles.cardIconButton}
-                          type="button"
-                          onClick={(event) => {
-                            event.stopPropagation();
-                            openDeleteModal([record.budgetItemId]);
-                          }}
-                          aria-label="Delete line item"
-                        >
-                          <FontAwesomeIcon icon={faTrash} />
-                        </button>
+                        {openMenuId === record.budgetItemId && (
+                          <div
+                            id={`budget-card-menu-${record.key}`}
+                            role="menu"
+                            className={styles.cardMenu}
+                            onClick={(event) => event.stopPropagation()}
+                          >
+                            <button
+                              type="button"
+                              role="menuitem"
+                              className={styles.cardMenuItem}
+                              onClick={(event) => {
+                                event.stopPropagation();
+                                setOpenMenuId(null);
+                                openEventModal(record);
+                              }}
+                            >
+                              <span className={styles.cardMenuItemIcon}>
+                                <FontAwesomeIcon icon={faClock} />
+                              </span>
+                              <span>Manage events</span>
+                            </button>
+                            <button
+                              type="button"
+                              role="menuitem"
+                              className={styles.cardMenuItem}
+                              onClick={(event) => {
+                                event.stopPropagation();
+                                setOpenMenuId(null);
+                                openDuplicateModal(record);
+                              }}
+                            >
+                              <span className={styles.cardMenuItemIcon}>
+                                <FontAwesomeIcon icon={faClone} />
+                              </span>
+                              <span>Duplicate line item</span>
+                            </button>
+                            <button
+                              type="button"
+                              role="menuitem"
+                              className={`${styles.cardMenuItem} ${styles.cardMenuItemDanger}`}
+                              onClick={(event) => {
+                                event.stopPropagation();
+                                setOpenMenuId(null);
+                                openDeleteModal([record.budgetItemId]);
+                              }}
+                            >
+                              <span className={styles.cardMenuItemIcon}>
+                                <FontAwesomeIcon icon={faTrash} />
+                              </span>
+                              <span>Delete line item</span>
+                            </button>
+                          </div>
+                        )}
                       </div>
                     </div>
                   </article>

--- a/frontend/src/dashboard/project/features/budget/pages/budget-page.module.css
+++ b/frontend/src/dashboard/project/features/budget/pages/budget-page.module.css
@@ -270,6 +270,7 @@
   border-radius: 20px;
   border: 1px solid #2a2a2a;
   padding: 14px 16px;
+  padding-right: 72px;
   display: flex;
   flex-direction: column;
   gap: 12px;
@@ -348,39 +349,21 @@
 }
 
 .cardControls {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  z-index: 20;
   display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  flex: 0 0 auto;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 8px;
 }
 
-/* Mobile: Position controls in top right corner */
-@media (max-width: 768px) {
-  .cardControls {
-    position: absolute;
-    top: 12px;
-    right: 12px;
-    z-index: 10;
-  }
-  
-  .card {
-    padding-right: 100px; /* Add space for controls */
-  }
-  
-  .cardMetricRow {
-    justify-content: flex-end;
-  }
-  
-  .cardMetrics {
-    align-items: flex-end;
-  }
-}
-
-.cardIconButton {
+.cardMenuTrigger {
   position: relative;
-  width: 24px;
-  height: 24px;
-  border-radius: 50%;
+  width: 28px;
+  height: 28px;
+  border-radius: 999px;
   border: 1px solid #2a2a2a;
   background: #131313;
   color: #eaeaea;
@@ -390,15 +373,95 @@
   transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
 }
 
-.cardIconButton :global(svg) {
+.cardMenuTrigger :global(svg) {
   font-size: 12px;
+  transition: transform 0.2s ease;
 }
 
-.cardIconButton:hover,
-.cardIconButton:focus-visible {
+.cardMenuTrigger:hover,
+.cardMenuTrigger:focus-visible {
   background: #FA3356;
   border-color: #FA3356;
   color: #ffffff;
+}
+
+.cardMenuTriggerActive {
+  background: #1d1d1d;
+  border-color: #3a3a3a;
+}
+
+.cardMenuTriggerActive :global(svg) {
+  transform: rotate(180deg);
+}
+
+.cardMenu {
+  min-width: 200px;
+  padding: 8px 0;
+  border-radius: 14px;
+  border: 1px solid rgba(250, 51, 86, 0.4);
+  background: rgba(15, 15, 15, 0.98);
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.5);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.cardMenuItem {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 16px;
+  width: 100%;
+  background: transparent;
+  border: none;
+  color: #f1f1f1;
+  font-size: 0.85rem;
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.cardMenuItem:hover,
+.cardMenuItem:focus-visible {
+  background: rgba(250, 51, 86, 0.14);
+  color: #ffffff;
+  outline: none;
+}
+
+.cardMenuItemDanger {
+  color: #ff99aa;
+}
+
+.cardMenuItemDanger:hover,
+.cardMenuItemDanger:focus-visible {
+  background: rgba(250, 51, 86, 0.2);
+  color: #ffffff;
+}
+
+.cardMenuItemIcon {
+  width: 18px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: inherit;
+}
+
+.cardMenuItemIcon :global(svg) {
+  font-size: 14px;
+}
+
+@media (max-width: 768px) {
+  .card {
+    padding-right: 72px;
+  }
+
+  .cardMetricRow {
+    justify-content: flex-end;
+  }
+
+  .cardMetrics {
+    align-items: flex-end;
+  }
 }
 
 .cardEventBadge {


### PR DESCRIPTION
## Summary
- replace the inline budget card action icons with a dropdown menu triggered from a chevron button
- style the new dropdown trigger and menu, adjusting card spacing for the consolidated control

## Testing
- npm run lint *(fails: existing lint errors in unrelated files such as MessagesProvider.tsx and TasksOverviewCard.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68e595675dfc832481cef90cdf3f5e7d