### PR TITLE
Adjust budget pagination placement next to filters

### DIFF
--- a/frontend/src/dashboard/project/features/budget/components/BudgetTable.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetTable.tsx
@@ -5,7 +5,6 @@ import React, {
   useRef,
   useState,
 } from "react";
-import { Pagination } from "antd";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   faChevronDown,
@@ -40,7 +39,6 @@ interface BudgetItemsTableProps {
   pageSize: number;
   currentPage: number;
   setCurrentPage: (page: number) => void;
-  setPageSize: (size: number) => void;
   isSelectMode: boolean;
 }
 
@@ -60,7 +58,6 @@ const BudgetItemsTable: React.FC<BudgetItemsTableProps> = React.memo(
     pageSize,
     currentPage,
     setCurrentPage,
-    setPageSize,
     isSelectMode,
   }) => {
     const [isMobile, setIsMobile] = useState(false);
@@ -288,16 +285,6 @@ const BudgetItemsTable: React.FC<BudgetItemsTableProps> = React.memo(
         );
       },
       []
-    );
-
-    const handlePaginationChange = useCallback(
-      (page: number, size: number) => {
-        setCurrentPage(page);
-        if (size !== pageSize) {
-          setPageSize(size);
-        }
-      },
-      [pageSize, setCurrentPage, setPageSize]
     );
 
     const listStyle = useMemo(() => {
@@ -582,19 +569,6 @@ const BudgetItemsTable: React.FC<BudgetItemsTableProps> = React.memo(
           )}
         </div>
 
-        {dataSource.length > 0 && (
-          <Pagination
-            className={styles.cardPagination}
-            current={currentPage}
-            pageSize={pageSize}
-            total={dataSource.length}
-            showSizeChanger
-            pageSizeOptions={["10", "20", "50", "100"]}
-            size="small"
-            onChange={handlePaginationChange}
-            onShowSizeChange={handlePaginationChange}
-          />
-        )}
       </div>
     );
   }

