### PR TITLE
Portal header overlay to body for iOS viewport stability

### DIFF
--- a/frontend/src/shared/ui/Header.tsx
+++ b/frontend/src/shared/ui/Header.tsx
@@ -17,10 +17,15 @@ import ScrambleText from "scramble-text";
 const Headermain: React.FC = () => {
     // portal root for overlay (escapes transforms/backdrop-filters)
     const overlayRoot = useMemo(() => {
+        const existing = document.getElementById("overlay-root");
+        if (existing) {
+            return existing as HTMLDivElement;
+        }
         const el = document.createElement("div");
         el.id = "overlay-root";
         return el;
     }, []);
+    const [isPortalReady, setIsPortalReady] = useState(false);
     useInactivityLogout();
     const location = useLocation();
     const navigate = useNavigate();
@@ -87,6 +92,8 @@ const Headermain: React.FC = () => {
     });
 
     useEffect(() => {
+        if (!isPortalReady) return;
+
         gsap.set(".span-open", {
             attr: { d: "M0 2S175 1 500 1s500 1 500 1V0H0Z" }
         });
@@ -96,14 +103,14 @@ const Headermain: React.FC = () => {
                 attr: { d: "M0 502S175 272 500 272s500 230 500 230V0H0Z" },
                 ease: "Power2.easeIn",
                 onStart: () => {
-                    const navMenu = document.querySelector(".nav-bar-menu") as HTMLElement;
+                    const navMenu = overlayRoot.querySelector(".nav-bar-menu") as HTMLElement | null;
                     if (navMenu) {
                         navMenu.classList.add("opened");
-                        gsap.set(".nav-bar-menu", { visibility: "visible" });
+                        gsap.set(navMenu, { visibility: "visible" });
                     }
                 },
                 onReverseComplete: () => {
-                    const navMenu = document.querySelector(".nav-bar-menu") as HTMLElement;
+                    const navMenu = overlayRoot.querySelector(".nav-bar-menu") as HTMLElement | null;
                     if (navMenu) {
                         navMenu.classList.remove("opened");
                     }
@@ -124,7 +131,12 @@ const Headermain: React.FC = () => {
             .eventCallback("onComplete", () => {
                 setActive(true);
             });
-    }, []);
+
+        return () => {
+            menuAnimation.current?.kill();
+            menuAnimation.current = null;
+        };
+    }, [isPortalReady, overlayRoot]);
 
     const handleToggle = (): void => {
         if (isActive) {
@@ -150,13 +162,17 @@ const Headermain: React.FC = () => {
 
     // mount portal root once
     useEffect(() => {
-        document.body.appendChild(overlayRoot);
+        if (!overlayRoot.parentElement) {
+            document.body.appendChild(overlayRoot);
+        }
+        setIsPortalReady(true);
         return () => {
             if (overlayRoot.parentElement) {
                 overlayRoot.parentElement.removeChild(overlayRoot);
             }
             document.body.classList.remove("menu-open");
             document.body.classList.remove("ovhidden");
+            setIsPortalReady(false);
         };
     }, [overlayRoot]);
 
@@ -211,7 +227,9 @@ const Headermain: React.FC = () => {
     }, []);
 
     useEffect(() => {
-        const root = document.querySelector(".nav-bar-menu") as HTMLElement | null;
+        if (!isPortalReady) return;
+
+        const root = overlayRoot.querySelector(".nav-bar-menu") as HTMLElement | null;
         if (!root) return;
 
         const fitOverlayToViewport = () => {
@@ -240,7 +258,7 @@ const Headermain: React.FC = () => {
             vv.removeEventListener("resize", handleViewportChange);
             vv.removeEventListener("scroll", handleViewportChange);
         };
-    }, []);
+    }, [isPortalReady, overlayRoot]);
 
     return (
         <>
@@ -292,7 +310,7 @@ const Headermain: React.FC = () => {
                         </button>
                     </div>
                 </div>
-                {createPortal(
+                {isPortalReady && createPortal(
                     <div className="nav-bar-menu" role="dialog" aria-modal="true">
                         <div className="svg-wrapper">
                             <svg viewBox="0 0 1000 1000" preserveAspectRatio="none">

--- a/frontend/src/shared/ui/Header.tsx
+++ b/frontend/src/shared/ui/Header.tsx
@@ -1,4 +1,5 @@
-import React, { useRef, useState, useEffect } from "react";
+import React, { useRef, useState, useEffect, useMemo } from "react";
+import { createPortal } from "react-dom";
 import { useNavigate, useLocation, Link } from "react-router-dom";
 
 // Use modular shared styles (already globally imported in main.tsx)
@@ -14,6 +15,12 @@ import gsap from "gsap";
 import ScrambleText from "scramble-text";
 
 const Headermain: React.FC = () => {
+    // portal root for overlay (escapes transforms/backdrop-filters)
+    const overlayRoot = useMemo(() => {
+        const el = document.createElement("div");
+        el.id = "overlay-root";
+        return el;
+    }, []);
     useInactivityLogout();
     const location = useLocation();
     const navigate = useNavigate();
@@ -122,6 +129,7 @@ const Headermain: React.FC = () => {
     const handleToggle = (): void => {
         if (isActive) {
             document.body.classList.remove("ovhidden");
+            document.body.classList.remove("menu-open");
             if (menuAnimation.current) {
                 menuAnimation.current.reverse();
                 menuAnimation.current.eventCallback("onReverseComplete", () => setActive(false));
@@ -130,6 +138,7 @@ const Headermain: React.FC = () => {
             }
         } else {
             document.body.classList.add("ovhidden");
+            document.body.classList.add("menu-open"); // enables solid underlay
             if (menuAnimation.current) {
                 menuAnimation.current.play();
                 menuAnimation.current.eventCallback("onComplete", () => setActive(true));
@@ -138,6 +147,18 @@ const Headermain: React.FC = () => {
             }
         }
     };
+
+    // mount portal root once
+    useEffect(() => {
+        document.body.appendChild(overlayRoot);
+        return () => {
+            if (overlayRoot.parentElement) {
+                overlayRoot.parentElement.removeChild(overlayRoot);
+            }
+            document.body.classList.remove("menu-open");
+            document.body.classList.remove("ovhidden");
+        };
+    }, [overlayRoot]);
 
     const handleDashboardHomeClick = (): void => {
         navigate("/dashboard");
@@ -186,6 +207,38 @@ const Headermain: React.FC = () => {
         window.addEventListener("resize", handleResize);
         return () => {
             window.removeEventListener("resize", handleResize);
+        };
+    }, []);
+
+    useEffect(() => {
+        const root = document.querySelector(".nav-bar-menu") as HTMLElement | null;
+        if (!root) return;
+
+        const fitOverlayToViewport = () => {
+            const vv = window.visualViewport;
+            if (!vv) return; // older iOS
+            root.style.position = "fixed";
+            root.style.left = `${vv.offsetLeft}px`;
+            root.style.top = `${vv.offsetTop}px`;
+            root.style.width = `${vv.width}px`;
+            root.style.height = `${vv.height}px`;
+        };
+
+        fitOverlayToViewport();
+
+        const vv = window.visualViewport;
+        if (!vv) return;
+
+        const handleViewportChange = () => {
+            fitOverlayToViewport();
+        };
+
+        vv.addEventListener("resize", handleViewportChange, { passive: true });
+        vv.addEventListener("scroll", handleViewportChange, { passive: true });
+
+        return () => {
+            vv.removeEventListener("resize", handleViewportChange);
+            vv.removeEventListener("scroll", handleViewportChange);
         };
     }, []);
 
@@ -239,67 +292,67 @@ const Headermain: React.FC = () => {
                         </button>
                     </div>
                 </div>
-                <div className="nav-bar-menu">
-                    <div className="svg-wrapper">
-                        <svg viewBox="0 0 1000 1000" preserveAspectRatio="none">
-                            <path 
-                                className="span-open" 
-                                d="M0 2S175 1 500 1s500 1 500 1V0H0Z" 
-                                fill="#0c0c0c" 
-                            />
-                        </svg>
-                    </div>
-                    <div className="menu-wrapper">
-                        <div className="menu-container">
-                            <ul className="menu">
-                                <li className="menu-item">
-                                    <Link onClick={handleToggle} to="/" className="my-3">
-                                        HOME
-                                    </Link>
-                                </li>
-                                <li className="menu-item">
-                                    <Link 
-                                        onClick={handleToggle} 
-                                        to="/works" 
-                                        className={`my-3 sign-out-link ${getLinkClass("/works")}`}
-                                    >
-                                        SHOWCASE
-                                    </Link>
-                                </li>
-                                <li className="menu-item">
-                                    {isAuthenticated ? (
-                                        <Link 
-                                            onClick={handleToggle} 
-                                            to="/dashboard" 
-                                            className={`my-3 sign-out-link ${getLinkClass("/dashboard")}`}
-                                        >
-                                            DASHBOARD
-                                        </Link>
-                                    ) : (
-                                        <Link 
-                                            onClick={handleToggle} 
-                                            to="/login" 
-                                            className={`my-3 sign-out-link ${getLinkClass("/login")}`}
-                                        >
-                                            LOGIN
-                                        </Link>
-                                    )}
-                                </li>
-                                <li className="menu-item">
-                                    {isAuthenticated ? (
-                                        <Link onClick={handleSignOut} to="/login" className="my-3 sign-out-link">
-                                            SIGN-OUT
-                                        </Link>
-                                    ) : (
-                                        <Link onClick={handleToggle} to="/register" className="my-3">
-                                            SIGN UP
-                                        </Link>
-                                    )}
-                                </li>
-                            </ul>
+                {createPortal(
+                    <div className="nav-bar-menu" role="dialog" aria-modal="true">
+                        <div className="svg-wrapper">
+                            <svg viewBox="0 0 1000 1000" preserveAspectRatio="none">
+                                <path className="span-open" d="M0 2S175 1 500 1s500 1 500 1V0H0Z" fill="#0c0c0c" />
+                            </svg>
                         </div>
-                    </div>
-                </div>
+                        <div className="menu-wrapper">
+                            <div className="menu-container">
+                                <ul className="menu">
+                                    {/* same items as before */}
+                                    <li className="menu-item">
+                                        <Link onClick={handleToggle} to="/" className="my-3">
+                                            HOME
+                                        </Link>
+                                    </li>
+                                    <li className="menu-item">
+                                        <Link
+                                            onClick={handleToggle}
+                                            to="/works"
+                                            className={`my-3 sign-out-link ${getLinkClass("/works")}`}
+                                        >
+                                            SHOWCASE
+                                        </Link>
+                                    </li>
+                                    <li className="menu-item">
+                                        {isAuthenticated ? (
+                                            <Link
+                                                onClick={handleToggle}
+                                                to="/dashboard"
+                                                className={`my-3 sign-out-link ${getLinkClass("/dashboard")}`}
+                                            >
+                                                DASHBOARD
+                                            </Link>
+                                        ) : (
+                                            <Link
+                                                onClick={handleToggle}
+                                                to="/login"
+                                                className={`my-3 sign-out-link ${getLinkClass("/login")}`}
+                                            >
+                                                LOGIN
+                                            </Link>
+                                        )}
+                                    </li>
+                                    <li className="menu-item">
+                                        {isAuthenticated ? (
+                                            <Link onClick={handleSignOut} to="/login" className="my-3 sign-out-link">
+                                                SIGN-OUT
+                                            </Link>
+                                        ) : (
+                                            <Link onClick={handleToggle} to="/register" className="my-3">
+                                                SIGN UP
+                                            </Link>
+                                        )}
+                                    </li>
+                                </ul>
+                            </div>
+                        </div>
+                    </div>,
+                    overlayRoot
+                )}
             </header>
         </>
     );

--- a/frontend/src/shared/ui/Header.tsx
+++ b/frontend/src/shared/ui/Header.tsx
@@ -312,6 +312,14 @@ const Headermain: React.FC = () => {
                 </div>
                 {isPortalReady && createPortal(
                     <div className="nav-bar-menu" role="dialog" aria-modal="true">
+                        <button
+                            type="button"
+                            className="toggle-button overlay-close-button"
+                            onClick={handleToggle}
+                            aria-label="Close menu"
+                        >
+                            <Menuopened />
+                        </button>
                         <div className="svg-wrapper">
                             <svg viewBox="0 0 1000 1000" preserveAspectRatio="none">
                                 <path className="span-open" d="M0 2S175 1 500 1s500 1 500 1V0H0Z" fill="#0c0c0c" />

--- a/frontend/src/shared/ui/header.css
+++ b/frontend/src/shared/ui/header.css
@@ -1,3 +1,22 @@
+html,
+body {
+  background: #0c0c0c;
+}
+
+body.menu-open {
+  overflow: hidden;
+  isolation: isolate;
+}
+
+body.menu-open::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background: #0c0c0c;
+  z-index: 2147483646;
+  pointer-events: none;
+}
+
 .menu {
   padding-left: 0;
   padding-top: 10vh;
@@ -31,28 +50,17 @@
   color: var(--text-color-2);
 }
 
-.nav-bar-menu {
-  z-index: 1;
+.svg-wrapper,
+.svg-wrapper svg {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
 }
 
 .svg-wrapper {
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
   z-index: 1;
-  pointer-events: none;
-
-}
-
-.svg-wrapper svg {
-  width: 100%;
-  height: 105vh;
-  /* Viewport height */
-
-  top: 0;
-  left: 0;
 }
 
 
@@ -230,16 +238,21 @@
 }
 
 .nav-bar-menu {
-  height: 100%;
-  left: 0;
-  overflow: hidden;
   position: fixed;
-  top: 0;
-  width: 100%;
+  inset: 0;
+  z-index: 2147483647;
+  background: #0c0c0c;
+  padding:
+    calc(env(safe-area-inset-top) + 16px)
+    calc(env(safe-area-inset-right) + 16px)
+    calc(env(safe-area-inset-bottom) + 24px)
+    calc(env(safe-area-inset-left) + 16px);
+  visibility: hidden;
   pointer-events: none;
 }
 
 .nav-bar-menu.opened {
+  visibility: visible;
   pointer-events: all;
 }
 
@@ -264,8 +277,9 @@
 .menu-wrapper {
   position: relative;
   width: 100%;
-  height: 100vh;
-  overflow: hidden auto;
+  height: 100%;
+  overflow: auto;
+  -webkit-overflow-scrolling: touch;
   z-index: 5;
 }
 

--- a/frontend/src/shared/ui/header.css
+++ b/frontend/src/shared/ui/header.css
@@ -248,12 +248,32 @@ body.menu-open::before {
     calc(env(safe-area-inset-bottom) + 24px)
     calc(env(safe-area-inset-left) + 16px);
   visibility: hidden;
+  overflow: hidden;
+  overscroll-behavior: contain;
   pointer-events: none;
 }
 
 .nav-bar-menu.opened {
   visibility: visible;
   pointer-events: all;
+}
+
+.overlay-close-button {
+  position: absolute;
+  top: calc(env(safe-area-inset-top) + 8px);
+  right: calc(env(safe-area-inset-right) + 8px);
+  width: 44px;
+  height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  z-index: 2;
+}
+
+.overlay-close-button svg {
+  width: 32px;
+  height: 32px;
 }
 
 .hidden {
@@ -278,8 +298,9 @@ body.menu-open::before {
   position: relative;
   width: 100%;
   height: 100%;
-  overflow: auto;
+  overflow: hidden auto;
   -webkit-overflow-scrolling: touch;
+  overscroll-behavior: contain;
   z-index: 5;
 }
 


### PR DESCRIPTION
## Summary
- render the header menu overlay through a React portal so it sits at the top-level DOM
- add body scroll locking, solid underlay handling, and an iOS visualViewport shim for the menu overlay
- refresh header menu styles to support the new overlay root and safe-area padding

## Testing
- npm run lint *(fails: pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e8a92bca608324bf7f0a044a1ba151