### PR TITLE
Shorten mobile budget filter label

### DIFF
--- a/frontend/src/dashboard/project/features/budget/components/BudgetMobileFilter.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetMobileFilter.tsx
@@ -102,7 +102,7 @@ const BudgetMobileFilter: React.FC<BudgetMobileFilterProps> = ({
       return currentSortOption.label;
     }
 
-    return "Filter & Sort";
+    return "Filter";
   }, [currentSortOption.label, currentSortOption.value, filterQuery]);
 
   const handleSortChange = (event: React.ChangeEvent<HTMLSelectElement>) => {

--- a/frontend/src/dashboard/project/features/budget/components/BudgetToolbar.module.css
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetToolbar.module.css
@@ -17,12 +17,22 @@
   box-sizing: border-box;
 }
 
+.primaryRow {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
 .groupControls {
   display: flex;
   align-items: center;
   gap: 12px;
   flex-wrap: wrap;
   min-height: 32px;
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
 .groupControlsInner {
@@ -37,6 +47,7 @@
   align-items: center;
   gap: 8px;
   flex-wrap: wrap;
+  min-width: 0;
 }
 
 .groupTabButton {
@@ -256,11 +267,10 @@
 }
 
 .mobileFilterWrap {
-  display: inline-flex;
+  display: flex;
   align-items: center;
-
-  min-width: 220px;
   flex: 0 0 auto;
+  min-width: 0;
 }
 
 .filterControls {
@@ -269,6 +279,7 @@
   gap: 12px;
   flex-wrap: wrap;
   min-height: 32px;
+  margin-left: auto;
 }
 
 .toolbarPagination {
@@ -319,6 +330,7 @@
   letter-spacing: 0.01em;
   transition: transform 0.15s ease, background-color 0.2s ease, border-color 0.2s ease,
     box-shadow 0.2s ease;
+  white-space: nowrap;
 }
 
 .mobileFilterActive {
@@ -410,16 +422,6 @@
     padding: 14px 16px;
     gap: 12px;
   }
-
-  .mobileFilterWrap {
-    min-width: 200px;
-  }
-}
-
-@media (max-width: 900px) {
-  .groupControls {
-    display: none;
-  }
 }
 
 @media (max-width: 768px) {
@@ -428,11 +430,38 @@
     align-items: stretch;
   }
 
+  .primaryRow {
+    width: 100%;
+    gap: 10px;
+  }
+
+  .groupControls {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+  }
+
+  .groupControls::-webkit-scrollbar {
+    display: none;
+  }
+
+  .groupTabs {
+    flex-wrap: nowrap;
+    gap: 6px;
+  }
+
+  .groupTabButton {
+    padding: 6px 12px;
+    font-size: 0.78rem;
+  }
+
   .filterControls {
     width: 100%;
     flex-direction: column;
     align-items: flex-start;
     gap: 10px;
+    margin-left: 0;
   }
 
   .rightControls {
@@ -491,7 +520,7 @@
   }
 
   .mobileFilterWrap {
-    flex: 1 1 auto;
+    flex: 0 0 auto;
     min-width: 0;
   }
 
@@ -499,5 +528,14 @@
     flex-shrink: 0;
     padding: 8px 14px;
     border-radius: 12px;
+  }
+}
+
+@media (max-width: 600px) {
+  .mobileFilterButton {
+    padding: 6px 12px;
+    border-radius: 14px;
+    font-size: 0.82rem;
+    gap: 0.4rem;
   }
 }

--- a/frontend/src/dashboard/project/features/budget/components/BudgetToolbar.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetToolbar.tsx
@@ -89,35 +89,35 @@ const BudgetToolbar: React.FC<BudgetToolbarProps> = ({
 
   return (
     <div className={styles.toolbar}>
-      <div className={styles.groupControls}>
-        <span id="budget-desktop-group-label" className={styles.srOnly}>
-          Group budget items
-        </span>
-        <div
-          className={styles.groupTabs}
-          role="group"
-          aria-labelledby="budget-desktop-group-label"
-        >
-          {GROUP_OPTIONS.map((option) => {
-            const isActive = option.value === groupBy;
-            const className = isActive
-              ? `${styles.groupTabButton} ${styles.activeGroupTab}`
-              : styles.groupTabButton;
-            return (
-              <button
-                key={option.value}
-                type="button"
-                aria-pressed={isActive}
-                className={className}
-                onClick={() => onGroupChange(option.value)}
-              >
-                <span>{option.label}</span>
-              </button>
-            );
-          })}
+      <div className={styles.primaryRow}>
+        <div className={styles.groupControls}>
+          <span id="budget-desktop-group-label" className={styles.srOnly}>
+            Group budget items
+          </span>
+          <div
+            className={styles.groupTabs}
+            role="group"
+            aria-labelledby="budget-desktop-group-label"
+          >
+            {GROUP_OPTIONS.map((option) => {
+              const isActive = option.value === groupBy;
+              const className = isActive
+                ? `${styles.groupTabButton} ${styles.activeGroupTab}`
+                : styles.groupTabButton;
+              return (
+                <button
+                  key={option.value}
+                  type="button"
+                  aria-pressed={isActive}
+                  className={className}
+                  onClick={() => onGroupChange(option.value)}
+                >
+                  <span>{option.label}</span>
+                </button>
+              );
+            })}
+          </div>
         </div>
-      </div>
-      <div className={styles.filterControls}>
         <div className={styles.mobileFilterWrap}>
           <BudgetMobileFilter
             filterQuery={filterQuery}
@@ -127,6 +127,8 @@ const BudgetToolbar: React.FC<BudgetToolbarProps> = ({
             onSortChange={onSortChange}
           />
         </div>
+      </div>
+      <div className={styles.filterControls}>
         {hasRows && (
           <Pagination
             className={styles.toolbarPagination}


### PR DESCRIPTION
## Summary
- reorganize the budget toolbar so the group controls and mobile filter live together on smaller screens
- adjust responsive styles to keep the controls compact and horizontally scrollable on phones
- rename the mobile filter control to “Filter” by default and prevent the label from wrapping so the toolbar stays on one line on phones

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e743687dbc83248595e134c164cca5