### PR TITLE
Improve Safari overlay viewport handling

### DIFF
--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -37,6 +37,49 @@ export default function App(): React.ReactElement {
   const [isLoading, setIsLoading] = useState<boolean>(true);
 
   useEffect(() => {
+    if (typeof window === "undefined" || typeof document === "undefined") {
+      return;
+    }
+
+    const updateViewportVars = () => {
+      const viewportHeight = window.visualViewport?.height ?? window.innerHeight;
+      const outerHeight = window.outerHeight || viewportHeight;
+      const safeOuterHeight = Math.max(outerHeight, viewportHeight);
+      const root = document.documentElement;
+      const body = document.body;
+
+      const viewportHeightValue = `${viewportHeight}px`;
+      const outerHeightValue = `${safeOuterHeight}px`;
+
+      root.style.setProperty("--app-viewport-height", viewportHeightValue);
+      root.style.setProperty("--app-outer-height", outerHeightValue);
+      body.style.setProperty("--app-viewport-height", viewportHeightValue);
+      body.style.setProperty("--app-outer-height", outerHeightValue);
+    };
+
+    updateViewportVars();
+
+    window.addEventListener("resize", updateViewportVars);
+    window.addEventListener("orientationchange", updateViewportVars);
+
+    const { visualViewport } = window;
+    if (visualViewport) {
+      visualViewport.addEventListener("resize", updateViewportVars);
+      visualViewport.addEventListener("scroll", updateViewportVars);
+    }
+
+    return () => {
+      window.removeEventListener("resize", updateViewportVars);
+      window.removeEventListener("orientationchange", updateViewportVars);
+
+      if (visualViewport) {
+        visualViewport.removeEventListener("resize", updateViewportVars);
+        visualViewport.removeEventListener("scroll", updateViewportVars);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
     if (isLoading) {
       const timer = setTimeout(() => {
         setIsLoading(false);

--- a/frontend/src/shared/styles/base/reset.css
+++ b/frontend/src/shared/styles/base/reset.css
@@ -8,6 +8,22 @@
 /* Root font size */
 :root {
   font-size: 16px;
+  --app-viewport-height: 100vh;
+  --app-outer-height: 100vh;
+}
+
+@supports (height: 100dvh) {
+  :root {
+    --app-viewport-height: 100dvh;
+    --app-outer-height: 100dvh;
+  }
+}
+
+@supports (height: 100lvh) {
+  :root {
+    --app-viewport-height: 100lvh;
+    --app-outer-height: 100lvh;
+  }
 }
 
 /* Remove default margins that cause layout issues */
@@ -21,18 +37,19 @@ section {
 
 /* HTML and body base styles */
 html {
-  height: 100vh; /* fallback for older browsers */
-  height: 100dvh;
+  height: var(--app-viewport-height);
+  min-height: var(--app-outer-height);
   overscroll-behavior: none;
   scrollbar-width: none;
+  background-color: var(--bg-color);
 }
 
 body {
   margin: 0;
   padding: 0;
   width: 100%;
-  min-height: 100vh; /* fallback */
-  min-height: 100dvh;
+  min-height: var(--app-outer-height);
+  background-color: var(--bg-color);
   color: var(--text-color);
   font-family: var(--font-family-primary);
   font-weight: 700;
@@ -42,6 +59,14 @@ body {
   overflow: -moz-scrollbars-none;
   -ms-overflow-style: none;
   letter-spacing: var(--letter-spacing-tight);
+}
+
+#root {
+  min-height: var(--app-outer-height);
+}
+
+main {
+  min-height: var(--app-viewport-height);
 }
 
 /* List styles */

--- a/frontend/src/shared/styles/components/ui.css
+++ b/frontend/src/shared/styles/components/ui.css
@@ -44,14 +44,15 @@
 }
 
 /* SVG overlay */
-/* SVG overlay */
 .svg-overlay {
   position: fixed;
   inset: 0;
   width: 100vw;
-  height: 100vh;
+  height: var(--app-outer-height);
+  min-height: var(--app-outer-height);
   z-index: 10000;
   pointer-events: none;
+  background-color: var(--bg-color);
 }
 
 .svg-overlay svg {


### PR DESCRIPTION
## Summary
- define shared viewport height CSS variables and apply them to html, body, and main containers so the background covers Safari's liquid glass controls
- update the app bootstrap to sync those CSS variables with window.outerHeight and visualViewport events on iOS
- have the SVG overlay consume the shared height variable so it stretches behind Safari's toolbars

## Testing
- not run (viewport/CSS update)


------
https://chatgpt.com/codex/tasks/task_e_68e9a33d53f883248219a3c7c358f40e