### PR TITLE
Fix mobile budget card metric alignment

### DIFF
--- a/frontend/src/dashboard/project/features/budget/components/HeaderStats.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/HeaderStats.tsx
@@ -1010,8 +1010,18 @@ const BudgetHeader: React.FC<BudgetHeaderProps> = ({
     </div>
   );
 
-  const topMetrics = metrics.slice(0, 3);
-  const bottomMetrics = metrics.slice(3);
+  const metricColumns = useMemo(() => {
+    const [ballpark, budgeted, actual, markup, finalMetric] = metrics;
+
+    const leftColumn = [ballpark, budgeted].filter(
+      (metric): metric is MetricConfig => Boolean(metric)
+    );
+    const rightColumn = [actual, markup, finalMetric].filter(
+      (metric): metric is MetricConfig => Boolean(metric)
+    );
+
+    return [leftColumn, rightColumn];
+  }, [metrics]);
 
   const mobileAccentStyle = accentStyle;
 
@@ -1112,12 +1122,11 @@ const BudgetHeader: React.FC<BudgetHeaderProps> = ({
       </div>
 
       <div className={mobileStyles.metricGrid}>
-        <div className={`${mobileStyles.metricRow} ${mobileStyles.metricRowTop}`}>
-          {topMetrics.map((metric) => renderMetricChip(metric))}
-        </div>
-        <div className={`${mobileStyles.metricRow} ${mobileStyles.metricRowBottom}`}>
-          {bottomMetrics.map((metric) => renderMetricChip(metric))}
-        </div>
+        {metricColumns.filter((column) => column.length > 0).map((column, index) => (
+          <div key={`metric-column-${index}`} className={mobileStyles.metricColumn}>
+            {column.map((metric) => renderMetricChip(metric))}
+          </div>
+        ))}
       </div>
 
       <div className={mobileStyles.groupControls}>

--- a/frontend/src/dashboard/project/features/budget/components/budget-header-mobile.module.css
+++ b/frontend/src/dashboard/project/features/budget/components/budget-header-mobile.module.css
@@ -278,16 +278,17 @@
 }
 
 .metricGrid {
-  display: flex;
+  display: grid;
   width: 100%;
-  flex-direction: column;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 6px;
 }
 
-.metricRow {
-  display: grid;
-  min-width: 0;
+.metricColumn {
+  display: flex;
+  flex-direction: column;
   gap: 6px;
+  min-width: 0;
 }
 
 .metricChipWrapper {
@@ -325,14 +326,6 @@
 
 .metricChipSwitch :global(.ant-switch-checked .ant-switch-handle::before) {
   background: #0f172a;
-}
-
-.metricRowTop {
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-}
-
-.metricRowBottom {
-  grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
 .metricChip {
@@ -432,6 +425,10 @@
 }
 
 @media (max-width: 480px) {
+  .metricGrid {
+    grid-template-columns: 1fr;
+  }
+
   .summaryLayout {
     gap: 6px;
   }


### PR DESCRIPTION
## Summary
- stack the mobile budget metrics into columns so related values align vertically
- update the mobile budget card styles to remove the extra divider row layout and support the new stacking

## Testing
- npm run lint *(fails: existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e5a0627e988324949971685473deca