### PR TITLE
Refactor budget line item modal UX

### DIFF
--- a/frontend/src/dashboard/project/features/budget/components/CreateLineItemModal.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/CreateLineItemModal.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useState } from "react";
-import Modal from "@/shared/ui/ModalWithStack";
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faXmark } from "@fortawesome/free-solid-svg-icons";
 import ConfirmModal from "@/shared/ui/ConfirmModal";
@@ -186,11 +186,65 @@ const initialState: ItemForm = fields.reduce<ItemForm>(
   {} as ItemForm
 );
 
-/* ------------------------------ Component ------------------------------ */
+const FULL_WIDTH_FIELDS = new Set<keyof ItemForm>(["description", "notes"]);
 
-if (typeof document !== "undefined") {
-  Modal.setAppElement("#root");
-}
+const SECTION_DEFINITIONS: Array<{
+  id: string;
+  title: string;
+  description?: string;
+  fields: readonly (keyof ItemForm)[];
+}> = [
+  {
+    id: "details",
+    title: "Details",
+    description: "Define the core information about this line item.",
+    fields: ["category", "elementKey", "elementId", "areaGroup", "invoiceGroup", "description"],
+  },
+  {
+    id: "quantities",
+    title: "Quantities",
+    fields: ["quantity", "unit"],
+  },
+  {
+    id: "financials",
+    title: "Financials",
+    description: "Track estimated and actual costs with markup adjustments.",
+    fields: [
+      "itemBudgetedCost",
+      "itemActualCost",
+      "itemReconciledCost",
+      "itemMarkUp",
+      "itemFinalCost",
+    ],
+  },
+  {
+    id: "payment",
+    title: "Payment",
+    fields: ["paymentType", "paymentTerms", "paymentStatus"],
+  },
+  {
+    id: "schedule",
+    title: "Schedule",
+    fields: ["startDate", "endDate"],
+  },
+  {
+    id: "vendor",
+    title: "Vendor & Client",
+    fields: ["poNumber", "vendor", "vendorInvoiceNumber", "client"],
+  },
+  {
+    id: "accounting",
+    title: "Accounting",
+    fields: ["amountPaid", "balanceDue"],
+  },
+  {
+    id: "notes",
+    title: "Notes",
+    fields: ["notes"],
+  },
+];
+
+/* ------------------------------ Component ------------------------------ */
 
 const CreateLineItemModal: React.FC<CreateLineItemModalProps> = ({
   isOpen,
@@ -215,6 +269,20 @@ const CreateLineItemModal: React.FC<CreateLineItemModalProps> = ({
 
   const [initialItemString, setInitialItemString] = useState<string>("");
   const [showUnsavedConfirm, setShowUnsavedConfirm] = useState<boolean>(false);
+  const [swipeOffset, setSwipeOffset] = useState(0);
+  const [isDragging, setIsDragging] = useState(false);
+  const modalRef = useRef<HTMLDivElement | null>(null);
+  const touchStartYRef = useRef<number | null>(null);
+  const isDraggingRef = useRef(false);
+  const lastOffsetRef = useRef(0);
+
+  const fieldMap = useMemo(() => {
+    const map = new Map<keyof ItemForm, FieldDef>();
+    fields.forEach((field) => {
+      map.set(field.name, field);
+    });
+    return map;
+  }, []);
 
   /* --------------------------- Lifecycle & Setup --------------------------- */
 
@@ -247,6 +315,40 @@ const CreateLineItemModal: React.FC<CreateLineItemModalProps> = ({
       setInitialItemString(JSON.stringify(defaultItem));
     }
   }, [isOpen, initialData, defaultElementKey, defaultStartDate, defaultEndDate]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    if (typeof window === "undefined") return;
+
+    requestAnimationFrame(() => {
+      const element = modalRef.current?.querySelector<HTMLElement>(
+        "input:not([type=hidden]), select, textarea",
+      );
+      element?.focus({ preventScroll: true });
+    });
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen || typeof document === "undefined") return;
+
+    const { style } = document.body;
+    const previousOverflow = style.overflow;
+    style.overflow = "hidden";
+
+    return () => {
+      style.overflow = previousOverflow;
+    };
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (isOpen) return;
+
+    setSwipeOffset(0);
+    setIsDragging(false);
+    isDraggingRef.current = false;
+    touchStartYRef.current = null;
+    lastOffsetRef.current = 0;
+  }, [isOpen]);
 
   /* ------------------------------- Helpers -------------------------------- */
 
@@ -403,6 +505,68 @@ const CreateLineItemModal: React.FC<CreateLineItemModalProps> = ({
     }
   };
 
+  const handleTouchStart = (event: React.TouchEvent<HTMLDivElement>) => {
+    if (event.touches.length !== 1) return;
+
+    touchStartYRef.current = event.touches[0].clientY;
+    isDraggingRef.current = true;
+    lastOffsetRef.current = 0;
+    setIsDragging(true);
+  };
+
+  const handleTouchMove = (event: React.TouchEvent<HTMLDivElement>) => {
+    if (!isDraggingRef.current || touchStartYRef.current === null) return;
+
+    const currentY = event.touches[0].clientY;
+    const delta = currentY - touchStartYRef.current;
+    const offset = delta > 0 ? delta : 0;
+    lastOffsetRef.current = offset;
+    setSwipeOffset(offset);
+
+    if (offset > 0) {
+      event.preventDefault();
+      event.stopPropagation();
+    }
+  };
+
+  const handleTouchEnd = () => {
+    if (!isDraggingRef.current) return;
+
+    const threshold = 140;
+    const shouldClose = lastOffsetRef.current > threshold;
+
+    if (shouldClose) {
+      setSwipeOffset(0);
+      setIsDragging(false);
+      isDraggingRef.current = false;
+      touchStartYRef.current = null;
+      lastOffsetRef.current = 0;
+      handleClose();
+      return;
+    }
+
+    setSwipeOffset(0);
+    setIsDragging(false);
+    isDraggingRef.current = false;
+    touchStartYRef.current = null;
+    lastOffsetRef.current = 0;
+  };
+
+  const handleOverlayMouseDown = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (event.target === event.currentTarget) {
+      handleClose();
+    }
+  };
+
+  const handleFormBodyClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (typeof document === "undefined") return;
+    const target = event.target as HTMLElement;
+    if (!target.closest("input, textarea, select, button")) {
+      const activeElement = document.activeElement as HTMLElement | null;
+      activeElement?.blur?.();
+    }
+  };
+
   const submitItem = async (isAutoSave = false) => {
     const data: ItemForm = { ...item };
 
@@ -456,6 +620,11 @@ const CreateLineItemModal: React.FC<CreateLineItemModalProps> = ({
   };
 
   const handleClose = () => {
+    setSwipeOffset(0);
+    setIsDragging(false);
+    isDraggingRef.current = false;
+    touchStartYRef.current = null;
+    lastOffsetRef.current = 0;
     const currentItemString = JSON.stringify(item);
     const hasChanges = currentItemString !== initialItemString;
 
@@ -487,230 +656,252 @@ const CreateLineItemModal: React.FC<CreateLineItemModalProps> = ({
 
   useEffect(() => {
     if (!isOpen) return;
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
-        e.preventDefault();
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        setSwipeOffset(0);
+        setIsDragging(false);
+        isDraggingRef.current = false;
+        touchStartYRef.current = null;
+        lastOffsetRef.current = 0;
+
+        const currentItemString = JSON.stringify(item);
+        const hasChanges = currentItemString !== initialItemString;
+        if (hasChanges) {
+          setShowUnsavedConfirm(true);
+        } else {
+          onRequestClose();
+        }
+        return;
+      }
+
+      if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+        event.preventDefault();
         void persistItem(false); // keyboard shortcut save, not autosave
       }
     };
-    document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [isOpen, item]);
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, item, initialItemString, onRequestClose, persistItem]);
 
   /* --------------------------------- Render -------------------------------- */
 
+  const renderField = (fieldName: keyof ItemForm) => {
+    const fieldDef = fieldMap.get(fieldName);
+    if (!fieldDef) return null;
+
+    const tooltip = TOOLTIP_TEXT[fieldName];
+    const disabled =
+      fieldName === "elementKey" ||
+      fieldName === "elementId" ||
+      (fieldName === "itemBudgetedCost" && (item.itemActualCost || item.itemReconciledCost)) ||
+      (fieldName === "itemActualCost" && !!item.itemReconciledCost);
+
+    const baseProps = {
+      name: fieldName as string,
+      value: item[fieldName] as string | number,
+      onChange: handleChange,
+      disabled,
+    } as const;
+
+    const labelClasses = [styles.field];
+    if (tooltip) labelClasses.push(styles.tooltipLabel);
+    if (FULL_WIDTH_FIELDS.has(fieldName)) labelClasses.push(styles.fieldFullWidth);
+
+    const datalistId =
+      fieldName === "areaGroup"
+        ? "area-group-options"
+        : fieldName === "invoiceGroup"
+        ? "invoice-group-options"
+        : fieldName === "client"
+        ? "client-options"
+        : undefined;
+
+    let control: React.ReactNode;
+
+    if (fieldDef.type === "select") {
+      const selectElement = (
+        <select {...baseProps}>
+          <option hidden value="" />
+          {(fieldDef.options ?? []).map((option) => (
+            <option key={option} value={option}>
+              {option}
+            </option>
+          ))}
+        </select>
+      );
+
+      if (fieldName === "paymentStatus") {
+        const statusValue = String(item[fieldName] ?? "").trim().toUpperCase();
+        const statusClass =
+          statusValue === "PAID"
+            ? styles.paid
+            : statusValue === "PARTIAL"
+            ? styles.partial
+            : statusValue === "UNPAID"
+            ? styles.unpaid
+            : undefined;
+
+        control = (
+          <div className={styles.paymentStatusContainer}>
+            {selectElement}
+            {statusClass ? <span className={`${styles.statusDot} ${statusClass}`} aria-hidden="true" /> : null}
+          </div>
+        );
+      } else {
+        control = selectElement;
+      }
+    } else if (fieldDef.type === "number" || fieldDef.type === "date") {
+      control = (
+        <input
+          type={fieldDef.type}
+          {...baseProps}
+          onKeyDown={(event) => {
+            if (event.key === "Enter") {
+              event.preventDefault();
+            }
+          }}
+        />
+      );
+    } else if (fieldDef.type === "textarea") {
+      control = (
+        <textarea
+          {...baseProps}
+          onKeyDown={(event) => {
+            if (event.key === "Enter" && !event.shiftKey) {
+              event.preventDefault();
+            }
+          }}
+        />
+      );
+    } else {
+      const placeholder =
+        fieldDef.type === "currency"
+          ? "$0.00"
+          : fieldDef.type === "percent"
+          ? "0%"
+          : "";
+
+      const blurHandler =
+        fieldDef.type && ["currency", "percent"].includes(fieldDef.type)
+          ? handleBlur
+          : undefined;
+
+      control = (
+        <input
+          type="text"
+          {...baseProps}
+          onKeyDown={(event) => {
+            if (event.key === "Enter") {
+              event.preventDefault();
+            }
+          }}
+          onBlur={blurHandler}
+          placeholder={placeholder}
+          list={datalistId}
+        />
+      );
+    }
+
+    return (
+      <label key={fieldName} className={labelClasses.join(" ")} title={tooltip || undefined}>
+        <span className={styles.fieldLabel}>{fieldDef.label}</span>
+        {control}
+      </label>
+    );
+  };
+
+  const portalContent =
+    isOpen && typeof document !== "undefined"
+      ? createPortal(
+          <div className={styles.sheetOverlay} role="presentation" onMouseDown={handleOverlayMouseDown}>
+            <div
+              ref={modalRef}
+              className={`${styles.sheetModal} ${isDragging ? styles.sheetModalDragging : ""}`}
+              role="dialog"
+              aria-modal="true"
+              aria-label={title}
+              style={swipeOffset ? { transform: `translateY(${swipeOffset}px)` } : undefined}
+            >
+              <div
+                className={styles.grabZone}
+                onTouchStart={handleTouchStart}
+                onTouchMove={handleTouchMove}
+                onTouchEnd={handleTouchEnd}
+                onTouchCancel={handleTouchEnd}
+              >
+                <div className={styles.grabHandle} />
+              </div>
+              <form className={styles.sheetForm} onSubmit={handleSubmit}>
+                <header className={styles.modalHeader}>
+                  <div className={styles.headerText}>
+                    <h2 className={styles.modalTitle}>{title}</h2>
+                    <p className={styles.modalSubtitle}>
+                      Capture every detail about your budget line item with structured sections and live totals.
+                    </p>
+                  </div>
+                  <div className={styles.headerActions}>
+                    <span className={styles.revisionPill}>Rev. {revision}</span>
+                    <button type="button" className={styles.closeButton} onClick={handleClose} aria-label="Close">
+                      <FontAwesomeIcon icon={faXmark} />
+                    </button>
+                  </div>
+                </header>
+                <div className={styles.modalBody} onClick={handleFormBodyClick}>
+                  {SECTION_DEFINITIONS.map((section) => (
+                    <section key={section.id} className={styles.section}>
+                      <div className={styles.sectionHeader}>
+                        <h3 className={styles.sectionTitle}>{section.title}</h3>
+                        {section.description ? (
+                          <p className={styles.sectionDescription}>{section.description}</p>
+                        ) : null}
+                      </div>
+                      <div className={styles.fieldGrid}>
+                        {section.fields.map((fieldName) => renderField(fieldName))}
+                      </div>
+                    </section>
+                  ))}
+                </div>
+
+                <datalist id="area-group-options">
+                  {areaGroupOptions.map((option) => (
+                    <option key={option} value={option} />
+                  ))}
+                </datalist>
+                <datalist id="invoice-group-options">
+                  {invoiceGroupOptions.map((option) => (
+                    <option key={option} value={option} />
+                  ))}
+                </datalist>
+                <datalist id="client-options">
+                  {clientOptions.map((option) => (
+                    <option key={option} value={option} />
+                  ))}
+                </datalist>
+
+                <footer className={styles.modalFooter}>
+                  <div className={styles.shortcutHint}>Press ⌘+Enter / Ctrl+Enter to save.</div>
+                  <div className={styles.footerActions}>
+                    <button type="button" className={styles.secondaryButton} onClick={handleClose}>
+                      Cancel
+                    </button>
+                    <button type="submit" className={styles.primaryButton}>
+                      {submitLabel || (title === "Edit Item" ? "Save" : "Create")}
+                    </button>
+                  </div>
+                </footer>
+              </form>
+            </div>
+          </div>,
+          document.body,
+        )
+      : null;
+
   return (
     <>
-      <style>
-        {`
-        .${styles.modalContent} {
-          font-size: 12px !important;
-          padding: 16px !important;
-        }
-        .${styles.form} label {
-          margin-bottom: 4px !important;
-        }
-        .${styles.form} input,
-        .${styles.form} textarea,
-        .${styles.form} select {
-          font-size: 11px !important;
-          padding: 2px 6px !important;
-        }
-        .${styles.fieldDivider} {
-          margin: 6px 0 !important;
-        }
-        .${styles.modalFooter} {
-          margin-top: 10px !important;
-        }
-        .${styles.shortcutHint} {
-          font-size: 10px !important;
-        }
-      `}
-      </style>
-
-      <Modal
-        isOpen={isOpen}
-        onRequestClose={handleClose}
-        contentLabel={title}
-        closeTimeoutMS={300}
-        shouldCloseOnOverlayClick={true}
-        shouldCloseOnEsc={true}
-        className={{
-          base: styles.modalContent,
-          afterOpen: styles.modalContentAfterOpen,
-          beforeClose: styles.modalContentBeforeClose,
-        }}
-        overlayClassName={{
-          base: styles.modalOverlay,
-          afterOpen: styles.modalOverlayAfterOpen,
-          beforeClose: styles.modalOverlayBeforeClose,
-        }}
-      >
-        <div className={styles.modalHeader}>
-          <div className={styles.modalTitle}>{title}</div>
-          <span className={styles.revisionLabel}>Rev.{revision}</span>
-          <button
-            className={styles.iconButton}
-            onClick={handleClose}
-            aria-label="Close"
-          >
-            <FontAwesomeIcon icon={faXmark} />
-          </button>
-        </div>
-
-        <form className={styles.form} onSubmit={handleSubmit}>
-          {fields.map((f) => {
-            const tooltip = TOOLTIP_TEXT[f.name];
-            const disabled =
-              f.name === "elementKey" ||
-              f.name === "elementId" ||
-              (f.name === "itemBudgetedCost" &&
-                (item.itemActualCost || item.itemReconciledCost)) ||
-              (f.name === "itemActualCost" && !!item.itemReconciledCost);
-
-            const commonProps = {
-              name: f.name as string,
-              value: item[f.name] as string | number,
-              onChange: handleChange,
-              disabled: !!disabled,
-            };
-
-            return (
-              <React.Fragment key={f.name}>
-                <label
-                  className={`${styles.field} ${tooltip ? styles.tooltipLabel : ""}`}
-                  title={tooltip || undefined}
-                >
-                  <span>{f.label}</span>
-
-                  {f.type === "select" ? (
-                    f.name === "paymentStatus" ? (
-                      <span className={styles.paymentStatusContainer}>
-                        <select {...commonProps}>
-                          <option hidden value="" />
-                          {(f.options ?? []).map((o) => (
-                            <option key={o} value={o}>
-                              {o}
-                            </option>
-                          ))}
-                        </select>
-                        {(item[f.name] as string) && (
-                          <span
-                            className={`${styles.statusDot} ${
-                              String(item[f.name]).trim().toUpperCase() === "PAID"
-                                ? styles.paid
-                                : String(item[f.name]).trim().toUpperCase() === "PARTIAL"
-                                ? styles.partial
-                                : styles.unpaid
-                            }`}
-                          />
-                        )}
-                      </span>
-                    ) : (
-                      <select {...commonProps}>
-                        <option hidden value="" />
-                        {(f.options ?? []).map((o) => (
-                          <option key={o} value={o}>
-                            {o}
-                          </option>
-                        ))}
-                      </select>
-                    )
-                  ) : f.type === "number" || f.type === "date" ? (
-                    <input 
-                      type={f.type} 
-                      {...commonProps}
-                      onKeyDown={(e) => {
-                        if (e.key === "Enter") {
-                          e.preventDefault();
-                        }
-                      }}
-                    />
-                  ) : f.type === "textarea" ? (
-                    <textarea
-                      {...commonProps}
-                      className={f.name === "description" ? styles.descriptionInput : undefined}
-                      onKeyDown={(e) => {
-                        if (e.key === "Enter" && !e.shiftKey) {
-                          e.preventDefault();
-                        }
-                      }}
-                    />
-                  ) : (
-                    // text / currency / percent
-                    <input
-                      type="text"
-                      {...commonProps}
-                      onKeyDown={(e) => {
-                        if (e.key === "Enter") {
-                          e.preventDefault();
-                        }
-                      }}
-                      onBlur={
-                        f.type && ["currency", "percent"].includes(f.type)
-                          ? handleBlur
-                          : undefined
-                      }
-                      placeholder={
-                        f.type === "currency" ? "$0.00" : f.type === "percent" ? "0%" : ""
-                      }
-                      list={
-                        f.name === "areaGroup"
-                          ? "area-group-options"
-                          : f.name === "invoiceGroup"
-                          ? "invoice-group-options"
-                          : f.name === "client"
-                          ? "client-options"
-                          : undefined
-                      }
-                    />
-                  )}
-                </label>
-
-                {[
-                  "invoiceGroup",
-                  "itemFinalCost",
-                  "paymentStatus",
-                  "endDate",
-                  "vendorInvoiceNumber",
-                ].includes(f.name as string) && <hr className={styles.fieldDivider} />}
-              </React.Fragment>
-            );
-          })}
-
-          <datalist id="area-group-options">
-            {areaGroupOptions.map((o) => (
-              <option key={o} value={o} />
-            ))}
-          </datalist>
-          <datalist id="invoice-group-options">
-            {invoiceGroupOptions.map((o) => (
-              <option key={o} value={o} />
-            ))}
-          </datalist>
-          <datalist id="client-options">
-            {clientOptions.map((o) => (
-              <option key={o} value={o} />
-            ))}
-          </datalist>
-
-          <div className={styles.modalFooter}>
-            <button type="submit" className="modal-button primary" style={{ borderRadius: 5 }}>
-              {submitLabel || (title === "Edit Item" ? "Save" : "Create")}
-            </button>
-            <button
-              type="button"
-              className="modal-button secondary"
-              style={{ borderRadius: 5 }}
-              onClick={handleClose}
-            >
-              Cancel
-            </button>
-          </div>
-
-          <div className={styles.shortcutHint}>Press ⌘+Enter / Ctrl+Enter to save.</div>
-        </form>
-      </Modal>
+      {portalContent}
 
       <ConfirmModal
         isOpen={showUnsavedConfirm}

--- a/frontend/src/dashboard/project/features/budget/components/create-line-item-modal.module.css
+++ b/frontend/src/dashboard/project/features/budget/components/create-line-item-modal.module.css
@@ -1,230 +1,458 @@
-.modalOverlay {
+.sheetOverlay {
   position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
+  inset: 0;
+  z-index: 14000;
   display: flex;
-  align-items: center;
+  align-items: flex-end;
   justify-content: center;
-  background: rgba(0, 0, 0, 0.75);
-  z-index: 1000;
-  box-sizing: border-box;
-  opacity: 0;
-  transition: opacity 0.3s ease;
+  overflow: hidden;
+  overscroll-behavior: contain;
+  background: rgba(10, 12, 16, 0.72);
+  backdrop-filter: blur(12px);
 }
-.modalOverlayAfterOpen {
-  opacity: 1;
+
+@media (min-width: 720px) {
+  .sheetOverlay {
+    align-items: center;
+    padding: clamp(20px, 4vh, 48px) 0;
+  }
 }
-.modalOverlayBeforeClose {
-  opacity: 0;
-}
-.modalContent {
-  background: #0c0c0c;
-  color: white;
-  border: 2px solid #ffffff;
-  border-radius: 16px;
-  padding: 22px;
-  width: 90%;
-  max-width: 600px;
-  max-height: 80vh;
+
+.sheetModal {
+  width: min(640px, 100%);
+  max-height: calc(100vh - max(16px, env(safe-area-inset-top)) - max(16px, env(safe-area-inset-bottom)));
+  background: rgba(20, 22, 28, 0.96);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 22px 22px 0 0;
   display: flex;
   flex-direction: column;
-  align-items: center;
-  opacity: 0;
-  transform: translateY(-20px);
-  transition: opacity 0.3s ease, transform 0.3s ease;
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
-  font-family: "Helvetica Neue", "Helvetica Display", sans-serif;
+  color: #f7f8fc;
+  box-shadow: 0 32px 60px rgba(0, 0, 0, 0.5);
+  overflow: hidden;
+  transition: transform 0.3s ease, opacity 0.25s ease;
 }
-.modalContentAfterOpen {
-  opacity: 1;
-  transform: translateY(0);
+
+.sheetModalDragging {
+  transition: none;
 }
-.modalContentBeforeClose {
-  opacity: 0;
-  transform: translateY(-20px);
+
+@media (min-width: 720px) {
+  .sheetModal {
+    border-radius: 22px;
+    margin: 0 auto;
+  }
 }
+
+@media (min-width: 1024px) {
+  .sheetOverlay {
+    padding: clamp(32px, 6vh, 72px) 0;
+  }
+
+  .sheetModal {
+    width: min(1024px, 100%);
+    max-height: calc(100vh - clamp(72px, 12vh, 128px));
+    border-radius: 28px;
+  }
+}
+
+.sheetModalDragging .grabHandle {
+  opacity: 0.4;
+}
+
+.grabZone {
+  display: flex;
+  justify-content: center;
+  padding: 14px 0 6px 0;
+  touch-action: none;
+  cursor: grab;
+  transition: opacity 0.2s ease;
+}
+
+.grabZone:hover {
+  opacity: 0.85;
+}
+
+.grabZone:active {
+  cursor: grabbing;
+  opacity: 0.6;
+}
+
+.grabHandle {
+  width: 68px;
+  height: 5px;
+  border-radius: 999px;
+  background: rgba(246, 247, 251, 0.45);
+  transition: background 0.2s ease;
+}
+
+.grabZone:hover .grabHandle {
+  background: rgba(246, 247, 251, 0.7);
+}
+
+.sheetForm {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
 .modalHeader {
   display: flex;
+  align-items: flex-start;
   justify-content: space-between;
-  align-items: center;
-  width: 100%;
-  padding: 0 1rem;
-  margin-bottom: 0.5rem;
+  gap: 18px;
+  padding: 0 clamp(22px, 5vw, 36px);
+  padding-bottom: 16px;
 }
+
+.headerText {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
 .modalTitle {
-  font-size: 1.25rem;
+  margin: 0;
+  font-size: clamp(1.35rem, 3vw, 1.75rem);
+  font-weight: 600;
+  letter-spacing: -0.01em;
 }
-.revisionLabel {
-  margin-left: 0.5rem;
-  font-size: 0.9rem;
-  color: #ccc;
+
+.modalSubtitle {
+  margin: 0;
+  color: rgba(247, 248, 252, 0.7);
+  font-size: 0.95rem;
+  line-height: 1.5;
 }
-.iconButton {
-  background: transparent;
-  border: none;
-  color: white;
-  padding: 4px;
-  cursor: pointer;
-  border-radius: 6px;
-  transition: background-color 0.2s ease, transform 0.2s ease;
+
+.headerActions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.revisionPill {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
+  padding: 5px 12px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(247, 248, 252, 0.85);
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
 }
-.iconButton:hover {
-  transform: scale(1.03);
-  background-color: rgba(255, 255, 255, 0.1);
+
+.closeButton {
+  border: none;
+  background: rgba(255, 255, 255, 0.08);
+  color: #f7f8fc;
+  width: 38px;
+  height: 38px;
+  border-radius: 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
 }
-.form {
-  flex: 1;
+
+.closeButton:hover {
+  background: rgba(255, 255, 255, 0.16);
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.25);
+}
+
+.closeButton:active {
+  transform: translateY(0);
+}
+
+.modalBody {
+  flex: 1 1 auto;
   overflow-y: auto;
-  width: 100%;
-  padding: 0 1rem;
+  scrollbar-width: none;
+  padding: 0 clamp(22px, 5vw, 36px) clamp(108px, 12vh, 128px);
 }
+
+.modalBody::-webkit-scrollbar {
+  display: none;
+}
+
+.section {
+  padding: 22px 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.section:last-of-type {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.sectionHeader {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 16px;
+}
+
+.sectionTitle {
+  margin: 0;
+  font-size: 1.08rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: #f7f8fc;
+}
+
+.sectionDescription {
+  margin: 0;
+  color: rgba(247, 248, 252, 0.65);
+  font-size: 0.92rem;
+  line-height: 1.45;
+}
+
+.fieldGrid {
+  display: grid;
+  gap: 14px 18px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
 .field {
   display: flex;
   flex-direction: column;
-  margin-bottom: 8px;
+  gap: 8px;
+  padding: 14px;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  background: rgba(255, 255, 255, 0.02);
+  transition: border-color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
 }
-.field input {
-  height: 32px;
-  border-radius: 6px;
-  border: 1px solid #555;
-  padding: 4px 8px;
-  background: #1a1a1a;
-  color: white;
+
+.field:focus-within {
+  border-color: rgba(99, 123, 255, 0.6);
+  background: rgba(99, 123, 255, 0.08);
+  box-shadow: 0 14px 32px rgba(33, 45, 122, 0.25);
 }
+
+.fieldFullWidth {
+  grid-column: 1 / -1;
+}
+
+.fieldLabel {
+  font-size: 0.82rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgba(247, 248, 252, 0.72);
+}
+
+.field input,
+.field textarea,
 .field select {
-  height: 32px;
-  border-radius: 6px;
-  border: 1px solid #555;
-  padding: 4px 8px;
-  background: #1a1a1a;
-  color: white;
+  width: 100%;
+  border: none;
+  border-radius: 12px;
+  background: rgba(9, 10, 13, 0.78);
+  color: #f7f8fc;
+  padding: 10px 12px;
+  font-size: 0.95rem;
+  font-family: inherit;
+  transition: background 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+  appearance: none;
 }
+
+.field input:focus,
+.field textarea:focus,
+.field select:focus {
+  outline: none;
+  background: rgba(18, 20, 26, 0.96);
+  box-shadow: 0 0 0 1px rgba(99, 123, 255, 0.8), 0 16px 28px rgba(31, 45, 124, 0.25);
+}
+
 .field input:disabled,
+.field textarea:disabled,
 .field select:disabled {
   opacity: 0.6;
   cursor: not-allowed;
-}
-.modalFooter {
-  display: flex;
-  justify-content: center;
-  gap: 12px;
-  margin-top: 12px;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
 }
 
-.fieldDivider {
-  margin: 25px 0 15px;      /* Adds vertical space */
-  border: none;         /* Removes default 3D styling */
-  border-top: 1px solid #ccc; /* Adds a subtle horizontal line */
-  width: 100%;          /* Stretches across the container */
-}
 .field textarea {
-  min-height: 80px;
-  border-radius: 6px;
-  border: 1px solid #555;
-  padding: 4px 8px;
-  background: #1a1a1a;
-  color: white;
+  min-height: 128px;
+  resize: vertical;
+  line-height: 1.5;
 }
 
-.descriptionInput {
-  min-height: 60px;
+.field input[type="number"] {
+  appearance: textfield;
+}
+
+.field input[type="number"]::-webkit-outer-spin-button,
+.field input[type="number"]::-webkit-inner-spin-button {
+  appearance: none;
+  margin: 0;
 }
 
 .tooltipLabel {
   cursor: help;
-
 }
 
 .paymentStatusContainer {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  gap: 10px;
+  width: 100%;
+}
+
+.paymentStatusContainer select {
+  flex: 1 1 auto;
 }
 
 .statusDot {
-  width: 10px;
-  height: 10px;
+  width: 12px;
+  height: 12px;
   border-radius: 50%;
-  display: inline-block;
+  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.1);
 }
 
 .paid {
-  background-color: #00b050;
+  background: linear-gradient(135deg, #3bc98e, #1f7a55);
 }
 
 .partial {
-  background-color: #ffd700;
+  background: linear-gradient(135deg, #ffd978, #d6a225);
 }
 
 .unpaid {
-  background-color: #ff4d4f;
+  background: linear-gradient(135deg, #ff7b88, #d9364f);
 }
 
-.calendarFields {
-  display: flex;
-  gap: 8px;
-  flex-wrap: wrap;
-  margin-bottom: 8px;
-}
-
-.eventsWrapper {
+.modalFooter {
+  position: sticky;
+  bottom: 0;
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  width: 100%;
-}
-
-.addEventButton {
-  display: block;
-  width: 100%;
-}
-
-.editEventButton {
-  margin-left: 10px;
-  background: none;
-  border: none;
-  color: #fa3356;
-  cursor: pointer;
-}
-
-.deleteEventBtn {
-  margin-left: 5px;
-  background: none;
-  border: none;
-  color: #fa3356;
-  cursor: pointer;
-}
-
-.eventRow {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.eventRowActions {
-  margin-left: auto;
-  display: flex;
-  gap: 4px;
-}
-
-.eventError {
-  color: #fa3356;
-  font-size: 0.9rem;
+  gap: 12px;
+  margin-top: auto;
+  padding: 20px clamp(22px, 5vw, 36px) max(28px, env(safe-area-inset-bottom) + 24px);
+  background: linear-gradient(
+    180deg,
+    rgba(20, 22, 28, 0) 0%,
+    rgba(20, 22, 28, 0.92) 28%,
+    rgba(20, 22, 28, 0.98) 100%
+  );
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
 }
 
 .shortcutHint {
-  margin-top: 8px;
-  font-size: 0.9rem;
-  color: #ccc;
-  text-align: center;
+  font-size: 0.85rem;
+  color: rgba(247, 248, 252, 0.6);
 }
 
+.footerActions {
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+}
 
+.primaryButton,
+.secondaryButton {
+  border-radius: 12px;
+  padding: 12px 22px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  border: none;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  font-family: inherit;
+}
 
+.primaryButton {
+  background: linear-gradient(135deg, #6e7bff, #4662ff);
+  color: #0b0c10;
+  box-shadow: 0 14px 28px rgba(70, 98, 255, 0.35);
+}
 
+.primaryButton:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 34px rgba(70, 98, 255, 0.45);
+}
 
+.primaryButton:active {
+  transform: translateY(0);
+}
 
+.secondaryButton {
+  background: rgba(255, 255, 255, 0.08);
+  color: #f7f8fc;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+}
+
+.secondaryButton:hover {
+  background: rgba(255, 255, 255, 0.15);
+  transform: translateY(-1px);
+}
+
+.secondaryButton:active {
+  transform: translateY(0);
+}
+
+.modalOverlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(7, 9, 12, 0.75);
+  backdrop-filter: blur(6px);
+  z-index: 16000;
+  opacity: 0;
+  transition: opacity 0.25s ease;
+}
+
+.modalOverlayAfterOpen {
+  opacity: 1;
+}
+
+.modalOverlayBeforeClose {
+  opacity: 0;
+}
+
+.modalContent {
+  background: rgba(18, 20, 26, 0.96);
+  color: #f7f8fc;
+  border-radius: 22px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  padding: 30px clamp(26px, 4vw, 38px);
+  max-width: 420px;
+  width: calc(100% - 56px);
+  box-shadow: 0 28px 60px rgba(0, 0, 0, 0.45);
+  opacity: 0;
+  transform: translateY(16px);
+  transition: opacity 0.25s ease, transform 0.25s ease;
+}
+
+.modalContentAfterOpen {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.modalContentBeforeClose {
+  opacity: 0;
+  transform: translateY(16px);
+}
+
+@media (max-width: 719px) {
+  .sheetModal {
+    border-radius: 22px 22px 0 0;
+    width: 100%;
+  }
+
+  .modalFooter {
+    padding-left: max(18px, env(safe-area-inset-left));
+    padding-right: max(18px, env(safe-area-inset-right));
+  }
+}


### PR DESCRIPTION
## Summary
- refactor the budget line item modal to use a portal-based sheet with grouped sections, swipe dismissal, and preserved form logic similar to the quick create task experience
- refresh the associated styles for responsive layout, modern header/footer treatments, and updated confirm dialog visuals

## Testing
- npm run test -- src/dashboard/project/features/budget/components/CreateLineItemModal.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e765e8dc188324a2c0af837cb4d996