### PR TITLE
Adjust budget card payment status presentation

### DIFF
--- a/frontend/src/dashboard/project/features/budget/components/BudgetTable.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetTable.tsx
@@ -487,11 +487,6 @@ const BudgetItemsTable: React.FC<BudgetItemsTableProps> = React.memo(
                         </div>
                       </div>
 
-                      {record.paymentStatus && (
-                        <div className={styles.cardPayment}>
-                          {renderPaymentStatus(String(record.paymentStatus))}
-                        </div>
-                      )}
                       <div
                         className={styles.cardControls}
                         ref={(node) => registerMenuContainer(record.budgetItemId, node)}
@@ -583,6 +578,13 @@ const BudgetItemsTable: React.FC<BudgetItemsTableProps> = React.memo(
                         )}
                       </div>
                     </div>
+                    {record.paymentStatus && (
+                      <div className={styles.cardFooter}>
+                        <div className={styles.cardPayment}>
+                          {renderPaymentStatus(String(record.paymentStatus))}
+                        </div>
+                      </div>
+                    )}
                   </article>
                 );
               })}

--- a/frontend/src/dashboard/project/features/budget/components/BudgetTable.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetTable.tsx
@@ -269,21 +269,32 @@ const BudgetItemsTable: React.FC<BudgetItemsTableProps> = React.memo(
         if (typeof status !== "string") return null;
         const cleaned = status.replace(/[·.]+$/, "").trim();
         if (!cleaned) return null;
-        const normalizedStatus = cleaned.toUpperCase();
-        const colorClass =
-          normalizedStatus === "PAID"
-            ? styles.paid
-            : normalizedStatus === "PARTIAL"
-            ? styles.partial
-            : styles.unpaid;
-        const display =
-          normalizedStatus === "PAID" || normalizedStatus === "PARTIAL"
-            ? cleaned
-            : "UNPAID";
+
+        const normalizedStatus = cleaned.toLowerCase();
+        let label = cleaned;
+        let colorClass = styles.unpaid;
+
+        if (normalizedStatus === "paid") {
+          label = "Paid";
+          colorClass = styles.paid;
+        } else if (normalizedStatus === "partial") {
+          label = "Partial";
+          colorClass = styles.partial;
+        } else if (normalizedStatus === "unpaid") {
+          label = "Unpaid";
+        } else {
+          label = `${cleaned.charAt(0).toUpperCase()}${cleaned
+            .slice(1)
+            .toLowerCase()}`;
+        }
+
         return (
           <span className={styles.paymentStatus}>
-            {display}
-            <span className={`${styles.statusDot} ${colorClass}`} />
+            {label}
+            <span
+              className={`${styles.statusDot} ${colorClass}`}
+              aria-hidden="true"
+            />
           </span>
         );
       },
@@ -478,10 +489,7 @@ const BudgetItemsTable: React.FC<BudgetItemsTableProps> = React.memo(
 
                       {record.paymentStatus && (
                         <div className={styles.cardPayment}>
-                          <span className={styles.cardFooterLabel}>Payment</span>
-                          <span className={styles.cardFooterValue}>
-                            {renderPaymentStatus(String(record.paymentStatus))}
-                          </span>
+                          {renderPaymentStatus(String(record.paymentStatus))}
                         </div>
                       )}
                       <div

--- a/frontend/src/dashboard/project/features/budget/components/BudgetTable.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetTable.tsx
@@ -576,15 +576,16 @@ const BudgetItemsTable: React.FC<BudgetItemsTableProps> = React.memo(
                             </button>
                           </div>
                         )}
+                        {record.paymentStatus && (
+                          <div
+                            className={styles.cardPayment}
+                            onClick={(event) => event.stopPropagation()}
+                          >
+                            {renderPaymentStatus(String(record.paymentStatus))}
+                          </div>
+                        )}
                       </div>
                     </div>
-                    {record.paymentStatus && (
-                      <div className={styles.cardFooter}>
-                        <div className={styles.cardPayment}>
-                          {renderPaymentStatus(String(record.paymentStatus))}
-                        </div>
-                      </div>
-                    )}
                   </article>
                 );
               })}

--- a/frontend/src/dashboard/project/features/budget/pages/budget-page.module.css
+++ b/frontend/src/dashboard/project/features/budget/pages/budget-page.module.css
@@ -387,8 +387,9 @@
   position: absolute;
   top: 12px;
   right: 12px;
+  bottom: 12px;
   z-index: 20;
-  display: inline-flex;
+  display: flex;
   flex-direction: column;
   align-items: flex-end;
   gap: 8px;
@@ -598,16 +599,12 @@
   color: inherit;
 }
 
