### PR TITLE
Move budget grouping controls into filter dropdown

### DIFF
--- a/frontend/src/dashboard/project/features/budget/components/BudgetMobileFilter.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetMobileFilter.tsx
@@ -59,7 +59,6 @@ interface BudgetMobileFilterProps {
   onSortChange: (field: string | null, order: SortOrder) => void;
   groupBy: GroupByOption;
   onGroupChange: (group: GroupByOption) => void;
-  hideGrouping?: boolean; // Add prop to hide grouping on desktop
 }
 
 const BudgetMobileFilter: React.FC<BudgetMobileFilterProps> = ({
@@ -70,7 +69,6 @@ const BudgetMobileFilter: React.FC<BudgetMobileFilterProps> = ({
   onSortChange,
   groupBy,
   onGroupChange,
-  hideGrouping = false,
 }) => {
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -106,10 +104,23 @@ const BudgetMobileFilter: React.FC<BudgetMobileFilterProps> = ({
     return match ? match.value : "default";
   }, [sortField, sortOrder]);
 
-  const isGroupActive = !hideGrouping && groupBy !== "none";
+  const activeGroupOption = useMemo(
+    () => GROUP_OPTIONS.find((option) => option.value === groupBy),
+    [groupBy]
+  );
+
+  const isGroupActive = groupBy !== "none";
 
   const isActive =
     filterQuery.trim().length > 0 || currentSortValue !== "default" || isGroupActive;
+
+  const filterButtonLabel = isGroupActive
+    ? activeGroupOption?.label ?? "Filter"
+    : "Filter";
+
+  const filterButtonAriaLabel = isGroupActive
+    ? `Group budget items by ${activeGroupOption?.label ?? "selection"}`
+    : "Filter budget items";
 
   const handleSortChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
     const nextValue = event.target.value as SortOptionValue;
@@ -140,12 +151,12 @@ const BudgetMobileFilter: React.FC<BudgetMobileFilterProps> = ({
         }`}
         aria-haspopup="menu"
         aria-expanded={open}
-        aria-label="Filter budget items"
+        aria-label={filterButtonAriaLabel}
         onClick={() => setOpen((prev) => !prev)}
         onKeyDown={handleKeyDown}
       >
         <span className={styles.mobileFilterButtonText}>
-          Filter
+          {filterButtonLabel}
         </span>
       </button>
       {open && (
@@ -153,37 +164,33 @@ const BudgetMobileFilter: React.FC<BudgetMobileFilterProps> = ({
           className={`${mobileStyles.filterPop} ${mobileStyles.filterPopStart} ${styles.mobileFilterPopover}`}
           role="menu"
         >
-          {!hideGrouping && (
-            <>
-              <div className={styles.mobileFilterSection}>
-                <span className={styles.mobileFilterLabel}>Group by</span>
-                <div
-                  className={styles.mobileFilterGroup}
-                  role="group"
-                  aria-label="Group budget items"
-                >
-                  {GROUP_OPTIONS.map((option) => {
-                    const isActiveOption = option.value === groupBy;
-                    const className = isActiveOption
-                      ? `${styles.mobileFilterGroupButton} ${styles.mobileFilterGroupButtonActive}`
-                      : styles.mobileFilterGroupButton;
-                    return (
-                      <button
-                        key={option.value}
-                        type="button"
-                        className={className}
-                        onClick={() => handleGroupChange(option.value)}
-                        aria-pressed={isActiveOption}
-                      >
-                        {option.label}
-                      </button>
-                    );
-                  })}
-                </div>
-              </div>
-              <div className={styles.mobileFilterDivider} />
-            </>
-          )}
+          <div className={styles.mobileFilterSection}>
+            <span className={styles.mobileFilterLabel}>Group by</span>
+            <div
+              className={styles.mobileFilterGroup}
+              role="group"
+              aria-label="Group budget items"
+            >
+              {GROUP_OPTIONS.map((option) => {
+                const isActiveOption = option.value === groupBy;
+                const className = isActiveOption
+                  ? `${styles.mobileFilterGroupButton} ${styles.mobileFilterGroupButtonActive}`
+                  : styles.mobileFilterGroupButton;
+                return (
+                  <button
+                    key={option.value}
+                    type="button"
+                    className={className}
+                    onClick={() => handleGroupChange(option.value)}
+                    aria-pressed={isActiveOption}
+                  >
+                    {option.label}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+          <div className={styles.mobileFilterDivider} />
           <div className={styles.mobileFilterSection}>
             <span className={styles.mobileFilterLabel}>Search</span>
             <div className={desktopStyles.filterField}>

--- a/frontend/src/dashboard/project/features/budget/components/BudgetToolbar.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/BudgetToolbar.tsx
@@ -10,13 +10,6 @@ type SortOrder = "ascend" | "descend" | null;
 
 type GroupByOption = "none" | "areaGroup" | "invoiceGroup" | "category";
 
-const GROUP_OPTIONS: { label: string; value: GroupByOption }[] = [
-  { label: "None", value: "none" },
-  { label: "Area Group", value: "areaGroup" },
-  { label: "Invoice Group", value: "invoiceGroup" },
-  { label: "Category", value: "category" },
-];
-
 // Hook to detect if we're on mobile/desktop
 const useIsMobile = () => {
   const [isMobile, setIsMobile] = useState(false);
@@ -107,34 +100,6 @@ const BudgetToolbar: React.FC<BudgetToolbarProps> = ({
 
   return (
     <div className={styles.toolbar}>
-      <div className={styles.groupControls}>
-        <span id="budget-desktop-group-label" className={styles.srOnly}>
-          Group budget items
-        </span>
-        <div
-          className={styles.groupTabs}
-          role="group"
-          aria-labelledby="budget-desktop-group-label"
-        >
-          {GROUP_OPTIONS.map((option) => {
-            const isActive = option.value === groupBy;
-            const className = isActive
-              ? `${styles.groupTabButton} ${styles.activeGroupTab}`
-              : styles.groupTabButton;
-            return (
-              <button
-                key={option.value}
-                type="button"
-                aria-pressed={isActive}
-                className={className}
-                onClick={() => onGroupChange(option.value)}
-              >
-                <span>{option.label}</span>
-              </button>
-            );
-          })}
-        </div>
-      </div>
       <div className={styles.filterControls}>
         <div className={styles.mobileFilterWrap}>
           <BudgetMobileFilter
@@ -145,7 +110,6 @@ const BudgetToolbar: React.FC<BudgetToolbarProps> = ({
             onSortChange={onSortChange}
             groupBy={groupBy}
             onGroupChange={onGroupChange}
-            hideGrouping={!isMobile}
           />
         </div>
         {hasRows && (


### PR DESCRIPTION
## Summary
- remove the desktop grouping pill controls from the budget toolbar and surface grouping inside the filter dropdown
- update the filter toggle button to display the active grouping label and adjust aria text accordingly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e76e0bb7e48324a45a64c1a2008925