### PR TITLE
Use project accent color in line item modal

### DIFF
--- a/frontend/src/dashboard/project/features/budget/components/CreateLineItemModal.test.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/CreateLineItemModal.test.tsx
@@ -5,8 +5,14 @@ import { vi, it, expect, beforeAll } from "vitest";
 
 // Mock ModalWithStack
 vi.mock("../../../../../../shared/ui/ModalWithStack", () => ({
-  default: ({ children, ...props }: { children?: React.ReactNode; [key: string]: unknown }) => 
+  default: ({ children, ...props }: { children?: React.ReactNode; [key: string]: unknown }) =>
     React.createElement('div', { 'data-testid': 'modal', ...props }, children),
+}));
+
+vi.mock("@/app/contexts/useData", () => ({
+  useData: () => ({
+    activeProject: { color: "#6E7BFF" },
+  }),
 }));
 
 // Import the component under test

--- a/frontend/src/dashboard/project/features/budget/components/CreateLineItemModal.tsx
+++ b/frontend/src/dashboard/project/features/budget/components/CreateLineItemModal.tsx
@@ -5,6 +5,8 @@ import { faXmark } from "@fortawesome/free-solid-svg-icons";
 import ConfirmModal from "@/shared/ui/ConfirmModal";
 import styles from "./create-line-item-modal.module.css";
 import { parseBudget, formatUSD } from "@/shared/utils/budgetUtils";
+import { useData } from "@/app/contexts/useData";
+import { generateSequentialPalette } from "@/shared/utils/colorUtils";
 
 /* eslint-disable */
 
