### PR TITLE
Align task action controls and hide mark done for completed tasks

### DIFF
--- a/frontend/src/dashboard/home/components/TasksOverviewCard.module.css
+++ b/frontend/src/dashboard/home/components/TasksOverviewCard.module.css
@@ -386,7 +386,20 @@
   display: flex;
   align-items: center;
   gap: 10px;
-  flex-wrap: wrap;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+}
+
+.taskActions::-webkit-scrollbar {
+  display: none;
+}
+
+.taskActions > * {
+  flex: 0 0 auto;
+  white-space: nowrap;
 }
 
 .mapButton {

--- a/frontend/src/dashboard/home/components/TasksOverviewCard.tsx
+++ b/frontend/src/dashboard/home/components/TasksOverviewCard.tsx
@@ -37,6 +37,7 @@ type DerivedTask = {
   mapUrl: string | null;
   overdue: boolean;
   dueDate: Date | null;
+  status?: string;
 };
 
 const dueDateFormatter = new Intl.DateTimeFormat(undefined, {
@@ -162,10 +163,11 @@ type TaskItemProps = {
 };
 
 const TaskItem: React.FC<TaskItemProps> = ({ task, onOpen, onMarkDone, onOpenMap }) => {
-  const { id, title, dayLabel, time, address, assignee, mapUrl, overdue, dueDate } = task;
+  const { id, title, dayLabel, time, address, assignee, mapUrl, overdue, dueDate, status } = task;
   const metaEntries: Array<{ icon: React.ReactNode; label: string }> = [];
   const dateLabel = dueDate ? dueDateFormatter.format(dueDate) : dayLabel;
   const timeLabel = time ?? (dueDate ? timeFormatter.format(dueDate) : undefined);
+  const isCompleted = typeof status === "string" && status.toLowerCase() === "done";
 
   if (dateLabel) {
     metaEntries.push({ icon: <CalendarDays aria-hidden="true" />, label: timeLabel ? `${dateLabel} · ${timeLabel}` : dateLabel });
@@ -208,13 +210,15 @@ const TaskItem: React.FC<TaskItemProps> = ({ task, onOpen, onMarkDone, onOpenMap
             <ArrowUpRight aria-hidden="true" />
           </button>
         )}
-        <Button
-          size="sm"
-          className={cn(styles.accentButton, styles.actionButton)}
-          onClick={() => onMarkDone(id)}
-        >
-          Mark done
-        </Button>
+        {!isCompleted ? (
+          <Button
+            size="sm"
+            className={cn(styles.accentButton, styles.actionButton)}
+            onClick={() => onMarkDone(id)}
+          >
+            Mark done
+          </Button>
+        ) : null}
       </div>
     </li>
   );
@@ -265,6 +269,7 @@ const TasksOverviewCard: React.FC<TasksOverviewCardProps> = ({ className }) => {
         mapUrl,
         overdue,
         dueDate,
+        status: source?.status,
       } satisfies DerivedTask;
     });
   }, [flatTasks, getTaskById]);

