### PR TITLE
Adjust budget toolbar mobile layout to icon-first controls

### DIFF
--- a/frontend/src/dashboard/project/features/budget/components/BudgetMobileFilter.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetMobileFilter.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { ArrowUpDown, ChevronDown, Search } from "lucide-react";
+import { FilterOutlined } from "@ant-design/icons";
 
 import mobileStyles from "@/dashboard/home/components/projects-panel.module.css";
 import desktopStyles from "@/dashboard/home/components/ProjectsPanelDesktop.module.css";
@@ -141,6 +142,28 @@ const BudgetMobileFilter: React.FC<BudgetMobileFilterProps> = ({
     isGroupActive,
   ]);
 
+  const buttonAriaLabel = useMemo(() => {
+    if (filterQuery.trim().length > 0) {
+      return `Filter budget items by ${filterQuery.trim()}`;
+    }
+
+    if (currentSortOption.value !== "default") {
+      return `Sort budget items by ${currentSortOption.label}`;
+    }
+
+    if (isGroupActive) {
+      return `Group budget items by ${currentGroupOption.label}`;
+    }
+
+    return "Filter and sort budget items";
+  }, [
+    currentGroupOption.label,
+    currentSortOption.label,
+    currentSortOption.value,
+    filterQuery,
+    isGroupActive,
+  ]);
+
   const handleSortChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
     const nextValue = event.target.value as SortOptionValue;
     const option = SORT_OPTIONS.find((opt) => opt.value === nextValue) ?? SORT_OPTIONS[0];
