### PR TITLE
Fix budget layout spacing and enable internal scrolling

### DIFF
--- a/frontend/src/dashboard/project/features/budget/components/BudgetTable.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetTable.tsx
@@ -300,10 +300,23 @@ const BudgetItemsTable: React.FC<BudgetItemsTableProps> = React.memo(
       [pageSize, setCurrentPage, setPageSize]
     );
 
-    const listStyle = useMemo(() => {
+    const containerStyle = useMemo<React.CSSProperties | undefined>(() => {
       if (!tableHeight) return undefined;
-      const minHeight = Math.max(0, tableHeight - PAGINATION_ESTIMATE);
-      return { minHeight };
+      return {
+        minHeight: tableHeight,
+        maxHeight: tableHeight,
+      };
+    }, [tableHeight]);
+
+    const listStyle = useMemo<React.CSSProperties | undefined>(() => {
+      if (!tableHeight) return undefined;
+      const available = Math.max(0, tableHeight - PAGINATION_ESTIMATE);
+      return {
+        minHeight: available,
+        maxHeight: available,
+        overflowY: "auto",
+        overflowX: "hidden",
+      };
     }, [tableHeight]);
 
     const registerMenuContainer = useCallback(
@@ -351,7 +364,7 @@ const BudgetItemsTable: React.FC<BudgetItemsTableProps> = React.memo(
     }, [setOpenMenuId]);
 
     return (
-      <div ref={tableRef} className={styles.tableContainer}>
+      <div ref={tableRef} className={styles.tableContainer} style={containerStyle}>
         {isSelectMode && dataSource.length > 0 && isMobile && (
           <div className={styles.cardListHeader}>
             <button

--- a/frontend/src/dashboard/project/features/budget/pages/BudgetPage.tsx
+++ b/frontend/src/dashboard/project/features/budget/pages/BudgetPage.tsx
@@ -44,7 +44,7 @@ import {
 import { v4 as uuid } from "uuid";
 
 
-const TABLE_BOTTOM_MARGIN = 20;
+const TABLE_BOTTOM_MARGIN = 0;
 
 // Inner component that uses the budget context
 const BudgetPageContent = () => {
@@ -95,7 +95,8 @@ const BudgetPageContent = () => {
     const updateTableHeight = () => {
       if (tableRef.current) {
         const top = tableRef.current.getBoundingClientRect().top;
-        setTableHeight(window.innerHeight - top - TABLE_BOTTOM_MARGIN);
+        const available = window.innerHeight - top - TABLE_BOTTOM_MARGIN;
+        setTableHeight(Math.max(0, available));
       }
     };
 
@@ -621,8 +622,17 @@ const BudgetPageContent = () => {
                                 beforeClose: styles.modalOverlayBeforeClose,
                               }}
                             />
-                            <div style={{ padding: "0" }}>
-                              <div>
+                            <div
+                              style={{
+                                padding: "0",
+                                display: "flex",
+                                flexDirection: "column",
+                                flex: 1,
+                                minHeight: 0,
+                                width: "100%",
+                              }}
+                            >
+                              <div style={{ display: "flex", flexDirection: "column", flex: 1, minHeight: 0 }}>
                                 {error && (
                                   <div style={{ marginTop: "10px", color: "#ff6b6b" }}>
                                     Error: {error}
@@ -635,7 +645,9 @@ const BudgetPageContent = () => {
                                     marginTop: "10px",
                                     display: "flex",
                                     flexDirection: "column",
-                                    alignItems: "flex-start",
+                                    alignItems: "stretch",
+                                    flex: 1,
+                                    minHeight: 0,
                                   }}
                                 >
                                   {(() => {

--- a/frontend/src/dashboard/project/features/budget/pages/budget-page.module.css
+++ b/frontend/src/dashboard/project/features/budget/pages/budget-page.module.css
@@ -148,6 +148,9 @@
   display: flex;
   flex-direction: column;
   gap: 16px;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: hidden;
 }
 
 .desktopTable {
@@ -265,6 +268,9 @@
   flex-direction: column;
   gap: 12px;
   width: 100%;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: hidden;
 }
 
 .cardList {


### PR DESCRIPTION
## Summary
- remove the extra padding from the budget table height calculation so the page aligns with the navigation chrome and resizes correctly
- allow the budget table containers to stretch to the available height and provide internal scrolling for the list content

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e72cc088f48324b10e54b7c10a4665