-.cardFooter {
-  display: flex;
-  justify-content: flex-end;
-  width: 100%;
-  margin-top: auto;
-}
-
 .cardPayment {
   display: inline-flex;
   align-items: center;
+  justify-content: flex-end;
+  margin-top: auto;
+  text-align: right;
 }
 
 .cardPagination {
@@ -664,9 +661,6 @@
     min-width: 88px;
   }
 
-  .cardFooter {
-    width: 100%;
-  }
 }
 
 @media (max-width: 768px) {
@@ -751,10 +745,6 @@
     text-align: left;
   }
 
-  .cardFooter {
-    justify-content: flex-end;
-    width: 100%;
-  }
 }
 
 @media (max-width: 480px) {
@@ -810,15 +800,6 @@
     justify-content: flex-start;
   }
 
-  .cardFooter {
-    padding-right: 12px;
-    margin-right: -60px;
-  }
-
-  .cardControls {
-    align-self: center;
-    margin-left: auto;
-  }
 }
 
 @media (max-width: 767px) {
@@ -827,11 +808,6 @@
     -webkit-line-clamp: 2;
     -webkit-box-orient: vertical;
     overflow: hidden;
-  }
-
-  .cardControls {
-    align-self: flex-start;
-    margin-left: 0;
   }
 }
 

--- a/frontend/src/dashboard/project/features/budget/pages/budget-page.module.css
+++ b/frontend/src/dashboard/project/features/budget/pages/budget-page.module.css
@@ -102,13 +102,16 @@
 .paymentStatus {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  margin-right: 10px;
+  gap: 4px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  text-transform: capitalize;
 }
 
 .statusDot {
-  width: 10px;
-  height: 10px;
+  width: 6px;
+  height: 6px;
   border-radius: 50%;
   display: inline-block;
 }
@@ -597,22 +600,11 @@
 
 .cardPayment {
   display: flex;
-  flex-direction: column;
-  gap: 4px;
-  flex: 0 0 auto;
-  min-width: 100px;
-}
-
-.cardFooterLabel {
-  font-size: 0.75rem;
-  color: #888888;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-}
-
-.cardFooterValue {
-  display: inline-flex;
+  justify-content: flex-end;
   align-items: center;
+  width: 100%;
+  margin-top: auto;
+  order: 10;
 }
 
 .cardPagination {
@@ -670,7 +662,7 @@
   }
 
   .cardPayment {
-    min-width: 0;
+    width: 100%;
   }
 }
 
@@ -757,9 +749,8 @@
   }
 
   .cardPayment {
-    flex-direction: row;
-    align-items: center;
-    gap: 8px;
+    justify-content: flex-end;
+    width: 100%;
   }
 }
 
@@ -787,10 +778,6 @@
 
   .cardControls {
     gap: 4px;
-  }
-
-  .cardFooterLabel {
-    font-size: 0.7rem;
   }
 
   .cardMetricValue {
@@ -821,7 +808,10 @@
   }
 
   .cardPayment {
-    align-items: flex-end;
+    align-self: flex-end;
+    width: auto;
+    margin-left: auto;
+    padding-right: 4px;
   }
 
   .cardControls {

--- a/frontend/src/dashboard/project/features/budget/pages/budget-page.module.css
+++ b/frontend/src/dashboard/project/features/budget/pages/budget-page.module.css
@@ -598,13 +598,16 @@
   color: inherit;
 }
 
-.cardPayment {
+.cardFooter {
   display: flex;
   justify-content: flex-end;
-  align-items: center;
   width: 100%;
   margin-top: auto;
-  order: 10;
+}
+
+.cardPayment {
+  display: inline-flex;
+  align-items: center;
 }
 
 .cardPagination {
@@ -661,7 +664,7 @@
     min-width: 88px;
   }
 
-  .cardPayment {
+  .cardFooter {
     width: 100%;
   }
 }
@@ -748,7 +751,7 @@
     text-align: left;
   }
 
-  .cardPayment {
+  .cardFooter {
     justify-content: flex-end;
     width: 100%;
   }
@@ -807,11 +810,9 @@
     justify-content: flex-start;
   }
 
-  .cardPayment {
-    align-self: flex-end;
-    width: auto;
-    margin-left: auto;
-    padding-right: 4px;
+  .cardFooter {
+    padding-right: 12px;
+    margin-right: -60px;
   }
 
   .cardControls {


### PR DESCRIPTION
## Summary
- simplify the budget item payment status rendering to show a concise label with the status dot
- restyle the payment indicator so it sits at the bottom-right of the card with reduced typography spacing

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e72f3bc2108324bcbaa7b8c0e6f7d2