### PR TITLE
Fix iOS viewport sizing for overlays

### DIFF
--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -22,6 +22,7 @@ import AppRoutes from "./routes";
 import Headermain from "../shared/ui/Header";
 import Preloader from "../shared/ui/Preloader";
 import { NotificationContainer } from "../shared/ui/ToastNotifications";
+import { useViewportHeightSync } from "../shared/hooks/useViewportHeightSync";
 
 gsap.registerPlugin(ScrollTrigger, useGSAP);
 
@@ -35,6 +36,7 @@ interface MainContentProps {
 
 export default function App(): React.ReactElement {
   const [isLoading, setIsLoading] = useState<boolean>(true);
+  useViewportHeightSync();
 
   useEffect(() => {
     if (isLoading) {

--- a/frontend/src/dashboard/home/pages/dashboard-styles.css
+++ b/frontend/src/dashboard/home/pages/dashboard-styles.css
@@ -6,6 +6,7 @@
   display: grid;
   grid-template-columns: 280px 1fr;
   height: 100vh;
+  height: var(--viewport-dvh, 100dvh);
   max-width: 1920px;
   margin: 0 auto;
   overflow: hidden;
@@ -20,6 +21,7 @@
   top: 0;
   align-self: start;
   height: 100vh;
+  height: var(--viewport-dvh, 100dvh);
   display: flex;
 }
 
@@ -35,6 +37,7 @@
   display: flex;
   flex-direction: column;
   height: 100vh;
+  height: var(--viewport-dvh, 100dvh);
   min-width: 0;
   overflow: hidden;
   padding: 0 12px;
@@ -59,15 +62,19 @@
     display: block;
     min-height: 100vh;
     min-height: 100dvh;
+    min-height: var(--viewport-dvh, 100dvh);
   }
 
   .dashboard-main {
     min-height: 100vh;
     min-height: 100dvh;
+    min-height: var(--viewport-dvh, 100dvh);
     height: 100vh;
     height: 100dvh;
+    height: var(--viewport-dvh, 100dvh);
     max-height: 100vh;
     max-height: 100dvh;
+    max-height: var(--viewport-dvh, 100dvh);
     display: flex;
     flex-direction: column;
     overflow: auto;

--- a/frontend/src/shared/hooks/useViewportHeightSync.ts
+++ b/frontend/src/shared/hooks/useViewportHeightSync.ts
@@ -1,0 +1,105 @@
+import { useEffect } from "react";
+
+const CSS_VAR_NAME = "--viewport-dvh";
+const OVERLAY_SELECTORS = [
+  ".overlay",
+  ".svg-overlay",
+  ".notifications-overlay",
+  ".navigation-drawer-backdrop",
+  ".preloader-container",
+  ".spinner-overlay",
+  ".ReactModal__Overlay",
+  ".modal",
+];
+
+function isIOSSafari(): boolean {
+  if (typeof navigator === "undefined") {
+    return false;
+  }
+
+  const ua = navigator.userAgent;
+  const isIOS = /iP(ad|hone|od)/.test(ua);
+  const isWebKit = /WebKit/.test(ua);
+  const isChrome = /CriOS/.test(ua);
+  const isFirefox = /FxiOS/.test(ua);
+
+  return isIOS && isWebKit && !isChrome && !isFirefox;
+}
+
+function applyViewportHeight(fullHeight: number): void {
+  const html = document.documentElement;
+  const body = document.body;
+
+  const heightValue = `${fullHeight}px`;
+  html.style.setProperty(CSS_VAR_NAME, heightValue);
+  html.style.height = heightValue;
+
+  body.style.setProperty(CSS_VAR_NAME, heightValue);
+  body.style.height = heightValue;
+
+  OVERLAY_SELECTORS.forEach((selector) => {
+    document.querySelectorAll<HTMLElement>(selector).forEach((element) => {
+      element.style.setProperty(CSS_VAR_NAME, heightValue);
+      if (element.style.position === "fixed" || element.style.position === "absolute") {
+        element.style.height = heightValue;
+      } else {
+        element.style.minHeight = heightValue;
+      }
+    });
+  });
+}
+
+export function syncViewportHeight(): void {
+  if (typeof window === "undefined" || !isIOSSafari()) {
+    return;
+  }
+
+  const height = Math.max(window.outerHeight || 0, window.innerHeight || 0);
+  applyViewportHeight(height);
+}
+
+export function useViewportHeightSync(): void {
+  useEffect(() => {
+    if (!isIOSSafari() || typeof window === "undefined") {
+      return;
+    }
+
+    const html = document.documentElement;
+    const body = document.body;
+    const previousHtmlHeight = html.style.height;
+    const previousBodyHeight = body.style.height;
+    const previousHtmlVar = html.style.getPropertyValue(CSS_VAR_NAME);
+    const previousBodyVar = body.style.getPropertyValue(CSS_VAR_NAME);
+
+    const updateHeight = () => {
+      syncViewportHeight();
+    };
+
+    updateHeight();
+
+    window.addEventListener("resize", updateHeight);
+    window.addEventListener("orientationchange", updateHeight);
+
+    return () => {
+      window.removeEventListener("resize", updateHeight);
+      window.removeEventListener("orientationchange", updateHeight);
+
+      html.style.height = previousHtmlHeight;
+      body.style.height = previousBodyHeight;
+
+      if (previousHtmlVar) {
+        html.style.setProperty(CSS_VAR_NAME, previousHtmlVar);
+      } else {
+        html.style.removeProperty(CSS_VAR_NAME);
+      }
+
+      if (previousBodyVar) {
+        body.style.setProperty(CSS_VAR_NAME, previousBodyVar);
+      } else {
+        body.style.removeProperty(CSS_VAR_NAME);
+      }
+    };
+  }, []);
+}
+
+export default useViewportHeightSync;

--- a/frontend/src/shared/styles/base/reset.css
+++ b/frontend/src/shared/styles/base/reset.css
@@ -8,6 +8,7 @@
 /* Root font size */
 :root {
   font-size: 16px;
+  --viewport-dvh: 100dvh;
 }
 
 /* Remove default margins that cause layout issues */
@@ -23,6 +24,7 @@ section {
 html {
   height: 100vh; /* fallback for older browsers */
   height: 100dvh;
+  height: var(--viewport-dvh, 100dvh);
   overscroll-behavior: none;
   scrollbar-width: none;
 }
@@ -33,6 +35,7 @@ body {
   width: 100%;
   min-height: 100vh; /* fallback */
   min-height: 100dvh;
+  min-height: var(--viewport-dvh, 100dvh);
   color: var(--text-color);
   font-family: var(--font-family-primary);
   font-weight: 700;

--- a/frontend/src/shared/styles/components/modals.css
+++ b/frontend/src/shared/styles/components/modals.css
@@ -5,6 +5,18 @@
   z-index: 2000 !important;
 }
 
+.ReactModal__Overlay {
+  height: 100vh;
+  height: var(--viewport-dvh, 100dvh);
+}
+
+.modal,
+.modal--after-open,
+.modal--before-close {
+  height: 100vh;
+  height: var(--viewport-dvh, 100dvh);
+}
+
 body.ReactModal__Body--open .dashboard-wrapper {
   filter: blur(4px);
   transition: filter 0.3s ease-in-out;

--- a/frontend/src/shared/styles/components/ui.css
+++ b/frontend/src/shared/styles/components/ui.css
@@ -51,21 +51,10 @@
   width: 100vw;
   height: 100vh;
   min-height: 100vh;
+  height: var(--viewport-dvh, 100dvh);
+  min-height: var(--viewport-dvh, 100dvh);
   z-index: 10000;
   pointer-events: none;
-}
-
-@supports (height: 100dvh) {
-  .svg-overlay {
-    height: 100dvh;
-  }
-}
-
-@supports (height: 100lvh) {
-  .svg-overlay {
-    height: 100lvh;
-    min-height: 100lvh;
-  }
 }
 
 .svg-overlay svg {
@@ -94,6 +83,7 @@
   width: 100%;
   height: 100vh; /* fallback */
   height: 100dvh;
+  height: var(--viewport-dvh, 100dvh);
   z-index: 2;
   display: flex;
   left: 0;
@@ -101,6 +91,24 @@
   top: 0;
   bottom: 0;
   pointer-events: none;
+}
+
+/* Accessibility improvements for Liquid Glass effects */
+@supports (backdrop-filter: blur(10px)) {
+  @media (prefers-reduced-transparency) {
+    .glass-effect {
+      backdrop-filter: none !important;
+      background-color: rgba(255, 255, 255, 0.9) !important;
+    }
+  }
+
+  @media (prefers-contrast) {
+    .glass-effect {
+      backdrop-filter: none !important;
+      background-color: #f0f0f0 !important;
+      border: 1px solid #333 !important;
+    }
+  }
 }
 
 /* Bar component */

--- a/frontend/src/shared/styles/layouts/dashboard.css
+++ b/frontend/src/shared/styles/layouts/dashboard.css
@@ -88,6 +88,7 @@
   flex-grow: 1;
   height: 100vh;
   height: 100dvh;
+  height: var(--viewport-dvh, 100dvh);
 }
 
 .all-projects-container-welcome {
@@ -101,6 +102,7 @@
   padding: var(--space-3);
   max-height: 100vh;
   max-height: 100dvh;
+  max-height: var(--viewport-dvh, 100dvh);
   overflow-y: auto;
 }
 

--- a/frontend/src/shared/ui/Header.tsx
+++ b/frontend/src/shared/ui/Header.tsx
@@ -249,7 +249,7 @@ const Headermain: React.FC = () => {
                             />
                         </svg>
                     </div>
-                    <div className="menu-wrapper">
+                    <div className="menu-wrapper glass-effect">
                         <div className="menu-container">
                             <ul className="menu">
                                 <li className="menu-item">

--- a/frontend/src/shared/ui/NavigationDrawer.tsx
+++ b/frontend/src/shared/ui/NavigationDrawer.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import DashboardNavPanel from "./DashboardNavPanel";
 import "./navigation-drawer.css";
+import { syncViewportHeight } from "../hooks/useViewportHeightSync";
 
 interface NavigationDrawerProps {
   open: boolean;
@@ -32,6 +33,7 @@ const NavigationDrawer: React.FC<NavigationDrawerProps> = ({
     documentElement.style.overflow = "hidden";
     body.style.touchAction = "none";
     documentElement.style.touchAction = "none";
+    syncViewportHeight();
 
     return () => {
       body.style.overflow = originalBodyOverflow;
@@ -46,7 +48,7 @@ const NavigationDrawer: React.FC<NavigationDrawerProps> = ({
       {open && (
         <>
           <motion.div
-            className="navigation-drawer-backdrop"
+            className="navigation-drawer-backdrop glass-effect"
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}

--- a/frontend/src/shared/ui/NotificationsDrawer.tsx
+++ b/frontend/src/shared/ui/NotificationsDrawer.tsx
@@ -15,6 +15,7 @@ import { MESSAGES_THREADS_URL, apiFetch } from '../utils/api';
 import type { Thread } from '@/app/contexts/DataProvider';
 import './notifications-drawer.css';
 import { MICRO_WOBBLE_SCALE, SPRING_FAST } from '@/shared/ui/motionTokens';
+import { syncViewportHeight } from '../hooks/useViewportHeightSync';
 
 interface NotificationsDrawerProps {
   open: boolean;
@@ -208,15 +209,24 @@ const NotificationsDrawer: React.FC<NotificationsDrawerProps> = ({
 
   useEffect(() => {
     const updateVh = () => {
-      document.documentElement.style.setProperty(
-        '--notifications-vh',
-        `${window.innerHeight}px`
-      );
+      syncViewportHeight();
+      const viewportHeight = Math.max(window.outerHeight || 0, window.innerHeight || 0);
+      document.documentElement.style.setProperty('--notifications-vh', `${viewportHeight}px`);
     };
     updateVh();
     window.addEventListener('resize', updateVh);
-    return () => window.removeEventListener('resize', updateVh);
+    window.addEventListener('orientationchange', updateVh);
+    return () => {
+      window.removeEventListener('resize', updateVh);
+      window.removeEventListener('orientationchange', updateVh);
+    };
   }, []);
+
+  useEffect(() => {
+    if (open) {
+      syncViewportHeight();
+    }
+  }, [open]);
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {

--- a/frontend/src/shared/ui/PendingApprovalScreen.tsx
+++ b/frontend/src/shared/ui/PendingApprovalScreen.tsx
@@ -6,7 +6,7 @@ const PendingApprovalScreen: React.FC = () => (
       display: 'flex',
       justifyContent: 'center',
       alignItems: 'center',
-      height: '100vh',
+      height: 'var(--viewport-dvh, 100dvh)',
       overflow: 'hidden',
       padding: '20px',
       textAlign: 'center',

--- a/frontend/src/shared/ui/Preloader.tsx
+++ b/frontend/src/shared/ui/Preloader.tsx
@@ -1,11 +1,16 @@
 import React, { useEffect, useRef, useState } from 'react';
 import gsap from 'gsap';
 import './preloader.css';
+import { syncViewportHeight } from '../hooks/useViewportHeightSync';
 
 const Preloader: React.FC = () => {
   const [open, setOpen] = useState(true);
   const svgRef = useRef<SVGSVGElement | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    syncViewportHeight();
+  }, [open]);
 
   useEffect(() => {
     if (!open) return; // skip when already closed
@@ -47,7 +52,7 @@ const Preloader: React.FC = () => {
   return (
     <div
       ref={containerRef}
-      className="preloader-container flex justify-center items-center h-screen"
+      className="preloader-container flex justify-center items-center"
       onClick={() => setOpen((state) => !state)}
     >
       <svg

--- a/frontend/src/shared/ui/SpinnerScreen.tsx
+++ b/frontend/src/shared/ui/SpinnerScreen.tsx
@@ -2,7 +2,10 @@ import React from 'react';
 import Spinner from './Spinner';
 
 const SpinnerScreen: React.FC = () => (
-  <div className="dashboard-wrapper welcome-screen" style={{ height: '100vh' }}>
+  <div
+    className="dashboard-wrapper welcome-screen"
+    style={{ height: 'var(--viewport-dvh, 100dvh)' }}
+  >
     <Spinner />
   </div>
 );

--- a/frontend/src/shared/ui/header.css
+++ b/frontend/src/shared/ui/header.css
@@ -224,6 +224,7 @@
   position: absolute;
   width: 100vw;
   height: 100vh;
+  height: var(--viewport-dvh, 100dvh);
   top: 0;
   left: 0;
   z-index: 0;
@@ -258,6 +259,7 @@
   top: 0px;
   width: 100vw;
   height: 100vh;
+  height: var(--viewport-dvh, 100dvh);
   background-color: var(--bg-color);
 }
 
@@ -265,6 +267,7 @@
   position: relative;
   width: 100%;
   height: 100vh;
+  height: var(--viewport-dvh, 100dvh);
   overflow: hidden auto;
   z-index: 5;
 }

--- a/frontend/src/shared/ui/navigation-drawer.css
+++ b/frontend/src/shared/ui/navigation-drawer.css
@@ -6,6 +6,7 @@
   width: 100vw;
   height: 100vh;
   height: 100svh;
+  height: var(--viewport-dvh, 100dvh);
   background: rgba(0, 0, 0, 0.6);
   backdrop-filter: blur(6px);
   z-index: 999;
@@ -15,6 +16,7 @@
   position: sticky;
   top: var(--topbar-h, 64px);
   height: calc(100svh - var(--topbar-h, 64px));
+  height: calc(var(--viewport-dvh, 100dvh) - var(--topbar-h, 64px));
   background: linear-gradient(180deg, rgba(255, 255, 255, 0.02), transparent 60%),
     var(--bg2, #111213);
   border: 1px solid var(--line, rgba(255, 255, 255, 0.06));

--- a/frontend/src/shared/ui/notifications-drawer.css
+++ b/frontend/src/shared/ui/notifications-drawer.css
@@ -4,6 +4,9 @@
   left: 0;
   right: 0;
   bottom: 0;
+  min-height: 100vh;
+  min-height: var(--viewport-dvh, 100dvh);
+  min-height: var(--notifications-vh, var(--viewport-dvh, 100dvh));
   background: rgba(0, 0, 0, 0.5);
   z-index: 900;
 }
@@ -12,7 +15,11 @@
   position: fixed;
   right: 0;
   height: 100vh;
+  height: var(--viewport-dvh, 100dvh);
+  height: var(--notifications-vh, var(--viewport-dvh, 100dvh));
   max-height: 100vh;
+  max-height: var(--viewport-dvh, 100dvh);
+  max-height: var(--notifications-vh, var(--viewport-dvh, 100dvh));
   width: 360px;
   max-width: 100%;
   background: var(--bg-color);

--- a/frontend/src/shared/ui/preloader.css
+++ b/frontend/src/shared/ui/preloader.css
@@ -4,6 +4,7 @@
   left: 0;
   width: 100%;
   height: 100vh;
+  height: var(--viewport-dvh, 100dvh);
   display: flex;
   justify-content: center;
   align-items: center;

--- a/frontend/src/shared/ui/spinner-overlay.css
+++ b/frontend/src/shared/ui/spinner-overlay.css
@@ -4,6 +4,8 @@
   left: 0;
   right: 0;
   bottom: 0;
+  height: 100vh;
+  height: var(--viewport-dvh, 100dvh);
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
## Summary
- add an iOS Safari specific viewport height sync hook and wire it into the app shell
- update layout and overlay styles to rely on a dynamic 100dvh CSS variable with accessibility fallbacks
- ensure navigation, notification, and preload overlays resync their heights when shown

## Testing
- npm run build *(fails: missing `recharts` dependency during Rollup resolution)*

------
https://chatgpt.com/codex/tasks/task_e_68eab06c14d08324b740941bca540114