### PR TITLE
Fix iOS Liquid Glass layout regressions

### DIFF
--- a/frontend/src/shared/styles/base/reset.css
+++ b/frontend/src/shared/styles/base/reset.css
@@ -44,6 +44,20 @@ body {
   letter-spacing: var(--letter-spacing-tight);
 }
 
+main {
+  height: 100vh; /* fallback */
+  height: 100dvh;
+  min-height: 100vh; /* fallback */
+  min-height: 100dvh;
+}
+
+/* Fullscreen overlay helpers */
+.ReactModal__Overlay,
+.overlay {
+  min-height: 100%;
+  height: 100%;
+}
+
 /* List styles */
 ul {
   list-style: none;
@@ -76,6 +90,24 @@ p {
 body::-webkit-scrollbar {
   width: 0 !important;
   overscroll-behavior: none;
+}
+
+/* Accessibility improvements for translucent glass effects */
+@supports (backdrop-filter: blur(10px)) {
+  @media (prefers-reduced-transparency) {
+    .glass-effect {
+      backdrop-filter: none;
+      background-color: rgba(255, 255, 255, 0.9);
+    }
+  }
+
+  @media (prefers-contrast) {
+    .glass-effect {
+      backdrop-filter: none;
+      background-color: #f0f0f0;
+      border: 1px solid #333;
+    }
+  }
 }
 
 

--- a/frontend/src/shared/utils/useModalStack.ts
+++ b/frontend/src/shared/utils/useModalStack.ts
@@ -1,6 +1,78 @@
 import { useEffect } from 'react';
 
 let openCount = 0;
+let teardownOverlayHeightFix: (() => void) | null = null;
+
+const OVERLAY_SELECTORS = [
+  '.ReactModal__Overlay',
+  '.modalOverlay',
+  '.modal-overlay',
+  '.overlay',
+];
+
+function applyOverlayHeightFix(): () => void {
+  if (typeof window === 'undefined' || typeof document === 'undefined') {
+    return () => {};
+  }
+
+  const html = document.documentElement;
+  const body = document.body;
+  const previousHtmlHeight = html.style.height;
+  const previousHtmlMinHeight = html.style.minHeight;
+  const previousBodyHeight = body.style.height;
+  const previousBodyMinHeight = body.style.minHeight;
+
+  const updateOverlayHeight = () => {
+    const fullHeight = window.outerHeight || window.innerHeight;
+    const heightValue = `${fullHeight}px`;
+
+    html.style.height = heightValue;
+    html.style.minHeight = heightValue;
+    body.style.height = heightValue;
+    body.style.minHeight = heightValue;
+    html.style.setProperty('--ios-fullscreen-height', heightValue);
+
+    for (const selector of OVERLAY_SELECTORS) {
+      document
+        .querySelectorAll<HTMLElement>(selector)
+        .forEach((element) => {
+          element.style.height = heightValue;
+          element.style.minHeight = heightValue;
+        });
+    }
+  };
+
+  const scheduleUpdate = () => {
+    updateOverlayHeight();
+    if (typeof window.requestAnimationFrame === 'function') {
+      window.requestAnimationFrame(updateOverlayHeight);
+    }
+  };
+
+  scheduleUpdate();
+
+  window.addEventListener('resize', scheduleUpdate);
+  window.addEventListener('orientationchange', scheduleUpdate);
+
+  return () => {
+    window.removeEventListener('resize', scheduleUpdate);
+    window.removeEventListener('orientationchange', scheduleUpdate);
+    html.style.height = previousHtmlHeight;
+    html.style.minHeight = previousHtmlMinHeight;
+    body.style.height = previousBodyHeight;
+    body.style.minHeight = previousBodyMinHeight;
+    html.style.removeProperty('--ios-fullscreen-height');
+
+    for (const selector of OVERLAY_SELECTORS) {
+      document
+        .querySelectorAll<HTMLElement>(selector)
+        .forEach((element) => {
+          element.style.height = '';
+          element.style.minHeight = '';
+        });
+    }
+  };
+}
 
 export default function useModalStack(isOpen: boolean): void {
   useEffect(() => {
@@ -9,6 +81,9 @@ export default function useModalStack(isOpen: boolean): void {
     if (isOpen) {
       openCount += 1;
       document.body.classList.add('ReactModal__Body--open');
+      if (!teardownOverlayHeightFix) {
+        teardownOverlayHeightFix = applyOverlayHeightFix();
+      }
     }
 
     return () => {
@@ -16,6 +91,10 @@ export default function useModalStack(isOpen: boolean): void {
         openCount = Math.max(0, openCount - 1);
         if (openCount === 0) {
           document.body.classList.remove('ReactModal__Body--open');
+          if (teardownOverlayHeightFix) {
+            teardownOverlayHeightFix();
+            teardownOverlayHeightFix = null;
+          }
         }
       }
     };


### PR DESCRIPTION
## Summary
- ensure global layouts and overlays respect dynamic viewport height and add accessibility fallbacks for translucent glass surfaces
- dynamically size modal overlays with the outer viewport height to avoid Safari 26 toolbar overlap issues

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68eaac67c8008324a4587e6db28965ea