### PR TITLE
Fix budget card action menu stacking

### DIFF
--- a/frontend/src/dashboard/project/features/budget/components/BudgetTable.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetTable.tsx
@@ -385,7 +385,9 @@ const BudgetItemsTable: React.FC<BudgetItemsTableProps> = React.memo(
                     key={record.key}
                     className={`${styles.card}${
                       isSelected ? ` ${styles.cardSelected}` : ""
-                    }${isLocked ? ` ${styles.cardLocked}` : ""}`}
+                    }${isLocked ? ` ${styles.cardLocked}` : ""}${
+                      openMenuId === record.budgetItemId ? ` ${styles.cardMenuOpen}` : ""
+                    }`}
                     role="button"
                     tabIndex={isLocked ? -1 : 0}
                     aria-pressed={isSelected}

--- a/frontend/src/dashboard/project/features/budget/pages/budget-page.module.css
+++ b/frontend/src/dashboard/project/features/budget/pages/budget-page.module.css
@@ -266,6 +266,7 @@
 
 .card {
   position: relative;
+  z-index: 0;
   background: linear-gradient(160deg, rgba(24, 24, 24, 0.95), rgba(9, 9, 9, 0.95));
   border-radius: 20px;
   border: 1px solid #2a2a2a;
@@ -278,7 +279,9 @@
   transition: box-shadow 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
 }
 
-.card:hover {
+.card:hover,
+.cardMenuOpen {
+  z-index: 30;
   transform: translateY(-2px);
   box-shadow: 0 18px 36px rgba(0, 0, 0, 0.5);
 }


### PR DESCRIPTION
## Summary
- mark budget cards with open action menus so they receive elevated styling
- raise the z-index and hover styling of cards to keep the dropdown above neighboring cards

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e59a0345388324b98bbbb14de77c5f