@@ -170,11 +193,15 @@ const BudgetMobileFilter: React.FC<BudgetMobileFilterProps> = ({
         }`}
         aria-haspopup="menu"
         aria-expanded={open}
+        aria-label={buttonAriaLabel}
         onClick={() => setOpen((prev) => !prev)}
         onKeyDown={handleKeyDown}
       >
-        <span>{buttonLabel}</span>
-        <ChevronDown size={14} aria-hidden />
+        <span className={styles.mobileFilterButtonContent}>
+          <FilterOutlined aria-hidden className={styles.mobileFilterIcon} />
+          <span className={styles.mobileFilterButtonText}>{buttonLabel}</span>
+        </span>
+        <ChevronDown size={14} aria-hidden className={styles.mobileFilterChevron} />
       </button>
       {open && (
         <div

--- a/frontend/src/dashboard/project/features/budget/components/BudgetMobileFilter.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetMobileFilter.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { ArrowUpDown, ChevronDown, Search } from "lucide-react";
-import { FilterOutlined } from "@ant-design/icons";
+import { SlidersOutlined } from "@ant-design/icons";
 
 import mobileStyles from "@/dashboard/home/components/projects-panel.module.css";
 import desktopStyles from "@/dashboard/home/components/ProjectsPanelDesktop.module.css";
@@ -198,7 +198,7 @@ const BudgetMobileFilter: React.FC<BudgetMobileFilterProps> = ({
         onKeyDown={handleKeyDown}
       >
         <span className={styles.mobileFilterButtonContent}>
-          <FilterOutlined aria-hidden className={styles.mobileFilterIcon} />
+          <SlidersOutlined aria-hidden className={styles.mobileFilterIcon} />
           <span className={styles.mobileFilterButtonText}>{buttonLabel}</span>
         </span>
         <ChevronDown size={14} aria-hidden className={styles.mobileFilterChevron} />

--- a/frontend/src/dashboard/project/features/budget/components/BudgetToolbar.module.css
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetToolbar.module.css
@@ -586,20 +586,74 @@
   }
 
   .mobilePagination :global(.ant-pagination-simple-pager) {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
     background: transparent;
     color: #ffffff;
+    font-size: 0.85rem;
+    font-weight: 600;
   }
 
   .mobilePagination :global(.ant-pagination-prev),
   .mobilePagination :global(.ant-pagination-next) {
+    display: inline-flex;
+    align-items: center;
+  }
+
+  .mobilePagination :global(.ant-pagination-prev .ant-pagination-item-link),
+  .mobilePagination :global(.ant-pagination-next .ant-pagination-item-link) {
+    display: grid;
+    place-items: center;
+    width: 32px;
+    height: 32px;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid rgba(255, 255, 255, 0.2);
     color: #ffffff;
+    transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+  }
+
+  .mobilePagination
+    :global(.ant-pagination-prev:hover .ant-pagination-item-link),
+  .mobilePagination
+    :global(.ant-pagination-next:hover .ant-pagination-item-link) {
+    background: rgba(255, 255, 255, 0.16);
+    border-color: rgba(255, 255, 255, 0.32);
+  }
+
+  .mobilePagination
+    :global(.ant-pagination-prev .ant-pagination-item-link:focus-visible),
+  .mobilePagination
+    :global(.ant-pagination-next .ant-pagination-item-link:focus-visible) {
+    outline: 2px solid rgba(255, 255, 255, 0.55);
+    outline-offset: 2px;
+  }
+
+  .mobilePagination
+    :global(.ant-pagination-prev.ant-pagination-disabled .ant-pagination-item-link),
+  .mobilePagination
+    :global(.ant-pagination-next.ant-pagination-disabled .ant-pagination-item-link) {
+    background: rgba(255, 255, 255, 0.04);
+    border-color: rgba(255, 255, 255, 0.12);
+    color: rgba(255, 255, 255, 0.4);
   }
 
   .mobilePagination :global(.ant-pagination-simple-pager input) {
-    background: rgba(255, 255, 255, 0.08);
-    border-radius: 6px;
-    border: 1px solid rgba(255, 255, 255, 0.16);
+    width: 52px;
+    height: 32px;
+    padding: 0 8px;
+    background: rgba(255, 255, 255, 0.12);
+    border-radius: 8px;
+    border: 1px solid rgba(255, 255, 255, 0.32);
     color: #ffffff;
+    font-weight: 700;
+    text-align: center;
+  }
+
+  .mobilePagination :global(.ant-pagination-simple-pager input:focus-visible) {
+    outline: 2px solid rgba(255, 255, 255, 0.55);
+    outline-offset: 2px;
   }
 
   .rightControls {

--- a/frontend/src/dashboard/project/features/budget/components/BudgetToolbar.module.css
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetToolbar.module.css
@@ -276,6 +276,14 @@
   align-self: center;
 }
 
+.desktopPagination {
+  display: inline-flex;
+}
+
+.mobilePagination {
+  display: none;
+}
+
 .toolbarPagination :global(.ant-select-selector) {
   background: transparent !important;
   border-color: #FA3356 !important;
@@ -319,6 +327,26 @@
   letter-spacing: 0.01em;
   transition: transform 0.15s ease, background-color 0.2s ease, border-color 0.2s ease,
     box-shadow 0.2s ease;
+}
+
+.mobileFilterButtonContent {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+}
+
+.mobileFilterIcon {
+  font-size: 16px;
+}
+
+.mobileFilterButtonText {
+  flex: 1 1 auto;
+  text-align: left;
+}
+
+.mobileFilterChevron {
+  margin-left: 8px;
 }
 
 .mobileFilterActive {
@@ -458,6 +486,16 @@
   white-space: nowrap;
 }
 
+.selectIcon {
+  font-size: 16px;
+}
+
+.selectLabel {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
 .addButton:active {
   transform: scale(0.98);
 }
@@ -491,21 +529,113 @@
 
 @media (max-width: 768px) {
   .toolbar {
-    flex-direction: column;
-    align-items: stretch;
+    padding: 12px 14px;
+    gap: 8px;
+    flex-wrap: nowrap;
+    align-items: center;
   }
 
   .filterControls {
-    width: 100%;
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 10px;
+    flex: 1 1 auto;
+    width: auto;
+    flex-direction: row;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .mobileFilterWrap {
+    flex: 0 0 auto;
+    min-width: 0;
+  }
+
+  .mobileFilterRoot {
+    width: auto;
+  }
+
+  .mobileFilterButton {
+    width: 38px;
+    height: 38px;
+    padding: 0;
+    border-radius: 50%;
+    justify-content: center;
+  }
+
+  .mobileFilterButtonContent {
+    justify-content: center;
+    width: auto;
+  }
+
+  .mobileFilterButtonText {
+    display: none;
+  }
+
+  .mobileFilterChevron {
+    display: none;
+  }
+
+  .mobileFilterIcon {
+    font-size: 18px;
+  }
+
+  .desktopPagination {
+    display: none !important;
+  }
+
+  .mobilePagination {
+    display: inline-flex;
+  }
+
+  .mobilePagination :global(.ant-pagination-simple-pager) {
+    background: transparent;
+    color: #ffffff;
+  }
+
+  .mobilePagination :global(.ant-pagination-prev),
+  .mobilePagination :global(.ant-pagination-next) {
+    color: #ffffff;
+  }
+
+  .mobilePagination :global(.ant-pagination-simple-pager input) {
+    background: rgba(255, 255, 255, 0.08);
+    border-radius: 6px;
+    border: 1px solid rgba(255, 255, 255, 0.16);
+    color: #ffffff;
   }
 
   .rightControls {
-    width: 100%;
-    justify-content: flex-start;
-    gap: 12px;
+    margin-left: 0;
+    flex: 0 0 auto;
+    justify-content: flex-end;
+    gap: 8px;
+  }
+
+  .selectModePill {
+    padding: 0;
+    background: transparent;
+    border: none;
+    gap: 8px;
+  }
+
+  .selectModeToggle {
+    padding: 0;
+    width: 38px;
+    height: 38px;
+    border-radius: 50%;
+    display: grid;
+    place-items: center;
+  }
+
+  .selectLabel {
+    display: none;
+  }
+
+  .selectIcon {
+    font-size: 18px;
+  }
+
+  .selectModeExpanded {
+    gap: 6px;
+    flex-wrap: wrap;
   }
 
   .selectionActions {
@@ -519,52 +649,15 @@
     font-size: 0.82rem;
   }
 
-  .mobileActionsContainer {
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
-    width: 100%;
- 
-  }
-
-  .mobileGroupControls {
-    display: flex;
-    width: 100%;
-    order: -1;
-  }
-
-  .mobileGroupControls .groupControlsInner {
-    width: 100%;
-  }
-
-  .mobileGroupControls .groupTabs {
-    width: 100%;
-    justify-content: center;
-    
-  }
-
-  .mobileGroupControls .groupTabButton {
-    padding: 8px 12px;
-    font-size: 0.75rem;
-    font-weight: 600;
-    border-radius: 24px;
-  }
-
-  .mobileFilterRow {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    width: 100%;
-  }
-
-  .mobileFilterWrap {
-    flex: 1 1 auto;
-    min-width: 0;
-  }
-
   .addButton {
-    flex-shrink: 0;
-    padding: 8px 14px;
-    border-radius: 12px;
+    padding: 0;
+    width: 38px;
+    height: 38px;
+    border-radius: 50%;
+    justify-content: center;
+  }
+
+  .addLabel {
+    display: none;
   }
 }

--- a/frontend/src/dashboard/project/features/budget/components/BudgetToolbar.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetToolbar.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from "react";
 import { Pagination } from "antd";
 import { Tooltip as AntTooltip } from "antd";
-import { SelectOutlined } from "@ant-design/icons";
+import { CheckOutlined } from "@ant-design/icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faClone, faTrash } from "@fortawesome/free-solid-svg-icons";
 import BudgetMobileFilter from "./BudgetMobileFilter";
@@ -169,7 +169,7 @@ const BudgetToolbar: React.FC<BudgetToolbarProps> = ({
               aria-pressed={isSelectMode}
               disabled={!hasRows}
             >
-              <SelectOutlined aria-hidden className={styles.selectIcon} />
+              <CheckOutlined aria-hidden className={styles.selectIcon} />
               <span className={styles.selectLabel}>Select</span>
             </button>
             {isSelectMode && (

--- a/frontend/src/dashboard/project/features/budget/components/BudgetToolbar.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetToolbar.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from "react";
 import { Pagination } from "antd";
 import { Tooltip as AntTooltip } from "antd";
+import { SelectOutlined } from "@ant-design/icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faClone, faTrash } from "@fortawesome/free-solid-svg-icons";
 import BudgetMobileFilter from "./BudgetMobileFilter";
@@ -130,17 +131,28 @@ const BudgetToolbar: React.FC<BudgetToolbarProps> = ({
           />
         </div>
         {hasRows && (
-          <Pagination
-            className={styles.toolbarPagination}
-            current={currentPage}
-            pageSize={pageSize}
-            total={totalCount}
-            showSizeChanger
-            pageSizeOptions={["10", "20", "50", "100"]}
-            size="small"
-            onChange={onPaginationChange}
-            onShowSizeChange={onPaginationChange}
-          />
+          <>
+            <Pagination
+              className={`${styles.toolbarPagination} ${styles.desktopPagination}`}
+              current={currentPage}
+              pageSize={pageSize}
+              total={totalCount}
+              showSizeChanger
+              pageSizeOptions={["10", "20", "50", "100"]}
+              size="small"
+              onChange={onPaginationChange}
+              onShowSizeChange={onPaginationChange}
+            />
+            <Pagination
+              className={`${styles.toolbarPagination} ${styles.mobilePagination}`}
+              current={currentPage}
+              pageSize={pageSize}
+              total={totalCount}
+              size="small"
+              simple
+              onChange={onPaginationChange}
+            />
+          </>
         )}
       </div>
       <div className={styles.rightControls}>
@@ -157,7 +169,8 @@ const BudgetToolbar: React.FC<BudgetToolbarProps> = ({
               aria-pressed={isSelectMode}
               disabled={!hasRows}
             >
-              Select
+              <SelectOutlined aria-hidden className={styles.selectIcon} />
+              <span className={styles.selectLabel}>Select</span>
             </button>
             {isSelectMode && (
               <div className={styles.selectModeExpanded}>


### PR DESCRIPTION
## Summary
- update the budget mobile filter trigger to render an icon-only affordance while preserving accessible labelling
- add a compact simple-pagination variant for mobile and switch select/add actions to icon treatments
- tighten the mobile toolbar layout with responsive styling so the controls sit on a single row

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e7501791788324a2badc181dd2f0b6