--- a/frontend/src/dashboard/project/features/budget/components/BudgetToolbar.module.css
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetToolbar.module.css
@@ -258,9 +258,45 @@
 .mobileFilterWrap {
   display: inline-flex;
   align-items: center;
-  
+
   min-width: 220px;
   flex: 0 0 auto;
+}
+
+.filterControls {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  min-height: 32px;
+}
+
+.toolbarPagination {
+  margin: 0 !important;
+  padding: 4px 0;
+  align-self: center;
+}
+
+.toolbarPagination :global(.ant-select-selector) {
+  background: transparent !important;
+  border-color: #FA3356 !important;
+  color: #ffffff !important;
+}
+
+.toolbarPagination :global(.ant-select-arrow) {
+  color: #ffffff !important;
+}
+
+.toolbarPagination :global(.ant-pagination-item a) {
+  color: #ffffff !important;
+}
+
+.toolbarPagination :global(.ant-pagination-item-active) {
+  border-color: #FA3356 !important;
+}
+
+.toolbarPagination :global(.ant-pagination-item-active a) {
+  color: #FA3356 !important;
 }
 
 .mobileFilterRoot {
@@ -390,6 +426,13 @@
   .toolbar {
     flex-direction: column;
     align-items: stretch;
+  }
+
+  .filterControls {
+    width: 100%;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 10px;
   }
 
   .rightControls {

--- a/frontend/src/dashboard/project/features/budget/components/BudgetToolbar.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetToolbar.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from "react";
+import { Pagination } from "antd";
 import { Tooltip as AntTooltip } from "antd";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faClone, faTrash } from "@fortawesome/free-solid-svg-icons";
@@ -35,6 +36,9 @@ interface BudgetToolbarProps {
   onClearSelection: () => void;
   isSelectMode: boolean;
   onToggleSelectMode: (next: boolean) => void;
+  currentPage: number;
+  pageSize: number;
+  onPaginationChange: (page: number, pageSize: number) => void;
 }
 
 const BudgetToolbar: React.FC<BudgetToolbarProps> = ({
@@ -56,6 +60,9 @@ const BudgetToolbar: React.FC<BudgetToolbarProps> = ({
   onClearSelection,
   isSelectMode,
   onToggleSelectMode,
+  currentPage,
+  pageSize,
+  onPaginationChange,
 }) => {
   const hasRows = totalCount > 0;
   const selectionLabel = useMemo(
@@ -110,14 +117,29 @@ const BudgetToolbar: React.FC<BudgetToolbarProps> = ({
           })}
         </div>
       </div>
-      <div className={styles.mobileFilterWrap}>
-        <BudgetMobileFilter
-          filterQuery={filterQuery}
-          onFilterQueryChange={onFilterQueryChange}
-          sortField={sortField}
-          sortOrder={sortOrder}
-          onSortChange={onSortChange}
-        />
+      <div className={styles.filterControls}>
+        <div className={styles.mobileFilterWrap}>
+          <BudgetMobileFilter
+            filterQuery={filterQuery}
+            onFilterQueryChange={onFilterQueryChange}
+            sortField={sortField}
+            sortOrder={sortOrder}
+            onSortChange={onSortChange}
+          />
+        </div>
+        {hasRows && (
+          <Pagination
+            className={styles.toolbarPagination}
+            current={currentPage}
+            pageSize={pageSize}
+            total={totalCount}
+            showSizeChanger
+            pageSizeOptions={["10", "20", "50", "100"]}
+            size="small"
+            onChange={onPaginationChange}
+            onShowSizeChange={onPaginationChange}
+          />
+        )}
       </div>
       <div className={styles.rightControls}>
         {hasRows && (

--- a/frontend/src/dashboard/project/features/budget/pages/BudgetPage.tsx
+++ b/frontend/src/dashboard/project/features/budget/pages/BudgetPage.tsx
@@ -712,6 +712,14 @@ const BudgetPageContent = () => {
                                           onToggleSelectMode={(next) =>
                                             stateManager.setIsSelectMode(next)
                                           }
+                                          currentPage={stateManager.currentPage}
+                                          pageSize={stateManager.pageSize}
+                                          onPaginationChange={(page, size) => {
+                                            stateManager.setCurrentPage(page);
+                                            if (size !== stateManager.pageSize) {
+                                              stateManager.setPageSize(size);
+                                            }
+                                          }}
                                         />
                                         <BudgetItemsTable
                                           dataSource={groupedData}
@@ -728,7 +736,6 @@ const BudgetPageContent = () => {
                                           pageSize={stateManager.pageSize}
                                           currentPage={stateManager.currentPage}
                                           setCurrentPage={stateManager.setCurrentPage}
-                                          setPageSize={stateManager.setPageSize}
                                           isSelectMode={stateManager.isSelectMode}
                                         />
                                       </>

--- a/frontend/src/dashboard/project/features/budget/pages/budget-page.module.css
+++ b/frontend/src/dashboard/project/features/budget/pages/budget-page.module.css
@@ -615,33 +615,6 @@
   align-items: center;
 }
 
-.cardPagination {
-  align-self: center;
-  margin-top: 12px;
-}
-
-.cardPagination :global(.ant-select-selector) {
-  background: transparent !important;
-  border-color: #FA3356 !important;
-  color: #ffffff !important;
-}
-
-.cardPagination :global(.ant-select-arrow) {
-  color: #ffffff !important;
-}
-
-.cardPagination :global(.ant-pagination-item a) {
-  color: #ffffff !important;
-}
-
-.cardPagination :global(.ant-pagination-item-active) {
-  border-color: #FA3356 !important;
-}
-
-.cardPagination :global(.ant-pagination-item-active a) {
-  color: #FA3356 !important;
-}
-
 @media (max-width: 1200px) {
   .cardList {
     grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));


### PR DESCRIPTION
## Summary
- relocate the budget table pagination into the toolbar so it sits beside the filter and sort controls
- style the toolbar pagination to match the existing dark theme and ensure responsive alignment
- remove the now-unused table-level pagination markup and related styles

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e728a50ab48324afa6506867246538