### PR TITLE
Refine mobile budget group pill styling

### DIFF
--- a/frontend/src/dashboard/project/features/budget/components/HeaderStats.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/HeaderStats.tsx
@@ -27,7 +27,6 @@ import {
 
 import summaryStyles from "./budget-header-summary.module.css";
 import mobileStyles from "./budget-header-mobile.module.css";
-import toolbarStyles from "./BudgetToolbar.module.css";
 
 /* =========================
    Types
@@ -1087,8 +1086,8 @@ const BudgetHeader: React.FC<BudgetHeaderProps> = ({
           {groupOptions.map((option) => {
             const isActive = option.value === groupBy;
             const className = isActive
-              ? `${toolbarStyles.tabButton} ${toolbarStyles.activeTab}`
-              : toolbarStyles.tabButton;
+              ? `${mobileStyles.groupTabButton} ${mobileStyles.groupTabButtonActive}`
+              : mobileStyles.groupTabButton;
             return (
               <button
                 key={option.value}

--- a/frontend/src/dashboard/project/features/budget/components/budget-header-mobile.module.css
+++ b/frontend/src/dashboard/project/features/budget/components/budget-header-mobile.module.css
@@ -410,13 +410,68 @@
   display: flex;
   justify-content: center;
   width: 100%;
+  margin-top: 4px;
 }
 
 .groupTabs {
-  display: flex;
-  flex-wrap: wrap;
+  display: inline-flex;
+  align-items: center;
   justify-content: center;
-  gap: 6px;
+  gap: 4px;
+  padding: 4px;
+  background: rgba(12, 12, 12, 0.72);
+  border-radius: 9999px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 10px 26px rgba(5, 10, 28, 0.32);
+  overflow-x: auto;
+  max-width: 100%;
+}
+
+.groupTabs::-webkit-scrollbar {
+  display: none;
+}
+
+.groupTabs {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+
+.groupTabButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 12px;
+  font-weight: 600;
+  font-size: clamp(0.72rem, 0.22vw + 0.68rem, 0.8rem);
+  letter-spacing: 0.01em;
+  color: rgba(255, 255, 255, 0.78);
+  border-radius: 9999px;
+  border: none;
+  background: transparent;
+  box-shadow: none;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease,
+    box-shadow 0.2s ease, transform 0.2s ease;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.groupTabButton:hover {
+  background-color: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.92);
+  transform: translateY(-1px);
+}
+
+.groupTabButton:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.5);
+  outline-offset: 2px;
+  background: rgba(255, 255, 255, 0.12);
+  color: rgba(255, 255, 255, 0.92);
+}
+
+.groupTabButtonActive {
+  background: rgba(255, 255, 255, 0.96);
+  color: #0f172a;
+  box-shadow: 0 8px 20px rgba(5, 10, 28, 0.32);
 }
 
 .srOnly {


### PR DESCRIPTION
## Summary
- restyle the budget header mobile group controls to mirror the compact segmented look from project header navigation pills
- update the mobile budget header logic to use the new pill styles for active state handling

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e6d483b5648324a66ab7c34f36a573