### PR TITLE
Refine budget select mode interactions

### DIFF
--- a/frontend/src/dashboard/project/features/budget/components/BudgetStateManager.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetStateManager.tsx
@@ -48,6 +48,8 @@ interface BudgetStateManagerState extends Record<string, unknown> {
   setFilterQuery: (query: string) => void;
   selectedRowKeys: string[];
   setSelectedRowKeys: React.Dispatch<React.SetStateAction<string[]>>;
+  isSelectMode: boolean;
+  setIsSelectMode: React.Dispatch<React.SetStateAction<boolean>>;
   
   // Edit/Create state
   editItem: BudgetItem | null;
@@ -108,6 +110,7 @@ const BudgetStateManager: React.FC<BudgetStateManagerProps> = ({
   const [sortOrder, setSortOrder] = useState<string | null>(null);
   const [filterQuery, setFilterQuery] = useState("");
   const [selectedRowKeys, setSelectedRowKeys] = useState<string[]>([]);
+  const [isSelectMode, setIsSelectMode] = useState(false);
   
   // Edit/Create state
   const [editItem, setEditItem] = useState<BudgetItem | null>(null);
@@ -128,6 +131,12 @@ const BudgetStateManager: React.FC<BudgetStateManagerProps> = ({
   useEffect(() => {
     setCurrentPage(1);
   }, [filterQuery]);
+
+  useEffect(() => {
+    if (!isSelectMode && selectedRowKeys.length > 0) {
+      setSelectedRowKeys([]);
+    }
+  }, [isSelectMode, selectedRowKeys.length]);
 
   // Line locking
   const [lockedLines, setLockedLines] = useState<string[]>([]);
@@ -351,6 +360,8 @@ const BudgetStateManager: React.FC<BudgetStateManagerProps> = ({
     setFilterQuery,
     selectedRowKeys,
     setSelectedRowKeys,
+    isSelectMode,
+    setIsSelectMode,
     
     // Edit/Create state
     editItem,
@@ -389,7 +400,7 @@ const BudgetStateManager: React.FC<BudgetStateManagerProps> = ({
   }), [
     undoStack, redoStack, pushHistory, handleUndo, handleRedo,
     isBudgetModalOpen, isRevisionModalOpen, isCreateModalOpen, isEventModalOpen, isConfirmingDelete,
-    groupBy, sortField, sortOrder, filterQuery, selectedRowKeys,
+    groupBy, sortField, sortOrder, filterQuery, selectedRowKeys, isSelectMode,
     editItem, prefillItem, nextElementKey,
     deleteTargets,
     eventItem, eventList,

--- a/frontend/src/dashboard/project/features/budget/components/BudgetTable.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetTable.tsx
@@ -171,6 +171,23 @@ const BudgetItemsTable: React.FC<BudgetItemsTableProps> = React.memo(
       setSelectedRowKeys((prevKeys) => prevKeys.filter((id) => !availableIdSet.has(id)));
     }, [availableIdSet, isSelectMode, setSelectedRowKeys]);
 
+    const toggleSelection = useCallback(
+      (record: BudgetItem, checked: boolean) => {
+        if (!isSelectMode) return;
+        const id = String(record.budgetItemId);
+        setSelectedRowKeys((prevKeys) => {
+          const nextKeys = new Set(prevKeys);
+          if (checked) {
+            nextKeys.add(id);
+          } else {
+            nextKeys.delete(id);
+          }
+          return Array.from(nextKeys);
+        });
+      },
+      [isSelectMode, setSelectedRowKeys]
+    );
+
     const handleCardKeyDown = useCallback(
       (
         event: React.KeyboardEvent<HTMLElement>,
@@ -199,23 +216,6 @@ const BudgetItemsTable: React.FC<BudgetItemsTableProps> = React.memo(
         }
       },
       [openDeleteModal, openEditModal, setOpenMenuId, toggleSelection]
-    );
-
-    const toggleSelection = useCallback(
-      (record: BudgetItem, checked: boolean) => {
-        if (!isSelectMode) return;
-        const id = String(record.budgetItemId);
-        setSelectedRowKeys((prevKeys) => {
-          const nextKeys = new Set(prevKeys);
-          if (checked) {
-            nextKeys.add(id);
-          } else {
-            nextKeys.delete(id);
-          }
-          return Array.from(nextKeys);
-        });
-      },
-      [isSelectMode, setSelectedRowKeys]
     );
 
     useEffect(() => {

--- a/frontend/src/dashboard/project/features/budget/components/BudgetTable.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetTable.tsx
@@ -41,6 +41,7 @@ interface BudgetItemsTableProps {
   currentPage: number;
   setCurrentPage: (page: number) => void;
   setPageSize: (size: number) => void;
+  isSelectMode: boolean;
 }
 
 const BudgetItemsTable: React.FC<BudgetItemsTableProps> = React.memo(
@@ -60,10 +61,10 @@ const BudgetItemsTable: React.FC<BudgetItemsTableProps> = React.memo(
     currentPage,
     setCurrentPage,
     setPageSize,
+    isSelectMode,
   }) => {
     const [isMobile, setIsMobile] = useState(false);
     const [openMenuId, setOpenMenuId] = useState<string | null>(null);
-    const selectAllRef = useRef<HTMLInputElement | null>(null);
     const menuContainersRef = useRef<Map<string, HTMLDivElement>>(new Map());
 
     useEffect(() => {
@@ -148,18 +149,11 @@ const BudgetItemsTable: React.FC<BudgetItemsTableProps> = React.memo(
     );
 
     const isSelectAllChecked =
-      availableIds.length > 0 && selectedInScope.length === availableIds.length;
-
-    const isSelectAllIndeterminate =
-      selectedInScope.length > 0 && selectedInScope.length < availableIds.length;
-
-    useEffect(() => {
-      if (!selectAllRef.current) return;
-      selectAllRef.current.indeterminate = isSelectAllIndeterminate;
-    }, [isSelectAllIndeterminate]);
+      isSelectMode && availableIds.length > 0 && selectedInScope.length === availableIds.length;
 
     const handleSelectAllChange = useCallback(
       (checked: boolean) => {
+        if (!isSelectMode) return;
         setSelectedRowKeys((prevKeys) => {
           if (checked) {
             const next = new Set(prevKeys);
@@ -169,16 +163,31 @@ const BudgetItemsTable: React.FC<BudgetItemsTableProps> = React.memo(
           return prevKeys.filter((id) => !availableIdSet.has(id));
         });
       },
-      [availableIds, availableIdSet, setSelectedRowKeys]
+      [availableIds, availableIdSet, isSelectMode, setSelectedRowKeys]
     );
 
     const handleClearSelection = useCallback(() => {
+      if (!isSelectMode) return;
       setSelectedRowKeys((prevKeys) => prevKeys.filter((id) => !availableIdSet.has(id)));
-    }, [availableIdSet, setSelectedRowKeys]);
+    }, [availableIdSet, isSelectMode, setSelectedRowKeys]);
 
     const handleCardKeyDown = useCallback(
-      (event: React.KeyboardEvent<HTMLElement>, record: BudgetItem, isLocked: boolean) => {
+      (
+        event: React.KeyboardEvent<HTMLElement>,
+        record: BudgetItem,
+        isLocked: boolean,
+        isInSelectMode: boolean,
+        isSelected: boolean
+      ) => {
         if (isLocked) return;
+        if (isInSelectMode) {
+          if (event.key === " " || event.key === "Enter") {
+            event.preventDefault();
+            setOpenMenuId(null);
+            toggleSelection(record, !isSelected);
+          }
+          return;
+        }
         if (event.key === "Enter") {
           event.preventDefault();
           setOpenMenuId(null);
@@ -189,11 +198,12 @@ const BudgetItemsTable: React.FC<BudgetItemsTableProps> = React.memo(
           openDeleteModal([record.budgetItemId]);
         }
       },
-      [openDeleteModal, openEditModal, setOpenMenuId]
+      [openDeleteModal, openEditModal, setOpenMenuId, toggleSelection]
     );
 
     const toggleSelection = useCallback(
       (record: BudgetItem, checked: boolean) => {
+        if (!isSelectMode) return;
         const id = String(record.budgetItemId);
         setSelectedRowKeys((prevKeys) => {
           const nextKeys = new Set(prevKeys);
@@ -205,7 +215,7 @@ const BudgetItemsTable: React.FC<BudgetItemsTableProps> = React.memo(
           return Array.from(nextKeys);
         });
       },
-      [setSelectedRowKeys]
+      [isSelectMode, setSelectedRowKeys]
     );
 
     useEffect(() => {
@@ -342,30 +352,27 @@ const BudgetItemsTable: React.FC<BudgetItemsTableProps> = React.memo(
 
     return (
       <div ref={tableRef} className={styles.tableContainer}>
-        {dataSource.length > 0 && isMobile && (
+        {isSelectMode && dataSource.length > 0 && isMobile && (
           <div className={styles.cardListHeader}>
-            <label className={styles.selectAllControl}>
-              <input
-                ref={selectAllRef}
-                type="checkbox"
-                checked={isSelectAllChecked}
-                onChange={(event) => handleSelectAllChange(event.target.checked)}
-                aria-label="Select all budget items"
-              />
-              <span>Select all</span>
+            <button
+              type="button"
+              className={styles.cardHeaderButton}
+              onClick={() => handleSelectAllChange(true)}
+              disabled={isSelectAllChecked}
+            >
+              {isSelectAllChecked ? "All selected" : "Select all"}
               <span className={styles.selectionCount}>
                 {selectedInScope.length}/{availableIds.length}
               </span>
-            </label>
-            {selectedInScope.length > 0 && (
-              <button
-                type="button"
-                className={styles.clearSelectionButton}
-                onClick={handleClearSelection}
-              >
-                Clear selection
-              </button>
-            )}
+            </button>
+            <button
+              type="button"
+              className={styles.clearSelectionButton}
+              onClick={handleClearSelection}
+              disabled={selectedInScope.length === 0}
+            >
+              Clear selection
+            </button>
           </div>
         )}
 
@@ -384,37 +391,44 @@ const BudgetItemsTable: React.FC<BudgetItemsTableProps> = React.memo(
                   <article
                     key={record.key}
                     className={`${styles.card}${
-                      isSelected ? ` ${styles.cardSelected}` : ""
+                      isSelectMode && isSelected ? ` ${styles.cardSelected}` : ""
                     }${isLocked ? ` ${styles.cardLocked}` : ""}${
                       openMenuId === record.budgetItemId ? ` ${styles.cardMenuOpen}` : ""
                     }`}
-                    role="button"
+                    role={isSelectMode ? "checkbox" : "button"}
                     tabIndex={isLocked ? -1 : 0}
-                    aria-pressed={isSelected}
+                    aria-checked={isSelectMode ? isSelected : undefined}
                     aria-disabled={isLocked}
                     onClick={() => {
-                      if (!isLocked) {
-                        setOpenMenuId(null);
+                      if (isLocked) return;
+                      setOpenMenuId(null);
+                      if (isSelectMode) {
+                        toggleSelection(record, !isSelected);
+                      } else {
                         openEditModal(record);
                       }
                     }}
-                    onKeyDown={(event) => handleCardKeyDown(event, record, isLocked)}
+                    onKeyDown={(event) =>
+                      handleCardKeyDown(event, record, isLocked, isSelectMode, isSelected)
+                    }
                   >
                     <div className={styles.cardRow}>
                       <div className={styles.cardPrimary}>
-                        <label className={styles.cardCheckbox}>
-                          <input
-                            type="checkbox"
-                            checked={isSelected}
-                            disabled={isLocked}
-                            onChange={(event) => {
-                              event.stopPropagation();
-                              toggleSelection(record, event.target.checked);
-                            }}
-                            onClick={(event) => event.stopPropagation()}
-                            aria-label="Select budget line item"
-                          />
-                        </label>
+                        {isSelectMode && (
+                          <label className={styles.cardCheckbox}>
+                            <input
+                              type="checkbox"
+                              checked={isSelected}
+                              disabled={isLocked}
+                              onChange={(event) => {
+                                event.stopPropagation();
+                                toggleSelection(record, event.target.checked);
+                              }}
+                              onClick={(event) => event.stopPropagation()}
+                              aria-label="Select budget line item"
+                            />
+                          </label>
+                        )}
                         <div className={styles.cardSummary}>
                           <div className={styles.cardIdentifiers}>
                             <span className={styles.cardKey}>

--- a/frontend/src/dashboard/project/features/budget/components/BudgetToolbar.module.css
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetToolbar.module.css
@@ -95,54 +95,92 @@
   flex-wrap: wrap;
 }
 
-.selectAllBlock {
-  display: inline-flex;
-  align-items: center;
-  gap: 10px;
-  padding: 6px 12px;
-  border-radius: 14px;
-  background: rgba(255, 255, 255, 0.06);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  color: rgba(255, 255, 255, 0.86);
-}
-
-.selectAllControl {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  font-size: 0.85rem;
-  font-weight: 500;
-  letter-spacing: 0.01em;
-}
-
-.selectAllControl input {
-  width: 16px;
-  height: 16px;
-  cursor: pointer;
-  accent-color: #fa3356;
-}
-
 .selectionCount {
   font-size: 0.75rem;
   font-weight: 600;
   color: rgba(255, 255, 255, 0.6);
 }
 
-.clearSelectionButton {
-  background: transparent;
-  border: none;
-  color: rgba(250, 51, 86, 0.85);
-  font-size: 0.78rem;
-  font-weight: 500;
-  cursor: pointer;
-  text-decoration: none;
-  transition: color 0.2s ease;
+.selectModePill {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: rgba(255, 255, 255, 0.88);
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
 }
 
-.clearSelectionButton:hover,
-.clearSelectionButton:focus-visible {
-  color: #ff4d73;
-  outline: none;
+.selectModePillActive {
+  background: rgba(255, 255, 255, 0.1);
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+.selectModeToggle {
+  border: none;
+  background: transparent;
+  color: inherit;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  padding: 4px 10px;
+  border-radius: 999px;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.selectModeToggle:hover {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.selectModeToggle:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.55);
+  outline-offset: 2px;
+}
+
+.selectModeToggle:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.selectModeExpanded {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.selectModeAction {
+  border: none;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.85);
+  font-size: 0.8rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  padding: 4px 10px;
+  border-radius: 999px;
+  transition: background 0.2s ease, color 0.2s ease;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.selectModeAction:hover {
+  background: rgba(255, 255, 255, 0.08);
+  color: #ffffff;
+}
+
+.selectModeAction:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.55);
+  outline-offset: 2px;
+}
+
+.selectModeAction:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  background: transparent;
 }
 
 .selectionActions {
@@ -191,6 +229,14 @@
 
 .iconActionButton:active {
   transform: translateY(0);
+}
+
+.iconActionButton:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.45);
+  transform: none;
 }
 
 .mobileFilterWrap {

--- a/frontend/src/dashboard/project/features/budget/components/BudgetToolbar.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetToolbar.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import React, { useMemo } from "react";
 import { Tooltip as AntTooltip } from "antd";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faClone, faTrash } from "@fortawesome/free-solid-svg-icons";
@@ -29,11 +29,12 @@ interface BudgetToolbarProps {
   groupBy: GroupByOption;
   onGroupChange: (group: GroupByOption) => void;
   isSelectAllChecked: boolean;
-  isSelectAllIndeterminate: boolean;
   onSelectAllChange: (checked: boolean) => void;
   selectionCount: number;
   totalCount: number;
   onClearSelection: () => void;
+  isSelectMode: boolean;
+  onToggleSelectMode: (next: boolean) => void;
 }
 
 const BudgetToolbar: React.FC<BudgetToolbarProps> = ({
@@ -49,20 +50,35 @@ const BudgetToolbar: React.FC<BudgetToolbarProps> = ({
   groupBy,
   onGroupChange,
   isSelectAllChecked,
-  isSelectAllIndeterminate,
   onSelectAllChange,
   selectionCount,
   totalCount,
   onClearSelection,
+  isSelectMode,
+  onToggleSelectMode,
 }) => {
-  const selectAllRef = useRef<HTMLInputElement | null>(null);
-
-  useEffect(() => {
-    if (!selectAllRef.current) return;
-    selectAllRef.current.indeterminate = isSelectAllIndeterminate;
-  }, [isSelectAllIndeterminate]);
-
   const hasRows = totalCount > 0;
+  const selectionLabel = useMemo(
+    () => `${selectionCount}/${totalCount}`,
+    [selectionCount, totalCount]
+  );
+  const allSelected = useMemo(
+    () => hasRows && isSelectAllChecked && selectionCount === totalCount,
+    [hasRows, isSelectAllChecked, selectionCount, totalCount]
+  );
+
+  const handleToggleSelectMode = () => {
+    const next = !isSelectMode;
+    onToggleSelectMode(next);
+    if (!next && selectionCount > 0) {
+      onClearSelection();
+    }
+  };
+
+  const handleSelectAll = () => {
+    if (!hasRows) return;
+    onSelectAllChange(true);
+  };
 
   return (
     <div className={styles.toolbar}>
@@ -96,58 +112,69 @@ const BudgetToolbar: React.FC<BudgetToolbarProps> = ({
       </div>
       <div className={styles.rightControls}>
         {hasRows && (
-          <div className={styles.selectAllBlock}>
-            <label className={styles.selectAllControl}>
-              <input
-                ref={selectAllRef}
-                type="checkbox"
-                checked={isSelectAllChecked}
-                disabled={!hasRows}
-                onChange={(event) => onSelectAllChange(event.target.checked)}
-                aria-label="Select all budget items"
-              />
-              <span>Select all</span>
-              <span className={styles.selectionCount}>
-                {selectionCount}/{totalCount}
-              </span>
-            </label>
-            {selectionCount > 0 && (
-              <button
-                type="button"
-                className={styles.clearSelectionButton}
-                onClick={onClearSelection}
-              >
-                Clear selection
-              </button>
+          <div
+            className={`${styles.selectModePill}${
+              isSelectMode ? ` ${styles.selectModePillActive}` : ""
+            }`}
+          >
+            <button
+              type="button"
+              className={styles.selectModeToggle}
+              onClick={handleToggleSelectMode}
+              aria-pressed={isSelectMode}
+              disabled={!hasRows}
+            >
+              Select
+            </button>
+            {isSelectMode && (
+              <div className={styles.selectModeExpanded}>
+                <button
+                  type="button"
+                  className={styles.selectModeAction}
+                  onClick={handleSelectAll}
+                  disabled={allSelected}
+                >
+                  {allSelected ? "All selected" : "Select all"}
+                  <span className={styles.selectionCount}>{selectionLabel}</span>
+                </button>
+                <button
+                  type="button"
+                  className={styles.selectModeAction}
+                  onClick={onClearSelection}
+                  disabled={selectionCount === 0}
+                >
+                  Clear selection
+                </button>
+                <div className={styles.selectionActions}>
+                  <div className={styles.iconSlot}>
+                    <AntTooltip title="Duplicate Selected">
+                      <button
+                        type="button"
+                        className={styles.iconActionButton}
+                        onClick={handleDuplicateSelected}
+                        aria-label="Duplicate selected"
+                        disabled={selectionCount === 0}
+                      >
+                        <FontAwesomeIcon icon={faClone} />
+                      </button>
+                    </AntTooltip>
+                  </div>
+                  <div className={styles.iconSlot}>
+                    <AntTooltip title="Delete Selected">
+                      <button
+                        type="button"
+                        className={styles.iconActionButton}
+                        onClick={() => openDeleteModal(selectedRowKeys)}
+                        aria-label="Delete selected"
+                        disabled={selectionCount === 0}
+                      >
+                        <FontAwesomeIcon icon={faTrash} />
+                      </button>
+                    </AntTooltip>
+                  </div>
+                </div>
+              </div>
             )}
-          </div>
-        )}
-        {selectedRowKeys.length > 0 && (
-          <div className={styles.selectionActions}>
-            <div className={styles.iconSlot}>
-              <AntTooltip title="Duplicate Selected">
-                <button
-                  type="button"
-                  className={styles.iconActionButton}
-                  onClick={handleDuplicateSelected}
-                  aria-label="Duplicate selected"
-                >
-                  <FontAwesomeIcon icon={faClone} />
-                </button>
-              </AntTooltip>
-            </div>
-            <div className={styles.iconSlot}>
-              <AntTooltip title="Delete Selected">
-                <button
-                  type="button"
-                  className={styles.iconActionButton}
-                  onClick={() => openDeleteModal(selectedRowKeys)}
-                  aria-label="Delete selected"
-                >
-                  <FontAwesomeIcon icon={faTrash} />
-                </button>
-              </AntTooltip>
-            </div>
           </div>
         )}
         <div className={styles.mobileFilterWrap}>

--- a/frontend/src/dashboard/project/features/budget/pages/BudgetPage.tsx
+++ b/frontend/src/dashboard/project/features/budget/pages/BudgetPage.tsx
@@ -654,12 +654,11 @@ const BudgetPageContent = () => {
                                       availableRowIdSet.has(id)
                                     );
                                     const isSelectAllChecked =
+                                      stateManager.isSelectMode &&
                                       availableRowIds.length > 0 &&
                                       selectedInScope.length === availableRowIds.length;
-                                    const isSelectAllIndeterminate =
-                                      selectedInScope.length > 0 &&
-                                      selectedInScope.length < availableRowIds.length;
                                     const handleSelectAllChange = (checked: boolean) => {
+                                      if (!stateManager.isSelectMode) return;
                                       stateManager.setSelectedRowKeys((prevKeys) => {
                                         if (checked) {
                                           const next = new Set(prevKeys);
@@ -703,11 +702,16 @@ const BudgetPageContent = () => {
                                           }
                                           onGroupChange={(group) => stateManager.setGroupBy(group)}
                                           isSelectAllChecked={isSelectAllChecked}
-                                          isSelectAllIndeterminate={isSelectAllIndeterminate}
                                           onSelectAllChange={handleSelectAllChange}
-                                          selectionCount={selectedInScope.length}
+                                          selectionCount={
+                                            stateManager.isSelectMode ? selectedInScope.length : 0
+                                          }
                                           totalCount={availableRowIds.length}
                                           onClearSelection={handleClearSelection}
+                                          isSelectMode={stateManager.isSelectMode}
+                                          onToggleSelectMode={(next) =>
+                                            stateManager.setIsSelectMode(next)
+                                          }
                                         />
                                         <BudgetItemsTable
                                           dataSource={groupedData}
@@ -725,6 +729,7 @@ const BudgetPageContent = () => {
                                           currentPage={stateManager.currentPage}
                                           setCurrentPage={stateManager.setCurrentPage}
                                           setPageSize={stateManager.setPageSize}
+                                          isSelectMode={stateManager.isSelectMode}
                                         />
                                       </>
                                     );

--- a/frontend/src/dashboard/project/features/budget/pages/budget-page.module.css
+++ b/frontend/src/dashboard/project/features/budget/pages/budget-page.module.css
@@ -192,29 +192,43 @@
   flex-wrap: wrap;
 }
 
-.selectAllControl {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  color: rgba(255, 255, 255, 0.82);
-  font-size: 0.85rem;
-  font-weight: 500;
-  cursor: pointer;
-  user-select: none;
-}
-
-.selectAllControl input {
-  width: 18px;
-  height: 18px;
-  margin: 0;
-  accent-color: #FA3356;
-}
-
 .selectionCount {
   font-size: 0.7rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: rgba(255, 255, 255, 0.55);
+}
+
+.cardHeaderButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 14px;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: transparent;
+  color: rgba(255, 255, 255, 0.85);
+  font-size: 0.8rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.cardHeaderButton:hover,
+.cardHeaderButton:focus-visible {
+  outline: none;
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.28);
+  color: #ffffff;
+}
+
+.cardHeaderButton:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  border-color: rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.02);
+  color: rgba(255, 255, 255, 0.45);
 }
 
 .clearSelectionButton {
@@ -236,6 +250,14 @@
   background: rgba(255, 255, 255, 0.08);
   border-color: rgba(255, 255, 255, 0.28);
   color: #ffffff;
+}
+
+.clearSelectionButton:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  border-color: rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.02);
+  color: rgba(255, 255, 255, 0.45);
 }
 
 .cardListWrapper {


### PR DESCRIPTION
## Summary
- add select mode state management so bulk actions and selections only activate when explicitly toggled
- redesign the budget toolbar pill to expose select, select-all, clear, clone, and delete actions within a single expanded control
- hide budget item checkboxes and adjust card behaviors until select mode is active, including updated mobile header styling

## Testing
- `npm run lint` *(fails: existing lint errors in unrelated contexts and dashboard files)*

------
https://chatgpt.com/codex/tasks/task_e_68e6dbe7d878832488984e0de6b3e8e0