### PR TITLE
Fix overlay and preloader viewport handling on iOS 26

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" href="/favicon.ico" type="image/x-icon" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover, shrink-to-fit=no"
+    />
     <!-- Basic dev CSP; tighten via server headers for production -->
     <!-- <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' https: wss:; img-src 'self' data: https: blob:; media-src 'self' https: blob:; font-src 'self' data: https:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval'; frame-ancestors 'self'; base-uri 'self'; form-action 'self'">    
   -->

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -22,6 +22,7 @@ import AppRoutes from "./routes";
 import Headermain from "../shared/ui/Header";
 import Preloader from "../shared/ui/Preloader";
 import { NotificationContainer } from "../shared/ui/ToastNotifications";
+import { useLiquidGlassViewportFix } from "@/shared/hooks/useLiquidGlassViewportFix";
 
 gsap.registerPlugin(ScrollTrigger, useGSAP);
 
@@ -35,6 +36,8 @@ interface MainContentProps {
 
 export default function App(): React.ReactElement {
   const [isLoading, setIsLoading] = useState<boolean>(true);
+
+  useLiquidGlassViewportFix();
 
   useEffect(() => {
     if (isLoading) {

--- a/frontend/src/shared/hooks/useLiquidGlassViewportFix.ts
+++ b/frontend/src/shared/hooks/useLiquidGlassViewportFix.ts
@@ -1,0 +1,119 @@
+import { useEffect } from 'react';
+
+const FULL_SCREEN_SELECTORS = '.svg-overlay, .preloader-container, .preloaded';
+
+const isIOSDevice = (): boolean => {
+  if (typeof navigator === 'undefined') {
+    return false;
+  }
+
+  return /iPad|iPhone|iPod/i.test(navigator.userAgent);
+};
+
+const computeFullHeight = (): number => {
+  const { innerHeight, outerHeight, screen, visualViewport } = window;
+  const viewportHeight = visualViewport ? visualViewport.height + visualViewport.offsetTop : 0;
+
+  const candidates = [
+    innerHeight,
+    outerHeight,
+    screen?.availHeight ?? 0,
+    screen?.height ?? 0,
+    viewportHeight,
+  ].filter((value): value is number => Number.isFinite(value) && value > 0);
+
+  return candidates.length > 0 ? Math.max(...candidates) : innerHeight;
+};
+
+export const useLiquidGlassViewportFix = (): void => {
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof document === 'undefined') {
+      return;
+    }
+
+    const html = document.documentElement;
+    const body = document.body;
+
+    const originalHtmlHeight = html.style.height;
+    const originalHtmlMinHeight = html.style.minHeight;
+    const originalBodyHeight = body.style.height;
+    const originalBodyMinHeight = body.style.minHeight;
+    const originalBodyOverflowX = body.style.overflowX;
+    const originalBodyWidth = body.style.width;
+
+    let orientationTimeout: number | null = null;
+
+    const applyFullHeight = () => {
+      const fullHeight = computeFullHeight();
+
+      html.style.height = `${fullHeight}px`;
+      html.style.minHeight = `${fullHeight}px`;
+      body.style.height = `${fullHeight}px`;
+      body.style.minHeight = `${fullHeight}px`;
+
+      const elements = document.querySelectorAll<HTMLElement>(FULL_SCREEN_SELECTORS);
+
+      elements.forEach((element) => {
+        element.style.height = `${fullHeight}px`;
+        element.style.minHeight = `${fullHeight}px`;
+        element.style.top = '0px';
+        element.style.left = '0px';
+        element.style.width = '100%';
+        element.style.transform = 'translateZ(0)';
+      });
+
+      if (isIOSDevice()) {
+        body.style.overflowX = 'hidden';
+        body.style.width = '100%';
+      }
+    };
+
+    const handleResize = () => {
+      applyFullHeight();
+    };
+
+    const handleOrientationChange = () => {
+      if (orientationTimeout !== null) {
+        window.clearTimeout(orientationTimeout);
+      }
+
+      orientationTimeout = window.setTimeout(() => {
+        applyFullHeight();
+      }, 100);
+    };
+
+    applyFullHeight();
+
+    window.addEventListener('resize', handleResize);
+    window.addEventListener('orientationchange', handleOrientationChange);
+    window.addEventListener('load', applyFullHeight);
+
+    const { visualViewport } = window;
+
+    const handleViewportResize = () => {
+      applyFullHeight();
+    };
+
+    visualViewport?.addEventListener('resize', handleViewportResize);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+      window.removeEventListener('orientationchange', handleOrientationChange);
+      window.removeEventListener('load', applyFullHeight);
+      visualViewport?.removeEventListener('resize', handleViewportResize);
+
+      if (orientationTimeout !== null) {
+        window.clearTimeout(orientationTimeout);
+      }
+
+      html.style.height = originalHtmlHeight;
+      html.style.minHeight = originalHtmlMinHeight;
+      body.style.height = originalBodyHeight;
+      body.style.minHeight = originalBodyMinHeight;
+      body.style.overflowX = originalBodyOverflowX;
+      body.style.width = originalBodyWidth;
+    };
+  }, []);
+};
+
+export default useLiquidGlassViewportFix;

--- a/frontend/src/shared/styles/base/reset.css
+++ b/frontend/src/shared/styles/base/reset.css
@@ -23,6 +23,10 @@ section {
 html {
   height: 100vh; /* fallback for older browsers */
   height: 100dvh;
+  height: 100svh;
+  min-height: 100vh;
+  min-height: 100dvh;
+  min-height: 100svh;
   overscroll-behavior: none;
   scrollbar-width: none;
 }
@@ -33,6 +37,7 @@ body {
   width: 100%;
   min-height: 100vh; /* fallback */
   min-height: 100dvh;
+  min-height: 100svh;
   color: var(--text-color);
   font-family: var(--font-family-primary);
   font-weight: 700;

--- a/frontend/src/shared/styles/components/ui.css
+++ b/frontend/src/shared/styles/components/ui.css
@@ -44,34 +44,55 @@
 }
 
 /* SVG overlay */
-/* SVG overlay */
 .svg-overlay {
   position: fixed;
-  inset: 0;
-  width: 100vw;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  width: 100%;
   height: 100vh;
+  height: 100dvh;
+  height: 100svh;
   min-height: 100vh;
+  min-height: 100dvh;
+  min-height: 100svh;
   z-index: 10000;
   pointer-events: none;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom)
+    env(safe-area-inset-left);
+  transform: translateZ(0);
 }
 
-@supports (height: 100dvh) {
-  .svg-overlay {
-    height: 100dvh;
-  }
-}
-
-@supports (height: 100lvh) {
-  .svg-overlay {
-    height: 100lvh;
-    min-height: 100lvh;
-  }
+.svg-overlay::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  background: inherit;
+  z-index: -1;
 }
 
 .svg-overlay svg {
   display: block;
   width: 100%;
   height: 100%;
+  flex: 1 1 auto;
+}
+
+@supports (backdrop-filter: blur(10px)) {
+  @media (prefers-reduced-transparency: reduce) {
+    .svg-overlay {
+      backdrop-filter: none !important;
+      background: rgba(255, 255, 255, 0.95) !important;
+    }
+  }
 }
 
 /* Cursor styles */

--- a/frontend/src/shared/ui/Preloader.tsx
+++ b/frontend/src/shared/ui/Preloader.tsx
@@ -47,7 +47,7 @@ const Preloader: React.FC = () => {
   return (
     <div
       ref={containerRef}
-      className="preloader-container flex justify-center items-center h-screen"
+      className="preloader-container flex justify-center items-center"
       onClick={() => setOpen((state) => !state)}
     >
       <svg

--- a/frontend/src/shared/ui/preloader.css
+++ b/frontend/src/shared/ui/preloader.css
@@ -1,13 +1,47 @@
-.preloader-container {
+.preloader-container,
+.preloaded {
   position: fixed;
   top: 0;
+  right: 0;
+  bottom: 0;
   left: 0;
   width: 100%;
   height: 100vh;
+  height: 100dvh;
+  height: 100svh;
+  min-height: 100vh;
+  min-height: 100dvh;
+  min-height: 100svh;
   display: flex;
   justify-content: center;
   align-items: center;
-  z-index: 1000;
+  z-index: 9999;
+  overflow: hidden;
+  padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom)
+    env(safe-area-inset-left);
+  transform: translateZ(0);
+}
+
+.preloader-container::before,
+.preloaded::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  background: inherit;
+  z-index: -1;
+}
+
+@supports (backdrop-filter: blur(10px)) {
+  @media (prefers-reduced-transparency: reduce) {
+    .preloader-container,
+    .preloaded {
+      backdrop-filter: none !important;
+      background: rgba(255, 255, 255, 0.95) !important;
+    }
+  }
 }
 
 


### PR DESCRIPTION
## Summary
- ensure the base viewport meta tag supports viewport-fit coverage for iOS 26
- update overlay and preloader styles to rely on small viewport units and safe-area padding
- add a shared hook that normalizes full-screen element heights across Liquid Glass viewport changes

## Testing
- npm run lint *(fails: pre-existing @typescript-eslint/no-unused-vars in frontend/src/dashboard/project/features/budget/components/BudgetToolbar.tsx:77)*

------
https://chatgpt.com/codex/tasks/task_e_68eab5e5f6a083248fa5463328c470fd