### PR TITLE
Fix overlay viewport sizing with dynamic visual viewport syncing

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -10,8 +10,11 @@ import App from './app/App';
 import 'antd/dist/reset.css';
 import './index.css';
 import './components/preloader/style.css';
+import { initializeViewportUnits } from './shared/utils/viewportUnits';
 
 Amplify.configure(awsConfig);
+
+initializeViewportUnits();
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement,

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -9,6 +9,7 @@ import awsConfig from './aws-exports'; // Ensure aws-exports.js exists and is ty
 import App from './app/App';
 
 import 'antd/dist/reset.css';
+import { initializeViewportUnits } from './shared/utils/viewportUnits';
 
 
 if (import.meta.env.DEV) {
@@ -17,6 +18,8 @@ if (import.meta.env.DEV) {
 
 // ✅ Amplify config
 Amplify.configure(awsConfig);
+
+initializeViewportUnits();
 
 // ✅ Root element typing with non-null assertion (!)
 const rootElement = document.getElementById('root')!;

--- a/frontend/src/shared/styles/base/reset.css
+++ b/frontend/src/shared/styles/base/reset.css
@@ -8,6 +8,10 @@
 /* Root font size */
 :root {
   font-size: 16px;
+  --viewport-height: 100vh;
+  --viewport-width: 100vw;
+  --viewport-offset-top: 0px;
+  --viewport-offset-left: 0px;
 }
 
 /* Remove default margins that cause layout issues */
@@ -21,8 +25,7 @@ section {
 
 /* HTML and body base styles */
 html {
-  height: 100vh; /* fallback for older browsers */
-  height: 100dvh;
+  min-height: var(--viewport-height, 100vh);
   overscroll-behavior: none;
   scrollbar-width: none;
 }
@@ -31,8 +34,7 @@ body {
   margin: 0;
   padding: 0;
   width: 100%;
-  min-height: 100vh; /* fallback */
-  min-height: 100dvh;
+  min-height: var(--viewport-height, 100vh);
   color: var(--text-color);
   font-family: var(--font-family-primary);
   font-weight: 700;

--- a/frontend/src/shared/styles/components/ui.css
+++ b/frontend/src/shared/styles/components/ui.css
@@ -47,25 +47,15 @@
 /* SVG overlay */
 .svg-overlay {
   position: fixed;
-  inset: 0;
-  width: 100vw;
-  height: 100vh;
-  min-height: 100vh;
+  top: var(--viewport-offset-top, 0px);
+  left: var(--viewport-offset-left, 0px);
+  width: var(--viewport-width, 100vw);
+  height: var(--viewport-height, 100vh);
+  min-height: var(--viewport-height, 100vh);
+  max-width: var(--viewport-width, 100vw);
+  max-height: var(--viewport-height, 100vh);
   z-index: 10000;
   pointer-events: none;
-}
-
-@supports (height: 100dvh) {
-  .svg-overlay {
-    height: 100dvh;
-  }
-}
-
-@supports (height: 100lvh) {
-  .svg-overlay {
-    height: 100lvh;
-    min-height: 100lvh;
-  }
 }
 
 .svg-overlay svg {
@@ -91,15 +81,14 @@
 /* Overlay component */
 .overlay {
   position: fixed;
-  width: 100%;
-  height: 100vh; /* fallback */
-  height: 100dvh;
+  top: var(--viewport-offset-top, 0px);
+  left: var(--viewport-offset-left, 0px);
+  width: var(--viewport-width, 100vw);
+  height: var(--viewport-height, 100vh);
+  max-width: var(--viewport-width, 100vw);
+  max-height: var(--viewport-height, 100vh);
   z-index: 2;
   display: flex;
-  left: 0;
-  right: 0;
-  top: 0;
-  bottom: 0;
   pointer-events: none;
 }
 

--- a/frontend/src/shared/ui/Preloader.tsx
+++ b/frontend/src/shared/ui/Preloader.tsx
@@ -47,7 +47,7 @@ const Preloader: React.FC = () => {
   return (
     <div
       ref={containerRef}
-      className="preloader-container flex justify-center items-center h-screen"
+      className="preloader-container flex justify-center items-center"
       onClick={() => setOpen((state) => !state)}
     >
       <svg

--- a/frontend/src/shared/ui/preloader.css
+++ b/frontend/src/shared/ui/preloader.css
@@ -1,9 +1,11 @@
 .preloader-container {
   position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100vh;
+  top: var(--viewport-offset-top, 0px);
+  left: var(--viewport-offset-left, 0px);
+  width: var(--viewport-width, 100vw);
+  height: var(--viewport-height, 100vh);
+  max-width: var(--viewport-width, 100vw);
+  max-height: var(--viewport-height, 100vh);
   display: flex;
   justify-content: center;
   align-items: center;

--- a/frontend/src/shared/utils/viewportUnits.ts
+++ b/frontend/src/shared/utils/viewportUnits.ts
@@ -1,0 +1,73 @@
+const VIEWPORT_HEIGHT_VAR = '--viewport-height';
+const VIEWPORT_WIDTH_VAR = '--viewport-width';
+const VIEWPORT_OFFSET_TOP_VAR = '--viewport-offset-top';
+const VIEWPORT_OFFSET_LEFT_VAR = '--viewport-offset-left';
+
+const DEFAULT_HEIGHT = '100vh';
+const DEFAULT_WIDTH = '100vw';
+
+let rafId: number | null = null;
+let initialized = false;
+
+function setViewportUnits() {
+  if (typeof document === 'undefined' || typeof window === 'undefined') {
+    return;
+  }
+
+  const docEl = document.documentElement;
+  const vv = window.visualViewport;
+
+  const height = vv?.height ?? window.innerHeight;
+  const width = vv?.width ?? window.innerWidth;
+
+  docEl.style.setProperty(VIEWPORT_HEIGHT_VAR, `${height}px`);
+  docEl.style.setProperty(VIEWPORT_WIDTH_VAR, `${width}px`);
+  docEl.style.setProperty(VIEWPORT_OFFSET_TOP_VAR, `${vv?.offsetTop ?? 0}px`);
+  docEl.style.setProperty(VIEWPORT_OFFSET_LEFT_VAR, `${vv?.offsetLeft ?? 0}px`);
+}
+
+function scheduleUpdate() {
+  if (rafId !== null) {
+    return;
+  }
+
+  rafId = window.requestAnimationFrame(() => {
+    rafId = null;
+    setViewportUnits();
+  });
+}
+
+function addEventListeners() {
+  window.addEventListener('resize', scheduleUpdate, { passive: true });
+  window.addEventListener('orientationchange', scheduleUpdate, { passive: true });
+
+  if (window.visualViewport) {
+    window.visualViewport.addEventListener('resize', scheduleUpdate, { passive: true });
+    window.visualViewport.addEventListener('scroll', scheduleUpdate, { passive: true });
+  }
+}
+
+export function initializeViewportUnits(): void {
+  if (initialized || typeof window === 'undefined') {
+    return;
+  }
+
+  initialized = true;
+
+  const docEl = document.documentElement;
+  if (!docEl.style.getPropertyValue(VIEWPORT_HEIGHT_VAR)) {
+    docEl.style.setProperty(VIEWPORT_HEIGHT_VAR, DEFAULT_HEIGHT);
+  }
+  if (!docEl.style.getPropertyValue(VIEWPORT_WIDTH_VAR)) {
+    docEl.style.setProperty(VIEWPORT_WIDTH_VAR, DEFAULT_WIDTH);
+  }
+  if (!docEl.style.getPropertyValue(VIEWPORT_OFFSET_TOP_VAR)) {
+    docEl.style.setProperty(VIEWPORT_OFFSET_TOP_VAR, '0px');
+  }
+  if (!docEl.style.getPropertyValue(VIEWPORT_OFFSET_LEFT_VAR)) {
+    docEl.style.setProperty(VIEWPORT_OFFSET_LEFT_VAR, '0px');
+  }
+
+  setViewportUnits();
+  addEventListeners();
+}


### PR DESCRIPTION
## Summary
- add a visual viewport synchronizer that updates CSS variables for viewport height, width, and offsets
- replace hard-coded 100vh usage in overlays, preloaders, and global reset with the synchronized CSS variables
- initialize the viewport sync during app bootstrap so full-screen layers follow Safari 26 toolbar changes

## Testing
- npm run lint -- --max-warnings=0 *(fails: `frontend/src/dashboard/project/components/BudgetToolbar.tsx(77,9)` is assigned a value but never used)*

------
https://chatgpt.com/codex/tasks/task_e_68eabb7e77608324bb13e1affc5f1477