--- a/frontend/src/dashboard/project/components/Tasks/TasksComponent.module.css
+++ b/frontend/src/dashboard/project/components/Tasks/TasksComponent.module.css
@@ -343,8 +343,22 @@
 
 .taskActions {
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: row;
+  flex-wrap: nowrap;
   gap: 0.5rem;
+  align-items: center;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+}
+
+.taskActions::-webkit-scrollbar {
+  display: none;
+}
+
+.taskActions > * {
+  flex: 0 0 auto;
+  white-space: nowrap;
 }
 
 .mapButton {

--- a/frontend/src/dashboard/project/components/Tasks/TasksComponent.tsx
+++ b/frontend/src/dashboard/project/components/Tasks/TasksComponent.tsx
@@ -98,6 +98,7 @@ const TaskListItem: React.FC<TaskListItemProps> = ({
   const displayStatusLabel = statusLabel === baseStatusLabel ? statusLabel : `${statusLabel} · ${baseStatusLabel}`;
   const assigneeLabel = formatAssigneeDisplay(task.assignedTo);
   const directionsLinks = buildDirectionsLinks(task.address);
+  const isCompleted = typeof task.status === "string" && task.status.toLowerCase() === "done";
 
   const metaEntries: Array<{ icon: React.ReactNode; label: string }> = [];
   const dueLabel = formatDue(task);
@@ -164,16 +165,18 @@ const TaskListItem: React.FC<TaskListItemProps> = ({
               <ArrowUpRight aria-hidden="true" size={16} />
             </Button>
           ) : null}
-          <Button
-            size="sm"
-            className={styles.accentButton}
-            onClick={(event) => {
-              event.stopPropagation();
-              onMarkDone(task.id);
-            }}
-          >
-            Mark done
-          </Button>
+          {!isCompleted ? (
+            <Button
+              size="sm"
+              className={styles.accentButton}
+              onClick={(event) => {
+                event.stopPropagation();
+                onMarkDone(task.id);
+              }}
+            >
+              Mark done
+            </Button>
+          ) : null}
           <Button
             variant="outline"
             size="sm"

--- a/frontend/src/dashboard/project/components/Tasks/TasksComponentMobile.module.css
+++ b/frontend/src/dashboard/project/components/Tasks/TasksComponentMobile.module.css
@@ -885,10 +885,23 @@
 
 .taskActions {
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: row;
   align-items: center;
   gap: 0.5rem;
   padding: 0 1.05rem 1rem;
+  flex-wrap: nowrap;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+}
+
+.taskActions::-webkit-scrollbar {
+  display: none;
+}
+
+.taskActions > * {
+  flex: 0 0 auto;
+  white-space: nowrap;
 }
 
 .taskActionButton {
@@ -899,6 +912,8 @@
   font-weight: 600;
   letter-spacing: 0.01em;
   text-transform: none;
+  white-space: nowrap;
+  flex: 0 0 auto;
 }
 
 .taskActionButton svg {

--- a/frontend/src/dashboard/project/components/Tasks/components/TaskList.tsx
+++ b/frontend/src/dashboard/project/components/Tasks/components/TaskList.tsx
@@ -52,6 +52,8 @@ const TaskList: React.FC<TaskListProps> = ({
         const primaryMapUrl = directionsLinks
           ? directionsLinks.googleMaps || directionsLinks.appleMaps
           : null;
+        const isCompleted =
+          typeof task.status === "string" && task.status.toLowerCase() === "done";
         const { category, label } = getTaskStatusBadge(task.status, task.dueDate, statusContext);
         const tone = getTaskStatusTone(category);
         const badgeClassKey = BADGE_CLASS_BY_TONE[tone];
@@ -120,16 +122,18 @@ const TaskList: React.FC<TaskListProps> = ({
                   <ArrowUpRight aria-hidden="true" size={16} />
                 </Button>
               ) : null}
-              <Button
-                size="sm"
-                className={`${styles.taskActionButton} ${styles.taskMarkDoneButton}`}
-                onClick={(event) => {
-                  event.stopPropagation();
-                  onTaskMarkDone(task.id);
-                }}
-              >
-                <Check aria-hidden="true" size={16} /> Mark done
-              </Button>
+              {!isCompleted ? (
+                <Button
+                  size="sm"
+                  className={`${styles.taskActionButton} ${styles.taskMarkDoneButton}`}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    onTaskMarkDone(task.id);
+                  }}
+                >
+                  <Check aria-hidden="true" size={16} /> Mark done
+                </Button>
+              ) : null}
               <Button
                 variant="outline"
                 size="sm"


### PR DESCRIPTION
## Summary
- keep map task action buttons in a single horizontal row on desktop and mobile views
- hide the Mark done action when a task is already completed across task cards
- extend task overview data to carry status so completed tasks no longer render the Mark done control

## Testing
- `npm run lint` *(fails: existing lint errors in unrelated files such as MessagesProvider.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68e6d90353b48324a68f2875c874ab47