### PR TITLE
Align budget desktop budget controls into unified toolbar

### DIFF
--- a/frontend/src/dashboard/project/features/budget/components/BudgetTable.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetTable.tsx
@@ -342,7 +342,7 @@ const BudgetItemsTable: React.FC<BudgetItemsTableProps> = React.memo(
 
     return (
       <div ref={tableRef} className={styles.tableContainer}>
-        {dataSource.length > 0 && (
+        {dataSource.length > 0 && isMobile && (
           <div className={styles.cardListHeader}>
             <label className={styles.selectAllControl}>
               <input

--- a/frontend/src/dashboard/project/features/budget/components/BudgetToolbar.module.css
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetToolbar.module.css
@@ -1,33 +1,47 @@
 .toolbar {
-  color: var(--text-color);
+  --toolbar-bg-start: rgba(16, 16, 16, 0.96);
+  --toolbar-bg-end: rgba(12, 12, 12, 0.88);
   width: 100%;
   display: flex;
-  justify-content: space-between;
   align-items: center;
-  gap: 1rem;
-  padding: 6px;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 16px 20px;
+  border-radius: 20px;
+  background: linear-gradient(160deg, var(--toolbar-bg-start), var(--toolbar-bg-end));
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04), 0 18px 40px rgba(15, 23, 42, 0.32);
+  color: rgba(255, 255, 255, 0.92);
+  flex-wrap: wrap;
+  box-sizing: border-box;
+}
+
+.groupControls {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  min-height: 32px;
 }
 
 .groupTabs {
-  display: flex;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
   flex-wrap: wrap;
-  align-items: flex-start;
-  align-content: flex-end;
-  gap: 6px;
-  margin-right: auto;
 }
 
-.tabButton {
+.groupTabButton {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   padding: 6px 14px;
   font-weight: 600;
-  font-size: clamp(0.78rem, 0.2vw + 0.74rem, 0.88rem);
+  font-size: clamp(0.78rem, 0.22vw + 0.74rem, 0.88rem);
   letter-spacing: 0.01em;
   color: rgba(255, 255, 255, 0.78);
   border-radius: 999px;
-  border: 1px solid rgba(255, 255, 255, 0.14);
+  border: 1px solid rgba(255, 255, 255, 0.16);
   background: transparent;
   box-shadow: 0 4px 12px rgba(5, 10, 28, 0.2);
   transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease,
@@ -35,47 +49,104 @@
   cursor: pointer;
 }
 
-.tabButton:hover {
-  background-color: rgba(255, 255, 255, 0.04);
-  border-color: rgba(255, 255, 255, 0.25);
+.groupTabButton:hover {
+  background-color: rgba(255, 255, 255, 0.06);
+  border-color: rgba(255, 255, 255, 0.26);
   color: rgba(255, 255, 255, 0.92);
   transform: translateY(-1px);
 }
 
-.tabButton:focus-visible {
-  outline: 2px solid rgba(255, 255, 255, 0.5);
+.groupTabButton:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.55);
   outline-offset: 2px;
 }
 
-.tabButton:focus-visible:not(.activeTab) {
-  background: rgba(255, 255, 255, 0.12);
-  border-color: rgba(255, 255, 255, 0.22);
-  color: rgba(255, 255, 255, 0.92);
-  transform: translateY(-1px);
-}
-
-.activeTab {
-  background: rgba(255, 255, 255, 0.98);
+.activeGroupTab {
+  background: rgba(255, 255, 255, 0.96);
   border-color: transparent;
   color: #111213;
   box-shadow: 0 8px 20px rgba(5, 10, 28, 0.32);
 }
 
-.activeTab:hover {
-  background: rgba(255, 255, 255, 0.98);
+.activeGroupTab:hover {
+  background: rgba(255, 255, 255, 0.96);
   border-color: transparent;
   color: #111213;
   transform: none;
 }
 
-.actions {
-  display: flex;
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+.rightControls {
+  display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
+  justify-content: flex-end;
+  gap: 14px;
+  margin-left: auto;
+  flex-wrap: wrap;
+}
+
+.selectAllBlock {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 12px;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: rgba(255, 255, 255, 0.86);
+}
+
+.selectAllControl {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.85rem;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+}
+
+.selectAllControl input {
+  width: 16px;
+  height: 16px;
+  cursor: pointer;
+  accent-color: #fa3356;
+}
+
+.selectionCount {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.clearSelectionButton {
+  background: transparent;
+  border: none;
+  color: rgba(250, 51, 86, 0.85);
+  font-size: 0.78rem;
+  font-weight: 500;
+  cursor: pointer;
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.clearSelectionButton:hover,
+.clearSelectionButton:focus-visible {
+  color: #ff4d73;
+  outline: none;
 }
 
 .selectionActions {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: flex-end;
   gap: 0.5rem;
@@ -90,11 +161,36 @@
   height: 28px;
 }
 
-.mobileRight {
-  display: flex;
+.iconActionButton {
+  display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
-  margin-left: auto;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.85);
+  font-size: 12px;
+  cursor: pointer;
+  transition: color 0.2s ease, transform 0.2s ease, background-color 0.2s ease;
+}
+
+.iconActionButton:hover,
+.iconActionButton:focus-visible {
+  color: #ffffff;
+  background-color: rgba(255, 255, 255, 0.1);
+  transform: translateY(-1px);
+}
+
+.iconActionButton:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.55);
+  outline-offset: 2px;
+}
+
+.iconActionButton:active {
+  transform: translateY(0);
 }
 
 .mobileFilterWrap {
@@ -102,6 +198,7 @@
   align-items: center;
   justify-content: flex-end;
   min-width: 220px;
+  flex: 0 0 auto;
 }
 
 .mobileFilterRoot {
@@ -153,59 +250,28 @@
   transform: scale(0.98);
 }
 
-.iconActionButton {
+.addButton {
   display: inline-flex;
   align-items: center;
-  justify-content: center;
-  width: 28px;
-  height: 28px;
-  padding: 0;
-  border: none;
-  border-radius: 8px;
-  background: transparent;
-  color: rgba(255, 255, 255, 0.85);
-  font-size: 12px;
-  cursor: pointer;
-  transition: color 0.2s ease, transform 0.2s ease, background-color 0.2s ease;
-}
-
-.iconActionButton:hover,
-.iconActionButton:focus-visible {
-  color: #ffffff;
-  background-color: rgba(255, 255, 255, 0.1);
-  transform: translateY(-1px);
-}
-
-.iconActionButton:focus-visible {
-  outline: 2px solid rgba(255, 255, 255, 0.55);
-  outline-offset: 2px;
-}
-
-.iconActionButton:active {
-  transform: translateY(0);
-}
-
-.addButton {
-  display: none;
-  align-items: center;
   gap: 0.5rem;
-  padding: 8px 16px;
-  border: 1px solid rgba(255, 255, 255, 0.15);
-  border-radius: 16px;
-  background-color: transparent;
+  padding: 10px 18px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 18px;
+  background-color: rgba(255, 255, 255, 0.06);
   color: #ffffff;
-  font-size: 0.875rem;
+  font-size: 0.9rem;
   font-weight: 500;
   letter-spacing: 0.01em;
   flex-shrink: 0;
   cursor: pointer;
   transition: transform 0.15s ease, background-color 0.2s ease, border-color 0.2s ease,
     box-shadow 0.2s ease;
+  box-shadow: 0 12px 28px rgba(5, 10, 28, 0.32);
 }
 
 .addButton:hover {
-  background-color: rgba(255, 255, 255, 0.04);
-  border-color: rgba(255, 255, 255, 0.25);
+  background-color: rgba(255, 255, 255, 0.1);
+  border-color: rgba(255, 255, 255, 0.3);
 }
 
 .addButton:focus-visible {
@@ -241,63 +307,58 @@
   }
 }
 
-@media (max-width: 768px) {
+@media (max-width: 1080px) {
   .toolbar {
-    justify-content: flex-end;
-    flex-wrap: wrap;
+    padding: 14px 16px;
+    gap: 12px;
   }
 
-  .groupTabs {
+  .mobileFilterWrap {
+    min-width: 200px;
+  }
+}
+
+@media (max-width: 900px) {
+  .groupControls {
     display: none;
   }
+}
 
-  .iconActionButton {
-    width: 32px;
-    height: 32px;
-    font-size: 0.82rem;
+@media (max-width: 768px) {
+  .toolbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .rightControls {
+    width: 100%;
+    justify-content: flex-start;
+    gap: 12px;
+  }
+
+  .selectAllBlock {
+    width: 100%;
+    justify-content: space-between;
+    gap: 8px;
   }
 
   .selectionActions {
     min-width: 72px;
   }
 
-  .iconSlot {
+  .iconSlot,
+  .iconActionButton {
     width: 32px;
     height: 32px;
-  }
-
-  .actions {
-    width: 100%;
-    justify-content: flex-start;
-  }
-
-  .mobileRight {
-    flex: 1 1 100%;
-    width: 100%;
-    margin-left: 0;
-    justify-content: flex-start;
+    font-size: 0.82rem;
   }
 
   .mobileFilterWrap {
-    display: flex;
-    flex: 0 0 auto;
-  }
-
-  .mobileFilterButton {
-    padding: 8px 12px;
-    width: auto;
-  }
-
-  .mobileFilterRoot {
-    width: auto;
-  }
-
-  .selectionActions {
-    min-width: auto;
+    flex: 1 1 auto;
+    min-width: 0;
   }
 
   .addButton {
-    display: inline-flex;
     margin-left: auto;
   }
 }

--- a/frontend/src/dashboard/project/features/budget/components/BudgetToolbar.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetToolbar.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import { Tooltip as AntTooltip } from "antd";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faClone, faTrash } from "@fortawesome/free-solid-svg-icons";
@@ -6,6 +6,15 @@ import BudgetMobileFilter from "./BudgetMobileFilter";
 import styles from "./BudgetToolbar.module.css";
 
 type SortOrder = "ascend" | "descend" | null;
+
+type GroupByOption = "none" | "areaGroup" | "invoiceGroup" | "category";
+
+const GROUP_OPTIONS: { label: string; value: GroupByOption }[] = [
+  { label: "None", value: "none" },
+  { label: "Area Group", value: "areaGroup" },
+  { label: "Invoice Group", value: "invoiceGroup" },
+  { label: "Category", value: "category" },
+];
 
 interface BudgetToolbarProps {
   selectedRowKeys: string[];
@@ -17,6 +26,14 @@ interface BudgetToolbarProps {
   sortField: string | null;
   sortOrder: SortOrder;
   onSortChange: (field: string | null, order: SortOrder) => void;
+  groupBy: GroupByOption;
+  onGroupChange: (group: GroupByOption) => void;
+  isSelectAllChecked: boolean;
+  isSelectAllIndeterminate: boolean;
+  onSelectAllChange: (checked: boolean) => void;
+  selectionCount: number;
+  totalCount: number;
+  onClearSelection: () => void;
 }
 
 const BudgetToolbar: React.FC<BudgetToolbarProps> = ({
@@ -29,31 +46,81 @@ const BudgetToolbar: React.FC<BudgetToolbarProps> = ({
   sortField,
   sortOrder,
   onSortChange,
-}) => (
-  <div className={styles.toolbar}>
-    <div className={styles.actions}>
-      <div className={styles.mobileRight}>
-        <div className={styles.mobileFilterWrap}>
-          <BudgetMobileFilter
-            filterQuery={filterQuery}
-            onFilterQueryChange={onFilterQueryChange}
-            sortField={sortField}
-            sortOrder={sortOrder}
-            onSortChange={onSortChange}
-          />
+  groupBy,
+  onGroupChange,
+  isSelectAllChecked,
+  isSelectAllIndeterminate,
+  onSelectAllChange,
+  selectionCount,
+  totalCount,
+  onClearSelection,
+}) => {
+  const selectAllRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    if (!selectAllRef.current) return;
+    selectAllRef.current.indeterminate = isSelectAllIndeterminate;
+  }, [isSelectAllIndeterminate]);
+
+  const hasRows = totalCount > 0;
+
+  return (
+    <div className={styles.toolbar}>
+      <div className={styles.groupControls}>
+        <span id="budget-desktop-group-label" className={styles.srOnly}>
+          Group budget items
+        </span>
+        <div
+          className={styles.groupTabs}
+          role="group"
+          aria-labelledby="budget-desktop-group-label"
+        >
+          {GROUP_OPTIONS.map((option) => {
+            const isActive = option.value === groupBy;
+            const className = isActive
+              ? `${styles.groupTabButton} ${styles.activeGroupTab}`
+              : styles.groupTabButton;
+            return (
+              <button
+                key={option.value}
+                type="button"
+                aria-pressed={isActive}
+                className={className}
+                onClick={() => onGroupChange(option.value)}
+              >
+                <span>{option.label}</span>
+              </button>
+            );
+          })}
         </div>
-        {openCreateModal && (
-          <button
-            type="button"
-            className={styles.addButton}
-            onClick={openCreateModal}
-            aria-label="Add item"
-          >
-            <span className={styles.addIcon} aria-hidden="true">
-              +
-            </span>
-            <span className={styles.addLabel}>Add Item</span>
-          </button>
+      </div>
+      <div className={styles.rightControls}>
+        {hasRows && (
+          <div className={styles.selectAllBlock}>
+            <label className={styles.selectAllControl}>
+              <input
+                ref={selectAllRef}
+                type="checkbox"
+                checked={isSelectAllChecked}
+                disabled={!hasRows}
+                onChange={(event) => onSelectAllChange(event.target.checked)}
+                aria-label="Select all budget items"
+              />
+              <span>Select all</span>
+              <span className={styles.selectionCount}>
+                {selectionCount}/{totalCount}
+              </span>
+            </label>
+            {selectionCount > 0 && (
+              <button
+                type="button"
+                className={styles.clearSelectionButton}
+                onClick={onClearSelection}
+              >
+                Clear selection
+              </button>
+            )}
+          </div>
         )}
         {selectedRowKeys.length > 0 && (
           <div className={styles.selectionActions}>
@@ -83,10 +150,32 @@ const BudgetToolbar: React.FC<BudgetToolbarProps> = ({
             </div>
           </div>
         )}
+        <div className={styles.mobileFilterWrap}>
+          <BudgetMobileFilter
+            filterQuery={filterQuery}
+            onFilterQueryChange={onFilterQueryChange}
+            sortField={sortField}
+            sortOrder={sortOrder}
+            onSortChange={onSortChange}
+          />
+        </div>
+        {openCreateModal && (
+          <button
+            type="button"
+            className={styles.addButton}
+            onClick={openCreateModal}
+            aria-label="Add item"
+          >
+            <span className={styles.addIcon} aria-hidden="true">
+              +
+            </span>
+            <span className={styles.addLabel}>Add Item</span>
+          </button>
+        )}
       </div>
     </div>
-  </div>
-);
+  );
+};
 
 export default BudgetToolbar;
 

--- a/frontend/src/dashboard/project/features/budget/components/HeaderStats.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/HeaderStats.tsx
@@ -122,7 +122,6 @@ interface BudgetHeaderProps {
   budgetItems?: BudgetItem[];
   onBallparkChange?: (val: number) => void;
   onOpenRevisionModal: () => void;
-  onOpenCreateModal?: () => void;
   initialMetric?: MetricTitle;
 }
 
@@ -265,7 +264,6 @@ const BudgetHeader: React.FC<BudgetHeaderProps> = ({
   budgetItems = [],
   onBallparkChange,
   onOpenRevisionModal,
-  onOpenCreateModal,
   initialMetric,
 }) => {
   const [selectedMetric, setSelectedMetric] = useState<MetricTitle>(
@@ -875,19 +873,6 @@ const BudgetHeader: React.FC<BudgetHeaderProps> = ({
           >
             {`Rev.${budgetHeader?.revision ?? 1}`}
           </button>
-          {onOpenCreateModal && (
-            <button
-              type="button"
-              className={summaryStyles.addButton}
-              onClick={onOpenCreateModal}
-              aria-label="Add item"
-            >
-              <span className={summaryStyles.addIcon} aria-hidden="true">
-                +
-              </span>
-              <span className={summaryStyles.addLabel}>Add Item</span>
-            </button>
-          )}
         </div>
       </div>
       <div className={summaryStyles.bodyRow}>
@@ -975,36 +960,6 @@ const BudgetHeader: React.FC<BudgetHeaderProps> = ({
               })}
             </ul>
           </div>
-        </div>
-      </div>
-
-      {/* Group controls for desktop */}
-      <div className={summaryStyles.groupControls}>
-        <span id="budget-desktop-group-label" className={summaryStyles.srOnly}>
-          Group budget items
-        </span>
-        <div
-          className={summaryStyles.groupTabs}
-          role="group"
-          aria-labelledby="budget-desktop-group-label"
-        >
-          {groupOptions.map((option) => {
-            const isActive = option.value === groupBy;
-            const className = isActive
-              ? `${summaryStyles.groupTabButton} ${summaryStyles.activeGroupTab}`
-              : summaryStyles.groupTabButton;
-            return (
-              <button
-                key={option.value}
-                type="button"
-                aria-pressed={isActive}
-                className={className}
-                onClick={() => setGroupBy(option.value)}
-              >
-                <span>{option.label}</span>
-              </button>
-            );
-          })}
         </div>
       </div>
     </div>

--- a/frontend/src/dashboard/project/features/budget/pages/BudgetPage.tsx
+++ b/frontend/src/dashboard/project/features/budget/pages/BudgetPage.tsx
@@ -550,9 +550,12 @@ const BudgetPageContent = () => {
                               budgetHeader={budgetHeader as { budgetItemId: string; revision: number; [key: string]: unknown } | null}
                               budgetItems={budgetItems as { [key: string]: unknown }[]}
                               groupBy={stateManager.groupBy as "none" | "areaGroup" | "invoiceGroup" | "category"}
-                              setGroupBy={(g) => stateManager.setGroupBy(g as "none" | "areaGroup" | "invoiceGroup" | "category")}
+                              setGroupBy={(g) =>
+                                stateManager.setGroupBy(
+                                  g as "none" | "areaGroup" | "invoiceGroup" | "category"
+                                )
+                              }
                               onOpenRevisionModal={() => stateManager.setRevisionModalOpen(true)}
-                              onOpenCreateModal={eventHandlers.openCreateModal}
                               onBallparkChange={handleBallparkChange}
                             />
                             <BudgetFileModal
@@ -635,44 +638,97 @@ const BudgetPageContent = () => {
                                     alignItems: "flex-start",
                                   }}
                                 >
-                                  <BudgetToolbar
-                                    selectedRowKeys={stateManager.selectedRowKeys}
-                                    handleDuplicateSelected={eventHandlers.handleDuplicateSelected}
-                                    openDeleteModal={eventHandlers.openDeleteModal}
-                                    openCreateModal={eventHandlers.openCreateModal}
-                                    filterQuery={stateManager.filterQuery as string}
-                                    onFilterQueryChange={stateManager.setFilterQuery as (query: string) => void}
-                                    sortField={stateManager.sortField as string | null}
-                                    sortOrder={stateManager.sortOrder as "ascend" | "descend" | null}
-                                    onSortChange={(field, order) => {
-                                      stateManager.setSortField(field);
-                                      stateManager.setSortOrder(order);
-                                    }}
-                                  />
-                                  <BudgetItemsTable
-                                    dataSource={
+                                  {(() => {
+                                    const groupedData =
                                       budgetItems.length > 0
                                         ? (tableConfig.groupedTableData as (Record<string, unknown> & {
                                             budgetItemId: string;
                                             key: string;
                                           })[])
-                                        : []
-                                    }
-                                    selectedRowKeys={stateManager.selectedRowKeys}
-                                    setSelectedRowKeys={stateManager.setSelectedRowKeys}
-                                    lockedLines={stateManager.lockedLines}
-                                    openEditModal={eventHandlers.openEditModal}
-                                    openDuplicateModal={eventHandlers.openDuplicateModal}
-                                    openDeleteModal={eventHandlers.openDeleteModal}
-                                    openEventModal={eventHandlers.openEventModal}
-                                    eventsByLineItem={eventsByLineItem}
-                                    tableRef={tableRef}
-                                    tableHeight={tableHeight}
-                                    pageSize={stateManager.pageSize}
-                                    currentPage={stateManager.currentPage}
-                                    setCurrentPage={stateManager.setCurrentPage}
-                                    setPageSize={stateManager.setPageSize}
-                                  />
+                                        : [];
+                                    const availableRowIds = groupedData.map((item) =>
+                                      String(item.budgetItemId)
+                                    );
+                                    const availableRowIdSet = new Set(availableRowIds);
+                                    const selectedInScope = stateManager.selectedRowKeys.filter((id) =>
+                                      availableRowIdSet.has(id)
+                                    );
+                                    const isSelectAllChecked =
+                                      availableRowIds.length > 0 &&
+                                      selectedInScope.length === availableRowIds.length;
+                                    const isSelectAllIndeterminate =
+                                      selectedInScope.length > 0 &&
+                                      selectedInScope.length < availableRowIds.length;
+                                    const handleSelectAllChange = (checked: boolean) => {
+                                      stateManager.setSelectedRowKeys((prevKeys) => {
+                                        if (checked) {
+                                          const next = new Set(prevKeys);
+                                          availableRowIds.forEach((id) => next.add(id));
+                                          return Array.from(next);
+                                        }
+                                        return prevKeys.filter((id) => !availableRowIdSet.has(id));
+                                      });
+                                    };
+                                    const handleClearSelection = () => {
+                                      stateManager.setSelectedRowKeys((prevKeys) =>
+                                        prevKeys.filter((id) => !availableRowIdSet.has(id))
+                                      );
+                                    };
+
+                                    return (
+                                      <>
+                                        <BudgetToolbar
+                                          selectedRowKeys={stateManager.selectedRowKeys}
+                                          handleDuplicateSelected={eventHandlers.handleDuplicateSelected}
+                                          openDeleteModal={eventHandlers.openDeleteModal}
+                                          openCreateModal={eventHandlers.openCreateModal}
+                                          filterQuery={stateManager.filterQuery as string}
+                                          onFilterQueryChange={
+                                            stateManager.setFilterQuery as (query: string) => void
+                                          }
+                                          sortField={stateManager.sortField as string | null}
+                                          sortOrder={
+                                            stateManager.sortOrder as "ascend" | "descend" | null
+                                          }
+                                          onSortChange={(field, order) => {
+                                            stateManager.setSortField(field);
+                                            stateManager.setSortOrder(order);
+                                          }}
+                                          groupBy={
+                                            stateManager.groupBy as
+                                              | "none"
+                                              | "areaGroup"
+                                              | "invoiceGroup"
+                                              | "category"
+                                          }
+                                          onGroupChange={(group) => stateManager.setGroupBy(group)}
+                                          isSelectAllChecked={isSelectAllChecked}
+                                          isSelectAllIndeterminate={isSelectAllIndeterminate}
+                                          onSelectAllChange={handleSelectAllChange}
+                                          selectionCount={selectedInScope.length}
+                                          totalCount={availableRowIds.length}
+                                          onClearSelection={handleClearSelection}
+                                        />
+                                        <BudgetItemsTable
+                                          dataSource={groupedData}
+                                          selectedRowKeys={stateManager.selectedRowKeys}
+                                          setSelectedRowKeys={stateManager.setSelectedRowKeys}
+                                          lockedLines={stateManager.lockedLines}
+                                          openEditModal={eventHandlers.openEditModal}
+                                          openDuplicateModal={eventHandlers.openDuplicateModal}
+                                          openDeleteModal={eventHandlers.openDeleteModal}
+                                          openEventModal={eventHandlers.openEventModal}
+                                          eventsByLineItem={eventsByLineItem}
+                                          tableRef={tableRef}
+                                          tableHeight={tableHeight}
+                                          pageSize={stateManager.pageSize}
+                                          currentPage={stateManager.currentPage}
+                                          setCurrentPage={stateManager.setCurrentPage}
+                                          setPageSize={stateManager.setPageSize}
+                                        />
+                                      </>
+                                    );
+                                  })()}
                                 </div>
                               </div>
                             </div>


### PR DESCRIPTION
## Summary
- move the budget header's grouping controls into the toolbar alongside select all, filter, and add actions
- restyle the toolbar to match the desktop budget header surface while keeping selection actions and mobile behavior intact
- compute select-all state in the budget page so the toolbar can drive selection and keep mobile-only controls inside the table component

## Testing
- npm run lint (fails: existing lint errors in unrelated files)

------
https://chatgpt.com/codex/tasks/task_e_68e6cc32c8648324b5a7f2565ec8885f