### PR TITLE
Delay marketing nav until overlay reveal completes

### DIFF
--- a/frontend/src/pages/home/home.tsx
+++ b/frontend/src/pages/home/home.tsx
@@ -1,6 +1,5 @@
 // Home.tsx
 import React, { useEffect, useRef, useState } from "react";
-import { createPortal } from "react-dom";
 import { Helmet } from "react-helmet-async";
 import { useScrollContext } from "@/app/contexts/useScrollContext";
 import { gsap } from "gsap";
@@ -13,6 +12,7 @@ import PortfolioCard from "../../shared/ui/PortfolioCard";
 import Ticker from "../../shared/ui/Ticker";
 import SingleTicker from "../../shared/ui/SingleTicker";
 import ScrollToTopButton from "../../shared/ui/ScrollToTopButton";
+import { SvgOverlayPortal } from "@/shared/ui/SvgOverlayPortal";
 import { useData } from "@/app/contexts/useData";
 import "@/shared/css/marketingpages.css";
 import "./home.css";
@@ -67,14 +67,6 @@ export const Home: React.FC = () => {
 
   const isDesktop = typeof window !== "undefined" && window.innerWidth > 768;
 
-  const overlay = (
-    <div className="svg-overlay" aria-hidden="true">
-      <svg viewBox="0 0 100 100" width="100%" height="100%" preserveAspectRatio="none">
-        <path id="revealPath" d="M0,100S17.5,100,50,100s50,0,100,0V0H0Z" />
-      </svg>
-    </div>
-  );
-
   return (
     <>
       <Helmet>
@@ -115,7 +107,12 @@ export const Home: React.FC = () => {
         <meta name="twitter:image:alt" content="MYLG Platform Mockup" />
       </Helmet>
 
-      {typeof document !== "undefined" ? createPortal(overlay, document.body) : overlay}
+      <SvgOverlayPortal
+        viewBox="0 0 100 100"
+        pathId="revealPath"
+        pathD="M0,100S17.5,100,50,100s50,0,100,0V0H0Z"
+        navRevealDelayMs={1250}
+      />
 
       <div className={opacityClass}>
 

--- a/frontend/src/shared/ui/SvgOverlayPortal.tsx
+++ b/frontend/src/shared/ui/SvgOverlayPortal.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useLayoutEffect } from "react";
 import { createPortal } from "react-dom";
 
 interface SvgOverlayPortalProps {
@@ -6,14 +6,43 @@ interface SvgOverlayPortalProps {
   readonly pathId?: string;
   readonly pathD?: string;
   readonly preserveAspectRatio?: string;
+  readonly navRevealDelayMs?: number;
 }
+
+const useIsomorphicLayoutEffect =
+  typeof window !== "undefined" ? useLayoutEffect : useEffect;
 
 export const SvgOverlayPortal: React.FC<SvgOverlayPortalProps> = ({
   viewBox = "0 0 1000 1000",
   pathId = "revealPath",
   pathD = "M0,1005S175,995,500,995s500,5,500,5V0H0Z",
   preserveAspectRatio = "none",
+  navRevealDelayMs = 1250,
 }) => {
+  useIsomorphicLayoutEffect(() => {
+    if (typeof document === "undefined") {
+      return () => undefined;
+    }
+
+    const body = document.body;
+    const navHiddenClass = "marketing-nav-hidden";
+    body.classList.add(navHiddenClass);
+
+    let revealTimer: number | undefined;
+    if (typeof window !== "undefined") {
+      revealTimer = window.setTimeout(() => {
+        body.classList.remove(navHiddenClass);
+      }, navRevealDelayMs);
+    }
+
+    return () => {
+      if (typeof window !== "undefined" && revealTimer !== undefined) {
+        window.clearTimeout(revealTimer);
+      }
+      body.classList.remove(navHiddenClass);
+    };
+  }, [navRevealDelayMs]);
+
   const overlay = (
     <div className="svg-overlay" aria-hidden="true">
       <svg viewBox={viewBox} preserveAspectRatio={preserveAspectRatio}>

--- a/frontend/src/shared/ui/SvgOverlayPortal.tsx
+++ b/frontend/src/shared/ui/SvgOverlayPortal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useLayoutEffect } from "react";
+import React, { useEffect, useLayoutEffect, useRef } from "react";
 import { createPortal } from "react-dom";
 
 interface SvgOverlayPortalProps {
@@ -12,6 +12,54 @@ interface SvgOverlayPortalProps {
 const useIsomorphicLayoutEffect =
   typeof window !== "undefined" ? useLayoutEffect : useEffect;
 
+const NAV_HIDDEN_CLASS = "marketing-nav-hidden";
+
+const activeOverlayTokens = new Set<symbol>();
+
+let pendingVisibilityCheck: number | undefined;
+
+const cancelPendingVisibilityCheck = () => {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  if (pendingVisibilityCheck !== undefined) {
+    window.cancelAnimationFrame(pendingVisibilityCheck);
+    pendingVisibilityCheck = undefined;
+  }
+};
+
+const ensureNavHidden = (body: HTMLElement) => {
+  if (!body.classList.contains(NAV_HIDDEN_CLASS)) {
+    body.classList.add(NAV_HIDDEN_CLASS);
+  }
+
+  cancelPendingVisibilityCheck();
+};
+
+const requestNavReveal = (body: HTMLElement) => {
+  if (activeOverlayTokens.size > 0) {
+    return;
+  }
+
+  if (typeof window === "undefined") {
+    body.classList.remove(NAV_HIDDEN_CLASS);
+    return;
+  }
+
+  if (pendingVisibilityCheck !== undefined) {
+    return;
+  }
+
+  pendingVisibilityCheck = window.requestAnimationFrame(() => {
+    pendingVisibilityCheck = undefined;
+
+    if (activeOverlayTokens.size === 0) {
+      body.classList.remove(NAV_HIDDEN_CLASS);
+    }
+  });
+};
+
 export const SvgOverlayPortal: React.FC<SvgOverlayPortalProps> = ({
   viewBox = "0 0 1000 1000",
   pathId = "revealPath",
@@ -19,19 +67,25 @@ export const SvgOverlayPortal: React.FC<SvgOverlayPortalProps> = ({
   preserveAspectRatio = "none",
   navRevealDelayMs = 1250,
 }) => {
+  const overlayTokenRef = useRef<symbol>();
+
   useIsomorphicLayoutEffect(() => {
     if (typeof document === "undefined") {
       return () => undefined;
     }
 
     const body = document.body;
-    const navHiddenClass = "marketing-nav-hidden";
-    body.classList.add(navHiddenClass);
+    const overlayToken = overlayTokenRef.current ?? Symbol("svg-overlay");
+    overlayTokenRef.current = overlayToken;
+
+    activeOverlayTokens.add(overlayToken);
+    ensureNavHidden(body);
 
     let revealTimer: number | undefined;
     if (typeof window !== "undefined") {
       revealTimer = window.setTimeout(() => {
-        body.classList.remove(navHiddenClass);
+        activeOverlayTokens.delete(overlayToken);
+        requestNavReveal(body);
       }, navRevealDelayMs);
     }
 
@@ -39,7 +93,9 @@ export const SvgOverlayPortal: React.FC<SvgOverlayPortalProps> = ({
       if (typeof window !== "undefined" && revealTimer !== undefined) {
         window.clearTimeout(revealTimer);
       }
-      body.classList.remove(navHiddenClass);
+
+      activeOverlayTokens.delete(overlayToken);
+      requestNavReveal(body);
     };
   }, [navRevealDelayMs]);
 

--- a/frontend/src/shared/ui/header.css
+++ b/frontend/src/shared/ui/header.css
@@ -445,6 +445,11 @@
   }
 }
 
+body.marketing-nav-hidden header.header {
+  visibility: hidden;
+  pointer-events: none;
+}
+
 
 
 


### PR DESCRIPTION
## Summary
- hide the marketing navigation while the overlay reveal animation is running by applying a temporary body class in `SvgOverlayPortal`
- add global header styling for the new body class so the navigation stays hidden until the reveal finishes
- update the Home page to use `SvgOverlayPortal`, reusing the centralized reveal behaviour

## Testing
- `npm run lint -- --max-warnings=0` *(fails: existing unused variable in BudgetToolbar.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68e8676b79ec832480ee6a401810588a