### PR TITLE
Refine desktop task drawer close control

### DIFF
--- a/frontend/src/dashboard/project/components/Tasks/TasksComponentMobile.module.css
+++ b/frontend/src/dashboard/project/components/Tasks/TasksComponentMobile.module.css
@@ -1167,12 +1167,46 @@
   }
 
   .desktopDrawerHeader {
+    position: relative;
     display: flex;
     align-items: center;
     justify-content: space-between;
     gap: 1.25rem;
-    padding: 1.5rem 1.75rem 1.25rem;
+    padding: 1.5rem 2.75rem 1.25rem 1.75rem;
     border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  }
+
+  .desktopDrawerCloseButton {
+    position: absolute;
+    top: 1.35rem;
+    right: 1.75rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 34px;
+    height: 34px;
+    border-radius: 999px;
+    border: 1px solid rgba(255, 255, 255, 0.18);
+    background: rgba(7, 8, 10, 0.72);
+    color: rgba(255, 255, 255, 0.95);
+    cursor: pointer;
+    transition: background 0.2s ease, transform 0.2s ease;
+  }
+
+  .desktopDrawerCloseButton svg {
+    width: 14px;
+    height: 14px;
+  }
+
+  .desktopDrawerCloseButton:focus-visible {
+    outline: 2px solid var(--brand, #fa3356);
+    outline-offset: 2px;
+  }
+
+  .desktopDrawerCloseButton:not(:disabled):hover,
+  .desktopDrawerCloseButton:not(:disabled):focus-visible {
+    background: rgba(7, 8, 10, 0.92);
+    transform: translateY(-1px);
   }
 
   .desktopDrawerActions {

--- a/frontend/src/dashboard/project/components/Tasks/TasksComponentMobile.module.css
+++ b/frontend/src/dashboard/project/components/Tasks/TasksComponentMobile.module.css
@@ -1172,7 +1172,7 @@
     align-items: center;
     justify-content: space-between;
     gap: 1.25rem;
-    padding: 1.5rem 2.75rem 1.25rem 1.75rem;
+    padding: 1.5rem 4rem 1.25rem 1.75rem;
     border-bottom: 1px solid rgba(255, 255, 255, 0.08);
   }
 
@@ -1215,6 +1215,7 @@
     justify-content: flex-end;
     gap: 0.75rem;
     flex-wrap: wrap;
+    padding-right: 0.25rem;
   }
 
   .desktopDrawerButton {

--- a/frontend/src/dashboard/project/components/Tasks/TasksComponentMobile.module.css
+++ b/frontend/src/dashboard/project/components/Tasks/TasksComponentMobile.module.css
@@ -1152,6 +1152,7 @@
   }
 
   .desktopSheet {
+    position: relative;
     top: 0;
     bottom: 0;
     left: 0;
@@ -1167,12 +1168,11 @@
   }
 
   .desktopDrawerHeader {
-    position: relative;
     display: flex;
     align-items: center;
     justify-content: space-between;
     gap: 1.25rem;
-    padding: 1.5rem 4rem 1.25rem 1.75rem;
+    padding: 3.5rem 3.25rem 1.25rem 1.75rem;
     border-bottom: 1px solid rgba(255, 255, 255, 0.08);
   }
 
@@ -1191,6 +1191,7 @@
     color: rgba(255, 255, 255, 0.95);
     cursor: pointer;
     transition: background 0.2s ease, transform 0.2s ease;
+    z-index: 1;
   }
 
   .desktopDrawerCloseButton svg {

--- a/frontend/src/dashboard/project/components/Tasks/components/TaskDrawer.tsx
+++ b/frontend/src/dashboard/project/components/Tasks/components/TaskDrawer.tsx
@@ -198,15 +198,15 @@ const TaskDrawer: React.FC<TaskDrawerProps> = ({
       >
         {isDesktop ? (
           <>
+            <button
+              type="button"
+              className={styles.desktopDrawerCloseButton}
+              onClick={onClose}
+              aria-label="Close map"
+            >
+              <X size={14} strokeWidth={2.25} aria-hidden="true" />
+            </button>
             <header className={styles.desktopDrawerHeader}>
-              <button
-                type="button"
-                className={styles.desktopDrawerCloseButton}
-                onClick={onClose}
-                aria-label="Close map"
-              >
-                <X size={14} strokeWidth={2.25} aria-hidden="true" />
-              </button>
               <div className={styles.sheetTitleGroup}>
                 <span className={styles.sheetTitle}>Project tasks</span>
                 <span className={styles.sheetSubtitle}>

--- a/frontend/src/dashboard/project/components/Tasks/components/TaskDrawer.tsx
+++ b/frontend/src/dashboard/project/components/Tasks/components/TaskDrawer.tsx
@@ -199,6 +199,14 @@ const TaskDrawer: React.FC<TaskDrawerProps> = ({
         {isDesktop ? (
           <>
             <header className={styles.desktopDrawerHeader}>
+              <button
+                type="button"
+                className={styles.desktopDrawerCloseButton}
+                onClick={onClose}
+                aria-label="Close map"
+              >
+                <X size={14} strokeWidth={2.25} aria-hidden="true" />
+              </button>
               <div className={styles.sheetTitleGroup}>
                 <span className={styles.sheetTitle}>Project tasks</span>
                 <span className={styles.sheetSubtitle}>
@@ -206,13 +214,6 @@ const TaskDrawer: React.FC<TaskDrawerProps> = ({
                 </span>
               </div>
               <div className={styles.desktopDrawerActions}>
-                <button
-                  type="button"
-                  className={`${styles.desktopDrawerButton} ${styles.desktopDrawerGhostButton}`}
-                  onClick={onClose}
-                >
-                  <X size={16} strokeWidth={2.25} aria-hidden="true" /> Close map
-                </button>
                 <button
                   type="button"
                   className={`${styles.desktopDrawerButton} ${styles.desktopDrawerPrimaryButton}`}


### PR DESCRIPTION
## Summary
- replace the desktop task drawer "Close map" action with an icon-only button anchored to the header corner
- add desktop-specific styling for the circular close control and adjust header padding to prevent layout overlap

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e6e0ef885883248e9eb3df27978817