### PR TITLE
Render works overlays via body portal

### DIFF
--- a/frontend/src/pages/works/allworkposts/1-sens-c.tsx
+++ b/frontend/src/pages/works/allworkposts/1-sens-c.tsx
@@ -14,6 +14,7 @@ import { useData } from "@/app/contexts/useData";
 import ReactModal from "react-modal"; // Import ReactModal
 import { useScrollContext } from "@/app/contexts/useScrollContext";
 import InlineSVG from "../../../shared/ui/InlineSVG";
+import { SvgOverlayPortal } from "../../../shared/ui/SvgOverlayPortal";
 
 
 
@@ -263,11 +264,7 @@ const SensC = () => {
 
 
       <div className={`${opacityClass} ${isModalOpen ? 'no-scroll' : ''}`}>
-        <div className="svg-overlay">
-          <svg viewBox="0 0 1000 1000" preserveAspectRatio="none">
-            <path id="revealPath" d="M0,1005S175,995,500,995s500,5,500,5V0H0Z"></path>
-          </svg>
-        </div>
+        <SvgOverlayPortal />
 
 
         <div className="workpage-heading">
@@ -350,7 +347,6 @@ const SensC = () => {
 };
 
 export default SensC;
-
 
 
 

--- a/frontend/src/pages/works/allworkposts/A-Flower-Bath.tsx
+++ b/frontend/src/pages/works/allworkposts/A-Flower-Bath.tsx
@@ -9,6 +9,7 @@ import SingleTicker from "../../../shared/ui/SingleTicker";
 import { useData } from "@/app/contexts/useData";
 import ReactModal from "react-modal";
 import { useScrollContext } from "@/app/contexts/useScrollContext";
+import { SvgOverlayPortal } from "../../../shared/ui/SvgOverlayPortal";
 
 /** Inline remote SVG so GSAP can target its inner nodes */
 function InlineSVG({ src, className, onReady }) {
@@ -256,14 +257,7 @@ const AFLowerBath = () => {
         className={`${opacityClass} ${isModalOpen ? "no-scroll" : ""}`}
       >
         {/* Overlay reveal mask */}
-        <div className="svg-overlay">
-          <svg viewBox="0 0 1000 1000" preserveAspectRatio="none">
-            <path
-              id="revealPath"
-              d="M0,1005S175,995,500,995s500,5,500,5V0H0Z"
-            />
-          </svg>
-        </div>
+        <SvgOverlayPortal />
 
         {/* Remote SVG header (animated) */}
         <div className="workpage-heading">
@@ -360,7 +354,6 @@ const AFLowerBath = () => {
 };
 
 export default AFLowerBath;
-
 
 
 

--- a/frontend/src/pages/works/allworkposts/Academy-of-Pop.tsx
+++ b/frontend/src/pages/works/allworkposts/Academy-of-Pop.tsx
@@ -13,6 +13,7 @@ import { useData } from "@/app/contexts/useData";
 
 
 import InlineSVG from "../../../shared/ui/InlineSVG";
+import { SvgOverlayPortal } from "../../../shared/ui/SvgOverlayPortal";
 
 
 const AcademyOfPop = () => {
@@ -352,12 +353,7 @@ const AcademyOfPop = () => {
             <div className={`${opacityClass} ${isModalOpen ? 'no-scroll' : ''}`}>
 
 
-                <div className="svg-overlay">
-                    <svg viewBox="0 0 1000 1000" width="100%" height="100%" preserveAspectRatio="none">
-
-                        <path id="revealPath" d="M0,1005S175,995,500,995s500,5,500,5V0H0Z"></path>
-                    </svg>
-                </div>
+                <SvgOverlayPortal />
 
 
                 <div className="workpage-heading">
@@ -821,7 +817,6 @@ const AcademyOfPop = () => {
 
 
 export default AcademyOfPop;
-
 
 
 

--- a/frontend/src/pages/works/allworkposts/Agenda-Festival.tsx
+++ b/frontend/src/pages/works/allworkposts/Agenda-Festival.tsx
@@ -14,6 +14,7 @@ import SingleTicker from "../../../shared/ui/SingleTicker";
 
 import { useData } from "@/app/contexts/useData";
 import InlineSVG from "../../../shared/ui/InlineSVG";
+import { SvgOverlayPortal } from "../../../shared/ui/SvgOverlayPortal";
 
 
 const AgendaFestival = () => {
@@ -306,11 +307,7 @@ const AgendaFestival = () => {
     </Helmet>
 
         <div className={`${opacityClass} ${isModalOpen ? 'no-scroll' : ''}`}>
-            <div className="svg-overlay">
-                <svg viewBox="0 0 1000 1000" width="100%" height="100%" preserveAspectRatio="none">
-                    <path id="revealPath" d="M0,1005S175,995,500,995s500,5,500,5V0H0Z"></path>
-                </svg>
-            </div>
+            <SvgOverlayPortal />
 
 
             <div className="workpage-heading">
@@ -581,7 +578,6 @@ const AgendaFestival = () => {
 };
 
 export default AgendaFestival;
-
 
 
 

--- a/frontend/src/pages/works/allworkposts/Barebells.tsx
+++ b/frontend/src/pages/works/allworkposts/Barebells.tsx
@@ -17,6 +17,7 @@ import BlogPostButton from "../../../shared/ui/BlogPostButton";
 import { InfoSection } from "../../../shared/ui";
 import SingleTicker from "../../../shared/ui/SingleTicker";
 import InlineSVG from "../../../shared/ui/InlineSVG";
+import { SvgOverlayPortal } from "../../../shared/ui/SvgOverlayPortal";
 
 
 
@@ -352,11 +353,7 @@ type WorkItem = {
     </Helmet>
 
         <div className={`${opacityClass} ${isModalOpen ? 'no-scroll' : ''}`}>
-            <div className="svg-overlay">
-                <svg viewBox="0 0 1000 1000" width="100%" height="100%" preserveAspectRatio="none">
-                    <path id="revealPath" d="M0,1005S175,995,500,995s500,5,500,5V0H0Z"></path>
-                </svg>
-            </div>
+            <SvgOverlayPortal />
 
 
             <div className="workpage-heading">
@@ -643,7 +640,6 @@ type WorkItem = {
 };
 
 export default Barebells;
-
 
 
 

--- a/frontend/src/pages/works/allworkposts/Be-Sweet-16.tsx
+++ b/frontend/src/pages/works/allworkposts/Be-Sweet-16.tsx
@@ -19,6 +19,7 @@ import Ticker from "../../../shared/ui/Ticker";
 import { InfoSection } from "../../../shared/ui";
 import SingleTicker from "../../../shared/ui/SingleTicker";
 import InlineSVG from "../../../shared/ui/InlineSVG";
+import { SvgOverlayPortal } from "../../../shared/ui/SvgOverlayPortal";
 
 
 
@@ -298,11 +299,7 @@ const BeSweet16 = () => {
 
         <div className={`${opacityClass} ${isModalOpen ? 'no-scroll' : ''}`}>
             
-            <div className="svg-overlay">
-                <svg viewBox="0 0 1000 1000" preserveAspectRatio="none">
-                    <path id="revealPath" d="M0,1005S175,995,500,995s500,5,500,5V0H0Z"></path>
-                </svg>
-            </div>
+            <SvgOverlayPortal />
 
 
             <div className="workpage-heading">
@@ -612,7 +609,6 @@ const BeSweet16 = () => {
 };
 
 export default BeSweet16;
-
 
 
 

--- a/frontend/src/pages/works/allworkposts/Bloom-and-Bliss.tsx
+++ b/frontend/src/pages/works/allworkposts/Bloom-and-Bliss.tsx
@@ -9,6 +9,7 @@ import { InfoSection } from "../../../shared/ui";
 import SingleTicker from "../../../shared/ui/SingleTicker";
 import { useData } from "@/app/contexts/useData";
 import InlineSVG from "../../../shared/ui/InlineSVG";
+import { SvgOverlayPortal } from "../../../shared/ui/SvgOverlayPortal";
 
 
 
@@ -335,11 +336,7 @@ const BloomAndBliss = () => {
     </Helmet>
 
         <div className={`${opacityClass} ${isModalOpen ? 'no-scroll' : ''}`}>
-            <div className="svg-overlay">
-                <svg viewBox="0 0 1000 1000" preserveAspectRatio="none">
-                    <path id="revealPath" d="M0,1005S175,995,500,995s500,5,500,5V0H0Z"></path>
-                </svg>
-            </div>
+            <SvgOverlayPortal />
 
 
             <div className="workpage-heading">
@@ -600,7 +597,6 @@ const BloomAndBliss = () => {
 };
 
 export default BloomAndBliss;
-
 
 
 

--- a/frontend/src/pages/works/allworkposts/Chevron.tsx
+++ b/frontend/src/pages/works/allworkposts/Chevron.tsx
@@ -15,6 +15,7 @@ import SingleTicker from "../../../shared/ui/SingleTicker";
 
 import { useData } from "@/app/contexts/useData";
 import InlineSVG from "../../../shared/ui/InlineSVG";
+import { SvgOverlayPortal } from "../../../shared/ui/SvgOverlayPortal";
 
 const Chevron = () => {
 
@@ -273,11 +274,7 @@ const Chevron = () => {
 
 
         <div className={`${opacityClass} ${isModalOpen ? 'no-scroll' : ''}`}>
-            <div className="svg-overlay">
-                <svg viewBox="0 0 1000 1000" preserveAspectRatio="none">
-                    <path id="revealPath" d="M0,1005S175,995,500,995s500,5,500,5V0H0Z"></path>
-                </svg>
-            </div>
+            <SvgOverlayPortal />
 
 
             <div className="workpage-heading">
@@ -600,7 +597,6 @@ const Chevron = () => {
 };
 
 export default Chevron;
-
 
 
 

--- a/frontend/src/pages/works/allworkposts/D-ROCK.tsx
+++ b/frontend/src/pages/works/allworkposts/D-ROCK.tsx
@@ -14,6 +14,7 @@ import { useData } from "@/app/contexts/useData";
 import ReactModal from "react-modal"; // Import ReactModal
 import { useScrollContext } from "@/app/contexts/useScrollContext";
 import InlineSVG from "../../../shared/ui/InlineSVG";
+import { SvgOverlayPortal } from "../../../shared/ui/SvgOverlayPortal";
 
 const DRock = () => {
 
@@ -260,11 +261,7 @@ const DRock = () => {
       </Helmet>
 
       <div className={`${opacityClass} ${isModalOpen ? 'no-scroll' : ''}`}>
-        <div className="svg-overlay">
-          <svg viewBox="0 0 1000 1000" preserveAspectRatio="none">
-            <path id="revealPath" d="M0,1005S175,995,500,995s500,5,500,5V0H0Z"></path>
-          </svg>
-        </div>
+        <SvgOverlayPortal />
 
 
         <div className="workpage-heading">
@@ -349,7 +346,6 @@ const DRock = () => {
 };
 
 export default DRock;
-
 
 
 

--- a/frontend/src/pages/works/allworkposts/Frank-Zummo-Sum41.tsx
+++ b/frontend/src/pages/works/allworkposts/Frank-Zummo-Sum41.tsx
@@ -14,6 +14,7 @@ import { useData } from "@/app/contexts/useData";
 import ReactModal from "react-modal"; // Import ReactModal
 import { useScrollContext } from "@/app/contexts/useScrollContext";
 import InlineSVG from "../../../shared/ui/InlineSVG";
+import { SvgOverlayPortal } from "../../../shared/ui/SvgOverlayPortal";
 
 
 
@@ -305,11 +306,7 @@ const FrankZummoSum41 = () => {
             </script>
         </Helmet>
       <div className={`${opacityClass} ${isModalOpen ? 'no-scroll' : ''}`}>
-        <div className="svg-overlay">
-          <svg viewBox="0 0 1000 1000" preserveAspectRatio="none">
-            <path id="revealPath" d="M0,1005S175,995,500,995s500,5,500,5V0H0Z"></path>
-          </svg>
-        </div>
+        <SvgOverlayPortal />
 
 
         <div className="workpage-heading">
@@ -389,7 +386,6 @@ const FrankZummoSum41 = () => {
 };
 
 export default FrankZummoSum41;
-
 
 
 

--- a/frontend/src/pages/works/allworkposts/Ghost-Circus-Apparel.tsx
+++ b/frontend/src/pages/works/allworkposts/Ghost-Circus-Apparel.tsx
@@ -16,6 +16,7 @@ import SingleTicker from "../../../shared/ui/SingleTicker";
 
 import { useData } from "@/app/contexts/useData";
 import InlineSVG from "../../../shared/ui/InlineSVG";
+import { SvgOverlayPortal } from "../../../shared/ui/SvgOverlayPortal";
 
 const GhostCircusApparel = () => {
 
@@ -337,11 +338,7 @@ const GhostCircusApparel = () => {
 
         <div className={`${opacityClass} ${isModalOpen ? 'no-scroll' : ''}`}>
 
-            <div className="svg-overlay">
-                <svg viewBox="0 0 1000 1000" preserveAspectRatio="none">
-                    <path id="revealPath" d="M0,1005S175,995,500,995s500,5,500,5V0H0Z"></path>
-                </svg>
-            </div>
+            <SvgOverlayPortal />
 
 
             <div className="workpage-heading">
@@ -639,7 +636,6 @@ const GhostCircusApparel = () => {
 };
 
 export default GhostCircusApparel;
-
 
 
 

--- a/frontend/src/pages/works/allworkposts/Goldru$h.tsx
+++ b/frontend/src/pages/works/allworkposts/Goldru$h.tsx
@@ -17,6 +17,7 @@ import SingleTicker from "../../../shared/ui/SingleTicker";
 
 import { useData } from "@/app/contexts/useData";
 import InlineSVG from "../../../shared/ui/InlineSVG";
+import { SvgOverlayPortal } from "../../../shared/ui/SvgOverlayPortal";
 
 const Goldru$h = () => {
 
@@ -328,11 +329,7 @@ const Goldru$h = () => {
 
         <div className={`${opacityClass} ${isModalOpen ? 'no-scroll' : ''}`}>
 
-            <div className="svg-overlay">
-                <svg viewBox="0 0 1000 1000" preserveAspectRatio="none">
-                    <path id="revealPath" d="M0,1005S175,995,500,995s500,5,500,5V0H0Z"></path>
-                </svg>
-            </div>
+            <SvgOverlayPortal />
 
 
             <div className="workpage-heading">
@@ -585,7 +582,6 @@ const Goldru$h = () => {
 };
 
 export default Goldru$h;
-
 
 
 

--- a/frontend/src/pages/works/allworkposts/Gucci-Aria.tsx
+++ b/frontend/src/pages/works/allworkposts/Gucci-Aria.tsx
@@ -17,6 +17,7 @@ import SingleTicker from "../../../shared/ui/SingleTicker";
 
 import { useData } from "@/app/contexts/useData";
 import InlineSVG from "../../../shared/ui/InlineSVG";
+import { SvgOverlayPortal } from "../../../shared/ui/SvgOverlayPortal";
 
 
 
@@ -322,11 +323,7 @@ const { opacity } = useData();
         </script>
     </Helmet>
         <div className={`${opacityClass} ${isModalOpen ? 'no-scroll' : ''}`}>
-            <div className="svg-overlay">
-                <svg viewBox="0 0 1000 1000" preserveAspectRatio="none">
-                    <path id="revealPath" d="M0,1005S175,995,500,995s500,5,500,5V0H0Z"></path>
-                </svg>
-            </div>
+            <SvgOverlayPortal />
 
             
                 <div className="workpage-heading">
@@ -550,7 +547,6 @@ const { opacity } = useData();
 };
 
 export default Gucci;
-
 
 
 

--- a/frontend/src/pages/works/allworkposts/J22-INTERIORS.tsx
+++ b/frontend/src/pages/works/allworkposts/J22-INTERIORS.tsx
@@ -18,6 +18,7 @@ import SingleTicker from "../../../shared/ui/SingleTicker";
 
 import { useData } from "@/app/contexts/useData";
 import InlineSVG from "../../../shared/ui/InlineSVG";
+import { SvgOverlayPortal } from "../../../shared/ui/SvgOverlayPortal";
 
 
 
@@ -290,11 +291,7 @@ const J22Interiors = () => {
                                   </Helmet>
 
         <div className={`${opacityClass} ${isModalOpen ? 'no-scroll' : ''}`}>
-            <div className="svg-overlay">
-                <svg viewBox="0 0 1000 1000" preserveAspectRatio="none">
-                    <path id="revealPath" d="M0,1005S175,995,500,995s500,5,500,5V0H0Z"></path>
-                </svg>
-            </div>
+            <SvgOverlayPortal />
 
 
             <div className="workpage-heading">
@@ -701,7 +698,6 @@ const J22Interiors = () => {
 };
 
 export default J22Interiors;
-
 
 
 

--- a/frontend/src/pages/works/allworkposts/Jewelie-Stark.tsx
+++ b/frontend/src/pages/works/allworkposts/Jewelie-Stark.tsx
@@ -13,6 +13,7 @@ import { useData } from "@/app/contexts/useData";
 import ReactModal from "react-modal"; // Import ReactModal
 import { useScrollContext } from "@/app/contexts/useScrollContext";
 import InlineSVG from "../../../shared/ui/InlineSVG";
+import { SvgOverlayPortal } from "../../../shared/ui/SvgOverlayPortal";
 
 
 const JewelieStark = () => {
@@ -260,11 +261,7 @@ const JewelieStark = () => {
       </Helmet>
 
       <div className={`${opacityClass} ${isModalOpen ? 'no-scroll' : ''}`}>
-        <div className="svg-overlay">
-          <svg viewBox="0 0 1000 1000" preserveAspectRatio="none">
-            <path id="revealPath" d="M0,1005S175,995,500,995s500,5,500,5V0H0Z"></path>
-          </svg>
-        </div>
+        <SvgOverlayPortal />
 
 
         <div className="workpage-heading">
@@ -343,7 +340,6 @@ const JewelieStark = () => {
   );
 };
 export default JewelieStark;
-
 
 
 

--- a/frontend/src/pages/works/allworkposts/Keys-Art-Basel.tsx
+++ b/frontend/src/pages/works/allworkposts/Keys-Art-Basel.tsx
@@ -12,6 +12,7 @@ import { InfoSection } from "../../../shared/ui";
 import SingleTicker from "../../../shared/ui/SingleTicker";
 import { useData } from "@/app/contexts/useData";
 import InlineSVG from "../../../shared/ui/InlineSVG";
+import { SvgOverlayPortal } from "../../../shared/ui/SvgOverlayPortal";
 
 interface WorkItem {
     id: number;
@@ -333,11 +334,7 @@ useEffect(() => {
       
 
         <div className={`${opacityClass} ${isModalOpen ? 'no-scroll' : ''}`}>
-            <div className="svg-overlay">
-                <svg viewBox="0 0 1000 1000" preserveAspectRatio="none">
-                    <path id="revealPath" d="M0,1005S175,995,500,995s500,5,500,5V0H0Z"></path>
-                </svg>
-            </div>
+            <SvgOverlayPortal />
 
 
             <div className="workpage-heading">
@@ -596,7 +593,6 @@ useEffect(() => {
 };
 
 export default KeysArtBasel;
-
 
 
 

--- a/frontend/src/pages/works/allworkposts/Keys-Soulcare.tsx
+++ b/frontend/src/pages/works/allworkposts/Keys-Soulcare.tsx
@@ -17,6 +17,7 @@ import SingleTicker from "../../../shared/ui/SingleTicker";
 
 import { useData } from "@/app/contexts/useData";
 import InlineSVG from "../../../shared/ui/InlineSVG";
+import { SvgOverlayPortal } from "../../../shared/ui/SvgOverlayPortal";
 
 const KeysSoulcare = () => {
 
@@ -328,11 +329,7 @@ const KeysSoulcare = () => {
     </Helmet>
 
         <div className={`${opacityClass} ${isModalOpen ? 'no-scroll' : ''}`}>
-            <div className="svg-overlay">
-                <svg viewBox="0 0 1000 1000" preserveAspectRatio="none">
-                    <path id="revealPath" d="M0,1005S175,995,500,995s500,5,500,5V0H0Z"></path>
-                </svg>
-            </div>
+            <SvgOverlayPortal />
 
 
             <div className="workpage-heading">
@@ -815,7 +812,6 @@ const KeysSoulcare = () => {
 };
 
 export default KeysSoulcare;
-
 
 
 

--- a/frontend/src/pages/works/allworkposts/Logitech.tsx
+++ b/frontend/src/pages/works/allworkposts/Logitech.tsx
@@ -9,6 +9,7 @@ import BlogPostButton from "../../../shared/ui/BlogPostButton";
 import { InfoSection } from "../../../shared/ui";
 import SingleTicker from "../../../shared/ui/SingleTicker";
 import InlineSVG from "../../../shared/ui/InlineSVG";
+import { SvgOverlayPortal } from "../../../shared/ui/SvgOverlayPortal";
 
 interface WorkItem {
     id: number | string;
@@ -146,11 +147,7 @@ const Logitech = () => {
             <link rel="dns-prefetch" href="https://d1cazymewvlm0k.cloudfront.net" />
             <script type="application/ld+json">{JSON.stringify(structuredData)}</script>
         </Helmet>
-            <div className="svg-overlay">
-                <svg viewBox="0 0 1000 1000" preserveAspectRatio="none">
-                    <path id="revealPath" d="M0,1005S175,995,500,995s500,5,500,5V0H0Z"></path>
-                </svg>
-            </div>
+            <SvgOverlayPortal />
 
             <div className="works">
                 <div className="workpage-heading">
@@ -379,7 +376,6 @@ const Logitech = () => {
 };
 
 export default Logitech;
-
 
 
 

--- a/frontend/src/pages/works/allworkposts/MZ-Stellar-Brass.tsx
+++ b/frontend/src/pages/works/allworkposts/MZ-Stellar-Brass.tsx
@@ -12,6 +12,7 @@ import InlineSVG from "../../../shared/ui/InlineSVG";
 import { InfoSection } from "../../../shared/ui";
 import SingleTicker from "../../../shared/ui/SingleTicker";
 import { useData } from "@/app/contexts/useData";
+import { SvgOverlayPortal } from "../../../shared/ui/SvgOverlayPortal";
 
 
 const MZ = () => {
@@ -372,11 +373,7 @@ const MZ = () => {
             </Helmet>
 
         <div className={`${opacityClass} ${isModalOpen ? 'no-scroll' : ''}`}>
-            <div className="svg-overlay">
-                <svg viewBox="0 0 1000 1000" preserveAspectRatio="none">
-                    <path id="revealPath" d="M0,1005S175,995,500,995s500,5,500,5V0H0Z"></path>
-                </svg>
-            </div>
+            <SvgOverlayPortal />
 
 
             <div className="workpage-heading">
@@ -1218,7 +1215,6 @@ const MZ = () => {
 };
 
 export default MZ;
-
 
 
 

--- a/frontend/src/pages/works/allworkposts/Machine-Head.tsx
+++ b/frontend/src/pages/works/allworkposts/Machine-Head.tsx
@@ -11,6 +11,7 @@ import { useData } from "@/app/contexts/useData";
 import ReactModal from "react-modal"; // Import ReactModal
 import { useScrollContext } from "@/app/contexts/useScrollContext";
 import InlineSvg from "../../../shared/ui/InlineSVG";
+import { SvgOverlayPortal } from "../../../shared/ui/SvgOverlayPortal";
 
 
 
@@ -259,11 +260,7 @@ const MachineHead = () => {
                    <title>Machine Head - *MYLG!*</title>
                </Helmet>
       <div className={`${opacityClass} ${isModalOpen ? 'no-scroll' : ''}`}>
-        <div className="svg-overlay">
-          <svg viewBox="0 0 1000 1000" preserveAspectRatio="none">
-            <path id="revealPath" d="M0,1005S175,995,500,995s500,5,500,5V0H0Z"></path>
-          </svg>
-        </div>
+        <SvgOverlayPortal />
 
 
         <div className="workpage-heading">
@@ -342,7 +339,6 @@ const MachineHead = () => {
   );
 };
 export default MachineHead;
-
 
 
 

--- a/frontend/src/pages/works/allworkposts/Mistifi-Vape.tsx
+++ b/frontend/src/pages/works/allworkposts/Mistifi-Vape.tsx
@@ -29,6 +29,7 @@ interface WorkItem {
 import { InfoSection } from "../../../shared/ui";
 import SingleTicker from "../../../shared/ui/SingleTicker";
 import InlineSVG from "../../../shared/ui/InlineSVG";
+import { SvgOverlayPortal } from "../../../shared/ui/SvgOverlayPortal";
 
 
 
@@ -333,11 +334,7 @@ const MistifiVape = () => {
 
         <div className={`${opacityClass} ${isModalOpen ? 'no-scroll' : ''}`}>
             
-            <div className="svg-overlay">
-                <svg viewBox="0 0 1000 1000" preserveAspectRatio="none">
-                    <path id="revealPath" d="M0,1005S175,995,500,995s500,5,500,5V0H0Z"></path>
-                </svg>
-            </div>
+            <SvgOverlayPortal />
 
             
                 <div className="workpage-heading">
@@ -650,7 +647,6 @@ const MistifiVape = () => {
 };
 
 export default MistifiVape;
-
 
 
 

--- a/frontend/src/pages/works/allworkposts/NOCCO.tsx
+++ b/frontend/src/pages/works/allworkposts/NOCCO.tsx
@@ -17,6 +17,7 @@ import Ticker from "../../../shared/ui/Ticker";
 import { InfoSection } from "../../../shared/ui";
 import SingleTicker from "../../../shared/ui/SingleTicker";
 import InlineSVG from "../../../shared/ui/InlineSVG";
+import { SvgOverlayPortal } from "../../../shared/ui/SvgOverlayPortal";
 
 
 const Nocco = () => {
@@ -313,11 +314,7 @@ const Nocco = () => {
       </Helmet>
 
         <div className={`${opacityClass} ${isModalOpen ? 'no-scroll' : ''}`}>
-            <div className="svg-overlay">
-                <svg viewBox="0 0 1000 1000" preserveAspectRatio="none">
-                    <path id="revealPath" d="M0,1005S175,995,500,995s500,5,500,5V0H0Z"></path>
-                </svg>
-            </div>
+            <SvgOverlayPortal />
 
             
                 <div className="workpage-heading">
@@ -524,7 +521,6 @@ const Nocco = () => {
 };
 
 export default Nocco;
-
 
 
 

--- a/frontend/src/pages/works/allworkposts/Nike-Femme.tsx
+++ b/frontend/src/pages/works/allworkposts/Nike-Femme.tsx
@@ -12,6 +12,7 @@ import { useData } from "@/app/contexts/useData";
 import ReactModal from "react-modal"; // Import ReactModal
 import { useScrollContext } from "@/app/contexts/useScrollContext";
 import InlineSVG from "../../../shared/ui/InlineSVG";
+import { SvgOverlayPortal } from "../../../shared/ui/SvgOverlayPortal";
 
 
 
@@ -263,11 +264,7 @@ const NikeFemme = () => {
 
 
       <div className={`${opacityClass} ${isModalOpen ? 'no-scroll' : ''}`}>
-        <div className="svg-overlay">
-          <svg viewBox="0 0 1000 1000" preserveAspectRatio="none">
-            <path id="revealPath" d="M0,1005S175,995,500,995s500,5,500,5V0H0Z"></path>
-          </svg>
-        </div>
+        <SvgOverlayPortal />
 
 
         <div className="workpage-heading">
@@ -346,7 +343,6 @@ const NikeFemme = () => {
   );
 };
 export default NikeFemme;
-
 
 
 

--- a/frontend/src/pages/works/allworkposts/Now-United.tsx
+++ b/frontend/src/pages/works/allworkposts/Now-United.tsx
@@ -20,6 +20,7 @@ import { useData } from "@/app/contexts/useData";
 import { InfoSection } from "../../../shared/ui";
 import SingleTicker from "../../../shared/ui/SingleTicker";
 import InlineSVG from "../../../shared/ui/InlineSVG";
+import { SvgOverlayPortal } from "../../../shared/ui/SvgOverlayPortal";
 
 
 
@@ -359,11 +360,7 @@ const Barebells = () => {
      
 
         <div className={`${opacityClass} ${isModalOpen ? 'no-scroll' : ''}`}>
-            <div className="svg-overlay">
-                <svg viewBox="0 0 1000 1000" width="100%" height="100%" preserveAspectRatio="none">
-                    <path id="revealPath" d="M0,1005S175,995,500,995s500,5,500,5V0H0Z"></path>
-                </svg>
-            </div>
+            <SvgOverlayPortal />
 
 
             <div className="workpage-heading">
@@ -924,7 +921,6 @@ const Barebells = () => {
 };
 
 export default Barebells;
-
 
 
 

--- a/frontend/src/pages/works/allworkposts/Pipe-Dream-Events.tsx
+++ b/frontend/src/pages/works/allworkposts/Pipe-Dream-Events.tsx
@@ -9,6 +9,7 @@ import { InfoSection } from "../../../shared/ui";
 import SingleTicker from "../../../shared/ui/SingleTicker";
 import { useData } from "@/app/contexts/useData";
 import InlineSVG from "../../../shared/ui/InlineSVG";
+import { SvgOverlayPortal } from "../../../shared/ui/SvgOverlayPortal";
 
 gsap.registerPlugin(ScrollTrigger); // Register ScrollTrigger plugin
 
@@ -279,14 +280,7 @@ const PipedDreamEvents = () => {
       </Helmet>
 
       <div className={`${opacityClass} ${isModalOpen ? "no-scroll" : ""}`}>
-        <div className="svg-overlay">
-          <svg viewBox="0 0 1000 1000" preserveAspectRatio="none">
-            <path
-              id="revealPath"
-              d="M0,1005S175,995,500,995s500,5,500,5V0H0Z"
-            ></path>
-          </svg>
-        </div>
+        <SvgOverlayPortal />
 
         <div className="workpage-heading">
           <InlineSVG src="https://d2qb21tb4meex0.cloudfront.net/svg/pipedreamevents/pipedreameventsheader.svg" onReady={() => setSvgReady(true)} />
@@ -503,7 +497,6 @@ const PipedDreamEvents = () => {
 };
 
 export default PipedDreamEvents;
-
 
 
 

--- a/frontend/src/pages/works/allworkposts/Solo-J.tsx
+++ b/frontend/src/pages/works/allworkposts/Solo-J.tsx
@@ -11,6 +11,7 @@ import { useData } from "@/app/contexts/useData";
 import ReactModal from "react-modal"; // Import ReactModal
 import { useScrollContext } from "@/app/contexts/useScrollContext";
 import InlineSVG from "../../../shared/ui/InlineSVG";
+import { SvgOverlayPortal } from "../../../shared/ui/SvgOverlayPortal";
 
 
 const SoloJ = () => {
@@ -259,11 +260,7 @@ const SoloJ = () => {
                    </Helmet>
 
       <div className={`${opacityClass} ${isModalOpen ? 'no-scroll' : ''}`}>
-        <div className="svg-overlay">
-          <svg viewBox="0 0 1000 1000" preserveAspectRatio="none">
-            <path id="revealPath" d="M0,1005S175,995,500,995s500,5,500,5V0H0Z"></path>
-          </svg>
-        </div>
+        <SvgOverlayPortal />
 
 
         <div className="workpage-heading">
@@ -343,7 +340,6 @@ const SoloJ = () => {
 };
 
 export default SoloJ;
-
 
 
 

--- a/frontend/src/pages/works/allworkposts/TROIA.tsx
+++ b/frontend/src/pages/works/allworkposts/TROIA.tsx
@@ -15,6 +15,7 @@ import { InfoSection } from "../../../shared/ui";
 import SingleTicker from "../../../shared/ui/SingleTicker";
 import { useData } from "@/app/contexts/useData";
 import InlineSVG from "../../../shared/ui/InlineSVG";
+import { SvgOverlayPortal } from "../../../shared/ui/SvgOverlayPortal";
 
 
 
@@ -350,11 +351,7 @@ const Troia = () => {
 
        
         <div className={`${opacityClass} ${isModalOpen ? 'no-scroll' : ''}`}>
-        <div className="svg-overlay">
-            <svg viewBox="0 0 1000 1000" preserveAspectRatio="none">
-                <path id="revealPath" d="M0,1005S175,995,500,995s500,5,500,5V0H0Z"></path>
-            </svg>
-        </div>
+        <SvgOverlayPortal />
 
 
             
@@ -752,7 +749,6 @@ const Troia = () => {
 };
 
 export default Troia;
-
 
 
 

--- a/frontend/src/pages/works/allworkposts/The-Oscars.tsx
+++ b/frontend/src/pages/works/allworkposts/The-Oscars.tsx
@@ -9,6 +9,7 @@ import { InfoSection } from "../../../shared/ui";
 import SingleTicker from "../../../shared/ui/SingleTicker";
 import { useData } from "@/app/contexts/useData";
 import InlineSVG from "../../../shared/ui/InlineSVG";
+import { SvgOverlayPortal } from "../../../shared/ui/SvgOverlayPortal";
 
 
 
@@ -294,11 +295,7 @@ const TheOscars = () => {
         <div className={`${opacityClass} ${isModalOpen ? 'no-scroll' : ''}`}>
 
 
-            <div className="svg-overlay">
-                <svg viewBox="0 0 1000 1000" preserveAspectRatio="none">
-                    <path id="revealPath" d="M0,1005S175,995,500,995s500,5,500,5V0H0Z"></path>
-                </svg>
-            </div>
+            <SvgOverlayPortal />
 
 
             <div className="workpage-heading">
@@ -567,7 +564,6 @@ const TheOscars = () => {
 };
 
 export default TheOscars;
-
 
 
 

--- a/frontend/src/pages/works/allworkposts/The-Party-Never-Ends.tsx
+++ b/frontend/src/pages/works/allworkposts/The-Party-Never-Ends.tsx
@@ -15,6 +15,7 @@ import SingleTicker from "../../../shared/ui/SingleTicker";
 
 import { useData } from "@/app/contexts/useData";
 import InlineSVG from "../../../shared/ui/InlineSVG";
+import { SvgOverlayPortal } from "../../../shared/ui/SvgOverlayPortal";
 
 
 
@@ -331,11 +332,7 @@ const ThePartyNeverEnds = () => {
            
            
            
-            <div className="svg-overlay">
-                <svg viewBox="0 0 1000 1000" preserveAspectRatio="none">
-                    <path id="revealPath" d="M0,1005S175,995,500,995s500,5,500,5V0H0Z"></path>
-                </svg>
-            </div>
+            <SvgOverlayPortal />
 
             
             
@@ -696,7 +693,6 @@ const ThePartyNeverEnds = () => {
 };
 
 export default ThePartyNeverEnds;
-
 
 
 

--- a/frontend/src/pages/works/allworkposts/The-gold-princess.tsx
+++ b/frontend/src/pages/works/allworkposts/The-gold-princess.tsx
@@ -12,6 +12,7 @@ import { useData } from "@/app/contexts/useData";
 import ReactModal from "react-modal"; // Import ReactModal
 import { useScrollContext } from "@/app/contexts/useScrollContext";
 import InlineSVG from "../../../shared/ui/InlineSVG";
+import { SvgOverlayPortal } from "../../../shared/ui/SvgOverlayPortal";
 
 
 const TheGoldPrincess = () => {
@@ -279,11 +280,7 @@ const TheGoldPrincess = () => {
                 <meta name="twitter:image:alt" content="The Gold Princess Photography" />
             </Helmet>
       <div className={`${opacityClass} ${isModalOpen ? 'no-scroll' : ''}`}>
-        <div className="svg-overlay">
-          <svg viewBox="0 0 1000 1000" preserveAspectRatio="none">
-            <path id="revealPath" d="M0,1005S175,995,500,995s500,5,500,5V0H0Z"></path>
-          </svg>
-        </div>
+        <SvgOverlayPortal />
 
 
         <div className="workpage-heading">
@@ -363,7 +360,6 @@ const TheGoldPrincess = () => {
 };
 
 export default TheGoldPrincess;
-
 
 
 

--- a/frontend/src/pages/works/allworkposts/Ulta.tsx
+++ b/frontend/src/pages/works/allworkposts/Ulta.tsx
@@ -13,6 +13,7 @@ import { InfoSection } from "../../../shared/ui";
 import SingleTicker from "../../../shared/ui/SingleTicker";
 import { useData } from "@/app/contexts/useData";
 import InlineSVG from "../../../shared/ui/InlineSVG";
+import { SvgOverlayPortal } from "../../../shared/ui/SvgOverlayPortal";
 
 
 
@@ -287,11 +288,7 @@ const Ulta = () => {
         <div className={`${opacityClass} ${isModalOpen ? 'no-scroll' : ''}`}>
 
 
-            <div className="svg-overlay">
-                <svg viewBox="0 0 1000 1000" preserveAspectRatio="none">
-                    <path id="revealPath" d="M0,1005S175,995,500,995s500,5,500,5V0H0Z"></path>
-                </svg>
-            </div>
+            <SvgOverlayPortal />
 
 
             <div className="workpage-heading">
@@ -794,7 +791,6 @@ const Ulta = () => {
     );
 };
 export default Ulta;
-
 
 
 

--- a/frontend/src/pages/works/allworkposts/brand-by-people.tsx
+++ b/frontend/src/pages/works/allworkposts/brand-by-people.tsx
@@ -12,6 +12,7 @@ import { useData } from "@/app/contexts/useData";
 import ReactModal from "react-modal"; // Import ReactModal
 import { useScrollContext } from "@/app/contexts/useScrollContext";
 import InlineSVG from "../../../shared/ui/InlineSVG";
+import { SvgOverlayPortal } from "../../../shared/ui/SvgOverlayPortal";
 
 
 
@@ -260,11 +261,7 @@ const BrandByPeople = () => {
                   </Helmet>
             
       <div className={`${opacityClass} ${isModalOpen ? 'no-scroll' : ''}`}>
-        <div className="svg-overlay">
-          <svg viewBox="0 0 1000 1000" preserveAspectRatio="none">
-            <path id="revealPath" d="M0,1005S175,995,500,995s500,5,500,5V0H0Z"></path>
-          </svg>
-        </div>
+        <SvgOverlayPortal />
 
 
         <div className="workpage-heading">
@@ -344,7 +341,6 @@ const BrandByPeople = () => {
 };
 
 export default BrandByPeople;
-
 
 
 

--- a/frontend/src/pages/works/allworkposts/elf-Makeup-Hollywood-Bowl.tsx
+++ b/frontend/src/pages/works/allworkposts/elf-Makeup-Hollywood-Bowl.tsx
@@ -15,6 +15,7 @@ import SingleTicker from "../../../shared/ui/SingleTicker";
 
 import { useData } from "@/app/contexts/useData";
 import InlineSVG from "../../../shared/ui/InlineSVG";
+import { SvgOverlayPortal } from "../../../shared/ui/SvgOverlayPortal";
 
 
 const ElfMakeUpHollywoodBowl = () => {
@@ -323,11 +324,7 @@ const ElfMakeUpHollywoodBowl = () => {
 
         <div className={`${opacityClass} ${isModalOpen ? 'no-scroll' : ''}`}>
 
-            <div className="svg-overlay">
-                <svg viewBox="0 0 1000 1000" preserveAspectRatio="none">
-                    <path id="revealPath" d="M0,1005S175,995,500,995s500,5,500,5V0H0Z"></path>
-                </svg>
-            </div>
+            <SvgOverlayPortal />
 
 
             <div className="workpage-heading">
@@ -532,7 +529,6 @@ const ElfMakeUpHollywoodBowl = () => {
 };
 
 export default ElfMakeUpHollywoodBowl;
-
 
 
 

--- a/frontend/src/pages/works/allworkposts/elf-Makeup.tsx
+++ b/frontend/src/pages/works/allworkposts/elf-Makeup.tsx
@@ -18,6 +18,7 @@ import { InfoSection } from "../../../shared/ui";
 import SingleTicker from "../../../shared/ui/SingleTicker";
 import { useData } from "@/app/contexts/useData";
 import InlineSVG from "../../../shared/ui/InlineSVG";
+import { SvgOverlayPortal } from "../../../shared/ui/SvgOverlayPortal";
 
 
 
@@ -398,11 +399,7 @@ const ElfMakeup = () => {
             <div className={`${opacityClass} ${isModalOpen ? 'no-scroll' : ''}`}>
 
 
-                <div className="svg-overlay">
-                    <svg viewBox="0 0 1000 1000" preserveAspectRatio="none">
-                        <path id="revealPath" d="M0,1005S175,995,500,995s500,5,500,5V0H0Z"></path>
-                    </svg>
-                </div>
+                <SvgOverlayPortal />
 
 
                 <div className="workpage-heading">
@@ -674,7 +671,6 @@ const ElfMakeup = () => {
 
 
 export default ElfMakeup;
-
 
 
 

--- a/frontend/src/pages/works/allworkposts/elf-studio.tsx
+++ b/frontend/src/pages/works/allworkposts/elf-studio.tsx
@@ -14,6 +14,7 @@ import { InfoSection } from "../../../shared/ui";
 import SingleTicker from "../../../shared/ui/SingleTicker";
 import { useData } from "@/app/contexts/useData";
 import InlineSVG from "../../../shared/ui/InlineSVG";
+import { SvgOverlayPortal } from "../../../shared/ui/SvgOverlayPortal";
 
 const Elfstudio = () => {
 
@@ -339,11 +340,7 @@ useEffect(() => {
     </Helmet>
 
         <div className={`${opacityClass} ${isModalOpen ? 'no-scroll' : ''}`}>
-            <div className="svg-overlay">
-                <svg viewBox="0 0 1000 1000" preserveAspectRatio="none">
-                    <path id="revealPath" d="M0,1005S175,995,500,995s500,5,500,5V0H0Z"></path>
-                </svg>
-            </div>
+            <SvgOverlayPortal />
 
             
                 <div className="workpage-heading">
@@ -585,7 +582,6 @@ useEffect(() => {
 };
 
 export default Elfstudio;
-
 
 
 

--- a/frontend/src/pages/works/allworkposts/gatane.tsx
+++ b/frontend/src/pages/works/allworkposts/gatane.tsx
@@ -15,6 +15,7 @@ import { useData } from "@/app/contexts/useData";
 import ReactModal from "react-modal"; // Import ReactModal
 import { useScrollContext } from "@/app/contexts/useScrollContext";
 import InlineSVG from "../../../shared/ui/InlineSVG";
+import { SvgOverlayPortal } from "../../../shared/ui/SvgOverlayPortal";
 
 const Gatane = () => {
 
@@ -261,11 +262,7 @@ const Gatane = () => {
                           </Helmet>
                     
       <div className={`${opacityClass} ${isModalOpen ? 'no-scroll' : ''}`}>
-        <div className="svg-overlay">
-          <svg viewBox="0 0 1000 1000" preserveAspectRatio="none">
-            <path id="revealPath" d="M0,1005S175,995,500,995s500,5,500,5V0H0Z"></path>
-          </svg>
-        </div>
+        <SvgOverlayPortal />
 
 
         <div className="workpage-heading">
@@ -345,7 +342,6 @@ const Gatane = () => {
 };
 
 export default Gatane;
-
 
 
 

--- a/frontend/src/pages/works/allworkposts/km-tour.tsx
+++ b/frontend/src/pages/works/allworkposts/km-tour.tsx
@@ -13,6 +13,7 @@ import InlineSVG from "../../../shared/ui/InlineSVG";
 import { useData } from "@/app/contexts/useData";
 import { InfoSection } from "../../../shared/ui";
 import SingleTicker from "../../../shared/ui/SingleTicker";
+import { SvgOverlayPortal } from "../../../shared/ui/SvgOverlayPortal";
 
 
 
@@ -276,11 +277,7 @@ const KmTour = () => {
             </Helmet>
 
         <div className={`${opacityClass} ${isModalOpen ? 'no-scroll' : ''}`}>
-            <div className="svg-overlay">
-                <svg viewBox="0 0 1000 1000" preserveAspectRatio="none">
-                    <path id="revealPath" d="M0,1005S175,995,500,995s500,5,500,5V0H0Z"></path>
-                </svg>
-            </div>
+            <SvgOverlayPortal />
 
 
             <div className="workpage-heading">
@@ -555,7 +552,6 @@ const KmTour = () => {
 };
 
 export default KmTour;
-
 
 
 

--- a/frontend/src/pages/works/allworkposts/natasha-bedingfield.tsx
+++ b/frontend/src/pages/works/allworkposts/natasha-bedingfield.tsx
@@ -22,6 +22,7 @@ import Ticker from "../../../shared/ui/Ticker";
 import { InfoSection } from "../../../shared/ui";
 import SingleTicker from "../../../shared/ui/SingleTicker";
 import InlineSVG from "../../../shared/ui/InlineSVG";
+import { SvgOverlayPortal } from "../../../shared/ui/SvgOverlayPortal";
 
 
 
@@ -297,11 +298,7 @@ const NatashaBedingfield = () => {
         
 
         <div className={`${opacityClass} ${isModalOpen ? 'no-scroll' : ''}`}>
-            <div className="svg-overlay">
-                <svg viewBox="0 0 1000 1000" preserveAspectRatio="none">
-                    <path id="revealPath" d="M0,1005S175,995,500,995s500,5,500,5V0H0Z"></path>
-                </svg>
-            </div>
+            <SvgOverlayPortal />
 
 
             <div className="workpage-heading">
@@ -596,7 +593,6 @@ const NatashaBedingfield = () => {
 };
 
 export default NatashaBedingfield;
-
 
 
 

--- a/frontend/src/pages/works/allworkposts/strikefit.tsx
+++ b/frontend/src/pages/works/allworkposts/strikefit.tsx
@@ -10,6 +10,7 @@ import InlineSVG from "../../../shared/ui/InlineSVG";
 import { InfoSection } from "../../../shared/ui";
 import SingleTicker from "../../../shared/ui/SingleTicker";
 import { useData } from "@/app/contexts/useData";
+import { SvgOverlayPortal } from "../../../shared/ui/SvgOverlayPortal";
 
 
 const StrikeFit = () => {
@@ -304,11 +305,7 @@ const StrikeFit = () => {
             </Helmet>
 
         <div className={`${opacityClass} ${isModalOpen ? 'no-scroll' : ''}`}>
-            <div className="svg-overlay">
-                <svg viewBox="0 0 1000 1000" preserveAspectRatio="none">
-                    <path id="revealPath" d="M0,1005S175,995,500,995s500,5,500,5V0H0Z"></path>
-                </svg>
-            </div>
+            <SvgOverlayPortal />
 
 
             <div className="workpage-heading">
@@ -529,7 +526,6 @@ const StrikeFit = () => {
 };
 
 export default StrikeFit;
-
 
 
 

--- a/frontend/src/pages/works/allworkposts/yanis.tsx
+++ b/frontend/src/pages/works/allworkposts/yanis.tsx
@@ -10,6 +10,7 @@ import { useData } from "@/app/contexts/useData";
 import ReactModal from "react-modal"; // Import ReactModal
 import { useScrollContext } from "@/app/contexts/useScrollContext";
 import InlineSVG from "../../../shared/ui/InlineSVG";
+import { SvgOverlayPortal } from "../../../shared/ui/SvgOverlayPortal";
 
 
 
@@ -258,11 +259,7 @@ const Yanis = () => {
                        </Helmet>
     
       <div className={`${opacityClass} ${isModalOpen ? 'no-scroll' : ''}`}>
-        <div className="svg-overlay">
-          <svg viewBox="0 0 1000 1000" preserveAspectRatio="none">
-            <path id="revealPath" d="M0,1005S175,995,500,995s500,5,500,5V0H0Z"></path>
-          </svg>
-        </div>
+        <SvgOverlayPortal />
 
 
         <div className="workpage-heading">
@@ -342,7 +339,6 @@ const Yanis = () => {
 };
 
 export default Yanis;
-
 
 
 

--- a/frontend/src/shared/ui/SvgOverlayPortal.tsx
+++ b/frontend/src/shared/ui/SvgOverlayPortal.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { createPortal } from "react-dom";
+
+interface SvgOverlayPortalProps {
+  readonly viewBox?: string;
+  readonly pathId?: string;
+  readonly pathD?: string;
+  readonly preserveAspectRatio?: string;
+}
+
+export const SvgOverlayPortal: React.FC<SvgOverlayPortalProps> = ({
+  viewBox = "0 0 1000 1000",
+  pathId = "revealPath",
+  pathD = "M0,1005S175,995,500,995s500,5,500,5V0H0Z",
+  preserveAspectRatio = "none",
+}) => {
+  const overlay = (
+    <div className="svg-overlay" aria-hidden="true">
+      <svg viewBox={viewBox} preserveAspectRatio={preserveAspectRatio}>
+        <path id={pathId} d={pathD} />
+      </svg>
+    </div>
+  );
+
+  if (typeof document === "undefined") {
+    return overlay;
+  }
+
+  return createPortal(overlay, document.body);
+};
+
+export default SvgOverlayPortal;


### PR DESCRIPTION
## Summary
- add a reusable `SvgOverlayPortal` that renders the reveal overlay through `document.body`
- update each works detail page to use the portal so the transition mask stays above the global header

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e847349e50832488774d73d2ec24f7