### PR TITLE
Fix work post overlay mask closing path

### DIFF
--- a/frontend/src/pages/works/allworkposts/1-sens-c.tsx
+++ b/frontend/src/pages/works/allworkposts/1-sens-c.tsx
@@ -189,7 +189,7 @@ const SensC = () => {
           ease: "Power1.easeIn"
         })
         .to("#revealPath", {
-          attr: { d: "M0,2S175,1,500,1s500,1,500,1V0H0Z" }, // Final state
+          attr: { d: "M0,0S175,0,500,0s500,0,500,0V0H0Z" }, // Final state
           duration: 0.5,
           ease: "power1.easeOut"
         });

--- a/frontend/src/pages/works/allworkposts/A-Flower-Bath.tsx
+++ b/frontend/src/pages/works/allworkposts/A-Flower-Bath.tsx
@@ -185,7 +185,7 @@ const AFLowerBath = () => {
       duration: 0.75,
       ease: "power1.in",
     }).to("#revealPath", {
-      attr: { d: "M0,2S175,1,500,1s500,1,500,1V0H0Z" },
+      attr: { d: "M0,0S175,0,500,0s500,0,500,0V0H0Z" },
       duration: 0.5,
       ease: "power1.out",
     });

--- a/frontend/src/pages/works/allworkposts/Academy-of-Pop.tsx
+++ b/frontend/src/pages/works/allworkposts/Academy-of-Pop.tsx
@@ -274,7 +274,7 @@ const AcademyOfPop = () => {
                 ease: "Power1.easeIn"
             }).to("#revealPath", {
                 attr: {
-                    d: "M0,2S175,1,500,1s500,1,500,1V0H0Z"
+                    d: "M0,0S175,0,500,0s500,0,500,0V0H0Z"
                 },
                 duration: 0.5,
                 ease: "power1.easeOut"

--- a/frontend/src/pages/works/allworkposts/Agenda-Festival.tsx
+++ b/frontend/src/pages/works/allworkposts/Agenda-Festival.tsx
@@ -230,7 +230,7 @@ const AgendaFestival = () => {
                 ease: "Power1.easeIn"
             }).to("#revealPath", {
                 attr: {
-                    d: "M0,2S175,1,500,1s500,1,500,1V0H0Z"
+                    d: "M0,0S175,0,500,0s500,0,500,0V0H0Z"
                 },
                 duration: 0.5,
                 ease: "power1.easeOut"

--- a/frontend/src/pages/works/allworkposts/Barebells.tsx
+++ b/frontend/src/pages/works/allworkposts/Barebells.tsx
@@ -270,7 +270,7 @@ type WorkItem = {
                 ease: "Power1.easeIn"
             }).to("#revealPath", {
                 attr: {
-                    d: "M0,2S175,1,500,1s500,1,500,1V0H0Z"
+                    d: "M0,0S175,0,500,0s500,0,500,0V0H0Z"
                 },
                 duration: 0.5,
                 ease: "power1.easeOut"

--- a/frontend/src/pages/works/allworkposts/Be-Sweet-16.tsx
+++ b/frontend/src/pages/works/allworkposts/Be-Sweet-16.tsx
@@ -235,7 +235,7 @@ const BeSweet16 = () => {
                 ease: "Power1.easeIn"
             }).to("#revealPath", {
                 attr: {
-                    d: "M0,2S175,1,500,1s500,1,500,1V0H0Z"
+                    d: "M0,0S175,0,500,0s500,0,500,0V0H0Z"
                 },
                 duration: 0.5,
                 ease: "power1.easeOut"

--- a/frontend/src/pages/works/allworkposts/Bloom-and-Bliss.tsx
+++ b/frontend/src/pages/works/allworkposts/Bloom-and-Bliss.tsx
@@ -265,7 +265,7 @@ const BloomAndBliss = () => {
                 ease: "Power1.easeIn"
             }).to("#revealPath", {
                 attr: {
-                    d: "M0,2S175,1,500,1s500,1,500,1V0H0Z"
+                    d: "M0,0S175,0,500,0s500,0,500,0V0H0Z"
                 },
                 duration: 0.5,
                 ease: "power1.easeOut"

--- a/frontend/src/pages/works/allworkposts/Chevron.tsx
+++ b/frontend/src/pages/works/allworkposts/Chevron.tsx
@@ -210,7 +210,7 @@ const Chevron = () => {
                 ease: "Power1.easeIn"
             }).to("#revealPath", {
                 attr: {
-                    d: "M0,2S175,1,500,1s500,1,500,1V0H0Z"
+                    d: "M0,0S175,0,500,0s500,0,500,0V0H0Z"
                 },
                 duration: 0.5,
                 ease: "power1.easeOut"

--- a/frontend/src/pages/works/allworkposts/D-ROCK.tsx
+++ b/frontend/src/pages/works/allworkposts/D-ROCK.tsx
@@ -187,7 +187,7 @@ const DRock = () => {
           ease: "Power1.easeIn"
         })
         .to("#revealPath", {
-          attr: { d: "M0,2S175,1,500,1s500,1,500,1V0H0Z" }, // Final state
+          attr: { d: "M0,0S175,0,500,0s500,0,500,0V0H0Z" }, // Final state
           duration: 0.5,
           ease: "power1.easeOut"
         });

--- a/frontend/src/pages/works/allworkposts/Frank-Zummo-Sum41.tsx
+++ b/frontend/src/pages/works/allworkposts/Frank-Zummo-Sum41.tsx
@@ -215,7 +215,7 @@ const FrankZummoSum41 = () => {
           ease: "Power1.easeIn"
         })
         .to("#revealPath", {
-          attr: { d: "M0,2S175,1,500,1s500,1,500,1V0H0Z" }, // Final state
+          attr: { d: "M0,0S175,0,500,0s500,0,500,0V0H0Z" }, // Final state
           duration: 0.5,
           ease: "power1.easeOut"
         });

--- a/frontend/src/pages/works/allworkposts/Ghost-Circus-Apparel.tsx
+++ b/frontend/src/pages/works/allworkposts/Ghost-Circus-Apparel.tsx
@@ -262,7 +262,7 @@ const GhostCircusApparel = () => {
                 ease: "Power1.easeIn"
             }).to("#revealPath", {
                 attr: {
-                    d: "M0,2S175,1,500,1s500,1,500,1V0H0Z"
+                    d: "M0,0S175,0,500,0s500,0,500,0V0H0Z"
                 },
                 duration: 0.5,
                 ease: "power1.easeOut"

--- a/frontend/src/pages/works/allworkposts/Goldru$h.tsx
+++ b/frontend/src/pages/works/allworkposts/Goldru$h.tsx
@@ -228,7 +228,7 @@ const Goldru$h = () => {
                 })
                 .to("#revealPath", {
                     attr: {
-                        d: "M0,2S175,1,500,1s500,1,500,1V0H0Z",
+                        d: "M0,0S175,0,500,0s500,0,500,0V0H0Z",
                     },
                     duration: 0.5,
                     ease: "power1.easeOut",

--- a/frontend/src/pages/works/allworkposts/Gucci-Aria.tsx
+++ b/frontend/src/pages/works/allworkposts/Gucci-Aria.tsx
@@ -243,7 +243,7 @@ const { opacity } = useData();
                 ease: "Power1.easeIn"
             }).to("#revealPath", {
                 attr: {
-                    d: "M0,2S175,1,500,1s500,1,500,1V0H0Z"
+                    d: "M0,0S175,0,500,0s500,0,500,0V0H0Z"
                 },
                 duration: 0.5,
                 ease: "power1.easeOut"

--- a/frontend/src/pages/works/allworkposts/J22-INTERIORS.tsx
+++ b/frontend/src/pages/works/allworkposts/J22-INTERIORS.tsx
@@ -230,7 +230,7 @@ const J22Interiors = () => {
                 ease: "Power1.easeIn"
             }).to("#revealPath", {
                 attr: {
-                    d: "M0,2S175,1,500,1s500,1,500,1V0H0Z"
+                    d: "M0,0S175,0,500,0s500,0,500,0V0H0Z"
                 },
                 duration: 0.5,
                 ease: "power1.easeOut"

--- a/frontend/src/pages/works/allworkposts/Jewelie-Stark.tsx
+++ b/frontend/src/pages/works/allworkposts/Jewelie-Stark.tsx
@@ -187,7 +187,7 @@ const JewelieStark = () => {
           ease: "Power1.easeIn"
         })
         .to("#revealPath", {
-          attr: { d: "M0,2S175,1,500,1s500,1,500,1V0H0Z" }, // Final state
+          attr: { d: "M0,0S175,0,500,0s500,0,500,0V0H0Z" }, // Final state
           duration: 0.5,
           ease: "power1.easeOut"
         });

--- a/frontend/src/pages/works/allworkposts/Keys-Art-Basel.tsx
+++ b/frontend/src/pages/works/allworkposts/Keys-Art-Basel.tsx
@@ -260,7 +260,7 @@ useEffect(() => {
                 ease: "Power1.easeIn"
             }).to("#revealPath", {
                 attr: {
-                    d: "M0,2S175,1,500,1s500,1,500,1V0H0Z"
+                    d: "M0,0S175,0,500,0s500,0,500,0V0H0Z"
                 },
                 duration: 0.5,
                 ease: "power1.easeOut"

--- a/frontend/src/pages/works/allworkposts/Keys-Soulcare.tsx
+++ b/frontend/src/pages/works/allworkposts/Keys-Soulcare.tsx
@@ -250,7 +250,7 @@ const KeysSoulcare = () => {
                 ease: "Power1.easeIn"
             }).to("#revealPath", {
                 attr: {
-                    d: "M0,2S175,1,500,1s500,1,500,1V0H0Z"
+                    d: "M0,0S175,0,500,0s500,0,500,0V0H0Z"
                 },
                 duration: 0.5,
                 ease: "power1.easeOut"

--- a/frontend/src/pages/works/allworkposts/Logitech.tsx
+++ b/frontend/src/pages/works/allworkposts/Logitech.tsx
@@ -81,7 +81,7 @@ const Logitech = () => {
                 ease: "Power1.easeIn"
             })
             .to("#revealPath", {
-                attr: { d: "M0,2S175,1,500,1s500,1,500,1V0H0Z" },
+                attr: { d: "M0,0S175,0,500,0s500,0,500,0V0H0Z" },
                 duration: 0.5,
                 ease: "power1.easeOut"
             });

--- a/frontend/src/pages/works/allworkposts/MZ-Stellar-Brass.tsx
+++ b/frontend/src/pages/works/allworkposts/MZ-Stellar-Brass.tsx
@@ -273,7 +273,7 @@ const MZ = () => {
                 })
                 .to("#revealPath", {
                     attr: {
-                        d: "M0,2S175,1,500,1s500,1,500,1V0H0Z",
+                        d: "M0,0S175,0,500,0s500,0,500,0V0H0Z",
                     },
                     duration: 0.5,
                     ease: "power1.easeOut",

--- a/frontend/src/pages/works/allworkposts/Machine-Head.tsx
+++ b/frontend/src/pages/works/allworkposts/Machine-Head.tsx
@@ -187,7 +187,7 @@ const MachineHead = () => {
           ease: "Power1.easeIn"
         })
         .to("#revealPath", {
-          attr: { d: "M0,2S175,1,500,1s500,1,500,1V0H0Z" }, // Final state
+          attr: { d: "M0,0S175,0,500,0s500,0,500,0V0H0Z" }, // Final state
           duration: 0.5,
           ease: "power1.easeOut"
         });

--- a/frontend/src/pages/works/allworkposts/Mistifi-Vape.tsx
+++ b/frontend/src/pages/works/allworkposts/Mistifi-Vape.tsx
@@ -254,7 +254,7 @@ const MistifiVape = () => {
                 ease: "Power1.easeIn"
             }).to("#revealPath", {
                 attr: {
-                    d: "M0,2S175,1,500,1s500,1,500,1V0H0Z"
+                    d: "M0,0S175,0,500,0s500,0,500,0V0H0Z"
                 },
                 duration: 0.5,
                 ease: "power1.easeOut"

--- a/frontend/src/pages/works/allworkposts/NOCCO.tsx
+++ b/frontend/src/pages/works/allworkposts/NOCCO.tsx
@@ -241,7 +241,7 @@ const Nocco = () => {
                 ease: "Power1.easeIn"
             }).to("#revealPath", {
                 attr: {
-                    d: "M0,2S175,1,500,1s500,1,500,1V0H0Z"
+                    d: "M0,0S175,0,500,0s500,0,500,0V0H0Z"
                 },
                 duration: 0.5,
                 ease: "power1.easeOut"

--- a/frontend/src/pages/works/allworkposts/Nike-Femme.tsx
+++ b/frontend/src/pages/works/allworkposts/Nike-Femme.tsx
@@ -189,7 +189,7 @@ const NikeFemme = () => {
           ease: "Power1.easeIn"
         })
         .to("#revealPath", {
-          attr: { d: "M0,2S175,1,500,1s500,1,500,1V0H0Z" }, // Final state
+          attr: { d: "M0,0S175,0,500,0s500,0,500,0V0H0Z" }, // Final state
           duration: 0.5,
           ease: "power1.easeOut"
         });

--- a/frontend/src/pages/works/allworkposts/Now-United.tsx
+++ b/frontend/src/pages/works/allworkposts/Now-United.tsx
@@ -279,7 +279,7 @@ const Barebells = () => {
                 ease: "Power1.easeIn"
             }).to("#revealPath", {
                 attr: {
-                    d: "M0,2S175,1,500,1s500,1,500,1V0H0Z"
+                    d: "M0,0S175,0,500,0s500,0,500,0V0H0Z"
                 },
                 duration: 0.5,
                 ease: "power1.easeOut"

--- a/frontend/src/pages/works/allworkposts/Pipe-Dream-Events.tsx
+++ b/frontend/src/pages/works/allworkposts/Pipe-Dream-Events.tsx
@@ -171,7 +171,7 @@ const PipedDreamEvents = () => {
         })
         .to("#revealPath", {
           attr: {
-            d: "M0,2S175,1,500,1s500,1,500,1V0H0Z",
+            d: "M0,0S175,0,500,0s500,0,500,0V0H0Z",
           },
           duration: 0.5,
           ease: "power1.easeOut",

--- a/frontend/src/pages/works/allworkposts/Solo-J.tsx
+++ b/frontend/src/pages/works/allworkposts/Solo-J.tsx
@@ -186,7 +186,7 @@ const SoloJ = () => {
           ease: "Power1.easeIn"
         })
         .to("#revealPath", {
-          attr: { d: "M0,2S175,1,500,1s500,1,500,1V0H0Z" }, // Final state
+          attr: { d: "M0,0S175,0,500,0s500,0,500,0V0H0Z" }, // Final state
           duration: 0.5,
           ease: "power1.easeOut"
         });

--- a/frontend/src/pages/works/allworkposts/TROIA.tsx
+++ b/frontend/src/pages/works/allworkposts/TROIA.tsx
@@ -272,7 +272,7 @@ const Troia = () => {
                 ease: "Power1.easeIn"
             }).to("#revealPath", {
                 attr: {
-                    d: "M0,2S175,1,500,1s500,1,500,1V0H0Z"
+                    d: "M0,0S175,0,500,0s500,0,500,0V0H0Z"
                 },
                 duration: 0.5,
                 ease: "power1.easeOut"

--- a/frontend/src/pages/works/allworkposts/The-Oscars.tsx
+++ b/frontend/src/pages/works/allworkposts/The-Oscars.tsx
@@ -216,7 +216,7 @@ const TheOscars = () => {
                 ease: "Power1.easeIn"
             }).to("#revealPath", {
                 attr: {
-                    d: "M0,2S175,1,500,1s500,1,500,1V0H0Z"
+                    d: "M0,0S175,0,500,0s500,0,500,0V0H0Z"
                 },
                 duration: 0.5,
                 ease: "power1.easeOut"

--- a/frontend/src/pages/works/allworkposts/The-Party-Never-Ends.tsx
+++ b/frontend/src/pages/works/allworkposts/The-Party-Never-Ends.tsx
@@ -251,7 +251,7 @@ const ThePartyNeverEnds = () => {
                 ease: "Power1.easeIn"
             }).to("#revealPath", {
                 attr: {
-                    d: "M0,2S175,1,500,1s500,1,500,1V0H0Z"
+                    d: "M0,0S175,0,500,0s500,0,500,0V0H0Z"
                 },
                 duration: 0.5,
                 ease: "power1.easeOut"

--- a/frontend/src/pages/works/allworkposts/The-gold-princess.tsx
+++ b/frontend/src/pages/works/allworkposts/The-gold-princess.tsx
@@ -189,7 +189,7 @@ const TheGoldPrincess = () => {
           ease: "Power1.easeIn"
         })
         .to("#revealPath", {
-          attr: { d: "M0,2S175,1,500,1s500,1,500,1V0H0Z" }, // Final state
+          attr: { d: "M0,0S175,0,500,0s500,0,500,0V0H0Z" }, // Final state
           duration: 0.5,
           ease: "power1.easeOut"
         });

--- a/frontend/src/pages/works/allworkposts/Ulta.tsx
+++ b/frontend/src/pages/works/allworkposts/Ulta.tsx
@@ -208,7 +208,7 @@ const Ulta = () => {
                 ease: "Power1.easeIn"
             }).to("#revealPath", {
                 attr: {
-                    d: "M0,2S175,1,500,1s500,1,500,1V0H0Z"
+                    d: "M0,0S175,0,500,0s500,0,500,0V0H0Z"
                 },
                 duration: 0.5,
                 ease: "power1.easeOut"

--- a/frontend/src/pages/works/allworkposts/brand-by-people.tsx
+++ b/frontend/src/pages/works/allworkposts/brand-by-people.tsx
@@ -186,7 +186,7 @@ const BrandByPeople = () => {
           ease: "Power1.easeIn"
         })
         .to("#revealPath", {
-          attr: { d: "M0,2S175,1,500,1s500,1,500,1V0H0Z" }, // Final state
+          attr: { d: "M0,0S175,0,500,0s500,0,500,0V0H0Z" }, // Final state
           duration: 0.5,
           ease: "power1.easeOut"
         });

--- a/frontend/src/pages/works/allworkposts/elf-Makeup-Hollywood-Bowl.tsx
+++ b/frontend/src/pages/works/allworkposts/elf-Makeup-Hollywood-Bowl.tsx
@@ -245,7 +245,7 @@ const ElfMakeUpHollywoodBowl = () => {
                 ease: "Power1.easeIn"
             }).to("#revealPath", {
                 attr: {
-                    d: "M0,2S175,1,500,1s500,1,500,1V0H0Z"
+                    d: "M0,0S175,0,500,0s500,0,500,0V0H0Z"
                 },
                 duration: 0.5,
                 ease: "power1.easeOut"

--- a/frontend/src/pages/works/allworkposts/elf-Makeup.tsx
+++ b/frontend/src/pages/works/allworkposts/elf-Makeup.tsx
@@ -321,7 +321,7 @@ const ElfMakeup = () => {
                 ease: "Power1.easeIn"
             }).to("#revealPath", {
                 attr: {
-                    d: "M0,2S175,1,500,1s500,1,500,1V0H0Z"
+                    d: "M0,0S175,0,500,0s500,0,500,0V0H0Z"
                 },
                 duration: 0.5,
                 ease: "power1.easeOut"

--- a/frontend/src/pages/works/allworkposts/elf-studio.tsx
+++ b/frontend/src/pages/works/allworkposts/elf-studio.tsx
@@ -261,7 +261,7 @@ useEffect(() => {
                 ease: "Power1.easeIn"
             })
             .to("#revealPath", {
-                attr: { d: "M0,2S175,1,500,1s500,1,500,1V0H0Z" },
+                attr: { d: "M0,0S175,0,500,0s500,0,500,0V0H0Z" },
                 duration: 0.5,
                 ease: "power1.easeOut"
             });

--- a/frontend/src/pages/works/allworkposts/gatane.tsx
+++ b/frontend/src/pages/works/allworkposts/gatane.tsx
@@ -187,7 +187,7 @@ const Gatane = () => {
           ease: "Power1.easeIn"
         })
         .to("#revealPath", {
-          attr: { d: "M0,2S175,1,500,1s500,1,500,1V0H0Z" }, // Final state
+          attr: { d: "M0,0S175,0,500,0s500,0,500,0V0H0Z" }, // Final state
           duration: 0.5,
           ease: "power1.easeOut"
         });

--- a/frontend/src/pages/works/allworkposts/km-tour.tsx
+++ b/frontend/src/pages/works/allworkposts/km-tour.tsx
@@ -216,7 +216,7 @@ const KmTour = () => {
                 ease: "Power1.easeIn"
             }).to("#revealPath", {
                 attr: {
-                    d: "M0,2S175,1,500,1s500,1,500,1V0H0Z"
+                    d: "M0,0S175,0,500,0s500,0,500,0V0H0Z"
                 },
                 duration: 0.5,
                 ease: "power1.easeOut"

--- a/frontend/src/pages/works/allworkposts/natasha-bedingfield.tsx
+++ b/frontend/src/pages/works/allworkposts/natasha-bedingfield.tsx
@@ -234,7 +234,7 @@ const NatashaBedingfield = () => {
                 ease: "Power1.easeIn"
             }).to("#revealPath", {
                 attr: {
-                    d: "M0,2S175,1,500,1s500,1,500,1V0H0Z"
+                    d: "M0,0S175,0,500,0s500,0,500,0V0H0Z"
                 },
                 duration: 0.5,
                 ease: "power1.easeOut"

--- a/frontend/src/pages/works/allworkposts/strikefit.tsx
+++ b/frontend/src/pages/works/allworkposts/strikefit.tsx
@@ -228,7 +228,7 @@ const StrikeFit = () => {
                 ease: "Power1.easeIn"
             }).to("#revealPath", {
                 attr: {
-                    d: "M0,2S175,1,500,1s500,1,500,1V0H0Z"
+                    d: "M0,0S175,0,500,0s500,0,500,0V0H0Z"
                 },
                 duration: 0.5,
                 ease: "power1.easeOut"

--- a/frontend/src/pages/works/allworkposts/yanis.tsx
+++ b/frontend/src/pages/works/allworkposts/yanis.tsx
@@ -184,7 +184,7 @@ const Yanis = () => {
           ease: "Power1.easeIn"
         })
         .to("#revealPath", {
-          attr: { d: "M0,2S175,1,500,1s500,1,500,1V0H0Z" }, // Final state
+          attr: { d: "M0,0S175,0,500,0s500,0,500,0V0H0Z" }, // Final state
           duration: 0.5,
           ease: "power1.easeOut"
         });


### PR DESCRIPTION
## Summary
- ensure the work post SVG reveal animations end at y=0
- remove the persistent overlay band by adjusting the final mask path on each page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e8782f4a548324b8f2036777acd2e9