@@ -262,6 +264,7 @@ const CreateLineItemModal: React.FC<CreateLineItemModalProps> = ({
   submitLabel,
   revision = 1,
 }) => {
+  const { activeProject } = useData();
   const [item, setItem] = useState<ItemForm>({
     ...initialState,
     elementKey: defaultElementKey,
@@ -275,6 +278,46 @@ const CreateLineItemModal: React.FC<CreateLineItemModalProps> = ({
   const touchStartYRef = useRef<number | null>(null);
   const isDraggingRef = useRef(false);
   const lastOffsetRef = useRef(0);
+
+  const accentColor = useMemo(() => {
+    if (typeof activeProject?.color === "string" && activeProject.color.trim() !== "") {
+      const normalized = normalizeHexColor(activeProject.color);
+      if (normalized) {
+        return normalized;
+      }
+    }
+    return DEFAULT_ACCENT_COLOR;
+  }, [activeProject?.color]);
+
+  const accentRgbString = useMemo(() => {
+    const rgb = hexToRgb(accentColor);
+    if (!rgb) return DEFAULT_ACCENT_RGB;
+    return `${rgb[0]}, ${rgb[1]}, ${rgb[2]}`;
+  }, [accentColor]);
+
+  const [gradientStart, gradientEnd] = useMemo(() => {
+    const palette = generateSequentialPalette(accentColor, 3);
+    const start = palette[0] ?? accentColor;
+    const end = palette[palette.length - 1] ?? accentColor;
+    return [start, end] as const;
+  }, [accentColor]);
+
+  const shadowRgbString = useMemo(() => {
+    const rgb = hexToRgb(gradientEnd) ?? hexToRgb(accentColor);
+    if (!rgb) return DEFAULT_SHADOW_RGB;
+    return `${rgb[0]}, ${rgb[1]}, ${rgb[2]}`;
+  }, [gradientEnd, accentColor]);
+
+  const accentStyles = useMemo<React.CSSProperties>(
+    () => ({
+      "--line-item-accent": accentColor,
+      "--line-item-accent-rgb": accentRgbString,
+      "--line-item-accent-gradient-start": gradientStart,
+      "--line-item-accent-gradient-end": gradientEnd,
+      "--line-item-accent-shadow-rgb": shadowRgbString,
+    }),
+    [accentColor, accentRgbString, gradientStart, gradientEnd, shadowRgbString]
+  );
 
   const fieldMap = useMemo(() => {
     const map = new Map<keyof ItemForm, FieldDef>();
@@ -813,6 +856,10 @@ const CreateLineItemModal: React.FC<CreateLineItemModalProps> = ({
     );
   };
 
+  const modalStyle = swipeOffset
+    ? { ...accentStyles, transform: `translateY(${swipeOffset}px)` }
+    : accentStyles;
+
   const portalContent =
     isOpen && typeof document !== "undefined"
       ? createPortal(
@@ -823,7 +870,7 @@ const CreateLineItemModal: React.FC<CreateLineItemModalProps> = ({
               role="dialog"
               aria-modal="true"
               aria-label={title}
-              style={swipeOffset ? { transform: `translateY(${swipeOffset}px)` } : undefined}
+              style={modalStyle}
             >
               <div
                 className={styles.grabZone}
@@ -935,3 +982,35 @@ export default CreateLineItemModal;
 
 
 
+const DEFAULT_ACCENT_COLOR = "#6E7BFF";
+const DEFAULT_ACCENT_RGB = "110, 123, 255";
+const DEFAULT_SHADOW_RGB = "31, 45, 124";
+
+const normalizeHexColor = (value: string): string | null => {
+  const trimmed = value.trim();
+  if (!/^#([0-9a-f]{3}|[0-9a-f]{6})$/i.test(trimmed)) {
+    return null;
+  }
+
+  if (trimmed.length === 4) {
+    const [, r, g, b] = trimmed;
+    return `#${r}${r}${g}${g}${b}${b}`.toUpperCase();
+  }
+
+  return trimmed.toUpperCase();
+};
+
+const hexToRgb = (value: string): [number, number, number] | null => {
+  const normalized = value.startsWith("#") ? value.slice(1) : value;
+  if (normalized.length !== 6) return null;
+
+  const r = Number.parseInt(normalized.slice(0, 2), 16);
+  const g = Number.parseInt(normalized.slice(2, 4), 16);
+  const b = Number.parseInt(normalized.slice(4, 6), 16);
+
+  if ([r, g, b].some((component) => Number.isNaN(component))) {
+    return null;
+  }
+
+  return [r, g, b];
+};

--- a/frontend/src/dashboard/project/features/budget/components/create-line-item-modal.module.css
+++ b/frontend/src/dashboard/project/features/budget/components/create-line-item-modal.module.css
@@ -19,6 +19,11 @@
 }
 
 .sheetModal {
+  --line-item-accent: #6e7bff;
+  --line-item-accent-rgb: 110, 123, 255;
+  --line-item-accent-gradient-start: #6e7bff;
+  --line-item-accent-gradient-end: #4662ff;
+  --line-item-accent-shadow-rgb: 31, 45, 124;
   width: min(640px, 100%);
   max-height: calc(100vh - max(16px, env(safe-area-inset-top)) - max(16px, env(safe-area-inset-bottom)));
   background: rgba(20, 22, 28, 0.96);
@@ -230,9 +235,9 @@
 }
 
 .field:focus-within {
-  border-color: rgba(99, 123, 255, 0.6);
-  background: rgba(99, 123, 255, 0.08);
-  box-shadow: 0 14px 32px rgba(33, 45, 122, 0.25);
+  border-color: rgba(var(--line-item-accent-rgb), 0.6);
+  background: rgba(var(--line-item-accent-rgb), 0.08);
+  box-shadow: 0 14px 32px rgba(var(--line-item-accent-shadow-rgb), 0.25);
 }
 
 .fieldFullWidth {
@@ -268,7 +273,8 @@
 .field select:focus {
   outline: none;
   background: rgba(18, 20, 26, 0.96);
-  box-shadow: 0 0 0 1px rgba(99, 123, 255, 0.8), 0 16px 28px rgba(31, 45, 124, 0.25);
+  box-shadow: 0 0 0 1px rgba(var(--line-item-accent-rgb), 0.8),
+    0 16px 28px rgba(var(--line-item-accent-shadow-rgb), 0.25);
 }
 
 .field input:disabled,
@@ -371,14 +377,18 @@
 }
 
 .primaryButton {
-  background: linear-gradient(135deg, #6e7bff, #4662ff);
+  background: linear-gradient(
+    135deg,
+    var(--line-item-accent-gradient-start),
+    var(--line-item-accent-gradient-end)
+  );
   color: #0b0c10;
-  box-shadow: 0 14px 28px rgba(70, 98, 255, 0.35);
+  box-shadow: 0 14px 28px rgba(var(--line-item-accent-shadow-rgb), 0.35);
 }
 
 .primaryButton:hover {
   transform: translateY(-1px);
-  box-shadow: 0 16px 34px rgba(70, 98, 255, 0.45);
+  box-shadow: 0 16px 34px rgba(var(--line-item-accent-shadow-rgb), 0.45);
 }
 
 .primaryButton:active {


### PR DESCRIPTION
## Summary
- derive the create line item modal accent styles from the active project color via context
- replace hard-coded highlight colors with CSS variables and gradients tied to the computed accent
- update the modal unit test to stub the project data context

## Testing
- npm run test -- CreateLineItemModal.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e8664bd2b0832488e2710efc00a948